### PR TITLE
service: adjust the IO and CPU scheduling classes

### DIFF
--- a/distribution/osbuild-worker@.service
+++ b/distribution/osbuild-worker@.service
@@ -10,6 +10,8 @@ ExecStart=/usr/libexec/osbuild-composer/osbuild-worker -C /var/lib/osbuild
 CacheDirectory=osbuild-composer
 Restart=on-failure
 RestartSec=10s
+CPUSchedulingPolicy=batch
+IOSchedulingClass=idle
 
 [Install]
 WantedBy=osbuild-composer.service


### PR DESCRIPTION
Image generation is very much a batch job, latency is not important
and because it is so CPU and IO intensive, it really affects the
overall responsiveness of the system if left on the default settings.

Set scheduling to idle/batched for the worker. The composer service
is still left in the normal scheduling classes as its latency is
important for the UI.

Signed-off-by: Tom Gundersen <teg@jklm.no>