### PR TITLE
api/tests: fix blueprints freeze test

### DIFF
--- a/internal/weldr/api_test.go
+++ b/internal/weldr/api_test.go
@@ -257,14 +257,14 @@ func TestBlueprintsFreeze(t *testing.T) {
 		ExpectedStatus int
 		ExpectedJSON   string
 	}{
-		{rpmmd_mock.BaseFixture, "/api/v0/blueprints/freeze/test", http.StatusOK, `{"blueprints":[{"blueprint":{"name":"test","description":"Test","version":"0.0.0","packages":[{"name":"libsemanage","version":"2.9-1.fc30.x86_64"}],"modules":[],"groups":[]}}],"errors":[]}`},
+		{rpmmd_mock.BaseFixture, "/api/v0/blueprints/freeze/test", http.StatusOK, `{"blueprints":[{"blueprint":{"name":"test","description":"Test","version":"0.0.0","packages":[{"name":"dep-package1","version":"1.33-2.fc30.x86_64"}],"modules":[],"groups":[]}}],"errors":[]}`},
 	}
 
 	for _, c := range cases {
 		api, _ := createWeldrAPI(c.Fixture)
-		sendHTTP(api, true, "POST", "/api/v0/blueprints/new", `{"name":"test","description":"Test","packages":[{"name":"libsemanage","version":"*"}],"version":"0.0.0"}`)
-		testRoute(t, api, true, "GET", c.Path, ``, c.ExpectedStatus, c.ExpectedJSON)
-		sendHTTP(api, true, "DELETE", "/api/v0/blueprints/delete/test", ``)
+		sendHTTP(api, false, "POST", "/api/v0/blueprints/new", `{"name":"test","description":"Test","packages":[{"name":"dep-package1","version":"*"}],"version":"0.0.0"}`)
+		testRoute(t, api, false, "GET", c.Path, ``, c.ExpectedStatus, c.ExpectedJSON)
+		sendHTTP(api, false, "DELETE", "/api/v0/blueprints/delete/test", ``)
 	}
 }
 


### PR DESCRIPTION
The blueprints freeze test now creates the blueprint with the package dep-package1 which is mocked and will properly depsolve when the blueprint is frozen. This test can no longer run externally against
lorax-composer.