### PR TITLE
Sort fetched package list

### DIFF
--- a/internal/rpmmd/repository.go
+++ b/internal/rpmmd/repository.go
@@ -86,6 +86,9 @@ func FetchPackageList(repos []RepoConfig) (PackageList, error) {
 	}{repos}
 	var packages PackageList
 	err := runDNF("dump", arguments, &packages)
+	sort.Slice(packages, func(i, j int) bool {
+		return packages[i].Name < packages[j].Name
+	})
 	return packages, err
 }
 


### PR DESCRIPTION
When dnf-json dumps the packages from the repos passed to it, it does not sort the packages. In order to properly list and search the packages, the package list is now sorted before being returned by the FetchPackageList function.