### PR TITLE
Additional sources tests for adding and removing a source

### DIFF
--- a/internal/weldr/api.go
+++ b/internal/weldr/api.go
@@ -47,6 +47,8 @@ func New(repo rpmmd.RepoConfig, packages rpmmd.PackageList, logger *log.Logger, 
 	api.router.GET("/api/status", api.statusHandler)
 	api.router.GET("/api/v0/projects/source/list", api.sourceListHandler)
 	api.router.GET("/api/v0/projects/source/info/*sources", api.sourceInfoHandler)
+	api.router.POST("/api/v0/projects/source/new", api.sourceNewHandler)
+	api.router.DELETE("/api/v0/projects/source/delete/*source", api.sourceDeleteHandler)
 
 	api.router.GET("/api/v0/modules/list", api.modulesListAllHandler)
 	api.router.GET("/api/v0/modules/list/:modules", api.modulesListHandler)
@@ -223,6 +225,26 @@ func (api *API) sourceInfoHandler(writer http.ResponseWriter, request *http.Requ
 		Sources: map[string]sourceConfig{cfg.ID: cfg},
 		Errors:  []responseError{},
 	})
+}
+
+func (api *API) sourceNewHandler(writer http.ResponseWriter, request *http.Request, _ httprouter.Params) {
+	statusResponseOK(writer)
+}
+
+func (api *API) sourceDeleteHandler(writer http.ResponseWriter, request *http.Request, params httprouter.Params) {
+	name := strings.Split(params.ByName("source"), ",")
+
+	if name[0] == "/" {
+		errors := responseError{
+			Code: http.StatusNotFound,
+			ID:   "HTTPError",
+			Msg:  "Not Found",
+		}
+		statusResponseError(writer, http.StatusNotFound, errors)
+		return
+	}
+
+	statusResponseOK(writer)
 }
 
 type modulesListModule struct {

--- a/internal/weldr/api_test.go
+++ b/internal/weldr/api_test.go
@@ -358,3 +358,21 @@ func TestComposeQueue(t *testing.T) {
 		sendHTTP(api, false, "DELETE", "/api/v0/blueprints/delete/test", ``)
 	}
 }
+
+func TestSourcesNew(t *testing.T) {
+	var cases = []struct {
+		Method         string
+		Path           string
+		Body           string
+		ExpectedStatus int
+		ExpectedJSON   string
+	}{
+		{"POST", "/api/v0/projects/source/new", `{"name": "fish","url": "https://download.opensuse.org/repositories/shells:/fish:/release:/3/Fedora_29/","type": "yum-baseurl","check_ssl": false,"check_gpg": false}`, http.StatusOK, `{"status":true}`},
+		{"DELETE", "/api/v0/projects/source/delete/fish", ``, http.StatusOK, `{"status":true}`},
+	}
+
+	for _, c := range cases {
+		api := weldr.New(repo, packages, nil, store.New(nil))
+		testRoute(t, api, true, c.Method, c.Path, c.Body, c.ExpectedStatus, c.ExpectedJSON)
+	}
+}


### PR DESCRIPTION
I added tests to add and then remove a source. These currently work against lorax-composer and against the basic routes I added to the api. I chose the fish repo because that is what cockpit-composer uses to test adding and removing a source.