### PR TITLE
worker: move Job type to the jobqueue package

### DIFF
--- a/cmd/osbuild-worker/main.go
+++ b/cmd/osbuild-worker/main.go
@@ -8,6 +8,8 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+
+	"github.com/osbuild/osbuild-composer/internal/jobqueue"
 )
 
 type ComposerClient struct {
@@ -25,7 +27,7 @@ func NewClient() *ComposerClient {
 	return &ComposerClient{client}
 }
 
-func (c *ComposerClient) AddJob() (*Job, error) {
+func (c *ComposerClient) AddJob() (*jobqueue.Job, error) {
 	type request struct {
 	}
 
@@ -41,7 +43,7 @@ func (c *ComposerClient) AddJob() (*Job, error) {
 		return nil, errors.New("couldn't create job")
 	}
 
-	job := &Job{}
+	job := &jobqueue.Job{}
 	err = json.NewDecoder(response.Body).Decode(job)
 	if err != nil {
 		return nil, err
@@ -50,13 +52,9 @@ func (c *ComposerClient) AddJob() (*Job, error) {
 	return job, nil
 }
 
-func (c *ComposerClient) UpdateJob(job *Job, status string) error {
-	type request struct {
-		Status string `json:"status"`
-	}
-
+func (c *ComposerClient) UpdateJob(job *jobqueue.Job, status string) error {
 	var b bytes.Buffer
-	json.NewEncoder(&b).Encode(&request{status})
+	json.NewEncoder(&b).Encode(&jobqueue.JobStatus{status})
 	req, err := http.NewRequest("PATCH", "http://localhost/job-queue/v1/jobs/"+job.ID.String(), &b)
 	if err != nil {
 		return err

--- a/internal/jobqueue/api.go
+++ b/internal/jobqueue/api.go
@@ -6,9 +6,7 @@ import (
 	"net"
 	"net/http"
 
-	"github.com/osbuild/osbuild-composer/internal/pipeline"
 	"github.com/osbuild/osbuild-composer/internal/store"
-	"github.com/osbuild/osbuild-composer/internal/target"
 
 	"github.com/google/uuid"
 	"github.com/julienschmidt/httprouter"
@@ -77,11 +75,7 @@ func statusResponseError(writer http.ResponseWriter, code int, errors ...string)
 func (api *API) addJobHandler(writer http.ResponseWriter, request *http.Request, _ httprouter.Params) {
 	type requestBody struct {
 	}
-	type replyBody struct {
-		ID       uuid.UUID          `json:"id"`
-		Pipeline *pipeline.Pipeline `json:"pipeline"`
-		Targets  []*target.Target   `json:"targets"`
-	}
+	type replyBody Job
 
 	contentType := request.Header["Content-Type"]
 	if len(contentType) != 1 || contentType[0] != "application/json" {
@@ -103,9 +97,7 @@ func (api *API) addJobHandler(writer http.ResponseWriter, request *http.Request,
 }
 
 func (api *API) updateJobHandler(writer http.ResponseWriter, request *http.Request, params httprouter.Params) {
-	type requestBody struct {
-		Status string `json:"status"`
-	}
+	type requestBody JobStatus
 
 	contentType := request.Header["Content-Type"]
 	if len(contentType) != 1 || contentType[0] != "application/json" {

--- a/internal/jobqueue/job.go
+++ b/internal/jobqueue/job.go
@@ -1,4 +1,4 @@
-package main
+package jobqueue
 
 import (
 	"encoding/json"
@@ -6,15 +6,18 @@ import (
 	"os/exec"
 
 	"github.com/google/uuid"
-
 	"github.com/osbuild/osbuild-composer/internal/pipeline"
 	"github.com/osbuild/osbuild-composer/internal/target"
 )
 
 type Job struct {
-	ID       uuid.UUID         `json:"id"`
-	Pipeline pipeline.Pipeline `json:"pipeline"`
-	Targets  []target.Target   `json:"targets"`
+	ID       uuid.UUID          `json:"id"`
+	Pipeline *pipeline.Pipeline `json:"pipeline"`
+	Targets  []*target.Target   `json:"targets"`
+}
+
+type JobStatus struct {
+	Status string `json:"status"`
 }
 
 func (job *Job) Run() error {


### PR DESCRIPTION
The main purpose of this is to share the structs between the server
and the client, and let the compiler ensure that our marshaling and
unmarshaling matches.

In the future we also want to make it easier to write unittests for
this code.

Signed-off-by: Tom Gundersen <teg@jklm.no>