### PR TITLE
Compose status updates

### DIFF
--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -55,6 +55,7 @@ type Image struct {
 	File *os.File
 	Name string
 	Mime string
+	Size int64
 }
 
 type NotFoundError struct {
@@ -448,10 +449,17 @@ func (s *Store) GetImage(composeID uuid.UUID) (*Image, error) {
 			case *target.LocalTargetOptions:
 				file, err := os.Open(options.Location + "/" + name)
 				if err == nil {
+					fileStat, err := file.Stat()
+					if err != nil {
+						return nil, &NotFoundError{"image info could not be found"}
+					}
+					size := fileStat.Size()
+
 					return &Image{
 						File: file,
 						Name: name,
 						Mime: mime,
+						Size: size,
 					}, nil
 				}
 			}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -201,6 +201,7 @@ type ComposeEntry struct {
 	Blueprint   string    `json:"blueprint"`
 	Version     string    `json:"version"`
 	ComposeType string    `json:"compose_type"`
+	ImageSize   int64     `json:"image_size"`
 	QueueStatus string    `json:"queue_status"`
 	JobCreated  float64   `json:"job_created"`
 	JobStarted  float64   `json:"job_started,omitempty"`
@@ -232,7 +233,24 @@ func (s *Store) ListQueue(uuids []uuid.UUID) []*ComposeEntry {
 				JobCreated:  float64(compose.JobCreated.UnixNano()) / 1000000000,
 				JobStarted:  float64(compose.JobStarted.UnixNano()) / 1000000000,
 			}
-		case "FAILED", "FINISHED":
+		case "FINISHED":
+			image, err := s.GetImage(id)
+			imageSize := int64(0)
+			if err == nil {
+				imageSize = image.Size
+			}
+			return &ComposeEntry{
+				ID:          id,
+				Blueprint:   compose.Blueprint.Name,
+				Version:     compose.Blueprint.Version,
+				ComposeType: compose.OutputType,
+				ImageSize:   imageSize,
+				QueueStatus: compose.QueueStatus,
+				JobCreated:  float64(compose.JobCreated.UnixNano()) / 1000000000,
+				JobStarted:  float64(compose.JobStarted.UnixNano()) / 1000000000,
+				JobFinished: float64(compose.JobFinished.UnixNano()) / 1000000000,
+			}
+		case "FAILED":
 			return &ComposeEntry{
 				ID:          id,
 				Blueprint:   compose.Blueprint.Name,

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -198,6 +198,8 @@ func (s *Store) ListBlueprints() []string {
 type ComposeEntry struct {
 	ID          uuid.UUID `json:"id"`
 	Blueprint   string    `json:"blueprint"`
+	Version     string    `json:"version"`
+	ComposeType string    `json:"compose_type"`
 	QueueStatus string    `json:"queue_status"`
 	JobCreated  float64   `json:"job_created"`
 	JobStarted  float64   `json:"job_started,omitempty"`
@@ -214,6 +216,8 @@ func (s *Store) ListQueue(uuids []uuid.UUID) []*ComposeEntry {
 			return &ComposeEntry{
 				ID:          id,
 				Blueprint:   compose.Blueprint.Name,
+				Version:     compose.Blueprint.Version,
+				ComposeType: compose.OutputType,
 				QueueStatus: compose.QueueStatus,
 				JobCreated:  float64(compose.JobCreated.UnixNano()) / 1000000000,
 			}
@@ -221,6 +225,8 @@ func (s *Store) ListQueue(uuids []uuid.UUID) []*ComposeEntry {
 			return &ComposeEntry{
 				ID:          id,
 				Blueprint:   compose.Blueprint.Name,
+				Version:     compose.Blueprint.Version,
+				ComposeType: compose.OutputType,
 				QueueStatus: compose.QueueStatus,
 				JobCreated:  float64(compose.JobCreated.UnixNano()) / 1000000000,
 				JobStarted:  float64(compose.JobStarted.UnixNano()) / 1000000000,
@@ -229,6 +235,8 @@ func (s *Store) ListQueue(uuids []uuid.UUID) []*ComposeEntry {
 			return &ComposeEntry{
 				ID:          id,
 				Blueprint:   compose.Blueprint.Name,
+				Version:     compose.Blueprint.Version,
+				ComposeType: compose.OutputType,
 				QueueStatus: compose.QueueStatus,
 				JobCreated:  float64(compose.JobCreated.UnixNano()) / 1000000000,
 				JobStarted:  float64(compose.JobStarted.UnixNano()) / 1000000000,

--- a/internal/weldr/api.go
+++ b/internal/weldr/api.go
@@ -299,7 +299,7 @@ func (api *API) modulesListHandler(writer http.ResponseWriter, request *http.Req
 				if total > offset && total < end {
 					modules = append(modules, modulesListModule{pkg.Name, "rpm"})
 					// this removes names that have been found from the list of names
-					if len(names) < i - 1 {
+					if len(names) < i-1 {
 						names = append(names[:i], names[i+1:]...)
 					} else {
 						names = names[:i]

--- a/internal/weldr/api.go
+++ b/internal/weldr/api.go
@@ -854,15 +854,9 @@ func (api *API) composeImageHandler(writer http.ResponseWriter, request *http.Re
 		return
 	}
 
-	stat, err := image.File.Stat()
-	if err != nil {
-		statusResponseError(writer, http.StatusInternalServerError)
-		return
-	}
-
 	writer.Header().Set("Content-Disposition", "attachment; filename="+uuid.String()+"-"+image.Name)
 	writer.Header().Set("Content-Type", image.Mime)
-	writer.Header().Set("Content-Length", fmt.Sprintf("%d", stat.Size()))
+	writer.Header().Set("Content-Length", fmt.Sprintf("%d", image.Size))
 
 	io.Copy(writer, image.File)
 }


### PR DESCRIPTION
As part of the effort to reach parity with lorax-composer I added some missing compose status info. Each compose now includes the blueprint version it is based off of, its compose type, and the finished compose's file size (0 if the compose isn't finished). 