### PR TITLE
Provides: osbuild-composer in .spec

### DIFF
--- a/golang-github-osbuild-composer.spec
+++ b/golang-github-osbuild-composer.spec
@@ -31,6 +31,8 @@ BuildRequires:  golang(github.com/gobwas/glob)
 Requires: systemd
 Requires: osbuild
 
+Provides: osbuild-composer
+
 %description
 %{common_description}
 


### PR DESCRIPTION
this is a small helper to enable easy switch between backends
in the existing test suite where we reference everything by name.

The current working variant is:

	yum install $BACKEND
	systemctl enable $BACKEND.socket

where BACKEND is either lorax-composer or osbuild-composer!