### PR TITLE
rpmmd: add IgnoreSSL key to RepoConfig

### DIFF
--- a/dnf-json
+++ b/dnf-json
@@ -29,6 +29,9 @@ def dnfrepo(desc, parent_conf=None):
     else:
         assert False
 
+    if desc.get("ignoressl", False):
+        repo.sslverify = False
+
     return repo
 
 

--- a/internal/rpmmd/repository.go
+++ b/internal/rpmmd/repository.go
@@ -19,6 +19,7 @@ type RepoConfig struct {
 	Metalink   string `json:"metalink,omitempty"`
 	MirrorList string `json:"mirrorlist,omitempty"`
 	GPGKey     string `json:"gpgkey,omitempty"`
+	IgnoreSSL  bool   `json:"ignoressl"`
 }
 
 type PackageList []Package

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -589,7 +589,7 @@ func NewSourceConfig(repo rpmmd.RepoConfig, system bool) SourceConfig {
 	sc := SourceConfig{
 		Name:     repo.Id,
 		CheckGPG: true,
-		CheckSSL: true,
+		CheckSSL: !repo.IgnoreSSL,
 		System:   system,
 	}
 
@@ -612,6 +612,7 @@ func (s *SourceConfig) RepoConfig() rpmmd.RepoConfig {
 
 	repo.Name = s.Name
 	repo.Id = s.Name
+	repo.IgnoreSSL = !s.CheckSSL
 
 	if s.Type == "yum-baseurl" {
 		repo.BaseURL = s.URL


### PR DESCRIPTION
This is the opposite of dnf.conf's `sslverify`, because go's default for
booleans is always false. This is error prone: we'd like to default to
true.