### PR TITLE
Update api and store for parity with lorax

### DIFF
--- a/internal/rpmmd/repository.go
+++ b/internal/rpmmd/repository.go
@@ -32,7 +32,7 @@ type Package struct {
 
 type PackageSpec struct {
 	Name    string `json:"name"`
-	Epoch   uint   `json:"epoch,omitempty"`
+	Epoch   uint   `json:"epoch"`
 	Version string `json:"version,omitempty"`
 	Release string `json:"release,omitempty"`
 	Arch    string `json:"arch,omitempty"`

--- a/internal/weldr/api.go
+++ b/internal/weldr/api.go
@@ -174,6 +174,7 @@ func (api *API) sourceInfoHandler(writer http.ResponseWriter, request *http.Requ
 	}
 	type reply struct {
 		Sources map[string]sourceConfig `json:"sources"`
+		Errors  []string                `json:"errors"`
 	}
 
 	// we only have one repository
@@ -204,6 +205,7 @@ func (api *API) sourceInfoHandler(writer http.ResponseWriter, request *http.Requ
 
 	json.NewEncoder(writer).Encode(reply{
 		Sources: map[string]sourceConfig{cfg.ID: cfg},
+		Errors:  []string{},
 	})
 }
 

--- a/internal/weldr/api_test.go
+++ b/internal/weldr/api_test.go
@@ -88,8 +88,8 @@ func TestBasic(t *testing.T) {
 		{"/api/v0/projects/source/info", http.StatusNotFound, ``},
 		{"/api/v0/projects/source/info/", http.StatusNotFound, ``},
 		{"/api/v0/projects/source/info/foo", http.StatusBadRequest, `{"status":false,"errors":["repository not found: foo"]}`},
-		{"/api/v0/projects/source/info/test", http.StatusOK, `{"sources":{"test":{"id":"test","name":"Test","type":"yum-baseurl","url":"http://example.com/test/os","check_gpg":true,"check_ssl":true,"system":true}}}`},
-		{"/api/v0/projects/source/info/*", http.StatusOK, `{"sources":{"test":{"id":"test","name":"Test","type":"yum-baseurl","url":"http://example.com/test/os","check_gpg":true,"check_ssl":true,"system":true}}}`},
+		{"/api/v0/projects/source/info/test", http.StatusOK, `{"sources":{"test":{"id":"test","name":"Test","type":"yum-baseurl","url":"http://example.com/test/os","check_gpg":true,"check_ssl":true,"system":true}},"errors":[]}`},
+		{"/api/v0/projects/source/info/*", http.StatusOK, `{"sources":{"test":{"id":"test","name":"Test","type":"yum-baseurl","url":"http://example.com/test/os","check_gpg":true,"check_ssl":true,"system":true}},"errors":[]}`},
 
 		{"/api/v0/modules/list", http.StatusOK, `{"total":2,"offset":0,"limit":20,"modules":[{"name":"package1","group_type":"rpm"},{"name":"package2","group_type":"rpm"}]}`},
 		{"/api/v0/modules/list/*", http.StatusOK, `{"total":2,"offset":0,"limit":20,"modules":[{"name":"package1","group_type":"rpm"},{"name":"package2","group_type":"rpm"}]}`},
@@ -121,19 +121,19 @@ func TestBlueprints(t *testing.T) {
 	api := weldr.New(repo, packages, nil, nil, nil, nil, nil)
 
 	testRoute(t, api, "POST", "/api/v0/blueprints/new",
-		`{"name":"test","description":"Test","packages":[{"name":"httpd","version":"2.4.*"}],"version":"0"}`,
+		`{"name":"test","description":"Test","packages":[{"name":"httpd","version":"2.4.*"}],"version":"0.0.0"}`,
 		http.StatusOK, `{"status":true}`)
 
 	testRoute(t, api, "GET", "/api/v0/blueprints/info/test", ``,
-		http.StatusOK, `{"blueprints":[{"name":"test","description":"Test","modules":[],"packages":[{"name":"httpd","version":"2.4.*"}],"version":"0"}],
+		http.StatusOK, `{"blueprints":[{"name":"test","description":"Test","modules":[],"packages":[{"name":"httpd","version":"2.4.*"}],"groups":[],"version":"0.0.0"}],
 		"changes":[{"name":"test","changed":false}], "errors":[]}`)
 
 	testRoute(t, api, "POST", "/api/v0/blueprints/workspace",
-		`{"name":"test","description":"Test","packages":[{"name":"systemd","version":"123"}],"version":"0"}`,
+		`{"name":"test","description":"Test","packages":[{"name":"systemd","version":"123"}],"version":"0.0.0"}`,
 		http.StatusOK, `{"status":true}`)
 
 	testRoute(t, api, "GET", "/api/v0/blueprints/info/test", ``,
-		http.StatusOK, `{"blueprints":[{"name":"test","description":"Test","modules":[],"packages":[{"name":"systemd","version":"123"}],"version":"0"}],
+		http.StatusOK, `{"blueprints":[{"name":"test","description":"Test","modules":[],"packages":[{"name":"systemd","version":"123"}],"groups":[],"version":"0.0.0"}],
 		"changes":[{"name":"test","changed":true}], "errors":[]}`)
 
 	testRoute(t, api, "GET", "/api/v0/blueprints/diff/test/NEWEST/WORKSPACE", ``,
@@ -145,7 +145,7 @@ func TestCompose(t *testing.T) {
 	api := weldr.New(repo, packages, nil, nil, nil, jobChannel, nil)
 
 	testRoute(t, api, "POST", "/api/v0/blueprints/new",
-		`{"name":"test","description":"Test","packages":[{"name":"httpd","version":"2.4.*"}],"version":"0"}`,
+		`{"name":"test","description":"Test","packages":[{"name":"httpd","version":"2.4.*"}],"version":"0.0.0"}`,
 		http.StatusOK, `{"status":true}`)
 
 	testRoute(t, api, "POST", "/api/v0/compose", `{"blueprint_name": "http-server","compose_type": "tar","branch": "master"}`,

--- a/internal/weldr/store.go
+++ b/internal/weldr/store.go
@@ -26,10 +26,11 @@ type store struct {
 
 type blueprint struct {
 	Name        string             `json:"name"`
-	Description string             `json:"description,omitempty"`
+	Description string             `json:"description"`
 	Version     string             `json:"version,omitempty"`
 	Packages    []blueprintPackage `json:"packages"`
 	Modules     []blueprintPackage `json:"modules"`
+	Groups      []blueprintPackage `json:"groups"`
 }
 
 type blueprintPackage struct {
@@ -148,6 +149,12 @@ func (s *store) getBlueprint(name string, bp *blueprint, changed *bool) bool {
 	if bp.Modules == nil {
 		bp.Modules = []blueprintPackage{}
 	}
+	if bp.Groups == nil {
+		bp.Groups = []blueprintPackage{}
+	}
+	if bp.Version == "" {
+		bp.Version = "0.0.0"
+	}
 
 	if changed != nil {
 		*changed = inWorkspace
@@ -172,6 +179,12 @@ func (s *store) getBlueprintCommitted(name string, bp *blueprint) bool {
 	}
 	if bp.Modules == nil {
 		bp.Modules = []blueprintPackage{}
+	}
+	if bp.Groups == nil {
+		bp.Groups = []blueprintPackage{}
+	}
+	if bp.Version == "" {
+		bp.Version = "0.0.0"
 	}
 
 	return true


### PR DESCRIPTION
Add parameters to the api responses that while not displayed by cockpit-composer are used in props validation or blueprint updates. These updates bring osbuild-composer's api closer to lorax-composer's.