### PR TITLE
tests: add tests and minor cleanups for RHEL-8.2

### DIFF
--- a/internal/distro/rhel82/distro.go
+++ b/internal/distro/rhel82/distro.go
@@ -121,6 +121,7 @@ func New() *RHEL82 {
 			"kernel",
 			"firewalld",
 			"chrony",
+			"dracut-config-generic",
 			"langpacks-en",
 		},
 		ExcludedPackages: []string{
@@ -141,6 +142,7 @@ func New() *RHEL82 {
 		Packages: []string{
 			"@core",
 			"chrony",
+			"dracut-config-generic",
 			"firewalld",
 			"grub2-pc",
 			"kernel",
@@ -165,6 +167,7 @@ func New() *RHEL82 {
 		Packages: []string{
 			"kernel-core",
 			"chrony",
+			"dracut-config-generic",
 			"polkit",
 			"systemd-udev",
 			"selinux-policy-targeted",
@@ -224,6 +227,7 @@ func New() *RHEL82 {
 			"kernel",
 			"firewalld",
 			"chrony",
+			"dracut-config-generic",
 			"langpacks-en",
 		},
 		ExcludedPackages: []string{
@@ -285,6 +289,7 @@ func New() *RHEL82 {
 		Packages: []string{
 			"@core",
 			"chrony",
+			"dracut-config-generic",
 			"firewalld",
 			"grub2-pc",
 			"kernel",

--- a/internal/distro/rhel82/distro.go
+++ b/internal/distro/rhel82/distro.go
@@ -239,7 +239,6 @@ func New() *RHEL82 {
 			"kernel",
 			"selinux-policy-targeted",
 			"chrony",
-			// TODO enable and/or configure WAAgent correctly
 			"WALinuxAgent",
 			"python3",
 			"net-tools",
@@ -256,7 +255,7 @@ func New() *RHEL82 {
 		},
 		EnabledServices: []string{
 			"sshd",
-			"waagent", // needed to run in Azure
+			"waagent",
 		},
 		DefaultTarget: "multi-user.target",
 		IncludeFSTab:  true,

--- a/internal/distro/rhel82/distro.go
+++ b/internal/distro/rhel82/distro.go
@@ -317,12 +317,12 @@ func (r *RHEL82) Repositories() []rpmmd.RepoConfig {
 		{
 			Id:      "baseos",
 			Name:    "BaseOS",
-			BaseURL: "http://download-ipv4.eng.brq.redhat.com/rhel-8/nightly/RHEL-8/latest-RHEL-8/compose/BaseOS/x86_64/os",
+			BaseURL: "http://download-ipv4.eng.brq.redhat.com/rhel-8/nightly/RHEL-8/RHEL-8.2.0-20191213.n.1/compose/BaseOS/x86_64/os",
 		},
 		{
 			Id:      "appstream",
 			Name:    "AppStream",
-			BaseURL: "http://download-ipv4.eng.brq.redhat.com/rhel-8/nightly/RHEL-8/latest-RHEL-8/compose/AppStream/x86_64/os",
+			BaseURL: "http://download-ipv4.eng.brq.redhat.com/rhel-8/nightly/RHEL-8/RHEL-8.2.0-20191213.n.1/compose/AppStream/x86_64/os",
 		},
 	}
 }

--- a/internal/distro/rhel82/distro.go
+++ b/internal/distro/rhel82/distro.go
@@ -125,6 +125,10 @@ func New() *RHEL82 {
 		},
 		ExcludedPackages: []string{
 			"dracut-config-rescue",
+
+			// TODO setfiles failes because of usr/sbin/timedatex. Exlude until
+			// https://errata.devel.redhat.com/advisory/47339 lands
+			"timedatex",
 		},
 		IncludeFSTab:  false,
 		KernelOptions: "ro net.ifnames=0",
@@ -145,6 +149,10 @@ func New() *RHEL82 {
 		},
 		ExcludedPackages: []string{
 			"dracut-config-rescue",
+
+			// TODO setfiles failes because of usr/sbin/timedatex. Exlude until
+			// https://errata.devel.redhat.com/advisory/47339 lands
+			"timedatex",
 		},
 		IncludeFSTab:  true,
 		KernelOptions: "ro net.ifnames=0",
@@ -169,6 +177,10 @@ func New() *RHEL82 {
 			"firewalld",
 			"gobject-introspection",
 			"plymouth",
+
+			// TODO setfiles failes because of usr/sbin/timedatex. Exlude until
+			// https://errata.devel.redhat.com/advisory/47339 lands
+			"timedatex",
 		},
 		IncludeFSTab:  true,
 		KernelOptions: "ro net.ifnames=0",
@@ -216,6 +228,10 @@ func New() *RHEL82 {
 		},
 		ExcludedPackages: []string{
 			"dracut-config-rescue",
+
+			// TODO setfiles failes because of usr/sbin/timedatex. Exlude until
+			// https://errata.devel.redhat.com/advisory/47339 lands
+			"timedatex",
 		},
 		IncludeFSTab:  false,
 		KernelOptions: "ro net.ifnames=0",
@@ -278,6 +294,10 @@ func New() *RHEL82 {
 		},
 		ExcludedPackages: []string{
 			"dracut-config-rescue",
+
+			// TODO setfiles failes because of usr/sbin/timedatex. Exlude until
+			// https://errata.devel.redhat.com/advisory/47339 lands
+			"timedatex",
 		},
 		IncludeFSTab:  true,
 		KernelOptions: "ro net.ifnames=0",
@@ -579,7 +599,7 @@ func (r *RHEL82) qemuAssembler(format string, filename string, size uint64) *pip
 func (r *RHEL82) tarAssembler(filename, compression string) *pipeline.Assembler {
 	return pipeline.NewTarAssembler(
 		&pipeline.TarAssemblerOptions{
-			Filename: filename,
+			Filename:    filename,
 			Compression: compression,
 		})
 }

--- a/test/cases/rhel82_ami.json
+++ b/test/cases/rhel82_ami.json
@@ -1,0 +1,180 @@
+{
+  "boot": {
+    "type": "qemu-extract"
+  },
+  "compose": {
+    "distro": "rhel-8.2",
+    "arch": "x86_64",
+    "checksums": {
+      "baseos": "sha256:3ce6f4ffa7d05b81fec2ba5a1c4917b351231c3433f2f5eed86ed5f8f97168a1",
+      "appstream": "sha256:662e1dc0e465dd5e8efec9f42ef24ac9fd8418294254c3c98ea0342d6e903aed"
+    },
+    "filename": "image.raw.xz",
+    "output-format": "ami",
+    "blueprint": {}
+  },
+  "pipeline": {
+    "build": {
+      "pipeline": {
+        "stages": [
+          {
+            "name": "org.osbuild.dnf",
+            "options": {
+              "repos": [
+                {
+                  "baseurl": "http://download-ipv4.eng.brq.redhat.com/rhel-8/nightly/RHEL-8/RHEL-8.2.0-20191213.n.1/compose/BaseOS/x86_64/os",
+                  "checksum": "sha256:3ce6f4ffa7d05b81fec2ba5a1c4917b351231c3433f2f5eed86ed5f8f97168a1"
+                },
+                {
+                  "baseurl": "http://download-ipv4.eng.brq.redhat.com/rhel-8/nightly/RHEL-8/RHEL-8.2.0-20191213.n.1/compose/AppStream/x86_64/os",
+                  "checksum": "sha256:662e1dc0e465dd5e8efec9f42ef24ac9fd8418294254c3c98ea0342d6e903aed"
+                }
+              ],
+              "packages": [
+                "dnf",
+                "dracut-config-generic",
+                "e2fsprogs",
+                "glibc",
+                "grub2-pc",
+                "policycoreutils",
+                "python36",
+                "qemu-img",
+                "systemd",
+                "tar",
+                "xfsprogs"
+              ],
+              "releasever": "8",
+              "basearch": "x86_64",
+              "module_platform_id": "platform:el8"
+            }
+          }
+        ]
+      },
+      "runner": "org.osbuild.rhel82"
+    },
+    "stages": [
+      {
+        "name": "org.osbuild.dnf",
+        "options": {
+          "repos": [
+            {
+              "baseurl": "http://download-ipv4.eng.brq.redhat.com/rhel-8/nightly/RHEL-8/RHEL-8.2.0-20191213.n.1/compose/BaseOS/x86_64/os",
+              "checksum": "sha256:3ce6f4ffa7d05b81fec2ba5a1c4917b351231c3433f2f5eed86ed5f8f97168a1"
+            },
+            {
+              "baseurl": "http://download-ipv4.eng.brq.redhat.com/rhel-8/nightly/RHEL-8/RHEL-8.2.0-20191213.n.1/compose/AppStream/x86_64/os",
+              "checksum": "sha256:662e1dc0e465dd5e8efec9f42ef24ac9fd8418294254c3c98ea0342d6e903aed"
+            }
+          ],
+          "packages": [
+            "checkpolicy",
+            "chrony",
+            "cloud-init",
+            "cloud-init",
+            "cloud-utils-growpart",
+            "@core",
+            "dhcp-client",
+            "dracut-config-generic",
+            "gdisk",
+            "grub2",
+            "insights-client",
+            "kernel",
+            "langpacks-en",
+            "net-tools",
+            "NetworkManager",
+            "redhat-release",
+            "redhat-release-eula",
+            "rng-tools",
+            "rsync",
+            "selinux-policy-targeted",
+            "tar",
+            "yum-utils"
+          ],
+          "exclude_packages": [
+            "aic94xx-firmware",
+            "alsa-firmware",
+            "alsa-lib",
+            "alsa-tools-firmware",
+            "biosdevname",
+            "dracut-config-rescue",
+            "firewalld",
+            "iprutils",
+            "ivtv-firmware",
+            "iwl1000-firmware",
+            "iwl100-firmware",
+            "iwl105-firmware",
+            "iwl135-firmware",
+            "iwl2000-firmware",
+            "iwl2030-firmware",
+            "iwl3160-firmware",
+            "iwl3945-firmware",
+            "iwl4965-firmware",
+            "iwl5000-firmware",
+            "iwl5150-firmware",
+            "iwl6000-firmware",
+            "iwl6000g2a-firmware",
+            "iwl6000g2b-firmware",
+            "iwl6050-firmware",
+            "iwl7260-firmware",
+            "libertas-sd8686-firmware",
+            "libertas-sd8787-firmware",
+            "libertas-usb8388-firmware",
+            "plymouth",
+            "timedatex"
+          ],
+          "releasever": "8",
+          "basearch": "x86_64",
+          "module_platform_id": "platform:el8"
+        }
+      },
+      {
+        "name": "org.osbuild.fix-bls",
+        "options": {}
+      },
+      {
+        "name": "org.osbuild.fstab",
+        "options": {
+          "filesystems": [
+            {
+              "uuid": "0bd700f8-090f-4556-b797-b340297ea1bd",
+              "vfs_type": "xfs",
+              "path": "/",
+              "options": "defaults"
+            }
+          ]
+        }
+      },
+      {
+        "name": "org.osbuild.grub2",
+        "options": {
+          "root_fs_uuid": "0bd700f8-090f-4556-b797-b340297ea1bd",
+          "boot_fs_uuid": "00000000-0000-0000-0000-000000000000",
+          "kernel_opts": "ro console=ttyS0,115200n8 console=tty0 net.ifnames=0 rd.blacklist=nouveau nvme_core.io_timeout=4294967295 crashkernel=auto"
+        }
+      },
+      {
+        "name": "org.osbuild.locale",
+        "options": {
+          "language": "en_US"
+        }
+      },
+      {
+        "name": "org.osbuild.selinux",
+        "options": {
+          "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
+        }
+      }
+    ],
+    "assembler": {
+      "name": "org.osbuild.qemu",
+      "options": {
+        "format": "raw.xz",
+        "filename": "image.raw.xz",
+        "ptuuid": "0x14fc63d2",
+        "root_fs_uuid": "0bd700f8-090f-4556-b797-b340297ea1bd",
+        "root_fs_type": "xfs",
+        "size": 6442450944
+      }
+    }
+  }
+}

--- a/test/cases/rhel82_ext4_filesystem.json
+++ b/test/cases/rhel82_ext4_filesystem.json
@@ -1,0 +1,138 @@
+{
+  "compose": {
+    "distro": "rhel-8.2",
+    "arch": "x86_64",
+    "checksums": {
+      "baseos": "sha256:3ce6f4ffa7d05b81fec2ba5a1c4917b351231c3433f2f5eed86ed5f8f97168a1",
+      "appstream": "sha256:662e1dc0e465dd5e8efec9f42ef24ac9fd8418294254c3c98ea0342d6e903aed"
+    },
+    "filename": "filesystem.img",
+    "output-format": "ext4-filesystem",
+    "blueprint": {
+      "customizations": {
+        "user": [
+          {
+            "name": "redhat",
+            "key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC61wMCjOSHwbVb4VfVyl5sn497qW4PsdQ7Ty7aD6wDNZ/QjjULkDV/yW5WjDlDQ7UqFH0Sr7vywjqDizUAqK7zM5FsUKsUXWHWwg/ehKg8j9xKcMv11AkFoUoujtfAujnKODkk58XSA9whPr7qcw3vPrmog680pnMSzf9LC7J6kXfs6lkoKfBh9VnlxusCrw2yg0qI1fHAZBLPx7mW6+me71QZsS6sVz8v8KXyrXsKTdnF50FjzHcK9HXDBtSJS5wA3fkcRYymJe0o6WMWNdgSRVpoSiWaHHmFgdMUJaYoCfhXzyl7LtNb3Q+Sveg+tJK7JaRXBLMUllOlJ6ll5Hod"
+          }
+        ]
+      }
+    }
+  },
+  "pipeline": {
+    "build": {
+      "pipeline": {
+        "stages": [
+          {
+            "name": "org.osbuild.dnf",
+            "options": {
+              "repos": [
+                {
+                  "baseurl": "http://download-ipv4.eng.brq.redhat.com/rhel-8/nightly/RHEL-8/RHEL-8.2.0-20191213.n.1/compose/BaseOS/x86_64/os",
+                  "checksum": "sha256:3ce6f4ffa7d05b81fec2ba5a1c4917b351231c3433f2f5eed86ed5f8f97168a1"
+                },
+                {
+                  "baseurl": "http://download-ipv4.eng.brq.redhat.com/rhel-8/nightly/RHEL-8/RHEL-8.2.0-20191213.n.1/compose/AppStream/x86_64/os",
+                  "checksum": "sha256:662e1dc0e465dd5e8efec9f42ef24ac9fd8418294254c3c98ea0342d6e903aed"
+                }
+              ],
+              "packages": [
+                "dnf",
+                "dracut-config-generic",
+                "e2fsprogs",
+                "glibc",
+                "grub2-pc",
+                "policycoreutils",
+                "python36",
+                "qemu-img",
+                "systemd",
+                "tar",
+                "xfsprogs"
+              ],
+              "releasever": "8",
+              "basearch": "x86_64",
+              "module_platform_id": "platform:el8"
+            }
+          }
+        ]
+      },
+      "runner": "org.osbuild.rhel82"
+    },
+    "stages": [
+      {
+        "name": "org.osbuild.dnf",
+        "options": {
+          "repos": [
+            {
+              "baseurl": "http://download-ipv4.eng.brq.redhat.com/rhel-8/nightly/RHEL-8/RHEL-8.2.0-20191213.n.1/compose/BaseOS/x86_64/os",
+              "checksum": "sha256:3ce6f4ffa7d05b81fec2ba5a1c4917b351231c3433f2f5eed86ed5f8f97168a1"
+            },
+            {
+              "baseurl": "http://download-ipv4.eng.brq.redhat.com/rhel-8/nightly/RHEL-8/RHEL-8.2.0-20191213.n.1/compose/AppStream/x86_64/os",
+              "checksum": "sha256:662e1dc0e465dd5e8efec9f42ef24ac9fd8418294254c3c98ea0342d6e903aed"
+            }
+          ],
+          "packages": [
+            "policycoreutils",
+            "selinux-policy-targeted",
+            "kernel",
+            "firewalld",
+            "chrony",
+            "dracut-config-generic",
+            "langpacks-en"
+          ],
+          "exclude_packages": [
+            "dracut-config-rescue",
+            "timedatex"
+          ],
+          "releasever": "8",
+          "basearch": "x86_64",
+          "module_platform_id": "platform:el8"
+        }
+      },
+      {
+        "name": "org.osbuild.fix-bls",
+        "options": {}
+      },
+      {
+        "name": "org.osbuild.grub2",
+        "options": {
+          "root_fs_uuid": "0bd700f8-090f-4556-b797-b340297ea1bd",
+          "boot_fs_uuid": "00000000-0000-0000-0000-000000000000",
+          "kernel_opts": "ro net.ifnames=0"
+        }
+      },
+      {
+        "name": "org.osbuild.locale",
+        "options": {
+          "language": "en_US"
+        }
+      },
+      {
+        "name": "org.osbuild.users",
+        "options": {
+          "users": {
+            "redhat": {
+              "key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC61wMCjOSHwbVb4VfVyl5sn497qW4PsdQ7Ty7aD6wDNZ/QjjULkDV/yW5WjDlDQ7UqFH0Sr7vywjqDizUAqK7zM5FsUKsUXWHWwg/ehKg8j9xKcMv11AkFoUoujtfAujnKODkk58XSA9whPr7qcw3vPrmog680pnMSzf9LC7J6kXfs6lkoKfBh9VnlxusCrw2yg0qI1fHAZBLPx7mW6+me71QZsS6sVz8v8KXyrXsKTdnF50FjzHcK9HXDBtSJS5wA3fkcRYymJe0o6WMWNdgSRVpoSiWaHHmFgdMUJaYoCfhXzyl7LtNb3Q+Sveg+tJK7JaRXBLMUllOlJ6ll5Hod"
+            }
+          }
+        }
+      },
+      {
+        "name": "org.osbuild.selinux",
+        "options": {
+          "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
+        }
+      }
+    ],
+    "assembler": {
+      "name": "org.osbuild.rawfs",
+      "options": {
+        "filename": "filesystem.img",
+        "root_fs_uuid": "0bd700f8-090f-4556-b797-b340297ea1bd",
+        "size": 3221225472,
+        "fs_type": "xfs"
+      }
+    }
+  }
+}

--- a/test/cases/rhel82_openstack.json
+++ b/test/cases/rhel82_openstack.json
@@ -1,0 +1,138 @@
+{
+  "boot": {
+    "type": "qemu"
+  },
+  "compose": {
+    "distro": "rhel-8.2",
+    "arch": "x86_64",
+    "checksums": {
+      "baseos": "sha256:3ce6f4ffa7d05b81fec2ba5a1c4917b351231c3433f2f5eed86ed5f8f97168a1",
+      "appstream": "sha256:662e1dc0e465dd5e8efec9f42ef24ac9fd8418294254c3c98ea0342d6e903aed"
+    },
+    "filename": "image.qcow2",
+    "output-format": "openstack",
+    "blueprint": {}
+  },
+  "pipeline": {
+    "build": {
+      "pipeline": {
+        "stages": [
+          {
+            "name": "org.osbuild.dnf",
+            "options": {
+              "repos": [
+                {
+                  "baseurl": "http://download-ipv4.eng.brq.redhat.com/rhel-8/nightly/RHEL-8/RHEL-8.2.0-20191213.n.1/compose/BaseOS/x86_64/os",
+                  "checksum": "sha256:3ce6f4ffa7d05b81fec2ba5a1c4917b351231c3433f2f5eed86ed5f8f97168a1"
+                },
+                {
+                  "baseurl": "http://download-ipv4.eng.brq.redhat.com/rhel-8/nightly/RHEL-8/RHEL-8.2.0-20191213.n.1/compose/AppStream/x86_64/os",
+                  "checksum": "sha256:662e1dc0e465dd5e8efec9f42ef24ac9fd8418294254c3c98ea0342d6e903aed"
+                }
+              ],
+              "packages": [
+                "dnf",
+                "dracut-config-generic",
+                "e2fsprogs",
+                "glibc",
+                "grub2-pc",
+                "policycoreutils",
+                "python36",
+                "qemu-img",
+                "systemd",
+                "tar",
+                "xfsprogs"
+              ],
+              "releasever": "8",
+              "basearch": "x86_64",
+              "module_platform_id": "platform:el8"
+            }
+          }
+        ]
+      },
+      "runner": "org.osbuild.rhel82"
+    },
+    "stages": [
+      {
+        "name": "org.osbuild.dnf",
+        "options": {
+          "repos": [
+            {
+              "baseurl": "http://download-ipv4.eng.brq.redhat.com/rhel-8/nightly/RHEL-8/RHEL-8.2.0-20191213.n.1/compose/BaseOS/x86_64/os",
+              "checksum": "sha256:3ce6f4ffa7d05b81fec2ba5a1c4917b351231c3433f2f5eed86ed5f8f97168a1"
+            },
+            {
+              "baseurl": "http://download-ipv4.eng.brq.redhat.com/rhel-8/nightly/RHEL-8/RHEL-8.2.0-20191213.n.1/compose/AppStream/x86_64/os",
+              "checksum": "sha256:662e1dc0e465dd5e8efec9f42ef24ac9fd8418294254c3c98ea0342d6e903aed"
+            }
+          ],
+          "packages": [
+            "@Core",
+            "grub2-pc",
+            "langpacks-en",
+            "dracut-config-generic",
+            "kernel",
+            "selinux-policy-targeted",
+            "cloud-init",
+            "qemu-guest-agent",
+            "spice-vdagent"
+          ],
+          "exclude_packages": [
+            "dracut-config-rescue"
+          ],
+          "releasever": "8",
+          "basearch": "x86_64",
+          "module_platform_id": "platform:el8"
+        }
+      },
+      {
+        "name": "org.osbuild.fix-bls",
+        "options": {}
+      },
+      {
+        "name": "org.osbuild.fstab",
+        "options": {
+          "filesystems": [
+            {
+              "uuid": "0bd700f8-090f-4556-b797-b340297ea1bd",
+              "vfs_type": "xfs",
+              "path": "/",
+              "options": "defaults"
+            }
+          ]
+        }
+      },
+      {
+        "name": "org.osbuild.grub2",
+        "options": {
+          "root_fs_uuid": "0bd700f8-090f-4556-b797-b340297ea1bd",
+          "boot_fs_uuid": "00000000-0000-0000-0000-000000000000",
+          "kernel_opts": "ro net.ifnames=0"
+        }
+      },
+      {
+        "name": "org.osbuild.locale",
+        "options": {
+          "language": "en_US"
+        }
+      },
+      {
+        "name": "org.osbuild.selinux",
+        "options": {
+          "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
+        }
+      }
+    ],
+    "assembler": {
+      "name": "org.osbuild.qemu",
+      "options": {
+        "format": "qcow2",
+        "filename": "image.qcow2",
+        "ptuuid": "0x14fc63d2",
+        "root_fs_uuid": "0bd700f8-090f-4556-b797-b340297ea1bd",
+        "root_fs_type": "xfs",
+        "size": 3221225472
+      }
+    }
+  }
+}

--- a/test/cases/rhel82_partitioned_disk.json
+++ b/test/cases/rhel82_partitioned_disk.json
@@ -1,0 +1,154 @@
+{
+  "compose": {
+    "distro": "rhel-8.2",
+    "arch": "x86_64",
+    "checksums": {
+      "baseos": "sha256:3ce6f4ffa7d05b81fec2ba5a1c4917b351231c3433f2f5eed86ed5f8f97168a1",
+      "appstream": "sha256:662e1dc0e465dd5e8efec9f42ef24ac9fd8418294254c3c98ea0342d6e903aed"
+    },
+    "filename": "disk.img",
+    "output-format": "partitioned-disk",
+    "blueprint": {
+      "customizations": {
+        "user": [
+          {
+            "name": "redhat",
+            "key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC61wMCjOSHwbVb4VfVyl5sn497qW4PsdQ7Ty7aD6wDNZ/QjjULkDV/yW5WjDlDQ7UqFH0Sr7vywjqDizUAqK7zM5FsUKsUXWHWwg/ehKg8j9xKcMv11AkFoUoujtfAujnKODkk58XSA9whPr7qcw3vPrmog680pnMSzf9LC7J6kXfs6lkoKfBh9VnlxusCrw2yg0qI1fHAZBLPx7mW6+me71QZsS6sVz8v8KXyrXsKTdnF50FjzHcK9HXDBtSJS5wA3fkcRYymJe0o6WMWNdgSRVpoSiWaHHmFgdMUJaYoCfhXzyl7LtNb3Q+Sveg+tJK7JaRXBLMUllOlJ6ll5Hod"
+          }
+        ]
+      }
+    }
+  },
+  "pipeline": {
+    "build": {
+      "pipeline": {
+        "stages": [
+          {
+            "name": "org.osbuild.dnf",
+            "options": {
+              "repos": [
+                {
+                  "baseurl": "http://download-ipv4.eng.brq.redhat.com/rhel-8/nightly/RHEL-8/RHEL-8.2.0-20191213.n.1/compose/BaseOS/x86_64/os",
+                  "checksum": "sha256:3ce6f4ffa7d05b81fec2ba5a1c4917b351231c3433f2f5eed86ed5f8f97168a1"
+                },
+                {
+                  "baseurl": "http://download-ipv4.eng.brq.redhat.com/rhel-8/nightly/RHEL-8/RHEL-8.2.0-20191213.n.1/compose/AppStream/x86_64/os",
+                  "checksum": "sha256:662e1dc0e465dd5e8efec9f42ef24ac9fd8418294254c3c98ea0342d6e903aed"
+                }
+              ],
+              "packages": [
+                "dnf",
+                "dracut-config-generic",
+                "e2fsprogs",
+                "glibc",
+                "grub2-pc",
+                "policycoreutils",
+                "python36",
+                "qemu-img",
+                "systemd",
+                "tar",
+                "xfsprogs"
+              ],
+              "releasever": "8",
+              "basearch": "x86_64",
+              "module_platform_id": "platform:el8"
+            }
+          }
+        ]
+      },
+      "runner": "org.osbuild.rhel82"
+    },
+    "stages": [
+      {
+        "name": "org.osbuild.dnf",
+        "options": {
+          "repos": [
+            {
+              "baseurl": "http://download-ipv4.eng.brq.redhat.com/rhel-8/nightly/RHEL-8/RHEL-8.2.0-20191213.n.1/compose/BaseOS/x86_64/os",
+              "checksum": "sha256:3ce6f4ffa7d05b81fec2ba5a1c4917b351231c3433f2f5eed86ed5f8f97168a1"
+            },
+            {
+              "baseurl": "http://download-ipv4.eng.brq.redhat.com/rhel-8/nightly/RHEL-8/RHEL-8.2.0-20191213.n.1/compose/AppStream/x86_64/os",
+              "checksum": "sha256:662e1dc0e465dd5e8efec9f42ef24ac9fd8418294254c3c98ea0342d6e903aed"
+            }
+          ],
+          "packages": [
+            "@core",
+            "chrony",
+            "dracut-config-generic",
+            "firewalld",
+            "grub2-pc",
+            "kernel",
+            "langpacks-en",
+            "selinux-policy-targeted"
+          ],
+          "exclude_packages": [
+            "dracut-config-rescue",
+            "timedatex"
+          ],
+          "releasever": "8",
+          "basearch": "x86_64",
+          "module_platform_id": "platform:el8"
+        }
+      },
+      {
+        "name": "org.osbuild.fix-bls",
+        "options": {}
+      },
+      {
+        "name": "org.osbuild.fstab",
+        "options": {
+          "filesystems": [
+            {
+              "uuid": "0bd700f8-090f-4556-b797-b340297ea1bd",
+              "vfs_type": "xfs",
+              "path": "/",
+              "options": "defaults"
+            }
+          ]
+        }
+      },
+      {
+        "name": "org.osbuild.grub2",
+        "options": {
+          "root_fs_uuid": "0bd700f8-090f-4556-b797-b340297ea1bd",
+          "boot_fs_uuid": "00000000-0000-0000-0000-000000000000",
+          "kernel_opts": "ro net.ifnames=0"
+        }
+      },
+      {
+        "name": "org.osbuild.locale",
+        "options": {
+          "language": "en_US"
+        }
+      },
+      {
+        "name": "org.osbuild.users",
+        "options": {
+          "users": {
+            "redhat": {
+              "key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC61wMCjOSHwbVb4VfVyl5sn497qW4PsdQ7Ty7aD6wDNZ/QjjULkDV/yW5WjDlDQ7UqFH0Sr7vywjqDizUAqK7zM5FsUKsUXWHWwg/ehKg8j9xKcMv11AkFoUoujtfAujnKODkk58XSA9whPr7qcw3vPrmog680pnMSzf9LC7J6kXfs6lkoKfBh9VnlxusCrw2yg0qI1fHAZBLPx7mW6+me71QZsS6sVz8v8KXyrXsKTdnF50FjzHcK9HXDBtSJS5wA3fkcRYymJe0o6WMWNdgSRVpoSiWaHHmFgdMUJaYoCfhXzyl7LtNb3Q+Sveg+tJK7JaRXBLMUllOlJ6ll5Hod"
+            }
+          }
+        }
+      },
+      {
+        "name": "org.osbuild.selinux",
+        "options": {
+          "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
+        }
+      }
+    ],
+    "assembler": {
+      "name": "org.osbuild.qemu",
+      "options": {
+        "format": "raw",
+        "filename": "disk.img",
+        "ptuuid": "0x14fc63d2",
+        "root_fs_uuid": "0bd700f8-090f-4556-b797-b340297ea1bd",
+        "root_fs_type": "xfs",
+        "size": 3221225472
+      }
+    }
+  }
+}

--- a/test/cases/rhel82_qcow2.json
+++ b/test/cases/rhel82_qcow2.json
@@ -1,0 +1,139 @@
+{
+  "compose": {
+    "distro": "rhel-8.2",
+    "arch": "x86_64",
+    "checksums": {
+      "baseos": "sha256:3ce6f4ffa7d05b81fec2ba5a1c4917b351231c3433f2f5eed86ed5f8f97168a1",
+      "appstream": "sha256:662e1dc0e465dd5e8efec9f42ef24ac9fd8418294254c3c98ea0342d6e903aed"
+    },
+    "filename": "disk.qcow2",
+    "output-format": "qcow2",
+    "blueprint": {}
+  },
+  "pipeline": {
+    "build": {
+      "pipeline": {
+        "stages": [
+          {
+            "name": "org.osbuild.dnf",
+            "options": {
+              "repos": [
+                {
+                  "baseurl": "http://download-ipv4.eng.brq.redhat.com/rhel-8/nightly/RHEL-8/RHEL-8.2.0-20191213.n.1/compose/BaseOS/x86_64/os",
+                  "checksum": "sha256:3ce6f4ffa7d05b81fec2ba5a1c4917b351231c3433f2f5eed86ed5f8f97168a1"
+                },
+                {
+                  "baseurl": "http://download-ipv4.eng.brq.redhat.com/rhel-8/nightly/RHEL-8/RHEL-8.2.0-20191213.n.1/compose/AppStream/x86_64/os",
+                  "checksum": "sha256:662e1dc0e465dd5e8efec9f42ef24ac9fd8418294254c3c98ea0342d6e903aed"
+                }
+              ],
+              "packages": [
+                "dnf",
+                "dracut-config-generic",
+                "e2fsprogs",
+                "glibc",
+                "grub2-pc",
+                "policycoreutils",
+                "python36",
+                "qemu-img",
+                "systemd",
+                "tar",
+                "xfsprogs"
+              ],
+              "releasever": "8",
+              "basearch": "x86_64",
+              "module_platform_id": "platform:el8"
+            }
+          }
+        ]
+      },
+      "runner": "org.osbuild.rhel82"
+    },
+    "stages": [
+      {
+        "name": "org.osbuild.dnf",
+        "options": {
+          "repos": [
+            {
+              "baseurl": "http://download-ipv4.eng.brq.redhat.com/rhel-8/nightly/RHEL-8/RHEL-8.2.0-20191213.n.1/compose/BaseOS/x86_64/os",
+              "checksum": "sha256:3ce6f4ffa7d05b81fec2ba5a1c4917b351231c3433f2f5eed86ed5f8f97168a1"
+            },
+            {
+              "baseurl": "http://download-ipv4.eng.brq.redhat.com/rhel-8/nightly/RHEL-8/RHEL-8.2.0-20191213.n.1/compose/AppStream/x86_64/os",
+              "checksum": "sha256:662e1dc0e465dd5e8efec9f42ef24ac9fd8418294254c3c98ea0342d6e903aed"
+            }
+          ],
+          "packages": [
+            "kernel-core",
+            "chrony",
+            "dracut-config-generic",
+            "polkit",
+            "systemd-udev",
+            "selinux-policy-targeted",
+            "grub2-pc",
+            "langpacks-en"
+          ],
+          "exclude_packages": [
+            "dracut-config-rescue",
+            "etables",
+            "firewalld",
+            "gobject-introspection",
+            "plymouth",
+            "timedatex"
+          ],
+          "releasever": "8",
+          "basearch": "x86_64",
+          "module_platform_id": "platform:el8"
+        }
+      },
+      {
+        "name": "org.osbuild.fix-bls",
+        "options": {}
+      },
+      {
+        "name": "org.osbuild.fstab",
+        "options": {
+          "filesystems": [
+            {
+              "uuid": "0bd700f8-090f-4556-b797-b340297ea1bd",
+              "vfs_type": "xfs",
+              "path": "/",
+              "options": "defaults"
+            }
+          ]
+        }
+      },
+      {
+        "name": "org.osbuild.grub2",
+        "options": {
+          "root_fs_uuid": "0bd700f8-090f-4556-b797-b340297ea1bd",
+          "boot_fs_uuid": "00000000-0000-0000-0000-000000000000",
+          "kernel_opts": "ro net.ifnames=0"
+        }
+      },
+      {
+        "name": "org.osbuild.locale",
+        "options": {
+          "language": "en_US"
+        }
+      },
+      {
+        "name": "org.osbuild.selinux",
+        "options": {
+          "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
+        }
+      }
+    ],
+    "assembler": {
+      "name": "org.osbuild.qemu",
+      "options": {
+        "format": "qcow2",
+        "filename": "disk.qcow2",
+        "ptuuid": "0x14fc63d2",
+        "root_fs_uuid": "0bd700f8-090f-4556-b797-b340297ea1bd",
+        "root_fs_type": "xfs",
+        "size": 3221225472
+      }
+    }
+  }
+}

--- a/test/cases/rhel82_tar.json
+++ b/test/cases/rhel82_tar.json
@@ -1,0 +1,136 @@
+{
+  "compose": {
+    "output-format": "tar",
+    "distro": "rhel-8.2",
+    "arch": "x86_64",
+    "checksums": {
+      "baseos": "sha256:3ce6f4ffa7d05b81fec2ba5a1c4917b351231c3433f2f5eed86ed5f8f97168a1",
+      "appstream": "sha256:662e1dc0e465dd5e8efec9f42ef24ac9fd8418294254c3c98ea0342d6e903aed"
+    },
+    "filename": "root.tar.xz",
+    "blueprint": {
+      "customizations": {
+        "user": [
+          {
+            "name": "redhat",
+            "key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC61wMCjOSHwbVb4VfVyl5sn497qW4PsdQ7Ty7aD6wDNZ/QjjULkDV/yW5WjDlDQ7UqFH0Sr7vywjqDizUAqK7zM5FsUKsUXWHWwg/ehKg8j9xKcMv11AkFoUoujtfAujnKODkk58XSA9whPr7qcw3vPrmog680pnMSzf9LC7J6kXfs6lkoKfBh9VnlxusCrw2yg0qI1fHAZBLPx7mW6+me71QZsS6sVz8v8KXyrXsKTdnF50FjzHcK9HXDBtSJS5wA3fkcRYymJe0o6WMWNdgSRVpoSiWaHHmFgdMUJaYoCfhXzyl7LtNb3Q+Sveg+tJK7JaRXBLMUllOlJ6ll5Hod"
+          }
+        ]
+      }
+    }
+  },
+  "pipeline": {
+    "build": {
+      "pipeline": {
+        "stages": [
+          {
+            "name": "org.osbuild.dnf",
+            "options": {
+              "repos": [
+                {
+                  "baseurl": "http://download-ipv4.eng.brq.redhat.com/rhel-8/nightly/RHEL-8/RHEL-8.2.0-20191213.n.1/compose/BaseOS/x86_64/os",
+                  "checksum": "sha256:3ce6f4ffa7d05b81fec2ba5a1c4917b351231c3433f2f5eed86ed5f8f97168a1"
+                },
+                {
+                  "baseurl": "http://download-ipv4.eng.brq.redhat.com/rhel-8/nightly/RHEL-8/RHEL-8.2.0-20191213.n.1/compose/AppStream/x86_64/os",
+                  "checksum": "sha256:662e1dc0e465dd5e8efec9f42ef24ac9fd8418294254c3c98ea0342d6e903aed"
+                }
+              ],
+              "packages": [
+                "dnf",
+                "dracut-config-generic",
+                "e2fsprogs",
+                "glibc",
+                "grub2-pc",
+                "policycoreutils",
+                "python36",
+                "qemu-img",
+                "systemd",
+                "tar",
+                "xfsprogs"
+              ],
+              "releasever": "8",
+              "basearch": "x86_64",
+              "module_platform_id": "platform:el8"
+            }
+          }
+        ]
+      },
+      "runner": "org.osbuild.rhel82"
+    },
+    "stages": [
+      {
+        "name": "org.osbuild.dnf",
+        "options": {
+          "repos": [
+            {
+              "baseurl": "http://download-ipv4.eng.brq.redhat.com/rhel-8/nightly/RHEL-8/RHEL-8.2.0-20191213.n.1/compose/BaseOS/x86_64/os",
+              "checksum": "sha256:3ce6f4ffa7d05b81fec2ba5a1c4917b351231c3433f2f5eed86ed5f8f97168a1"
+            },
+            {
+              "baseurl": "http://download-ipv4.eng.brq.redhat.com/rhel-8/nightly/RHEL-8/RHEL-8.2.0-20191213.n.1/compose/AppStream/x86_64/os",
+              "checksum": "sha256:662e1dc0e465dd5e8efec9f42ef24ac9fd8418294254c3c98ea0342d6e903aed"
+            }
+          ],
+          "packages": [
+            "policycoreutils",
+            "selinux-policy-targeted",
+            "kernel",
+            "firewalld",
+            "chrony",
+            "dracut-config-generic",
+            "langpacks-en"
+          ],
+          "exclude_packages": [
+            "dracut-config-rescue",
+            "timedatex"
+          ],
+          "releasever": "8",
+          "basearch": "x86_64",
+          "module_platform_id": "platform:el8"
+        }
+      },
+      {
+        "name": "org.osbuild.fix-bls",
+        "options": {}
+      },
+      {
+        "name": "org.osbuild.grub2",
+        "options": {
+          "root_fs_uuid": "0bd700f8-090f-4556-b797-b340297ea1bd",
+          "boot_fs_uuid": "00000000-0000-0000-0000-000000000000",
+          "kernel_opts": "ro net.ifnames=0"
+        }
+      },
+      {
+        "name": "org.osbuild.locale",
+        "options": {
+          "language": "en_US"
+        }
+      },
+      {
+        "name": "org.osbuild.users",
+        "options": {
+          "users": {
+            "redhat": {
+              "key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC61wMCjOSHwbVb4VfVyl5sn497qW4PsdQ7Ty7aD6wDNZ/QjjULkDV/yW5WjDlDQ7UqFH0Sr7vywjqDizUAqK7zM5FsUKsUXWHWwg/ehKg8j9xKcMv11AkFoUoujtfAujnKODkk58XSA9whPr7qcw3vPrmog680pnMSzf9LC7J6kXfs6lkoKfBh9VnlxusCrw2yg0qI1fHAZBLPx7mW6+me71QZsS6sVz8v8KXyrXsKTdnF50FjzHcK9HXDBtSJS5wA3fkcRYymJe0o6WMWNdgSRVpoSiWaHHmFgdMUJaYoCfhXzyl7LtNb3Q+Sveg+tJK7JaRXBLMUllOlJ6ll5Hod"
+            }
+          }
+        }
+      },
+      {
+        "name": "org.osbuild.selinux",
+        "options": {
+          "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
+        }
+      }
+    ],
+    "assembler": {
+      "name": "org.osbuild.tar",
+      "options": {
+        "filename": "root.tar.xz",
+        "compression": "xz"
+      }
+    }
+  }
+}

--- a/test/cases/rhel82_vhd.json
+++ b/test/cases/rhel82_vhd.json
@@ -1,0 +1,153 @@
+{
+  "boot": {
+    "type": "qemu"
+  },
+  "compose": {
+    "distro": "rhel-8.2",
+    "arch": "x86_64",
+    "checksums": {
+      "baseos": "sha256:3ce6f4ffa7d05b81fec2ba5a1c4917b351231c3433f2f5eed86ed5f8f97168a1",
+      "appstream": "sha256:662e1dc0e465dd5e8efec9f42ef24ac9fd8418294254c3c98ea0342d6e903aed"
+    },
+    "filename": "image.vhd",
+    "output-format": "vhd",
+    "blueprint": {}
+  },
+  "pipeline": {
+    "build": {
+      "pipeline": {
+        "stages": [
+          {
+            "name": "org.osbuild.dnf",
+            "options": {
+              "repos": [
+                {
+                  "baseurl": "http://download-ipv4.eng.brq.redhat.com/rhel-8/nightly/RHEL-8/RHEL-8.2.0-20191213.n.1/compose/BaseOS/x86_64/os",
+                  "checksum": "sha256:3ce6f4ffa7d05b81fec2ba5a1c4917b351231c3433f2f5eed86ed5f8f97168a1"
+                },
+                {
+                  "baseurl": "http://download-ipv4.eng.brq.redhat.com/rhel-8/nightly/RHEL-8/RHEL-8.2.0-20191213.n.1/compose/AppStream/x86_64/os",
+                  "checksum": "sha256:662e1dc0e465dd5e8efec9f42ef24ac9fd8418294254c3c98ea0342d6e903aed"
+                }
+              ],
+              "packages": [
+                "dnf",
+                "dracut-config-generic",
+                "e2fsprogs",
+                "glibc",
+                "grub2-pc",
+                "policycoreutils",
+                "python36",
+                "qemu-img",
+                "systemd",
+                "tar",
+                "xfsprogs"
+              ],
+              "releasever": "8",
+              "basearch": "x86_64",
+              "module_platform_id": "platform:el8"
+            }
+          }
+        ]
+      },
+      "runner": "org.osbuild.rhel82"
+    },
+    "stages": [
+      {
+        "name": "org.osbuild.dnf",
+        "options": {
+          "repos": [
+            {
+              "baseurl": "http://download-ipv4.eng.brq.redhat.com/rhel-8/nightly/RHEL-8/RHEL-8.2.0-20191213.n.1/compose/BaseOS/x86_64/os",
+              "checksum": "sha256:3ce6f4ffa7d05b81fec2ba5a1c4917b351231c3433f2f5eed86ed5f8f97168a1"
+            },
+            {
+              "baseurl": "http://download-ipv4.eng.brq.redhat.com/rhel-8/nightly/RHEL-8/RHEL-8.2.0-20191213.n.1/compose/AppStream/x86_64/os",
+              "checksum": "sha256:662e1dc0e465dd5e8efec9f42ef24ac9fd8418294254c3c98ea0342d6e903aed"
+            }
+          ],
+          "packages": [
+            "@Core",
+            "grub2-pc",
+            "langpacks-en",
+            "dracut-config-generic",
+            "kernel",
+            "selinux-policy-targeted",
+            "chrony",
+            "WALinuxAgent",
+            "python3",
+            "net-tools",
+            "cloud-init",
+            "cloud-utils-growpart",
+            "gdisk"
+          ],
+          "exclude_packages": [
+            "dracut-config-rescue",
+            "timedatex"
+          ],
+          "releasever": "8",
+          "basearch": "x86_64",
+          "module_platform_id": "platform:el8"
+        }
+      },
+      {
+        "name": "org.osbuild.fix-bls",
+        "options": {}
+      },
+      {
+        "name": "org.osbuild.fstab",
+        "options": {
+          "filesystems": [
+            {
+              "uuid": "0bd700f8-090f-4556-b797-b340297ea1bd",
+              "vfs_type": "xfs",
+              "path": "/",
+              "options": "defaults"
+            }
+          ]
+        }
+      },
+      {
+        "name": "org.osbuild.grub2",
+        "options": {
+          "root_fs_uuid": "0bd700f8-090f-4556-b797-b340297ea1bd",
+          "boot_fs_uuid": "00000000-0000-0000-0000-000000000000",
+          "kernel_opts": "ro biosdevname=0 rootdelay=300 console=ttyS0 earlyprintk=ttyS0 net.ifnames=0"
+        }
+      },
+      {
+        "name": "org.osbuild.locale",
+        "options": {
+          "language": "en_US"
+        }
+      },
+      {
+        "name": "org.osbuild.systemd",
+        "options": {
+          "enabled_services": [
+            "sshd",
+            "waagent"
+          ],
+          "default_target": "multi-user.target"
+        }
+      },
+      {
+        "name": "org.osbuild.selinux",
+        "options": {
+          "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
+        }
+      }
+    ],
+    "assembler": {
+      "name": "org.osbuild.qemu",
+      "options": {
+        "format": "vpc",
+        "filename": "image.vhd",
+        "ptuuid": "0x14fc63d2",
+        "root_fs_uuid": "0bd700f8-090f-4556-b797-b340297ea1bd",
+        "root_fs_type": "xfs",
+        "size": 3221225472
+      }
+    }
+  }
+}

--- a/test/cases/rhel82_vmdk.json
+++ b/test/cases/rhel82_vmdk.json
@@ -1,0 +1,158 @@
+{
+  "boot": {
+    "type": "qemu"
+  },
+  "compose": {
+    "distro": "rhel-8.2",
+    "arch": "x86_64",
+    "checksums": {
+      "baseos": "sha256:3ce6f4ffa7d05b81fec2ba5a1c4917b351231c3433f2f5eed86ed5f8f97168a1",
+      "appstream": "sha256:662e1dc0e465dd5e8efec9f42ef24ac9fd8418294254c3c98ea0342d6e903aed"
+    },
+    "filename": "disk.vmdk",
+    "output-format": "vmdk",
+    "blueprint": {
+      "customizations": {
+        "user": [
+          {
+            "name": "redhat",
+            "key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC61wMCjOSHwbVb4VfVyl5sn497qW4PsdQ7Ty7aD6wDNZ/QjjULkDV/yW5WjDlDQ7UqFH0Sr7vywjqDizUAqK7zM5FsUKsUXWHWwg/ehKg8j9xKcMv11AkFoUoujtfAujnKODkk58XSA9whPr7qcw3vPrmog680pnMSzf9LC7J6kXfs6lkoKfBh9VnlxusCrw2yg0qI1fHAZBLPx7mW6+me71QZsS6sVz8v8KXyrXsKTdnF50FjzHcK9HXDBtSJS5wA3fkcRYymJe0o6WMWNdgSRVpoSiWaHHmFgdMUJaYoCfhXzyl7LtNb3Q+Sveg+tJK7JaRXBLMUllOlJ6ll5Hod"
+          }
+        ]
+      }
+    }
+  },
+  "pipeline": {
+    "build": {
+      "pipeline": {
+        "stages": [
+          {
+            "name": "org.osbuild.dnf",
+            "options": {
+              "repos": [
+                {
+                  "baseurl": "http://download-ipv4.eng.brq.redhat.com/rhel-8/nightly/RHEL-8/RHEL-8.2.0-20191213.n.1/compose/BaseOS/x86_64/os",
+                  "checksum": "sha256:3ce6f4ffa7d05b81fec2ba5a1c4917b351231c3433f2f5eed86ed5f8f97168a1"
+                },
+                {
+                  "baseurl": "http://download-ipv4.eng.brq.redhat.com/rhel-8/nightly/RHEL-8/RHEL-8.2.0-20191213.n.1/compose/AppStream/x86_64/os",
+                  "checksum": "sha256:662e1dc0e465dd5e8efec9f42ef24ac9fd8418294254c3c98ea0342d6e903aed"
+                }
+              ],
+              "packages": [
+                "dnf",
+                "dracut-config-generic",
+                "e2fsprogs",
+                "glibc",
+                "grub2-pc",
+                "policycoreutils",
+                "python36",
+                "qemu-img",
+                "systemd",
+                "tar",
+                "xfsprogs"
+              ],
+              "releasever": "8",
+              "basearch": "x86_64",
+              "module_platform_id": "platform:el8"
+            }
+          }
+        ]
+      },
+      "runner": "org.osbuild.rhel82"
+    },
+    "stages": [
+      {
+        "name": "org.osbuild.dnf",
+        "options": {
+          "repos": [
+            {
+              "baseurl": "http://download-ipv4.eng.brq.redhat.com/rhel-8/nightly/RHEL-8/RHEL-8.2.0-20191213.n.1/compose/BaseOS/x86_64/os",
+              "checksum": "sha256:3ce6f4ffa7d05b81fec2ba5a1c4917b351231c3433f2f5eed86ed5f8f97168a1"
+            },
+            {
+              "baseurl": "http://download-ipv4.eng.brq.redhat.com/rhel-8/nightly/RHEL-8/RHEL-8.2.0-20191213.n.1/compose/AppStream/x86_64/os",
+              "checksum": "sha256:662e1dc0e465dd5e8efec9f42ef24ac9fd8418294254c3c98ea0342d6e903aed"
+            }
+          ],
+          "packages": [
+            "@core",
+            "chrony",
+            "dracut-config-generic",
+            "firewalld",
+            "grub2-pc",
+            "kernel",
+            "langpacks-en",
+            "open-vm-tools",
+            "selinux-policy-targeted"
+          ],
+          "exclude_packages": [
+            "dracut-config-rescue",
+            "timedatex"
+          ],
+          "releasever": "8",
+          "basearch": "x86_64",
+          "module_platform_id": "platform:el8"
+        }
+      },
+      {
+        "name": "org.osbuild.fix-bls",
+        "options": {}
+      },
+      {
+        "name": "org.osbuild.fstab",
+        "options": {
+          "filesystems": [
+            {
+              "uuid": "0bd700f8-090f-4556-b797-b340297ea1bd",
+              "vfs_type": "xfs",
+              "path": "/",
+              "options": "defaults"
+            }
+          ]
+        }
+      },
+      {
+        "name": "org.osbuild.grub2",
+        "options": {
+          "root_fs_uuid": "0bd700f8-090f-4556-b797-b340297ea1bd",
+          "boot_fs_uuid": "00000000-0000-0000-0000-000000000000",
+          "kernel_opts": "ro net.ifnames=0"
+        }
+      },
+      {
+        "name": "org.osbuild.locale",
+        "options": {
+          "language": "en_US"
+        }
+      },
+      {
+        "name": "org.osbuild.users",
+        "options": {
+          "users": {
+            "redhat": {
+              "key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC61wMCjOSHwbVb4VfVyl5sn497qW4PsdQ7Ty7aD6wDNZ/QjjULkDV/yW5WjDlDQ7UqFH0Sr7vywjqDizUAqK7zM5FsUKsUXWHWwg/ehKg8j9xKcMv11AkFoUoujtfAujnKODkk58XSA9whPr7qcw3vPrmog680pnMSzf9LC7J6kXfs6lkoKfBh9VnlxusCrw2yg0qI1fHAZBLPx7mW6+me71QZsS6sVz8v8KXyrXsKTdnF50FjzHcK9HXDBtSJS5wA3fkcRYymJe0o6WMWNdgSRVpoSiWaHHmFgdMUJaYoCfhXzyl7LtNb3Q+Sveg+tJK7JaRXBLMUllOlJ6ll5Hod"
+            }
+          }
+        }
+      },
+      {
+        "name": "org.osbuild.selinux",
+        "options": {
+          "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
+        }
+      }
+    ],
+    "assembler": {
+      "name": "org.osbuild.qemu",
+      "options": {
+        "format": "vmdk",
+        "filename": "disk.vmdk",
+        "ptuuid": "0x14fc63d2",
+        "root_fs_uuid": "0bd700f8-090f-4556-b797-b340297ea1bd",
+        "root_fs_type": "xfs",
+        "size": 3221225472
+      }
+    }
+  }
+}

--- a/test/run
+++ b/test/run
@@ -160,22 +160,22 @@ def run_ssh_test(private_key):
             output = sp.stdout.decode('utf-8').strip()
             if output == "running":
                 print("ssh test passed")
-                return 0
+                return True
             elif output == "degraded":
                 print("ssh test passed, but the system is degraded")
-                return 0
+                return True
             elif output == "starting":
                 time.sleep(10)
             else:
                 print(f"ssh test failed, system status is: {output}")
-                return 1
+                return False
         except subprocess.TimeoutExpired:
             print("ssh timeout expired")
         except subprocess.CalledProcessError as e:
             time.sleep(10)
 
     print("ssh test failure")
-    return 1
+    return False
 
 
 def run_test(case, private_key, store):
@@ -205,23 +205,19 @@ def run_test(case, private_key, store):
         with netns():
             if case["boot"]["type"] == "qemu":
                 with qemu_boot_image(filename):
-                    if run_ssh_test(private_key) == 1:
-                        failed = True
+                    return run_ssh_test(private_key)
             elif case["boot"]["type"] == "qemu-extract":
                 with qemu_boot_image(filename):
-                    if run_ssh_test(private_key) == 1:
-                        failed = True
+                    return run_ssh_test(private_key)
             elif case["boot"]["type"] == "nspawn":
                 with nspawn_boot_image(filename, output_id):
-                    if run_ssh_test(private_key) == 1:
-                        failed = True
+                    return run_ssh_test(private_key)
             elif case["boot"]["type"] == "nspawn-extract":
                 with nspawn_boot_archive(filename, output_id):
-                    if run_ssh_test(private_key) == 1:
-                        failed = True
+                    return run_ssh_test(private_key)
             else:
                 print("unknown test type")
-                failed = True
+                return False
 
     return True
 

--- a/test/run
+++ b/test/run
@@ -149,7 +149,7 @@ def run_ssh_test(private_key):
            "-i", private_key,
            "-o", "StrictHostKeyChecking=no",
            "redhat@localhost",
-           "systemctl is-system-running --wait"]
+           "systemctl --wait is-system-running"]
     for _ in range(20):
         try:
             print("attempting ssh connection")
@@ -164,6 +164,8 @@ def run_ssh_test(private_key):
             elif output == "degraded":
                 print("ssh test passed, but the system is degraded")
                 return 0
+            elif output == "starting":
+                time.sleep(10)
             else:
                 print(f"ssh test failed, system status is: {output}")
                 return 1


### PR DESCRIPTION
These tests are dependent on access to the RHEL repositories, so can only be triggered manually, rather than as part of CI.