### PR TITLE
QCOW2 image generation and output test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ __pycache__
 
 /osbuild-composer
 /osbuild-worker
+/osbuild-pipeline

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@
 build:
 	go build -o osbuild-composer ./cmd/osbuild-composer/
 	go build -o osbuild-worker ./cmd/osbuild-worker/
+	go build -o osbuild-pipeline ./cmd/osbuild-pipeline/
 
 .PHONY: install
 install:

--- a/internal/blueprint/f30_helpers.go
+++ b/internal/blueprint/f30_helpers.go
@@ -78,7 +78,7 @@ func addF30FSTabStage(p *pipeline.Pipeline) {
 		panic("invalid UUID")
 	}
 	options := &pipeline.FSTabStageOptions{}
-	options.AddFilesystem(id, "extf4", "/", "defaults", 1, 1)
+	options.AddFilesystem(id, "ext4", "/", "defaults", 1, 1)
 	p.AddStage(pipeline.NewFSTabStage(options))
 }
 
@@ -87,6 +87,17 @@ func addF30SELinuxStage(p *pipeline.Pipeline) {
 		&pipeline.SELinuxStageOptions{
 			FileContexts: "etc/selinux/targeted/contexts/files/file_contexts",
 		}))
+}
+
+func addF30LocaleStage(p *pipeline.Pipeline) {
+	p.AddStage(pipeline.NewLocaleStage(
+		&pipeline.LocaleStageOptions{
+			Language: "en_US",
+		}))
+}
+
+func addF30FixBlsStage(p *pipeline.Pipeline) {
+	p.AddStage(pipeline.NewFixBLSStage())
 }
 
 func addF30QemuAssembler(p *pipeline.Pipeline, format string, filename string) {

--- a/internal/blueprint/pipelines/ami_empty_blueprint.json
+++ b/internal/blueprint/pipelines/ami_empty_blueprint.json
@@ -68,7 +68,7 @@
         "filesystems": [
           {
             "uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
-            "vfs_type": "extf4",
+            "vfs_type": "ext4",
             "path": "/",
             "options": "defaults",
             "freq": 1,

--- a/internal/blueprint/pipelines/disk_empty_blueprint.json
+++ b/internal/blueprint/pipelines/disk_empty_blueprint.json
@@ -68,7 +68,7 @@
         "filesystems": [
           {
             "uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
-            "vfs_type": "extf4",
+            "vfs_type": "ext4",
             "path": "/",
             "options": "defaults",
             "freq": 1,

--- a/internal/blueprint/pipelines/openstack_empty_blueprint.json
+++ b/internal/blueprint/pipelines/openstack_empty_blueprint.json
@@ -68,7 +68,7 @@
         "filesystems": [
           {
             "uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
-            "vfs_type": "extf4",
+            "vfs_type": "ext4",
             "path": "/",
             "options": "defaults",
             "freq": 1,

--- a/internal/blueprint/pipelines/qcow2_empty_blueprint.json
+++ b/internal/blueprint/pipelines/qcow2_empty_blueprint.json
@@ -38,23 +38,25 @@
           }
         ],
         "packages": [
-          "@Core",
+          "kernel-core",
+          "@Fedora Cloud Server",
           "chrony",
-          "kernel",
+          "polkit",
+          "systemd-udev",
           "selinux-policy-targeted",
           "grub2-pc",
-          "spice-vdagent",
-          "qemu-guest-agent",
-          "xen-libs",
           "langpacks-en"
+        ],
+        "exclude_packages": [
+          "dracut-config-rescue",
+          "etables",
+          "firewalld",
+          "gobject-introspection",
+          "plymouth"
         ],
         "releasever": "30",
         "basearch": "x86_64"
       }
-    },
-    {
-      "name": "org.osbuild.fix-bls",
-      "options": {}
     },
     {
       "name": "org.osbuild.locale",
@@ -68,7 +70,7 @@
         "filesystems": [
           {
             "uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
-            "vfs_type": "extf4",
+            "vfs_type": "ext4",
             "path": "/",
             "options": "defaults",
             "freq": 1,
@@ -90,6 +92,10 @@
       "options": {
         "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
       }
+    },
+    {
+      "name": "org.osbuild.fix-bls",
+      "options": {}
     }
   ],
   "assembler": {

--- a/internal/blueprint/pipelines/vhd_empty_blueprint.json
+++ b/internal/blueprint/pipelines/vhd_empty_blueprint.json
@@ -68,7 +68,7 @@
         "filesystems": [
           {
             "uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
-            "vfs_type": "extf4",
+            "vfs_type": "ext4",
             "path": "/",
             "options": "defaults",
             "freq": 1,

--- a/internal/blueprint/pipelines/vmdk_empty_blueprint.json
+++ b/internal/blueprint/pipelines/vmdk_empty_blueprint.json
@@ -68,7 +68,7 @@
         "filesystems": [
           {
             "uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
-            "vfs_type": "extf4",
+            "vfs_type": "ext4",
             "path": "/",
             "options": "defaults",
             "freq": 1,

--- a/internal/blueprint/qcow2_output.go
+++ b/internal/blueprint/qcow2_output.go
@@ -5,11 +5,42 @@ import "github.com/osbuild/osbuild-composer/internal/pipeline"
 type qcow2Output struct{}
 
 func (t *qcow2Output) translate(b *Blueprint) *pipeline.Pipeline {
-	p := getF30Pipeline()
+	p := &pipeline.Pipeline{
+		BuildPipeline: getF30BuildPipeline(),
+	}
+
+	options := &pipeline.DNFStageOptions{
+		ReleaseVersion:   "30",
+		BaseArchitecture: "x86_64",
+	}
+	options.AddRepository(getF30Repository())
+	packages := [...]string{"kernel-core",
+		"@Fedora Cloud Server",
+		"chrony",
+		"polkit",
+		"systemd-udev",
+		"selinux-policy-targeted",
+		"grub2-pc",
+		"langpacks-en"}
+	for _, pkg := range packages {
+		options.AddPackage(pkg)
+	}
+	excludedPackages := [...]string{"dracut-config-rescue",
+		"etables",
+		"firewalld",
+		"gobject-introspection",
+		"plymouth"}
+	for _, pkg := range excludedPackages {
+		options.ExcludePackage(pkg)
+	}
+	p.AddStage(pipeline.NewDNFStage(options))
+	addF30LocaleStage(p)
 	addF30FSTabStage(p)
 	addF30GRUB2Stage(p)
 	addF30SELinuxStage(p)
+	addF30FixBlsStage(p)
 	addF30QemuAssembler(p, "qcow2", t.getName())
+
 	return p
 }
 

--- a/internal/pipeline/dnf_stage.go
+++ b/internal/pipeline/dnf_stage.go
@@ -10,6 +10,7 @@ package pipeline
 type DNFStageOptions struct {
 	Repositories     []*DNFRepository `json:"repos"`
 	Packages         []string         `json:"packages"`
+	ExcludedPackages []string         `json:"exclude_packages,omitempty"`
 	ReleaseVersion   string           `json:"releasever"`
 	BaseArchitecture string           `json:"basearch"`
 }
@@ -48,6 +49,11 @@ func NewDNFStage(options *DNFStageOptions) *Stage {
 // AddPackage adds a package to a DNFStageOptions object.
 func (options *DNFStageOptions) AddPackage(pkg string) {
 	options.Packages = append(options.Packages, pkg)
+}
+
+// ExcludePackage adds an excluded package to a DNFStageOptions object.
+func (options *DNFStageOptions) ExcludePackage(pkg string) {
+	options.ExcludedPackages = append(options.ExcludedPackages, pkg)
 }
 
 // AddRepository adds a repository to a DNFStageOptions object.


### PR DESCRIPTION
Adjust the qcow2 output to the official Fedora image and add a test for it. It uses the public `blueprint.ToPipeline` API.