### PR TITLE
api: fix delete source route

### DIFF
--- a/internal/weldr/api.go
+++ b/internal/weldr/api.go
@@ -278,7 +278,8 @@ func (api *API) sourceDeleteHandler(writer http.ResponseWriter, request *http.Re
 		return
 	}
 
-	api.store.DeleteSource(name[0])
+	// remove leading / from first name
+	api.store.DeleteSource(name[0][1:])
 
 	statusResponseOK(writer)
 }


### PR DESCRIPTION
The delete source handler now removes the leading "/" from the parameters passed to it. Not removing the "/" caused sources to not be deleted from the store since they could not be found when their name contained a "/" as the first character.