### PR TITLE
osbuild-composer: Fix imports broken by new module name

### DIFF
--- a/cmd/osbuild-pipeline/main.go
+++ b/cmd/osbuild-pipeline/main.go
@@ -3,8 +3,8 @@ package main
 import (
 	"encoding/json"
 	"flag"
+	"github.com/osbuild/osbuild-composer/internal/blueprint"
 	"os"
-	"osbuild-composer/internal/blueprint"
 )
 
 func main() {

--- a/internal/blueprint/f30_helpers.go
+++ b/internal/blueprint/f30_helpers.go
@@ -1,7 +1,7 @@
 package blueprint
 
 import (
-	"osbuild-composer/internal/pipeline"
+	"github.com/osbuild/osbuild-composer/internal/pipeline"
 
 	"github.com/google/uuid"
 )


### PR DESCRIPTION
We've merged some stuff with old module name used in imports. This
commit fixes it.