### PR TITLE
dnf-json: get repository information from osbuild-composer

### DIFF
--- a/cmd/osbuild-composer/main.go
+++ b/cmd/osbuild-composer/main.go
@@ -33,12 +33,12 @@ func main() {
 	jobListener := listeners[1]
 
 	repo := rpmmd.RepoConfig{
-		Id:       "fedora-30",
+		Id:       "fedora",
 		Name:     "Fedora 30",
 		Metalink: "https://mirrors.fedoraproject.org/metalink?repo=fedora-30&arch=x86_64",
 	}
 
-	packages, err := rpmmd.FetchPackageList(repo)
+	packages, err := rpmmd.FetchPackageList([]rpmmd.RepoConfig{repo})
 	if err != nil {
 		panic(err)
 	}

--- a/dnf-json
+++ b/dnf-json
@@ -43,12 +43,7 @@ call = json.load(sys.stdin)
 command = call["command"]
 arguments = call.get("arguments", {})
 
-if command == "list":
-    base = create_base(arguments.get("repos", {}))
-    packages = [p.name for p in base.sack.query().available()]
-    json.dump(packages, sys.stdout)
-
-elif command == "dump":
+if command == "dump":
     base = create_base(arguments.get("repos", {}))
     packages = []
     for package in base.sack.query().available():

--- a/dnf-json
+++ b/dnf-json
@@ -11,24 +11,45 @@ def timestamp_to_rfc3339(timestamp):
     return d.strftime('%Y-%m-%dT%H:%M:%SZ')
 
 
+def dnfrepo(desc, parent_conf=None):
+    """Makes a dnf.repo.Repo out of a JSON repository description"""
+
+    repo = dnf.repo.Repo(desc["id"], parent_conf)
+    repo.name = desc["name"]
+
+    if "baseurl" in desc:
+        repo.baseurl = desc["baseurl"]
+    elif "metalink" in desc:
+        repo.metalink = desc["metalink"]
+    elif "mirrorlist" in desc:
+        repo.metalink = desc["mirrorlist"]
+    else:
+        assert False
+
+    return repo
+
+
+def create_base(repos):
+    base = dnf.Base()
+
+    for repo in repos:
+        base.repos.add(dnfrepo(repo, base.conf))
+
+    base.fill_sack(load_system_repo=False)
+    return base
+
+
 call = json.load(sys.stdin)
 command = call["command"]
 arguments = call.get("arguments", {})
 
-base = dnf.Base()
-
-repo = dnf.repo.Repo("fedora", base.conf)
-repo.name = "Fedora"
-repo.metalink = "https://mirrors.fedoraproject.org/metalink?repo=fedora-30&arch=x86_64"
-
-base.repos.add(repo)
-base.fill_sack(load_system_repo=False)
-
 if command == "list":
+    base = create_base(arguments.get("repos", {}))
     packages = [p.name for p in base.sack.query().available()]
     json.dump(packages, sys.stdout)
 
 elif command == "dump":
+    base = create_base(arguments.get("repos", {}))
     packages = []
     for package in base.sack.query().available():
         packages.append({
@@ -46,6 +67,7 @@ elif command == "dump":
     json.dump(packages, sys.stdout)
 
 elif command == "depsolve":
+    base = create_base(arguments.get("repos", {}))
     for pkgspec in arguments:
         base.install(pkgspec)
     base.resolve()

--- a/dnf-json
+++ b/dnf-json
@@ -17,12 +17,9 @@ arguments = call.get("arguments", {})
 
 base = dnf.Base()
 
-base.conf.substitutions["releasever"] = "30"
-base.conf.substitutions["basearch"] = "x86_64"
-
 repo = dnf.repo.Repo("fedora", base.conf)
 repo.name = "Fedora"
-repo.metalink = "https://mirrors.fedoraproject.org/metalink?repo=fedora-$releasever&arch=$basearch"
+repo.metalink = "https://mirrors.fedoraproject.org/metalink?repo=fedora-30&arch=x86_64"
 
 base.repos.add(repo)
 base.fill_sack(load_system_repo=False)

--- a/dnf-json
+++ b/dnf-json
@@ -11,16 +11,9 @@ def timestamp_to_rfc3339(timestamp):
     return d.strftime('%Y-%m-%dT%H:%M:%SZ')
 
 
-# base.sack.query().filter(provides=str(reldep))
-
-
-try:
-    command = sys.argv[1]
-    arguments = sys.argv[2:]
-except IndexError:
-    command = "list"
-    arguments = []
-
+call = json.load(sys.stdin)
+command = call["command"]
+arguments = call.get("arguments", {})
 
 base = dnf.Base()
 

--- a/internal/rpmmd/repository.go
+++ b/internal/rpmmd/repository.go
@@ -80,16 +80,20 @@ func runDNF(command string, arguments interface{}, result interface{}) error {
 	return cmd.Wait()
 }
 
-func FetchPackageList(repo RepoConfig) (PackageList, error) {
+func FetchPackageList(repos []RepoConfig) (PackageList, error) {
+	var arguments = struct {
+		Repos []RepoConfig `json:"repos"`
+	}{repos}
 	var packages PackageList
-	err := runDNF("dump", nil, &packages)
+	err := runDNF("dump", arguments, &packages)
 	return packages, err
 }
 
-func Depsolve(specs ...string) ([]PackageSpec, error) {
+func Depsolve(specs []string, repos []RepoConfig) ([]PackageSpec, error) {
 	var arguments = struct {
-		PackageSpecs []string `json:"package-specs"`
-	}{ specs }
+		PackageSpecs []string     `json:"package-specs"`
+		Repos        []RepoConfig `json:"repos"`
+	}{specs, repos}
 	var dependencies []PackageSpec
 	err := runDNF("depsolve", arguments, &dependencies)
 	return dependencies, err

--- a/internal/weldr/api.go
+++ b/internal/weldr/api.go
@@ -407,7 +407,7 @@ func (api *API) modulesInfoHandler(writer http.ResponseWriter, request *http.Req
 		}
 
 		if modulesRequested {
-			project.Dependencies, _ = rpmmd.Depsolve(pkg.Name)
+			project.Dependencies, _ = rpmmd.Depsolve([]string{pkg.Name}, []rpmmd.RepoConfig{api.repo})
 		}
 
 		projects = append(projects, project)
@@ -550,7 +550,7 @@ func (api *API) blueprintsDepsolveHandler(writer http.ResponseWriter, request *h
 				specs[i] += "-*-*.*"
 			}
 		}
-		dependencies, _ := rpmmd.Depsolve(specs...)
+		dependencies, _ := rpmmd.Depsolve(specs, []rpmmd.RepoConfig{api.repo})
 
 		blueprints = append(blueprints, entry{blueprint, dependencies})
 	}


### PR DESCRIPTION
We used to hard-code fedora 30 in there. Change the way dnf-json receives its arguments (JSON on stdin) and pass repository information through that.

This makes it possible to fetch information from multiple repositories. I haven't tested that yet, though.