### PR TITLE
Fix package name-version for wildcard version

### DIFF
--- a/internal/weldr/api.go
+++ b/internal/weldr/api.go
@@ -443,11 +443,14 @@ func (api *API) blueprintsDepsolveHandler(writer http.ResponseWriter, request *h
 		specs := make([]string, len(blueprint.Packages))
 		for i, pkg := range blueprint.Packages {
 			specs[i] = pkg.Name
-			if pkg.Version != "" {
+			// If a package has version "*" the package name suffix must be equal to "-*-*.*"
+			// Using just "-*" would find any other package containing the package name
+			if pkg.Version != "" && pkg.Version != "*" {
 				specs[i] += "-" + pkg.Version
+			} else if pkg.Version == "*" {
+				specs[i] += "-*-*.*"
 			}
 		}
-
 		dependencies, _ := rpmmd.Depsolve(specs...)
 
 		blueprints = append(blueprints, entry{blueprint, dependencies})


### PR DESCRIPTION
If a package had version "*" its name-version would be "name-*". This would match all packages containing "name" in their name. Instead the name-version is "name-*-*" so it matches any version of the package.