### PR TITLE
Fetch packages from user sources

### DIFF
--- a/cmd/osbuild-composer/main.go
+++ b/cmd/osbuild-composer/main.go
@@ -40,11 +40,6 @@ func main() {
 
 	rpm := rpmmd.NewRPMMD()
 
-	packages, err := rpm.FetchPackageList([]rpmmd.RepoConfig{repo})
-	if err != nil {
-		panic(err)
-	}
-
 	var logger *log.Logger
 	if verbose {
 		logger = log.New(os.Stdout, "", 0)
@@ -58,7 +53,7 @@ func main() {
 	store := store.New(&stateFile)
 
 	jobAPI := jobqueue.New(logger, store)
-	weldrAPI := weldr.New(rpm, repo, packages, logger, store)
+	weldrAPI := weldr.New(rpm, repo, logger, store)
 
 	go jobAPI.Serve(jobListener)
 	weldrAPI.Serve(weldrListener)

--- a/internal/rpmmd/repository.go
+++ b/internal/rpmmd/repository.go
@@ -8,6 +8,8 @@ import (
 	"os/exec"
 	"sort"
 	"time"
+
+	"github.com/osbuild/osbuild-composer/internal/store"
 )
 
 type RepoConfig struct {
@@ -158,4 +160,21 @@ func (packages PackageList) Search(name string) (int, int) {
 	}
 
 	return first, last - first
+}
+
+func SourceToRepo(source store.SourceConfig) RepoConfig {
+	var repo RepoConfig
+
+	repo.Name = source.Name
+	repo.Id = source.Name
+
+	if source.Type == "yum-baseurl" {
+		repo.BaseURL = source.URL
+	} else if source.Type == "yum-metalink" {
+		repo.Metalink = source.URL
+	} else if source.Type == "yum-mirrorlist" {
+		repo.MirrorList = source.URL
+	}
+
+	return repo
 }

--- a/internal/weldr/api.go
+++ b/internal/weldr/api.go
@@ -32,15 +32,14 @@ type API struct {
 	router *httprouter.Router
 }
 
-func New(rpmmd rpmmd.RPMMD, repo rpmmd.RepoConfig, packages rpmmd.PackageList, logger *log.Logger, store *store.Store) *API {
+func New(rpmmd rpmmd.RPMMD, repo rpmmd.RepoConfig, logger *log.Logger, store *store.Store) *API {
 	// This needs to be shared with the worker API so that they can communicate with each other
 	// builds := make(chan queue.Build, 200)
 	api := &API{
-		store:    store,
-		rpmmd:    rpmmd,
-		repo:     repo,
-		packages: packages,
-		logger:   logger,
+		store:  store,
+		rpmmd:  rpmmd,
+		repo:   repo,
+		logger: logger,
 	}
 
 	api.router = httprouter.New()

--- a/internal/weldr/api_test.go
+++ b/internal/weldr/api_test.go
@@ -16,7 +16,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/osbuild/osbuild-composer/internal/mocks/rpmmd"
+	rpmmd_mock "github.com/osbuild/osbuild-composer/internal/mocks/rpmmd"
 	"github.com/osbuild/osbuild-composer/internal/rpmmd"
 	"github.com/osbuild/osbuild-composer/internal/store"
 	"github.com/osbuild/osbuild-composer/internal/weldr"
@@ -159,13 +159,8 @@ func testRoute(t *testing.T, api *weldr.API, external bool, method, path, body s
 func createWeldrAPI(fixture rpmmd_mock.Fixture) (*weldr.API, *store.Store) {
 	s := store.New(nil)
 	rpm := rpmmd_mock.NewRPMMDMock(fixture)
-	packageList, err := rpm.FetchPackageList([]rpmmd.RepoConfig{repo})
 
-	if err != nil {
-		panic(err)
-	}
-
-	return weldr.New(rpm, repo, packageList, nil, s), s
+	return weldr.New(rpm, repo, nil, s), s
 }
 
 func TestBasic(t *testing.T) {


### PR DESCRIPTION
When users add their own sources they are now able to fetch packages from these sources. The package list is generated from the base repo and the user-defined repos. This allows users to add packages not found in the base repo to their blueprints.