### PR TITLE
Remove RuntimeDirectory

### DIFF
--- a/distribution/osbuild-composer.service
+++ b/distribution/osbuild-composer.service
@@ -6,7 +6,6 @@ Requires=osbuild-composer.socket
 [Service]
 Type=simple
 ExecStart=/usr/lib/osbuild-composer/osbuild-composer
-RuntimeDirectory=osbuild-composer weldr
 StateDirectory=osbuild-composer
 WorkingDirectory=/usr/lib/osbuild-composer/
 User=_osbuild-composer


### PR DESCRIPTION
This directory is currently only used for unix-domain sockets but they are created by systemd with the socket unit and therefore this line is redundant and maybe even causes problems.

We want the sockets to live even when the service is down (either because of error or intentional suspension) and it seems that setting the RuntimeDirectory to the directories that contain the sockets makes systemd remove both directories and unlink the sockets when the service fails and that is exactly what we don't want.