### PR TITLE
dnf-json: Use /var/cache as dnf cachedir

### DIFF
--- a/dnf-json
+++ b/dnf-json
@@ -24,7 +24,6 @@ except IndexError:
 
 base = dnf.Base()
 
-base.conf.cachedir = "./dnf-cache"
 base.conf.substitutions["releasever"] = "30"
 base.conf.substitutions["basearch"] = "x86_64"
 


### PR DESCRIPTION
When osbuild-composer is run as systemd service, we don't want to write
anything into working directory. Currently, we write dnf cache into it.
Instead, use absolute path to /var/cache as dnf cache.