### PR TITLE
Tests improvement

### DIFF
--- a/internal/jobqueue/api_test.go
+++ b/internal/jobqueue/api_test.go
@@ -1,75 +1,16 @@
 package jobqueue_test
 
 import (
-	"bytes"
-	"encoding/json"
-	"io/ioutil"
 	"net/http"
-	"net/http/httptest"
-	"reflect"
-	"strings"
 	"testing"
 
 	"github.com/osbuild/osbuild-composer/internal/blueprint"
 	"github.com/osbuild/osbuild-composer/internal/jobqueue"
 	"github.com/osbuild/osbuild-composer/internal/store"
+	"github.com/osbuild/osbuild-composer/internal/test"
 
 	"github.com/google/uuid"
 )
-
-func sendHTTP(api *jobqueue.API, method, path, body string) {
-	req := httptest.NewRequest(method, path, bytes.NewReader([]byte(body)))
-	req.Header.Set("Content-Type", "application/json")
-	resp := httptest.NewRecorder()
-	api.ServeHTTP(resp, req)
-}
-
-func testRoute(t *testing.T, api *jobqueue.API, method, path, body string, expectedStatus int, expectedJSON string) {
-	req := httptest.NewRequest(method, path, bytes.NewReader([]byte(body)))
-	req.Header.Set("Content-Type", "application/json")
-	resp := httptest.NewRecorder()
-	api.ServeHTTP(resp, req)
-
-	if resp.Code != expectedStatus {
-		t.Errorf("%s: expected status %v, but got %v", path, expectedStatus, resp.Code)
-		return
-	}
-
-	replyJSON, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		t.Errorf("%s: could not read reponse body: %v", path, err)
-		return
-	}
-
-	if expectedJSON == "" {
-		if len(replyJSON) != 0 {
-			t.Errorf("%s: expected no response body, but got:\n%s", path, replyJSON)
-		}
-		return
-	}
-
-	var reply, expected interface{}
-	err = json.Unmarshal(replyJSON, &reply)
-	if err != nil {
-		t.Errorf("%s: %v\n%s", path, err, string(replyJSON))
-		return
-	}
-
-	if expectedJSON == "*" {
-		return
-	}
-
-	err = json.Unmarshal([]byte(expectedJSON), &expected)
-	if err != nil {
-		t.Errorf("%s: expected JSON is invalid: %v", path, err)
-		return
-	}
-
-	if !reflect.DeepEqual(reply, expected) {
-		t.Errorf("%s: reply != expected:\n   reply: %s\nexpected: %s", path, strings.TrimSpace(string(replyJSON)), expectedJSON)
-		return
-	}
-}
 
 func TestBasic(t *testing.T) {
 	var cases = []struct {
@@ -92,7 +33,7 @@ func TestBasic(t *testing.T) {
 	for _, c := range cases {
 		api := jobqueue.New(nil, store.New(nil))
 
-		testRoute(t, api, c.Method, c.Path, c.Body, c.ExpectedStatus, c.ExpectedJSON)
+		test.TestRoute(t, api, false, c.Method, c.Path, c.Body, c.ExpectedStatus, c.ExpectedJSON)
 	}
 }
 
@@ -106,7 +47,7 @@ func TestCreate(t *testing.T) {
 		t.Fatalf("error pushing compose: %v", err)
 	}
 
-	testRoute(t, api, "POST", "/job-queue/v1/jobs", `{}`, http.StatusCreated,
+	test.TestRoute(t, api, false, "POST", "/job-queue/v1/jobs", `{}`, http.StatusCreated,
 		`{"id":"ffffffff-ffff-ffff-ffff-ffffffffffff","pipeline":{"build":{"pipeline":{"stages":[{"name":"org.osbuild.dnf","options":{"repos":[{"metalink":"https://mirrors.fedoraproject.org/metalink?repo=fedora-$releasever\u0026arch=$basearch","gpgkey":"-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBFturGcBEACv0xBo91V2n0uEC2vh69ywCiSyvUgN/AQH8EZpCVtM7NyjKgKm\nbbY4G3R0M3ir1xXmvUDvK0493/qOiFrjkplvzXFTGpPTi0ypqGgxc5d0ohRA1M75\nL+0AIlXoOgHQ358/c4uO8X0JAA1NYxCkAW1KSJgFJ3RjukrfqSHWthS1d4o8fhHy\nKJKEnirE5hHqB50dafXrBfgZdaOs3C6ppRIePFe2o4vUEapMTCHFw0woQR8Ah4/R\nn7Z9G9Ln+0Cinmy0nbIDiZJ+pgLAXCOWBfDUzcOjDGKvcpoZharA07c0q1/5ojzO\n4F0Fh4g/BUmtrASwHfcIbjHyCSr1j/3Iz883iy07gJY5Yhiuaqmp0o0f9fgHkG53\n2xCU1owmACqaIBNQMukvXRDtB2GJMuKa/asTZDP6R5re+iXs7+s9ohcRRAKGyAyc\nYKIQKcaA+6M8T7/G+TPHZX6HJWqJJiYB+EC2ERblpvq9TPlLguEWcmvjbVc31nyq\nSDoO3ncFWKFmVsbQPTbP+pKUmlLfJwtb5XqxNR5GEXSwVv4I7IqBmJz1MmRafnBZ\ng0FJUtH668GnldO20XbnSVBr820F5SISMXVwCXDXEvGwwiB8Lt8PvqzXnGIFDAu3\nDlQI5sxSqpPVWSyw08ppKT2Tpmy8adiBotLfaCFl2VTHwOae48X2dMPBvQARAQAB\ntDFGZWRvcmEgKDMwKSA8ZmVkb3JhLTMwLXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQI4BBMBAgAiBQJbbqxnAhsPBgsJCAcDAgYVCAIJCgsEFgIDAQIeAQIXgAAK\nCRDvPBEfz8ZZudTnD/9170LL3nyTVUCFmBjT9wZ4gYnpwtKVPa/pKnxbbS+Bmmac\ng9TrT9pZbqOHrNJLiZ3Zx1Hp+8uxr3Lo6kbYwImLhkOEDrf4aP17HfQ6VYFbQZI8\nf79OFxWJ7si9+3gfzeh9UYFEqOQfzIjLWFyfnas0OnV/P+RMQ1Zr+vPRqO7AR2va\nN9wg+Xl7157dhXPCGYnGMNSoxCbpRs0JNlzvJMuAea5nTTznRaJZtK/xKsqLn51D\nK07k9MHVFXakOH8QtMCUglbwfTfIpO5YRq5imxlWbqsYWVQy1WGJFyW6hWC0+RcJ\nOx5zGtOfi4/dN+xJ+ibnbyvy/il7Qm+vyFhCYqIPyS5m2UVJUuao3eApE38k78/o\n8aQOTnFQZ+U1Sw+6woFTxjqRQBXlQm2+7Bt3bqGATg4sXXWPbmwdL87Ic+mxn/ml\nSMfQux/5k6iAu1kQhwkO2YJn9eII6HIPkW+2m5N1JsUyJQe4cbtZE5Yh3TRA0dm7\n+zoBRfCXkOW4krchbgww/ptVmzMMP7GINJdROrJnsGl5FVeid9qHzV7aZycWSma7\nCxBYB1J8HCbty5NjtD6XMYRrMLxXugvX6Q4NPPH+2NKjzX4SIDejS6JjgrP3KA3O\npMuo7ZHMfveBngv8yP+ZD/1sS6l+dfExvdaJdOdgFCnp4p3gPbw5+Lv70HrMjA==\n=BfZ/\n-----END PGP PUBLIC KEY BLOCK-----\n","checksum":"sha256:9f596e18f585bee30ac41c11fb11a83ed6b11d5b341c1cb56ca4015d7717cb97"}],"packages":["dnf","e2fsprogs","policycoreutils","qemu-img","systemd","grub2-pc","tar"],"releasever":"30","basearch":"x86_64"}}]},"runner":"org.osbuild.fedora30"},"stages":[{"name":"org.osbuild.dnf","options":{"repos":[{"metalink":"https://mirrors.fedoraproject.org/metalink?repo=fedora-$releasever\u0026arch=$basearch","gpgkey":"-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBFturGcBEACv0xBo91V2n0uEC2vh69ywCiSyvUgN/AQH8EZpCVtM7NyjKgKm\nbbY4G3R0M3ir1xXmvUDvK0493/qOiFrjkplvzXFTGpPTi0ypqGgxc5d0ohRA1M75\nL+0AIlXoOgHQ358/c4uO8X0JAA1NYxCkAW1KSJgFJ3RjukrfqSHWthS1d4o8fhHy\nKJKEnirE5hHqB50dafXrBfgZdaOs3C6ppRIePFe2o4vUEapMTCHFw0woQR8Ah4/R\nn7Z9G9Ln+0Cinmy0nbIDiZJ+pgLAXCOWBfDUzcOjDGKvcpoZharA07c0q1/5ojzO\n4F0Fh4g/BUmtrASwHfcIbjHyCSr1j/3Iz883iy07gJY5Yhiuaqmp0o0f9fgHkG53\n2xCU1owmACqaIBNQMukvXRDtB2GJMuKa/asTZDP6R5re+iXs7+s9ohcRRAKGyAyc\nYKIQKcaA+6M8T7/G+TPHZX6HJWqJJiYB+EC2ERblpvq9TPlLguEWcmvjbVc31nyq\nSDoO3ncFWKFmVsbQPTbP+pKUmlLfJwtb5XqxNR5GEXSwVv4I7IqBmJz1MmRafnBZ\ng0FJUtH668GnldO20XbnSVBr820F5SISMXVwCXDXEvGwwiB8Lt8PvqzXnGIFDAu3\nDlQI5sxSqpPVWSyw08ppKT2Tpmy8adiBotLfaCFl2VTHwOae48X2dMPBvQARAQAB\ntDFGZWRvcmEgKDMwKSA8ZmVkb3JhLTMwLXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQI4BBMBAgAiBQJbbqxnAhsPBgsJCAcDAgYVCAIJCgsEFgIDAQIeAQIXgAAK\nCRDvPBEfz8ZZudTnD/9170LL3nyTVUCFmBjT9wZ4gYnpwtKVPa/pKnxbbS+Bmmac\ng9TrT9pZbqOHrNJLiZ3Zx1Hp+8uxr3Lo6kbYwImLhkOEDrf4aP17HfQ6VYFbQZI8\nf79OFxWJ7si9+3gfzeh9UYFEqOQfzIjLWFyfnas0OnV/P+RMQ1Zr+vPRqO7AR2va\nN9wg+Xl7157dhXPCGYnGMNSoxCbpRs0JNlzvJMuAea5nTTznRaJZtK/xKsqLn51D\nK07k9MHVFXakOH8QtMCUglbwfTfIpO5YRq5imxlWbqsYWVQy1WGJFyW6hWC0+RcJ\nOx5zGtOfi4/dN+xJ+ibnbyvy/il7Qm+vyFhCYqIPyS5m2UVJUuao3eApE38k78/o\n8aQOTnFQZ+U1Sw+6woFTxjqRQBXlQm2+7Bt3bqGATg4sXXWPbmwdL87Ic+mxn/ml\nSMfQux/5k6iAu1kQhwkO2YJn9eII6HIPkW+2m5N1JsUyJQe4cbtZE5Yh3TRA0dm7\n+zoBRfCXkOW4krchbgww/ptVmzMMP7GINJdROrJnsGl5FVeid9qHzV7aZycWSma7\nCxBYB1J8HCbty5NjtD6XMYRrMLxXugvX6Q4NPPH+2NKjzX4SIDejS6JjgrP3KA3O\npMuo7ZHMfveBngv8yP+ZD/1sS6l+dfExvdaJdOdgFCnp4p3gPbw5+Lv70HrMjA==\n=BfZ/\n-----END PGP PUBLIC KEY BLOCK-----\n","checksum":"sha256:9f596e18f585bee30ac41c11fb11a83ed6b11d5b341c1cb56ca4015d7717cb97"}],"packages":["policycoreutils","selinux-policy-targeted","kernel","firewalld","chrony","langpacks-en"],"exclude_packages":["dracut-config-rescue"],"releasever":"30","basearch":"x86_64"}},{"name":"org.osbuild.fix-bls","options":{}},{"name":"org.osbuild.locale","options":{"language":"en_US"}},{"name":"org.osbuild.grub2","options":{"root_fs_uuid":"76a22bf4-f153-4541-b6c7-0332c0dfaeac","boot_fs_uuid":"00000000-0000-0000-0000-000000000000","kernel_opts":"ro biosdevname=0 net.ifnames=0"}},{"name":"org.osbuild.selinux","options":{"file_contexts":"etc/selinux/targeted/contexts/files/file_contexts"}}],"assembler":{"name":"org.osbuild.tar","options":{"filename":"root.tar.xz"}}},"targets":[{"name":"org.osbuild.local","options":{"location":"/var/lib/osbuild-composer/outputs/ffffffff-ffff-ffff-ffff-ffffffffffff"}}]}`)
 }
 
@@ -121,14 +62,14 @@ func testUpdateTransition(t *testing.T, from, to string, expectedStatus int) {
 			t.Fatalf("error pushing compose: %v", err)
 		}
 		if from != "WAITING" {
-			sendHTTP(api, "POST", "/job-queue/v1/jobs", `{}`)
+			test.SendHTTP(api, false, "POST", "/job-queue/v1/jobs", `{}`)
 			if from != "RUNNING" {
-				sendHTTP(api, "PATCH", "/job-queue/v1/jobs/ffffffff-ffff-ffff-ffff-ffffffffffff", `{"status":"`+from+`"}`)
+				test.SendHTTP(api, false, "PATCH", "/job-queue/v1/jobs/ffffffff-ffff-ffff-ffff-ffffffffffff", `{"status":"`+from+`"}`)
 			}
 		}
 	}
 
-	testRoute(t, api, "PATCH", "/job-queue/v1/jobs/ffffffff-ffff-ffff-ffff-ffffffffffff", `{"status":"`+to+`"}`, expectedStatus, ``)
+	test.TestRoute(t, api, false, "PATCH", "/job-queue/v1/jobs/ffffffff-ffff-ffff-ffff-ffffffffffff", `{"status":"`+to+`"}`, expectedStatus, ``)
 }
 
 func TestUpdate(t *testing.T) {

--- a/internal/mocks/rpmmd/fixtures.go
+++ b/internal/mocks/rpmmd/fixtures.go
@@ -2,9 +2,15 @@ package rpmmd_mock
 
 import (
 	"fmt"
+	"github.com/google/uuid"
+	"github.com/osbuild/osbuild-composer/internal/blueprint"
 	"github.com/osbuild/osbuild-composer/internal/rpmmd"
+	"github.com/osbuild/osbuild-composer/internal/store"
+	"sort"
 	"time"
 )
+
+type FixtureGenerator func() Fixture
 
 func generatePackageList() rpmmd.PackageList {
 	baseTime, err := time.Parse(time.RFC3339, "2006-01-02T15:04:05Z")
@@ -37,72 +43,140 @@ func generatePackageList() rpmmd.PackageList {
 		packageList = append(packageList, basePackage, secondBuild)
 	}
 
+	sort.Slice(packageList, func(i, j int) bool {
+		return packageList[i].Name < packageList[j].Name
+	})
+
 	return packageList
 }
 
-var basePackageList = fetchPackageList{
-	generatePackageList(),
-	nil,
+func createBaseStoreFixture() *store.Store {
+	var bName = "test"
+	var b = blueprint.Blueprint{Name: bName, Version: "0.0.0"}
+
+	var date = time.Date(2019, 11, 27, 13, 19, 0, 0, time.FixedZone("UTC+1", 60*60))
+
+	s := store.New(nil)
+
+	s.Blueprints[bName] = b
+	s.Composes = map[uuid.UUID]store.Compose{
+		uuid.MustParse("e65f76f8-b0d9-4974-9dd7-745ae80b4721"): store.Compose{
+			QueueStatus: "WAITING",
+			Blueprint:   &b,
+			OutputType:  "tar",
+			Targets:     nil,
+			JobCreated:  date,
+		},
+		uuid.MustParse("e65f76f8-b0d9-4974-9dd7-745ae80b4722"): store.Compose{
+			QueueStatus: "RUNNING",
+			Blueprint:   &b,
+			OutputType:  "tar",
+			Targets:     nil,
+			JobCreated:  date,
+			JobStarted:  date,
+		},
+		uuid.MustParse("e65f76f8-b0d9-4974-9dd7-745ae80b4723"): store.Compose{
+			QueueStatus: "FINISHED",
+			Blueprint:   &b,
+			OutputType:  "tar",
+			Targets:     nil,
+			JobCreated:  date,
+			JobStarted:  date,
+			JobFinished: date,
+		},
+		uuid.MustParse("e65f76f8-b0d9-4974-9dd7-745ae80b4724"): store.Compose{
+			QueueStatus: "FAILED",
+			Blueprint:   &b,
+			OutputType:  "tar",
+			Targets:     nil,
+			JobCreated:  date,
+			JobStarted:  date,
+			JobFinished: date,
+		},
+	}
+
+	return s
 }
 
-var BaseFixture = Fixture{
-	basePackageList,
-	depsolve{
-		[]rpmmd.PackageSpec{
-			{
-				Name:    "dep-package1",
-				Epoch:   0,
-				Version: "1.33",
-				Release: "2.fc30",
-				Arch:    "x86_64",
+func BaseFixture() Fixture {
+	return Fixture{
+		fetchPackageList{
+			generatePackageList(),
+			nil,
+		},
+		depsolve{
+			[]rpmmd.PackageSpec{
+				{
+					Name:    "dep-package1",
+					Epoch:   0,
+					Version: "1.33",
+					Release: "2.fc30",
+					Arch:    "x86_64",
+				},
+				{
+					Name:    "dep-package2",
+					Epoch:   0,
+					Version: "2.9",
+					Release: "1.fc30",
+					Arch:    "x86_64",
+				},
 			},
-			{
-				Name:    "dep-package2",
-				Epoch:   0,
-				Version: "2.9",
-				Release: "1.fc30",
-				Arch:    "x86_64",
+			nil,
+		},
+		createBaseStoreFixture(),
+	}
+}
+
+func NonExistingPackage() Fixture {
+	return Fixture{
+		fetchPackageList{
+			generatePackageList(),
+			nil,
+		},
+		depsolve{
+			nil,
+			&rpmmd.DNFError{
+				Kind:   "MarkingErrors",
+				Reason: "Error occurred when marking packages for installation: Problems in request:\nmissing packages: fash",
 			},
 		},
-		nil,
-	},
+		createBaseStoreFixture(),
+	}
 }
 
-var NonExistingPackage = Fixture{
-	basePackageList,
-	depsolve{
-		nil,
-		&rpmmd.DNFError{
-			Kind:   "MarkingErrors",
-			Reason: "Error occurred when marking packages for installation: Problems in request:\nmissing packages: fash",
+func BadDepsolve() Fixture {
+	return Fixture{
+		fetchPackageList{
+			generatePackageList(),
+			nil,
 		},
-	},
+		depsolve{
+			nil,
+			&rpmmd.DNFError{
+				Kind:   "DepsolveError",
+				Reason: "There was a problem depsolving ['go2rpm']: \n Problem: conflicting requests\n  - nothing provides askalono-cli needed by go2rpm-1-4.fc31.noarch",
+			},
+		},
+		createBaseStoreFixture(),
+	}
 }
 
-var BadDepsolve = Fixture{
-	basePackageList,
-	depsolve{
-		nil,
-		&rpmmd.DNFError{
-			Kind:   "DepsolveError",
-			Reason: "There was a problem depsolving ['go2rpm']: \n Problem: conflicting requests\n  - nothing provides askalono-cli needed by go2rpm-1-4.fc31.noarch",
+func BadFetch() Fixture {
+	return Fixture{
+		fetchPackageList{
+			ret: nil,
+			err: &rpmmd.DNFError{
+				Kind:   "FetchError",
+				Reason: "There was a problem when fetching packages.",
+			},
 		},
-	},
-}
-
-var BadFetch = Fixture{
-	fetchPackageList{
-		ret: nil,
-		err: &rpmmd.DNFError{
-			Kind:   "FetchError",
-			Reason: "There was a problem when fetching packages.",
+		depsolve{
+			nil,
+			&rpmmd.DNFError{
+				Kind:   "DepsolveError",
+				Reason: "There was a problem depsolving ['go2rpm']: \n Problem: conflicting requests\n  - nothing provides askalono-cli needed by go2rpm-1-4.fc31.noarch",
+			},
 		},
-	},
-	depsolve{
-		nil,
-		&rpmmd.DNFError{
-			Kind:   "DepsolveError",
-			Reason: "There was a problem depsolving ['go2rpm']: \n Problem: conflicting requests\n  - nothing provides askalono-cli needed by go2rpm-1-4.fc31.noarch",
-		},
-	},
+		createBaseStoreFixture(),
+	}
 }

--- a/internal/mocks/rpmmd/rpmmd_mock.go
+++ b/internal/mocks/rpmmd/rpmmd_mock.go
@@ -1,6 +1,9 @@
 package rpmmd_mock
 
-import "github.com/osbuild/osbuild-composer/internal/rpmmd"
+import (
+	"github.com/osbuild/osbuild-composer/internal/rpmmd"
+	"github.com/osbuild/osbuild-composer/internal/store"
+)
 
 type fetchPackageList struct {
 	ret rpmmd.PackageList
@@ -14,6 +17,7 @@ type depsolve struct {
 type Fixture struct {
 	fetchPackageList
 	depsolve
+	*store.Store
 }
 
 type rpmmdMock struct {

--- a/internal/test/helpers.go
+++ b/internal/test/helpers.go
@@ -1,0 +1,144 @@
+package test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+type API interface {
+	ServeHTTP(writer http.ResponseWriter, request *http.Request)
+}
+
+func externalRequest(method, path, body string) *http.Response {
+	client := http.Client{
+		Transport: &http.Transport{
+			DialContext: func(_ context.Context, _, _ string) (net.Conn, error) {
+				return net.Dial("unix", "/run/weldr/api.socket")
+			},
+		},
+	}
+
+	req, err := http.NewRequest(method, "http://localhost"+path, bytes.NewReader([]byte(body)))
+	if err != nil {
+		panic(err)
+	}
+
+	if method == "POST" {
+		req.Header.Set("Content-Type", "application/json")
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		panic(err)
+	}
+
+	return resp
+}
+
+func internalRequest(api API, method, path, body string) *http.Response {
+	req := httptest.NewRequest(method, path, bytes.NewReader([]byte(body)))
+	req.Header.Set("Content-Type", "application/json")
+	resp := httptest.NewRecorder()
+	api.ServeHTTP(resp, req)
+
+	return resp.Result()
+}
+
+func SendHTTP(api API, external bool, method, path, body string) *http.Response {
+	if len(os.Getenv("OSBUILD_COMPOSER_TEST_EXTERNAL")) > 0 {
+		if !external {
+			return nil
+		}
+		return externalRequest(method, path, body)
+	} else {
+		return internalRequest(api, method, path, body)
+	}
+}
+
+// this function serves to drop fields that shouldn't be tested from the unmarshalled json objects
+func dropFields(obj interface{}, fields ...string) {
+	switch v := obj.(type) {
+	// if the interface type is a map attempt to delete the fields
+	case map[string]interface{}:
+		for i, field := range fields {
+			if _, ok := v[field]; ok {
+				delete(v, field)
+				// if the field is found remove it from the fields slice
+				if len(fields) < i-1 {
+					fields = append(fields[:i], fields[i+1:]...)
+				} else {
+					fields = fields[:i]
+				}
+			}
+		}
+		// call dropFields on the remaining elements since they may contain a map containing the field
+		for _, val := range v {
+			dropFields(val, fields...)
+		}
+	// if the type is a list of interfaces call dropFields on each interface
+	case []interface{}:
+		for _, element := range v {
+			dropFields(element, fields...)
+		}
+	default:
+		return
+	}
+}
+
+func TestRoute(t *testing.T, api API, external bool, method, path, body string, expectedStatus int, expectedJSON string, ignoreFields ...string) {
+	resp := SendHTTP(api, external, method, path, body)
+	if resp == nil {
+		t.Skip("This test is for internal testing only")
+	}
+
+	if resp.StatusCode != expectedStatus {
+		t.Errorf("%s: expected status %v, but got %v", path, expectedStatus, resp.StatusCode)
+	}
+
+	replyJSON, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		t.Errorf("%s: could not read response body: %v", path, err)
+		return
+	}
+
+	if expectedJSON == "" {
+		if len(replyJSON) != 0 {
+			t.Errorf("%s: expected no response body, but got:\n%s", path, replyJSON)
+		}
+		return
+	}
+
+	var reply, expected interface{}
+	err = json.Unmarshal(replyJSON, &reply)
+	if err != nil {
+		t.Errorf("%s: %v\n%s", path, err, string(replyJSON))
+		return
+	}
+
+	if expectedJSON == "*" {
+		return
+	}
+
+	err = json.Unmarshal([]byte(expectedJSON), &expected)
+	if err != nil {
+		t.Errorf("%s: expected JSON is invalid: %v", path, err)
+		return
+	}
+
+	dropFields(reply, ignoreFields...)
+	dropFields(expected, ignoreFields...)
+
+	if !reflect.DeepEqual(reply, expected) {
+		t.Errorf("%s: reply != expected:\n   reply: %s\nexpected: %s", path, strings.TrimSpace(string(replyJSON)), expectedJSON)
+		return
+	}
+}

--- a/internal/weldr/api_test.go
+++ b/internal/weldr/api_test.go
@@ -1,156 +1,21 @@
 package weldr_test
 
 import (
-	"bytes"
-	"context"
-	"encoding/json"
-	"io/ioutil"
 	"math/rand"
-	"net"
 	"net/http"
-	"net/http/httptest"
 	"os"
-	"reflect"
 	"strconv"
-	"strings"
 	"testing"
 	"time"
 
 	rpmmd_mock "github.com/osbuild/osbuild-composer/internal/mocks/rpmmd"
 	"github.com/osbuild/osbuild-composer/internal/store"
+	"github.com/osbuild/osbuild-composer/internal/test"
 	"github.com/osbuild/osbuild-composer/internal/weldr"
 
 	"github.com/osbuild/osbuild-composer/internal/distro"
 	_ "github.com/osbuild/osbuild-composer/internal/distro/test"
 )
-
-func externalRequest(method, path, body string) *http.Response {
-	client := http.Client{
-		Transport: &http.Transport{
-			DialContext: func(_ context.Context, _, _ string) (net.Conn, error) {
-				return net.Dial("unix", "/run/weldr/api.socket")
-			},
-		},
-	}
-
-	req, err := http.NewRequest(method, "http://localhost"+path, bytes.NewReader([]byte(body)))
-	if err != nil {
-		panic(err)
-	}
-
-	if method == "POST" {
-		req.Header.Set("Content-Type", "application/json")
-	}
-
-	resp, err := client.Do(req)
-	if err != nil {
-		panic(err)
-	}
-
-	return resp
-}
-
-func internalRequest(api *weldr.API, method, path, body string) *http.Response {
-	req := httptest.NewRequest(method, path, bytes.NewReader([]byte(body)))
-
-	if method == "POST" {
-		req.Header.Set("Content-Type", "application/json")
-	}
-	resp := httptest.NewRecorder()
-	api.ServeHTTP(resp, req)
-
-	return resp.Result()
-}
-
-func sendHTTP(api *weldr.API, external bool, method, path, body string) *http.Response {
-	if len(os.Getenv("OSBUILD_COMPOSER_TEST_EXTERNAL")) > 0 {
-		if !external {
-			return nil
-		}
-		return externalRequest(method, path, body)
-	} else {
-		return internalRequest(api, method, path, body)
-	}
-}
-
-// this function serves to drop fields that shouldn't be tested from the unmarshalled json objects
-func dropFields(obj interface{}, fields ...string) {
-	switch v := obj.(type) {
-	// if the interface type is a map attempt to delete the fields
-	case map[string]interface{}:
-		for i, field := range fields {
-			if _, ok := v[field]; ok {
-				delete(v, field)
-				// if the field is found remove it from the fields slice
-				if len(fields) < i-1 {
-					fields = append(fields[:i], fields[i+1:]...)
-				} else {
-					fields = fields[:i]
-				}
-			}
-		}
-		// call dropFields on the remaining elements since they may contain a map containing the field
-		for _, val := range v {
-			dropFields(val, fields...)
-		}
-	// if the type is a list of interfaces call dropFields on each interface
-	case []interface{}:
-		for _, element := range v {
-			dropFields(element, fields...)
-		}
-	default:
-		return
-	}
-}
-
-func testRoute(t *testing.T, api *weldr.API, external bool, method, path, body string, expectedStatus int, expectedJSON string, ignoreFields ...string) {
-	resp := sendHTTP(api, external, method, path, body)
-	if resp == nil {
-		t.Skip("This test is for internal testing only")
-	}
-
-	if resp.StatusCode != expectedStatus {
-		t.Errorf("%s: expected status %v, but got %v", path, expectedStatus, resp.StatusCode)
-	}
-
-	replyJSON, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		t.Errorf("%s: could not read response body: %v", path, err)
-		return
-	}
-
-	if expectedJSON == "" {
-		if len(replyJSON) != 0 {
-			t.Errorf("%s: expected no response body, but got:\n%s", path, replyJSON)
-		}
-		return
-	}
-
-	var reply, expected interface{}
-	err = json.Unmarshal(replyJSON, &reply)
-	if err != nil {
-		t.Errorf("%s: %v\n%s", path, err, string(replyJSON))
-		return
-	}
-
-	if expectedJSON == "*" {
-		return
-	}
-
-	err = json.Unmarshal([]byte(expectedJSON), &expected)
-	if err != nil {
-		t.Errorf("%s: expected JSON is invalid: %v", path, err)
-		return
-	}
-
-	dropFields(reply, ignoreFields...)
-	dropFields(expected, ignoreFields...)
-
-	if !reflect.DeepEqual(reply, expected) {
-		t.Errorf("%s: reply != expected:\n   reply: %s\nexpected: %s", path, strings.TrimSpace(string(replyJSON)), expectedJSON)
-		return
-	}
-}
 
 func createWeldrAPI(fixture rpmmd_mock.Fixture) (*weldr.API, *store.Store) {
 	s := store.New(nil)
@@ -183,7 +48,7 @@ func TestBasic(t *testing.T) {
 
 	for _, c := range cases {
 		api, _ := createWeldrAPI(rpmmd_mock.BaseFixture)
-		testRoute(t, api, true, "GET", c.Path, ``, c.ExpectedStatus, c.ExpectedJSON)
+		test.TestRoute(t, api, true, "GET", c.Path, ``, c.ExpectedStatus, c.ExpectedJSON)
 	}
 }
 
@@ -200,7 +65,7 @@ func TestBlueprintsNew(t *testing.T) {
 
 	for _, c := range cases {
 		api, _ := createWeldrAPI(rpmmd_mock.BaseFixture)
-		testRoute(t, api, true, c.Method, c.Path, c.Body, c.ExpectedStatus, c.ExpectedJSON)
+		test.TestRoute(t, api, true, c.Method, c.Path, c.Body, c.ExpectedStatus, c.ExpectedJSON)
 	}
 }
 
@@ -217,8 +82,8 @@ func TestBlueprintsWorkspace(t *testing.T) {
 
 	for _, c := range cases {
 		api, _ := createWeldrAPI(rpmmd_mock.BaseFixture)
-		sendHTTP(api, true, "POST", "/api/v0/blueprints/new", `{"name":"test","description":"Test","packages":[{"name":"httpd","version":"2.4.*"}],"version":"0.0.0"}`)
-		testRoute(t, api, true, c.Method, c.Path, c.Body, c.ExpectedStatus, c.ExpectedJSON)
+		test.SendHTTP(api, true, "POST", "/api/v0/blueprints/new", `{"name":"test","description":"Test","packages":[{"name":"httpd","version":"2.4.*"}],"version":"0.0.0"}`)
+		test.TestRoute(t, api, true, c.Method, c.Path, c.Body, c.ExpectedStatus, c.ExpectedJSON)
 	}
 }
 
@@ -238,12 +103,12 @@ func TestBlueprintsInfo(t *testing.T) {
 
 	for _, c := range cases {
 		api, _ := createWeldrAPI(rpmmd_mock.BaseFixture)
-		sendHTTP(api, true, "POST", "/api/v0/blueprints/new", `{"name":"test1","description":"Test","packages":[{"name":"httpd","version":"2.4.*"}],"version":"0.0.0"}`)
-		sendHTTP(api, true, "POST", "/api/v0/blueprints/new", `{"name":"test2","description":"Test","packages":[{"name":"httpd","version":"2.4.*"}],"version":"0.0.0"}`)
-		sendHTTP(api, true, "POST", "/api/v0/blueprints/workspace", `{"name":"test2","description":"Test","packages":[{"name":"systemd","version":"123"}],"version":"0.0.0"}`)
-		testRoute(t, api, true, c.Method, c.Path, c.Body, c.ExpectedStatus, c.ExpectedJSON)
-		sendHTTP(api, true, "DELETE", "/api/v0/blueprints/delete/test2", ``)
-		sendHTTP(api, true, "DELETE", "/api/v0/blueprints/delete/test1", ``)
+		test.SendHTTP(api, true, "POST", "/api/v0/blueprints/new", `{"name":"test1","description":"Test","packages":[{"name":"httpd","version":"2.4.*"}],"version":"0.0.0"}`)
+		test.SendHTTP(api, true, "POST", "/api/v0/blueprints/new", `{"name":"test2","description":"Test","packages":[{"name":"httpd","version":"2.4.*"}],"version":"0.0.0"}`)
+		test.SendHTTP(api, true, "POST", "/api/v0/blueprints/workspace", `{"name":"test2","description":"Test","packages":[{"name":"systemd","version":"123"}],"version":"0.0.0"}`)
+		test.TestRoute(t, api, true, c.Method, c.Path, c.Body, c.ExpectedStatus, c.ExpectedJSON)
+		test.SendHTTP(api, true, "DELETE", "/api/v0/blueprints/delete/test2", ``)
+		test.SendHTTP(api, true, "DELETE", "/api/v0/blueprints/delete/test1", ``)
 	}
 }
 
@@ -259,9 +124,9 @@ func TestBlueprintsFreeze(t *testing.T) {
 
 	for _, c := range cases {
 		api, _ := createWeldrAPI(c.Fixture)
-		sendHTTP(api, false, "POST", "/api/v0/blueprints/new", `{"name":"test","description":"Test","packages":[{"name":"dep-package1","version":"*"}],"version":"0.0.0"}`)
-		testRoute(t, api, false, "GET", c.Path, ``, c.ExpectedStatus, c.ExpectedJSON)
-		sendHTTP(api, false, "DELETE", "/api/v0/blueprints/delete/test", ``)
+		test.SendHTTP(api, false, "POST", "/api/v0/blueprints/new", `{"name":"test","description":"Test","packages":[{"name":"dep-package1","version":"*"}],"version":"0.0.0"}`)
+		test.TestRoute(t, api, false, "GET", c.Path, ``, c.ExpectedStatus, c.ExpectedJSON)
+		test.SendHTTP(api, false, "DELETE", "/api/v0/blueprints/delete/test", ``)
 	}
 }
 
@@ -278,10 +143,10 @@ func TestBlueprintsDiff(t *testing.T) {
 
 	for _, c := range cases {
 		api, _ := createWeldrAPI(rpmmd_mock.BaseFixture)
-		sendHTTP(api, true, "POST", "/api/v0/blueprints/new", `{"name":"test","description":"Test","packages":[{"name":"httpd","version":"2.4.*"}],"version":"0.0.0"}`)
-		sendHTTP(api, true, "POST", "/api/v0/blueprints/workspace", `{"name":"test","description":"Test","packages":[{"name":"systemd","version":"123"}],"version":"0.0.0"}`)
-		testRoute(t, api, true, c.Method, c.Path, c.Body, c.ExpectedStatus, c.ExpectedJSON)
-		sendHTTP(api, true, "DELETE", "/api/v0/blueprints/delete/test", ``)
+		test.SendHTTP(api, true, "POST", "/api/v0/blueprints/new", `{"name":"test","description":"Test","packages":[{"name":"httpd","version":"2.4.*"}],"version":"0.0.0"}`)
+		test.SendHTTP(api, true, "POST", "/api/v0/blueprints/workspace", `{"name":"test","description":"Test","packages":[{"name":"systemd","version":"123"}],"version":"0.0.0"}`)
+		test.TestRoute(t, api, true, c.Method, c.Path, c.Body, c.ExpectedStatus, c.ExpectedJSON)
+		test.SendHTTP(api, true, "DELETE", "/api/v0/blueprints/delete/test", ``)
 	}
 }
 
@@ -298,9 +163,9 @@ func TestBlueprintsDelete(t *testing.T) {
 
 	for _, c := range cases {
 		api, _ := createWeldrAPI(rpmmd_mock.BaseFixture)
-		sendHTTP(api, true, "POST", "/api/v0/blueprints/new", `{"name":"test","description":"Test","packages":[{"name":"httpd","version":"2.4.*"}],"version":"0.0.0"}`)
-		testRoute(t, api, true, c.Method, c.Path, c.Body, c.ExpectedStatus, c.ExpectedJSON)
-		sendHTTP(api, true, "DELETE", "/api/v0/blueprints/delete/test", ``)
+		test.SendHTTP(api, true, "POST", "/api/v0/blueprints/new", `{"name":"test","description":"Test","packages":[{"name":"httpd","version":"2.4.*"}],"version":"0.0.0"}`)
+		test.TestRoute(t, api, true, c.Method, c.Path, c.Body, c.ExpectedStatus, c.ExpectedJSON)
+		test.SendHTTP(api, true, "DELETE", "/api/v0/blueprints/delete/test", ``)
 	}
 }
 
@@ -310,13 +175,13 @@ func TestBlueprintsChanges(t *testing.T) {
 	id := strconv.Itoa(rand.Int())
 	ignoreFields := []string{"commit", "timestamp"}
 
-	sendHTTP(api, true, "POST", "/api/v0/blueprints/new", `{"name":"`+id+`","description":"Test","packages":[{"name":"httpd","version":"2.4.*"}],"version":"0.0.0"}`)
-	testRoute(t, api, true, "GET", "/api/v0/blueprints/changes/failing"+id, ``, http.StatusOK, `{"blueprints":[],"errors":[{"id":"UnknownBlueprint","msg":"failing`+id+`"}],"limit":20,"offset":0}`, ignoreFields...)
-	testRoute(t, api, true, "GET", "/api/v0/blueprints/changes/"+id, ``, http.StatusOK, `{"blueprints":[{"changes":[{"commit":"","message":"Recipe `+id+`, version 0.0.0 saved.","revision":null,"timestamp":""}],"name":"`+id+`","total":1}],"errors":[],"limit":20,"offset":0}`, ignoreFields...)
-	sendHTTP(api, true, "DELETE", "/api/v0/blueprints/delete/"+id, ``)
-	sendHTTP(api, true, "POST", "/api/v0/blueprints/new", `{"name":"`+id+`","description":"Test","packages":[{"name":"httpd","version":"2.4.*"}],"version":"0.0.0"}`)
-	testRoute(t, api, true, "GET", "/api/v0/blueprints/changes/"+id, ``, http.StatusOK, `{"blueprints":[{"changes":[{"commit":"","message":"Recipe `+id+`, version 0.0.0 saved.","revision":null,"timestamp":""},{"commit":"","message":"Recipe `+id+`, version 0.0.0 saved.","revision":null,"timestamp":""}],"name":"`+id+`","total":2}],"errors":[],"limit":20,"offset":0}`, ignoreFields...)
-	sendHTTP(api, true, "DELETE", "/api/v0/blueprints/delete/"+id, ``)
+	test.SendHTTP(api, true, "POST", "/api/v0/blueprints/new", `{"name":"`+id+`","description":"Test","packages":[{"name":"httpd","version":"2.4.*"}],"version":"0.0.0"}`)
+	test.TestRoute(t, api, true, "GET", "/api/v0/blueprints/changes/failing"+id, ``, http.StatusOK, `{"blueprints":[],"errors":[{"id":"UnknownBlueprint","msg":"failing`+id+`"}],"limit":20,"offset":0}`, ignoreFields...)
+	test.TestRoute(t, api, true, "GET", "/api/v0/blueprints/changes/"+id, ``, http.StatusOK, `{"blueprints":[{"changes":[{"commit":"","message":"Recipe `+id+`, version 0.0.0 saved.","revision":null,"timestamp":""}],"name":"`+id+`","total":1}],"errors":[],"limit":20,"offset":0}`, ignoreFields...)
+	test.SendHTTP(api, true, "DELETE", "/api/v0/blueprints/delete/"+id, ``)
+	test.SendHTTP(api, true, "POST", "/api/v0/blueprints/new", `{"name":"`+id+`","description":"Test","packages":[{"name":"httpd","version":"2.4.*"}],"version":"0.0.0"}`)
+	test.TestRoute(t, api, true, "GET", "/api/v0/blueprints/changes/"+id, ``, http.StatusOK, `{"blueprints":[{"changes":[{"commit":"","message":"Recipe `+id+`, version 0.0.0 saved.","revision":null,"timestamp":""},{"commit":"","message":"Recipe `+id+`, version 0.0.0 saved.","revision":null,"timestamp":""}],"name":"`+id+`","total":2}],"errors":[],"limit":20,"offset":0}`, ignoreFields...)
+	test.SendHTTP(api, true, "DELETE", "/api/v0/blueprints/delete/"+id, ``)
 }
 
 func TestCompose(t *testing.T) {
@@ -335,9 +200,9 @@ func TestCompose(t *testing.T) {
 
 	for _, c := range cases {
 		api, _ := createWeldrAPI(rpmmd_mock.BaseFixture)
-		sendHTTP(api, c.External, "POST", "/api/v0/blueprints/new", `{"name":"test","description":"Test","packages":[{"name":"httpd","version":"2.4.*"}],"version":"0.0.0"}`)
-		testRoute(t, api, c.External, c.Method, c.Path, c.Body, c.ExpectedStatus, c.ExpectedJSON, c.IgnoreFields...)
-		sendHTTP(api, c.External, "DELETE", "/api/v0/blueprints/delete/test", ``)
+		test.SendHTTP(api, c.External, "POST", "/api/v0/blueprints/new", `{"name":"test","description":"Test","packages":[{"name":"httpd","version":"2.4.*"}],"version":"0.0.0"}`)
+		test.TestRoute(t, api, c.External, c.Method, c.Path, c.Body, c.ExpectedStatus, c.ExpectedJSON, c.IgnoreFields...)
+		test.SendHTTP(api, c.External, "DELETE", "/api/v0/blueprints/delete/test", ``)
 	}
 }
 
@@ -359,23 +224,23 @@ func TestComposeQueue(t *testing.T) {
 
 	for _, c := range cases {
 		api, s := createWeldrAPI(rpmmd_mock.BaseFixture)
-		sendHTTP(api, false, "POST", "/api/v0/blueprints/new", `{"name":"test","description":"Test","packages":[{"name":"httpd","version":"2.4.*"}],"version":"0.0.0"}`)
+		test.SendHTTP(api, false, "POST", "/api/v0/blueprints/new", `{"name":"test","description":"Test","packages":[{"name":"httpd","version":"2.4.*"}],"version":"0.0.0"}`)
 		// create job and leave it waiting
-		sendHTTP(api, false, "POST", "/api/v0/compose", `{"blueprint_name": "test","compose_type": "tar","branch": "master"}`)
+		test.SendHTTP(api, false, "POST", "/api/v0/compose", `{"blueprint_name": "test","compose_type": "tar","branch": "master"}`)
 		// create job and leave it running
-		sendHTTP(api, false, "POST", "/api/v0/compose", `{"blueprint_name": "test","compose_type": "tar","branch": "master"}`)
+		test.SendHTTP(api, false, "POST", "/api/v0/compose", `{"blueprint_name": "test","compose_type": "tar","branch": "master"}`)
 		s.PopCompose()
 		// create job and mark it as finished
-		sendHTTP(api, false, "POST", "/api/v0/compose", `{"blueprint_name": "test","compose_type": "tar","branch": "master"}`)
+		test.SendHTTP(api, false, "POST", "/api/v0/compose", `{"blueprint_name": "test","compose_type": "tar","branch": "master"}`)
 		job := s.PopCompose()
 		s.UpdateCompose(job.ComposeID, "FINISHED")
 		// create job and mark it as failed
-		sendHTTP(api, false, "POST", "/api/v0/compose", `{"blueprint_name": "test","compose_type": "tar","branch": "master"}`)
+		test.SendHTTP(api, false, "POST", "/api/v0/compose", `{"blueprint_name": "test","compose_type": "tar","branch": "master"}`)
 		job = s.PopCompose()
 		s.UpdateCompose(job.ComposeID, "FAILED")
 
-		testRoute(t, api, false, c.Method, c.Path, c.Body, c.ExpectedStatus, c.ExpectedJSON, c.IgnoreFields...)
-		sendHTTP(api, false, "DELETE", "/api/v0/blueprints/delete/test", ``)
+		test.TestRoute(t, api, false, c.Method, c.Path, c.Body, c.ExpectedStatus, c.ExpectedJSON, c.IgnoreFields...)
+		test.SendHTTP(api, false, "DELETE", "/api/v0/blueprints/delete/test", ``)
 	}
 }
 
@@ -393,8 +258,8 @@ func TestSourcesNew(t *testing.T) {
 
 	for _, c := range cases {
 		api, _ := createWeldrAPI(rpmmd_mock.BaseFixture)
-		testRoute(t, api, true, c.Method, c.Path, c.Body, c.ExpectedStatus, c.ExpectedJSON)
-		sendHTTP(api, true, "DELETE", "/api/v0/projects/source/delete/fish", ``)
+		test.TestRoute(t, api, true, c.Method, c.Path, c.Body, c.ExpectedStatus, c.ExpectedJSON)
+		test.SendHTTP(api, true, "DELETE", "/api/v0/projects/source/delete/fish", ``)
 	}
 }
 
@@ -412,9 +277,9 @@ func TestSourcesDelete(t *testing.T) {
 
 	for _, c := range cases {
 		api, _ := createWeldrAPI(rpmmd_mock.BaseFixture)
-		sendHTTP(api, true, "POST", "/api/v0/projects/source/new", `{"name": "fish","url": "https://download.opensuse.org/repositories/shells:/fish:/release:/3/Fedora_29/","type": "yum-baseurl","check_ssl": false,"check_gpg": false}`)
-		testRoute(t, api, true, c.Method, c.Path, c.Body, c.ExpectedStatus, c.ExpectedJSON)
-		sendHTTP(api, true, "DELETE", "/api/v0/projects/source/delete/fish", ``)
+		test.SendHTTP(api, true, "POST", "/api/v0/projects/source/new", `{"name": "fish","url": "https://download.opensuse.org/repositories/shells:/fish:/release:/3/Fedora_29/","type": "yum-baseurl","check_ssl": false,"check_gpg": false}`)
+		test.TestRoute(t, api, true, c.Method, c.Path, c.Body, c.ExpectedStatus, c.ExpectedJSON)
+		test.SendHTTP(api, true, "DELETE", "/api/v0/projects/source/delete/fish", ``)
 	}
 }
 
@@ -432,7 +297,7 @@ func TestProjectsDepsolve(t *testing.T) {
 
 	for _, c := range cases {
 		api, _ := createWeldrAPI(c.Fixture)
-		testRoute(t, api, true, "GET", c.Path, ``, c.ExpectedStatus, c.ExpectedJSON)
+		test.TestRoute(t, api, true, "GET", c.Path, ``, c.ExpectedStatus, c.ExpectedJSON)
 	}
 }
 
@@ -453,7 +318,7 @@ func TestProjectsInfo(t *testing.T) {
 
 	for _, c := range cases {
 		api, _ := createWeldrAPI(c.Fixture)
-		testRoute(t, api, true, "GET", c.Path, ``, c.ExpectedStatus, c.ExpectedJSON)
+		test.TestRoute(t, api, true, "GET", c.Path, ``, c.ExpectedStatus, c.ExpectedJSON)
 	}
 }
 
@@ -475,7 +340,7 @@ func TestModulesInfo(t *testing.T) {
 
 	for _, c := range cases {
 		api, _ := createWeldrAPI(c.Fixture)
-		testRoute(t, api, true, "GET", c.Path, ``, c.ExpectedStatus, c.ExpectedJSON)
+		test.TestRoute(t, api, true, "GET", c.Path, ``, c.ExpectedStatus, c.ExpectedJSON)
 	}
 }
 
@@ -494,7 +359,7 @@ func TestProjectsList(t *testing.T) {
 
 	for _, c := range cases {
 		api, _ := createWeldrAPI(c.Fixture)
-		testRoute(t, api, true, "GET", c.Path, ``, c.ExpectedStatus, c.ExpectedJSON)
+		test.TestRoute(t, api, true, "GET", c.Path, ``, c.ExpectedStatus, c.ExpectedJSON)
 	}
 }
 
@@ -516,6 +381,6 @@ func TestModulesList(t *testing.T) {
 
 	for _, c := range cases {
 		api, _ := createWeldrAPI(c.Fixture)
-		testRoute(t, api, true, "GET", c.Path, ``, c.ExpectedStatus, c.ExpectedJSON)
+		test.TestRoute(t, api, true, "GET", c.Path, ``, c.ExpectedStatus, c.ExpectedJSON)
 	}
 }


### PR DESCRIPTION
This PR is somewhat connected with #101. While developing upload API I needed two things:

- support for DropFields in jobqueue tests. Therefore I extract common helpers to a new package.
- support for better way to describe initial store state. Therefore I added store fixtures.