### PR TITLE
api/tests: print all differences between expected and actual values

### DIFF
--- a/internal/weldr/api_test.go
+++ b/internal/weldr/api_test.go
@@ -116,7 +116,6 @@ func testRoute(t *testing.T, api *weldr.API, external bool, method, path, body s
 
 	if resp.StatusCode != expectedStatus {
 		t.Errorf("%s: expected status %v, but got %v", path, expectedStatus, resp.StatusCode)
-		return
 	}
 
 	replyJSON, err := ioutil.ReadAll(resp.Body)


### PR DESCRIPTION
After this change one can immediately see all the differences when developing
or running the tests.