### PR TITLE
enable passing of a blueprint to osbuild-pipeline

### DIFF
--- a/cmd/osbuild-pipeline/main.go
+++ b/cmd/osbuild-pipeline/main.go
@@ -3,16 +3,30 @@ package main
 import (
 	"encoding/json"
 	"flag"
-	"github.com/osbuild/osbuild-composer/internal/blueprint"
+	"io/ioutil"
 	"os"
+
+	"github.com/osbuild/osbuild-composer/internal/blueprint"
 )
 
 func main() {
 	var format string
+	var blueprintArg string
 	flag.StringVar(&format, "output-format", "qcow2", "output format")
+	flag.StringVar(&blueprintArg, "blueprint", "", "blueprint to translate")
 	flag.Parse()
 
 	blueprint := &blueprint.Blueprint{}
+	if blueprintArg != "" {
+		file, err := ioutil.ReadFile(blueprintArg)
+		if err != nil {
+			panic("Colud not find blueprint")
+		}
+		err = json.Unmarshal([]byte(file), &blueprint)
+		if err != nil {
+			panic("Colud not parse blueprint")
+		}
+	}
 	pipeline, err := blueprint.ToPipeline(format)
 	if err != nil {
 		panic(err.Error())


### PR DESCRIPTION
It is enabled via a command-line argument `-blueprint`.