### PR TITLE
job-queue: pass a well-formed job object to the worker

### DIFF
--- a/internal/job/job.go
+++ b/internal/job/job.go
@@ -8,5 +8,5 @@ import (
 type Job struct {
 	ComposeID string
 	Pipeline  pipeline.Pipeline
-	Target    target.Target
+	Targets   []target.Target
 }

--- a/internal/job/store.go
+++ b/internal/job/store.go
@@ -38,7 +38,7 @@ func (s *Store) UpdateJob(id string, job Job) bool {
 	req, _ := s.jobs[id]
 	req.ComposeID = job.ComposeID
 	req.Pipeline = job.Pipeline
-	req.Target = job.Target
+	req.Targets = job.Targets
 
 	return true
 }

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -1,3 +1,18 @@
 package pipeline
 
-type Pipeline string
+type Pipeline struct {
+	Stages    []Stage   `json:"stages,omitempty"`
+	Assembler Assembler `json:"assembler"`
+}
+
+type Stage struct {
+}
+
+type Assembler struct {
+	Name    string              `json:"name"`
+	Options AssemblerTarOptions `json:"options"`
+}
+
+type AssemblerTarOptions struct {
+	Filename string `json:"filename"`
+}

--- a/internal/target/target.go
+++ b/internal/target/target.go
@@ -1,3 +1,10 @@
 package target
 
-type Target string
+type Target struct {
+	Name    string       `json:"name"`
+	Options LocalOptions `json:"options"`
+}
+
+type LocalOptions struct {
+	Location string `json:"location"`
+}

--- a/internal/weldr/api.go
+++ b/internal/weldr/api.go
@@ -12,6 +12,7 @@ import (
 
 	"osbuild-composer/internal/job"
 	"osbuild-composer/internal/rpmmd"
+	"osbuild-composer/internal/target"
 )
 
 type API struct {
@@ -618,11 +619,18 @@ func (api *API) composeHandler(writer http.ResponseWriter, httpRequest *http.Req
 	changed := false
 	found := api.store.getBlueprint(cr.BlueprintName, &bp, &changed) // TODO: what to do with changed?
 
+	uuid := "ffffffff-ffff–ffff-ffff-ffffffffffff" // TODO: generate
+
 	if found {
 		api.pendingJobs <- job.Job{
-			ComposeID: "TODO",
+			ComposeID: uuid,
 			Pipeline:  bp.translateToPipeline(cr.ComposeType),
-			Target:    `{"output-path":"/var/cache/osbuild-composer"}`,
+			Targets: []target.Target{{
+				Name: "org.osbuild.local",
+				Options: target.LocalOptions{
+					Location: "/var/lib/osbuild-composer/" + uuid,
+				}},
+			},
 		}
 	} else {
 		statusResponseError(writer, http.StatusBadRequest, "blueprint does not exist")

--- a/internal/weldr/api_test.go
+++ b/internal/weldr/api_test.go
@@ -11,9 +11,7 @@ import (
 	"testing"
 
 	"osbuild-composer/internal/job"
-	"osbuild-composer/internal/pipeline"
 	"osbuild-composer/internal/rpmmd"
-	"osbuild-composer/internal/target"
 	"osbuild-composer/internal/weldr"
 )
 
@@ -157,12 +155,10 @@ func TestCompose(t *testing.T) {
 		http.StatusOK, `{"status":true}`)
 
 	job := <-jobChannel
-	expected_pipeline := pipeline.Pipeline(`{"pipeline":"string"}`)
-	expected_target := target.Target(`{"output-path":"/var/cache/osbuild-composer"}`)
-	if expected_target != job.Target {
-		t.Errorf("Expected this manifest: %s; got this: %s", expected_target, job.Target)
+	if job.Pipeline.Assembler.Name != "org.osbuild.tar" {
+		t.Errorf("Expected tar assembler, got: %s", job.Pipeline.Assembler.Name)
 	}
-	if expected_pipeline != job.Pipeline {
-		t.Errorf("Expected this manifest: %s; got this: %s", expected_pipeline, job.Pipeline)
+	if job.Targets[0].Name != "org.osbuild.local" {
+		t.Errorf("Expected local target, got: %s", job.Targets[0].Name)
 	}
 }

--- a/internal/weldr/store.go
+++ b/internal/weldr/store.go
@@ -2,7 +2,6 @@ package weldr
 
 import (
 	"encoding/json"
-	"fmt"
 	"log"
 	"osbuild-composer/internal/pipeline"
 	"sort"
@@ -158,5 +157,12 @@ func (s *store) deleteBlueprintFromWorkspace(name string) {
 }
 
 func (b *blueprint) translateToPipeline(outputFormat string) pipeline.Pipeline {
-	return pipeline.Pipeline(fmt.Sprintf("{\"pipeline\":\"%s\"}", "string"))
+	return pipeline.Pipeline{
+		Assembler: pipeline.Assembler{
+			Name: "org.osbuild.tar",
+			Options: pipeline.AssemblerTarOptions{
+				Filename: "image.tar",
+			},
+		},
+	}
 }


### PR DESCRIPTION
For now we will hardcode the org.osbuild.local target, so we might
as well fix this up front.

We do not yet support any target types, but for testing purposes we
claim to support 'tar', and we pass a noop tar pipeline to the worker.

This makes introspecting the job-queu api using curl a bit more
pleasant.

Signed-off-by: Tom Gundersen <teg@jklm.no>