### PR TITLE
dnf-json: fix depsolve command

### DIFF
--- a/dnf-json
+++ b/dnf-json
@@ -63,7 +63,7 @@ if command == "dump":
 
 elif command == "depsolve":
     base = create_base(arguments.get("repos", {}))
-    for pkgspec in arguments:
+    for pkgspec in arguments["package-specs"]:
         base.install(pkgspec)
     base.resolve()
     packages = []


### PR DESCRIPTION
When argument passing was switched from command line to stdin in cae1fdd,
depsolve command was broken. This commit fixes it.