### PR TITLE
Projects API improvements & dnf mocking

### DIFF
--- a/cmd/osbuild-composer/main.go
+++ b/cmd/osbuild-composer/main.go
@@ -38,7 +38,9 @@ func main() {
 		Metalink: "https://mirrors.fedoraproject.org/metalink?repo=fedora-30&arch=x86_64",
 	}
 
-	packages, err := rpmmd.FetchPackageList([]rpmmd.RepoConfig{repo})
+	rpm := rpmmd.NewRPMMD()
+
+	packages, err := rpm.FetchPackageList([]rpmmd.RepoConfig{repo})
 	if err != nil {
 		panic(err)
 	}
@@ -56,7 +58,7 @@ func main() {
 	store := store.New(&stateFile)
 
 	jobAPI := jobqueue.New(logger, store)
-	weldrAPI := weldr.New(repo, packages, logger, store)
+	weldrAPI := weldr.New(rpm, repo, packages, logger, store)
 
 	go jobAPI.Serve(jobListener)
 	weldrAPI.Serve(weldrListener)

--- a/dnf-json
+++ b/dnf-json
@@ -71,14 +71,11 @@ if command == "dump":
 elif command == "depsolve":
     base = create_base(arguments.get("repos", {}))
     errors = []
-    for pkgspec in arguments["package-specs"]:
-        try:
-            base.install_specs([pkgspec])
-        except dnf.exceptions.MarkingError as e:
-            errors.append((pkgspec, str(e)))
-    if errors:
-        formatted_errors = ", ".join((f"{package} ({err})" for package, err in errors))
-        exit_with_dnf_error("MarkingError", f"The following package(s) had problems: {formatted_errors}")
+
+    try:
+        base.install_specs(arguments["package-specs"])
+    except dnf.exceptions.MarkingErrors as e:
+        exit_with_dnf_error("MarkingErrors", f"Error occurred when marking packages for installation: {e}")
 
     try:
         base.resolve()

--- a/dnf-json
+++ b/dnf-json
@@ -5,6 +5,8 @@ import dnf
 import json
 import sys
 
+DNF_ERROR_EXIT_CODE = 10
+
 
 def timestamp_to_rfc3339(timestamp):
     d = datetime.datetime.utcfromtimestamp(package.buildtime)
@@ -39,6 +41,11 @@ def create_base(repos):
     return base
 
 
+def exit_with_dnf_error(kind: str, reason: str):
+    json.dump({"kind": kind, "reason": reason}, sys.stdout)
+    sys.exit(DNF_ERROR_EXIT_CODE)
+
+
 call = json.load(sys.stdin)
 command = call["command"]
 arguments = call.get("arguments", {})
@@ -63,8 +70,21 @@ if command == "dump":
 
 elif command == "depsolve":
     base = create_base(arguments.get("repos", {}))
-    base.install_specs(arguments["package-specs"])
-    base.resolve()
+    errors = []
+    for pkgspec in arguments["package-specs"]:
+        try:
+            base.install_specs([pkgspec])
+        except dnf.exceptions.MarkingError as e:
+            errors.append((pkgspec, str(e)))
+    if errors:
+        formatted_errors = ", ".join((f"{package} ({err})" for package, err in errors))
+        exit_with_dnf_error("MarkingError", f"The following package(s) had problems: {formatted_errors}")
+
+    try:
+        base.resolve()
+    except dnf.exceptions.DepsolveError as e:
+        exit_with_dnf_error("DepsolveError", f"There was a problem depsolving {arguments['package-specs']}: {e}")
+
     packages = []
     for package in base.transaction.install_set:
         packages.append({

--- a/internal/mocks/rpmmd/fixtures.go
+++ b/internal/mocks/rpmmd/fixtures.go
@@ -1,0 +1,19 @@
+package rpmmd_mock
+
+import (
+	"github.com/osbuild/osbuild-composer/internal/rpmmd"
+)
+
+var BaseFixture = Fixture{
+	fetchPackageList{
+		rpmmd.PackageList{
+			{Name: "package1"},
+			{Name: "package2"},
+		},
+		nil,
+	},
+	depsolve{
+		nil,
+		nil,
+	},
+}

--- a/internal/mocks/rpmmd/fixtures.go
+++ b/internal/mocks/rpmmd/fixtures.go
@@ -4,16 +4,55 @@ import (
 	"github.com/osbuild/osbuild-composer/internal/rpmmd"
 )
 
+var basePackageList = fetchPackageList{
+	rpmmd.PackageList{
+		{Name: "package1"},
+		{Name: "package2"},
+	},
+	nil,
+}
+
 var BaseFixture = Fixture{
-	fetchPackageList{
-		rpmmd.PackageList{
-			{Name: "package1"},
-			{Name: "package2"},
+	basePackageList,
+	depsolve{
+		[]rpmmd.PackageSpec{
+			{
+				Name:    "libgpg-error",
+				Epoch:   0,
+				Version: "1.33",
+				Release: "2.fc30",
+				Arch:    "x86_64",
+			},
+			{
+				Name:    "libsemanage",
+				Epoch:   0,
+				Version: "2.9",
+				Release: "1.fc30",
+				Arch:    "x86_64",
+			},
 		},
 		nil,
 	},
+}
+
+var NonExistingPackage = Fixture{
+	basePackageList,
 	depsolve{
 		nil,
+		&rpmmd.DNFError{
+			Kind:   "MarkingErrors",
+			Reason: "Error occurred when marking packages for installation: Problems in request:\nmissing packages: fash",
+		},
+	},
+}
+
+var BadDepsolve = Fixture{
+	basePackageList,
+	depsolve{
 		nil,
+		&rpmmd.DNFError{
+			Kind:   "DepsolveError",
+			Reason: "There was a problem depsolving ['go2rpm']: \n Problem: conflicting requests\n  - nothing provides askalono-cli needed by go2rpm-1-4.fc31.noarch",
+		},
 	},
 }

--- a/internal/mocks/rpmmd/rpmmd_mock.go
+++ b/internal/mocks/rpmmd/rpmmd_mock.go
@@ -1,0 +1,33 @@
+package rpmmd_mock
+
+import "github.com/osbuild/osbuild-composer/internal/rpmmd"
+
+type fetchPackageList struct {
+	ret rpmmd.PackageList
+	err error
+}
+type depsolve struct {
+	ret []rpmmd.PackageSpec
+	err error
+}
+
+type Fixture struct {
+	fetchPackageList
+	depsolve
+}
+
+type rpmmdMock struct {
+	Fixture Fixture
+}
+
+func NewRPMMDMock(fixture Fixture) rpmmd.RPMMD {
+	return &rpmmdMock{Fixture: fixture}
+}
+
+func (r *rpmmdMock) FetchPackageList(repos []rpmmd.RepoConfig) (rpmmd.PackageList, error) {
+	return r.Fixture.fetchPackageList.ret, r.Fixture.fetchPackageList.err
+}
+
+func (r *rpmmdMock) Depsolve(specs []string, repos []rpmmd.RepoConfig) ([]rpmmd.PackageSpec, error) {
+	return r.Fixture.depsolve.ret, r.Fixture.depsolve.err
+}

--- a/internal/rpmmd/repository.go
+++ b/internal/rpmmd/repository.go
@@ -39,6 +39,11 @@ type PackageSpec struct {
 	Arch    string `json:"arch,omitempty"`
 }
 
+type RPMMD interface {
+	FetchPackageList(repos []RepoConfig) (PackageList, error)
+	Depsolve(specs []string, repos []RepoConfig) ([]PackageSpec, error)
+}
+
 func runDNF(command string, arguments interface{}, result interface{}) error {
 	var call = struct {
 		Command   string      `json:"command"`
@@ -80,7 +85,13 @@ func runDNF(command string, arguments interface{}, result interface{}) error {
 	return cmd.Wait()
 }
 
-func FetchPackageList(repos []RepoConfig) (PackageList, error) {
+type rpmmdImpl struct{}
+
+func NewRPMMD() RPMMD {
+	return &rpmmdImpl{}
+}
+
+func (*rpmmdImpl) FetchPackageList(repos []RepoConfig) (PackageList, error) {
 	var arguments = struct {
 		Repos []RepoConfig `json:"repos"`
 	}{repos}
@@ -89,7 +100,7 @@ func FetchPackageList(repos []RepoConfig) (PackageList, error) {
 	return packages, err
 }
 
-func Depsolve(specs []string, repos []RepoConfig) ([]PackageSpec, error) {
+func (*rpmmdImpl) Depsolve(specs []string, repos []RepoConfig) ([]PackageSpec, error) {
 	var arguments = struct {
 		PackageSpecs []string     `json:"package-specs"`
 		Repos        []RepoConfig `json:"repos"`

--- a/internal/weldr/api_test.go
+++ b/internal/weldr/api_test.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/osbuild/osbuild-composer/internal/mocks/rpmmd"
 	"github.com/osbuild/osbuild-composer/internal/rpmmd"
 	"github.com/osbuild/osbuild-composer/internal/store"
 	"github.com/osbuild/osbuild-composer/internal/weldr"
@@ -22,11 +23,6 @@ var repo = rpmmd.RepoConfig{
 	Id:      "test",
 	Name:    "Test",
 	BaseURL: "http://example.com/test/os",
-}
-
-var packages = rpmmd.PackageList{
-	{Name: "package1"},
-	{Name: "package2"},
 }
 
 func externalRequest(method, path, body string) *http.Response {
@@ -158,6 +154,18 @@ func testRoute(t *testing.T, api *weldr.API, external bool, method, path, body s
 	}
 }
 
+func createWeldrAPI(fixture rpmmd_mock.Fixture) (*weldr.API, *store.Store) {
+	s := store.New(nil)
+	rpm := rpmmd_mock.NewRPMMDMock(fixture)
+	packageList, err := rpm.FetchPackageList([]rpmmd.RepoConfig{repo})
+
+	if err != nil {
+		panic(err)
+	}
+
+	return weldr.New(rpm, repo, packageList, nil, s), s
+}
+
 func TestBasic(t *testing.T) {
 	var cases = []struct {
 		Path           string
@@ -194,7 +202,7 @@ func TestBasic(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		api := weldr.New(repo, packages, nil, store.New(nil))
+		api, _ := createWeldrAPI(rpmmd_mock.BaseFixture)
 		testRoute(t, api, true, "GET", c.Path, ``, c.ExpectedStatus, c.ExpectedJSON)
 	}
 }
@@ -211,7 +219,7 @@ func TestBlueprintsNew(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		api := weldr.New(repo, packages, nil, store.New(nil))
+		api, _ := createWeldrAPI(rpmmd_mock.BaseFixture)
 		testRoute(t, api, true, c.Method, c.Path, c.Body, c.ExpectedStatus, c.ExpectedJSON)
 	}
 }
@@ -228,7 +236,7 @@ func TestBlueprintsWorkspace(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		api := weldr.New(repo, packages, nil, store.New(nil))
+		api, _ := createWeldrAPI(rpmmd_mock.BaseFixture)
 		sendHTTP(api, true, "POST", "/api/v0/blueprints/new", `{"name":"test","description":"Test","packages":[{"name":"httpd","version":"2.4.*"}],"version":"0.0.0"}`)
 		testRoute(t, api, true, c.Method, c.Path, c.Body, c.ExpectedStatus, c.ExpectedJSON)
 	}
@@ -249,7 +257,7 @@ func TestBlueprintsInfo(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		api := weldr.New(repo, packages, nil, store.New(nil))
+		api, _ := createWeldrAPI(rpmmd_mock.BaseFixture)
 		sendHTTP(api, true, "POST", "/api/v0/blueprints/new", `{"name":"test1","description":"Test","packages":[{"name":"httpd","version":"2.4.*"}],"version":"0.0.0"}`)
 		sendHTTP(api, true, "POST", "/api/v0/blueprints/new", `{"name":"test2","description":"Test","packages":[{"name":"httpd","version":"2.4.*"}],"version":"0.0.0"}`)
 		sendHTTP(api, true, "POST", "/api/v0/blueprints/workspace", `{"name":"test2","description":"Test","packages":[{"name":"systemd","version":"123"}],"version":"0.0.0"}`)
@@ -271,7 +279,7 @@ func TestBlueprintsDiff(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		api := weldr.New(repo, packages, nil, store.New(nil))
+		api, _ := createWeldrAPI(rpmmd_mock.BaseFixture)
 		sendHTTP(api, true, "POST", "/api/v0/blueprints/new", `{"name":"test","description":"Test","packages":[{"name":"httpd","version":"2.4.*"}],"version":"0.0.0"}`)
 		sendHTTP(api, true, "POST", "/api/v0/blueprints/workspace", `{"name":"test","description":"Test","packages":[{"name":"systemd","version":"123"}],"version":"0.0.0"}`)
 		testRoute(t, api, true, c.Method, c.Path, c.Body, c.ExpectedStatus, c.ExpectedJSON)
@@ -291,7 +299,7 @@ func TestBlueprintsDelete(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		api := weldr.New(repo, packages, nil, store.New(nil))
+		api, _ := createWeldrAPI(rpmmd_mock.BaseFixture)
 		sendHTTP(api, true, "POST", "/api/v0/blueprints/new", `{"name":"test","description":"Test","packages":[{"name":"httpd","version":"2.4.*"}],"version":"0.0.0"}`)
 		testRoute(t, api, true, c.Method, c.Path, c.Body, c.ExpectedStatus, c.ExpectedJSON)
 		sendHTTP(api, true, "DELETE", "/api/v0/blueprints/delete/test", ``)
@@ -313,7 +321,7 @@ func TestCompose(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		api := weldr.New(repo, packages, nil, store.New(nil))
+		api, _ := createWeldrAPI(rpmmd_mock.BaseFixture)
 		sendHTTP(api, c.External, "POST", "/api/v0/blueprints/new", `{"name":"test","description":"Test","packages":[{"name":"httpd","version":"2.4.*"}],"version":"0.0.0"}`)
 		testRoute(t, api, c.External, c.Method, c.Path, c.Body, c.ExpectedStatus, c.ExpectedJSON, c.IgnoreFields...)
 		sendHTTP(api, c.External, "DELETE", "/api/v0/blueprints/delete/test", ``)
@@ -337,8 +345,7 @@ func TestComposeQueue(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		s := store.New(nil)
-		api := weldr.New(repo, packages, nil, s)
+		api, s := createWeldrAPI(rpmmd_mock.BaseFixture)
 		sendHTTP(api, false, "POST", "/api/v0/blueprints/new", `{"name":"test","description":"Test","packages":[{"name":"httpd","version":"2.4.*"}],"version":"0.0.0"}`)
 		// create job and leave it waiting
 		sendHTTP(api, false, "POST", "/api/v0/compose", `{"blueprint_name": "test","compose_type": "tar","branch": "master"}`)
@@ -372,7 +379,7 @@ func TestSourcesNew(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		api := weldr.New(repo, packages, nil, store.New(nil))
+		api, _ := createWeldrAPI(rpmmd_mock.BaseFixture)
 		testRoute(t, api, true, c.Method, c.Path, c.Body, c.ExpectedStatus, c.ExpectedJSON)
 		sendHTTP(api, true, "DELETE", "/api/v0/projects/source/delete/fish", ``)
 	}
@@ -391,7 +398,7 @@ func TestSourcesDelete(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		api := weldr.New(repo, packages, nil, store.New(nil))
+		api, _ := createWeldrAPI(rpmmd_mock.BaseFixture)
 		sendHTTP(api, true, "POST", "/api/v0/projects/source/new", `{"name": "fish","url": "https://download.opensuse.org/repositories/shells:/fish:/release:/3/Fedora_29/","type": "yum-baseurl","check_ssl": false,"check_gpg": false}`)
 		testRoute(t, api, true, c.Method, c.Path, c.Body, c.ExpectedStatus, c.ExpectedJSON)
 		sendHTTP(api, true, "DELETE", "/api/v0/projects/source/delete/fish", ``)

--- a/internal/weldr/api_test.go
+++ b/internal/weldr/api_test.go
@@ -404,3 +404,21 @@ func TestSourcesDelete(t *testing.T) {
 		sendHTTP(api, true, "DELETE", "/api/v0/projects/source/delete/fish", ``)
 	}
 }
+
+func TestProjectsDepsolve(t *testing.T) {
+	var cases = []struct {
+		Fixture        rpmmd_mock.Fixture
+		Path           string
+		ExpectedStatus int
+		ExpectedJSON   string
+	}{
+		{rpmmd_mock.NonExistingPackage, "/api/v0/projects/depsolve/fash", http.StatusBadRequest, `{"status":false,"errors":[{"id":"PROJECTS_ERROR","msg":"BadRequest: DNF error occured: MarkingErrors: Error occurred when marking packages for installation: Problems in request:\nmissing packages: fash"}]}`},
+		{rpmmd_mock.BaseFixture, "/api/v0/projects/depsolve/fish", http.StatusOK, `{"projects":[{"name":"libgpg-error","epoch":0,"version":"1.33","release":"2.fc30","arch":"x86_64"},{"name":"libsemanage","epoch":0,"version":"2.9","release":"1.fc30","arch":"x86_64"}]}`},
+		{rpmmd_mock.BadDepsolve, "/api/v0/projects/depsolve/go2rpm", http.StatusBadRequest, `{"status":false,"errors":[{"id":"PROJECTS_ERROR","msg":"BadRequest: DNF error occured: DepsolveError: There was a problem depsolving ['go2rpm']: \n Problem: conflicting requests\n  - nothing provides askalono-cli needed by go2rpm-1-4.fc31.noarch"}]}`},
+	}
+
+	for _, c := range cases {
+		api, _ := createWeldrAPI(c.Fixture)
+		testRoute(t, api, true, "GET", c.Path, ``, c.ExpectedStatus, c.ExpectedJSON)
+	}
+}


### PR DESCRIPTION
This PR introduces support for mocking dnf-json, adds error reporting to dnf-json and implements one missing route for projects.

I've renamed rpmmd to dnfadapter. I don't like the name rpmmd - it isn't very descriptive and it was hard to work with it when I introduced the mocking part. I'm not sure if dnfadapter is the right name. Maybe dnfwrapper?