### PR TITLE
targets: add dummy azure and aws targets

### DIFF
--- a/internal/jobqueue/job.go
+++ b/internal/jobqueue/job.go
@@ -74,6 +74,8 @@ func (job *Job) Run() error {
 			if err != nil {
 				panic(err)
 			}
+		case *target.AWSTargetOptions:
+		case *target.AzureTargetOptions:
 		default:
 			panic("foo")
 		}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -444,7 +444,11 @@ func (s *Store) DeleteBlueprintFromWorkspace(name string) {
 
 func (s *Store) PushCompose(composeID uuid.UUID, bp *blueprint.Blueprint, composeType string) error {
 	targets := []*target.Target{
-		target.NewLocalTarget(target.NewLocalTargetOptions("/var/lib/osbuild-composer/outputs/" + composeID.String())),
+		target.NewLocalTarget(
+			&target.LocalTargetOptions{
+				Location: "/var/lib/osbuild-composer/outputs/" + composeID.String(),
+			},
+		),
 	}
 	d := distro.New("")
 	pipeline, err := d.Pipeline(bp, composeType)

--- a/internal/target/aws_target.go
+++ b/internal/target/aws_target.go
@@ -1,0 +1,18 @@
+package target
+
+type AWSTargetOptions struct {
+	Region          string `json:"region"`
+	AccessKeyID     string `json:"accessKeyID"`
+	SecretAccessKey string `json:"secretAccessKey"`
+	Bucket          string `json:"bucket"`
+	Key             string `json:"key"`
+}
+
+func (AWSTargetOptions) isTargetOptions() {}
+
+func NewAWSTarget(options *AWSTargetOptions) *Target {
+	return &Target{
+		Name:    "org.osbuild.aws",
+		Options: options,
+	}
+}

--- a/internal/target/azure_target.go
+++ b/internal/target/azure_target.go
@@ -1,0 +1,16 @@
+package target
+
+type AzureTargetOptions struct {
+	Account   string `json:"account"`
+	AccessKey string `json:"accessKey"`
+	Container string `json:"container"`
+}
+
+func (AzureTargetOptions) isTargetOptions() {}
+
+func NewAzureTarget(options *AzureTargetOptions) *Target {
+	return &Target{
+		Name:    "org.osbuild.azure",
+		Options: options,
+	}
+}

--- a/internal/target/local_target.go
+++ b/internal/target/local_target.go
@@ -6,12 +6,6 @@ type LocalTargetOptions struct {
 
 func (LocalTargetOptions) isTargetOptions() {}
 
-func NewLocalTargetOptions(location string) *LocalTargetOptions {
-	return &LocalTargetOptions{
-		Location: location,
-	}
-}
-
 func NewLocalTarget(options *LocalTargetOptions) *Target {
 	return &Target{
 		Name:    "org.osbuild.local",

--- a/internal/target/target.go
+++ b/internal/target/target.go
@@ -27,6 +27,10 @@ func (target *Target) UnmarshalJSON(data []byte) error {
 	}
 	var options TargetOptions
 	switch rawTarget.Name {
+	case "org.osbuild.azure":
+		options = new(AzureTargetOptions)
+	case "org.osbuild.aws":
+		options = new(AWSTargetOptions)
 	case "org.osbuild.local":
 		options = new(LocalTargetOptions)
 	default:


### PR DESCRIPTION
These are not currently implemented in the backend, but shows how
the API will look like.

Signed-off-by: Tom Gundersen <teg@jklm.no>