### PR TITLE
jobqueue: copy outputs from the right location

### DIFF
--- a/internal/jobqueue/job.go
+++ b/internal/jobqueue/job.go
@@ -105,7 +105,7 @@ func (job *Job) Run(d distro.Distro) (*store.Image, error, []error) {
 	for _, t := range job.Targets {
 		switch options := t.Options.(type) {
 		case *target.LocalTargetOptions:
-			err = runCommand("cp", "-a", "-L", "/var/cache/osbuild-composer/store/refs/"+result.OutputID+"/.", options.Location)
+			err = runCommand("cp", "-a", "-L", tmpStore+"/refs/"+result.OutputID+"/.", options.Location)
 			if err != nil {
 				r = append(r, err)
 				continue
@@ -146,7 +146,7 @@ func (job *Job) Run(d distro.Distro) (*store.Image, error, []error) {
 				options.Key = job.ID.String()
 			}
 
-			_, err = a.Upload("/var/cache/osbuild-composer/store/refs/"+result.OutputID+"/image.raw.xz", options.Bucket, options.Key)
+			_, err = a.Upload(tmpStore+"/refs/"+result.OutputID+"/image.raw.xz", options.Bucket, options.Key)
 			if err != nil {
 				r = append(r, err)
 				continue


### PR DESCRIPTION
d55abdfd75450dcfc27913e71f16dee2ea3346d7 disabled caching the osbuild
store by moving it to /var/tmp. Fix the directory we're copying the
outputs from as well.