### PR TITLE
osbuild-composer: Rename module to github.com/osbuild/osbuild-composer

### DIFF
--- a/cmd/osbuild-composer/main.go
+++ b/cmd/osbuild-composer/main.go
@@ -5,10 +5,10 @@ import (
 	"log"
 	"os"
 
-	"osbuild-composer/internal/jobqueue"
-	"osbuild-composer/internal/rpmmd"
-	"osbuild-composer/internal/store"
-	"osbuild-composer/internal/weldr"
+	"github.com/osbuild/osbuild-composer/internal/jobqueue"
+	"github.com/osbuild/osbuild-composer/internal/rpmmd"
+	"github.com/osbuild/osbuild-composer/internal/store"
+	"github.com/osbuild/osbuild-composer/internal/weldr"
 
 	"github.com/coreos/go-systemd/activation"
 )

--- a/cmd/osbuild-worker/job.go
+++ b/cmd/osbuild-worker/job.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/google/uuid"
 
-	"osbuild-composer/internal/pipeline"
-	"osbuild-composer/internal/target"
+	"github.com/osbuild/osbuild-composer/internal/pipeline"
+	"github.com/osbuild/osbuild-composer/internal/target"
 )
 
 type Job struct {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module osbuild-composer
+module github.com/osbuild/osbuild-composer
 
 go 1.12
 

--- a/internal/blueprint/ami_output.go
+++ b/internal/blueprint/ami_output.go
@@ -1,6 +1,6 @@
 package blueprint
 
-import "osbuild-composer/internal/pipeline"
+import "github.com/osbuild/osbuild-composer/internal/pipeline"
 
 type amiOutput struct{}
 

--- a/internal/blueprint/blueprint.go
+++ b/internal/blueprint/blueprint.go
@@ -3,7 +3,7 @@
 package blueprint
 
 import (
-	"osbuild-composer/internal/pipeline"
+	"github.com/osbuild/osbuild-composer/internal/pipeline"
 	"sort"
 )
 

--- a/internal/blueprint/disk_output.go
+++ b/internal/blueprint/disk_output.go
@@ -1,6 +1,6 @@
 package blueprint
 
-import "osbuild-composer/internal/pipeline"
+import "github.com/osbuild/osbuild-composer/internal/pipeline"
 
 type diskOutput struct{}
 

--- a/internal/blueprint/ext4_output.go
+++ b/internal/blueprint/ext4_output.go
@@ -1,6 +1,6 @@
 package blueprint
 
-import "osbuild-composer/internal/pipeline"
+import "github.com/osbuild/osbuild-composer/internal/pipeline"
 
 type ext4Output struct{}
 

--- a/internal/blueprint/liveiso_output.go
+++ b/internal/blueprint/liveiso_output.go
@@ -1,6 +1,6 @@
 package blueprint
 
-import "osbuild-composer/internal/pipeline"
+import "github.com/osbuild/osbuild-composer/internal/pipeline"
 
 type liveIsoOutput struct{}
 

--- a/internal/blueprint/openstack_output.go
+++ b/internal/blueprint/openstack_output.go
@@ -1,6 +1,6 @@
 package blueprint
 
-import "osbuild-composer/internal/pipeline"
+import "github.com/osbuild/osbuild-composer/internal/pipeline"
 
 type openstackOutput struct{}
 

--- a/internal/blueprint/qcow2_output.go
+++ b/internal/blueprint/qcow2_output.go
@@ -1,6 +1,6 @@
 package blueprint
 
-import "osbuild-composer/internal/pipeline"
+import "github.com/osbuild/osbuild-composer/internal/pipeline"
 
 type qcow2Output struct{}
 

--- a/internal/blueprint/tar_output.go
+++ b/internal/blueprint/tar_output.go
@@ -1,6 +1,6 @@
 package blueprint
 
-import "osbuild-composer/internal/pipeline"
+import "github.com/osbuild/osbuild-composer/internal/pipeline"
 
 type tarOutput struct{}
 

--- a/internal/blueprint/vhd_output.go
+++ b/internal/blueprint/vhd_output.go
@@ -1,6 +1,6 @@
 package blueprint
 
-import "osbuild-composer/internal/pipeline"
+import "github.com/osbuild/osbuild-composer/internal/pipeline"
 
 type vhdOutput struct{}
 

--- a/internal/blueprint/vmdk_output.go
+++ b/internal/blueprint/vmdk_output.go
@@ -1,6 +1,6 @@
 package blueprint
 
-import "osbuild-composer/internal/pipeline"
+import "github.com/osbuild/osbuild-composer/internal/pipeline"
 
 type vmdkOutput struct{}
 

--- a/internal/jobqueue/api.go
+++ b/internal/jobqueue/api.go
@@ -2,12 +2,12 @@ package jobqueue
 
 import (
 	"encoding/json"
+	"github.com/osbuild/osbuild-composer/internal/pipeline"
+	"github.com/osbuild/osbuild-composer/internal/store"
+	"github.com/osbuild/osbuild-composer/internal/target"
 	"log"
 	"net"
 	"net/http"
-	"osbuild-composer/internal/pipeline"
-	"osbuild-composer/internal/store"
-	"osbuild-composer/internal/target"
 
 	"github.com/google/uuid"
 	"github.com/julienschmidt/httprouter"

--- a/internal/jobqueue/api_test.go
+++ b/internal/jobqueue/api_test.go
@@ -10,9 +10,9 @@ import (
 	"strings"
 	"testing"
 
-	"osbuild-composer/internal/blueprint"
-	"osbuild-composer/internal/jobqueue"
-	"osbuild-composer/internal/store"
+	"github.com/osbuild/osbuild-composer/internal/blueprint"
+	"github.com/osbuild/osbuild-composer/internal/jobqueue"
+	"github.com/osbuild/osbuild-composer/internal/store"
 
 	"github.com/google/uuid"
 )

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -4,12 +4,12 @@ package store
 
 import (
 	"encoding/json"
+	"github.com/osbuild/osbuild-composer/internal/blueprint"
+	"github.com/osbuild/osbuild-composer/internal/pipeline"
+	"github.com/osbuild/osbuild-composer/internal/target"
 	"io/ioutil"
 	"log"
 	"os"
-	"osbuild-composer/internal/blueprint"
-	"osbuild-composer/internal/pipeline"
-	"osbuild-composer/internal/target"
 	"path/filepath"
 	"sort"
 	"sync"

--- a/internal/weldr/api.go
+++ b/internal/weldr/api.go
@@ -13,9 +13,9 @@ import (
 	"github.com/google/uuid"
 	"github.com/julienschmidt/httprouter"
 
-	"osbuild-composer/internal/blueprint"
-	"osbuild-composer/internal/rpmmd"
-	"osbuild-composer/internal/store"
+	"github.com/osbuild/osbuild-composer/internal/blueprint"
+	"github.com/osbuild/osbuild-composer/internal/rpmmd"
+	"github.com/osbuild/osbuild-composer/internal/store"
 )
 
 type API struct {
@@ -681,8 +681,8 @@ func (api *API) composeStatusHandler(writer http.ResponseWriter, request *http.R
 		id, err := uuid.Parse(uuidString)
 		if err != nil {
 			statusResponseError(writer, http.StatusBadRequest, "invalid UUID")
- 			return
- 		}
+			return
+		}
 		uuids = append(uuids, id)
 	}
 	reply.UUIDs = api.store.ListQueue(uuids)

--- a/internal/weldr/api_test.go
+++ b/internal/weldr/api_test.go
@@ -13,9 +13,9 @@ import (
 	"strings"
 	"testing"
 
-	"osbuild-composer/internal/rpmmd"
-	"osbuild-composer/internal/store"
-	"osbuild-composer/internal/weldr"
+	"github.com/osbuild/osbuild-composer/internal/rpmmd"
+	"github.com/osbuild/osbuild-composer/internal/store"
+	"github.com/osbuild/osbuild-composer/internal/weldr"
 )
 
 var repo = rpmmd.RepoConfig{


### PR DESCRIPTION
**Make sure to pull this PR and test if it's not breaking your workflow!**

This should be the best practice according to other popular go projects:
- https://github.com/prometheus/prometheus
- https://github.com/syncthing/syncthing
- https://github.com/drone/drone
- https://github.com/hashicorp/terraform

Also, this change fixes go get command (it currently fails due to bad package
name).