### PR TITLE
tests: fix failing tests due to a bad merge

### DIFF
--- a/internal/weldr/api_test.go
+++ b/internal/weldr/api_test.go
@@ -309,7 +309,7 @@ func TestBlueprintsDelete(t *testing.T) {
 }
 
 func TestBlueprintsChanges(t *testing.T) {
-	api := weldr.New(repo, packages, nil, store.New(nil))
+	api, _ := createWeldrAPI(rpmmd_mock.BaseFixture)
 	rand.Seed(time.Now().UnixNano())
 	id := strconv.Itoa(rand.Int())
 	ignoreFields := []string{"commit", "timestamp"}


### PR DESCRIPTION
I changed the API of weldr.New in 495f5b55 and Jacob added a new call of
that function in 9970150e, which created conflicting state.