### PR TITLE
blueprints: fix group handling

### DIFF
--- a/internal/blueprint/blueprint.go
+++ b/internal/blueprint/blueprint.go
@@ -42,7 +42,7 @@ func (b *Blueprint) GetPackages() []string {
 		packages = append(packages, pkg.ToNameVersion())
 	}
 	for _, group := range b.Groups {
-		packages = append(packages, group.Name)
+		packages = append(packages, "@"+group.Name)
 	}
 	return packages
 }

--- a/test/cases/groups_blueprint.json
+++ b/test/cases/groups_blueprint.json
@@ -1,0 +1,163 @@
+{
+  "boot": {
+    "type": "nspawn-extract"
+  },
+  "compose": {
+    "output-format": "tar",
+    "distro": "fedora-30",
+    "arch": "x86_64",
+    "filename": "root.tar.xz",
+    "blueprint-draft": {
+      "name": "tar-boot-test",
+      "description": "Image for boot test",
+      "packages": [],
+      "modules": [],
+      "groups": [
+        {
+          "name": "anaconda-tools"
+        }
+      ],
+      "customizations": {
+        "user": [
+          {
+            "name": "redhat",
+            "password": "$y$j9T$hMKTMCO/s27TcOMRH9eUN1$6G0Jrc20QiptW6P3fwm3LKDd/4IIVSr1N2u611UwNgB",
+            "groups": [
+              "wheel"
+            ]
+          }
+        ],
+        "sshkey": [
+          {
+            "user": "redhat",
+            "key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC61wMCjOSHwbVb4VfVyl5sn497qW4PsdQ7Ty7aD6wDNZ/QjjULkDV/yW5WjDlDQ7UqFH0Sr7vywjqDizUAqK7zM5FsUKsUXWHWwg/ehKg8j9xKcMv11AkFoUoujtfAujnKODkk58XSA9whPr7qcw3vPrmog680pnMSzf9LC7J6kXfs6lkoKfBh9VnlxusCrw2yg0qI1fHAZBLPx7mW6+me71QZsS6sVz8v8KXyrXsKTdnF50FjzHcK9HXDBtSJS5wA3fkcRYymJe0o6WMWNdgSRVpoSiWaHHmFgdMUJaYoCfhXzyl7LtNb3Q+Sveg+tJK7JaRXBLMUllOlJ6ll5Hod root@localhost"
+          }
+        ]
+      },
+      "services": {
+        "enabled": [
+          "sshd"
+        ]
+      }
+    }
+  },
+  "pipeline": {
+    "build": {
+      "pipeline": {
+        "stages": [
+          {
+            "name": "org.osbuild.dnf",
+            "options": {
+              "repos": [
+                {
+                  "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-30&arch=x86_64",
+                  "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBFturGcBEACv0xBo91V2n0uEC2vh69ywCiSyvUgN/AQH8EZpCVtM7NyjKgKm\nbbY4G3R0M3ir1xXmvUDvK0493/qOiFrjkplvzXFTGpPTi0ypqGgxc5d0ohRA1M75\nL+0AIlXoOgHQ358/c4uO8X0JAA1NYxCkAW1KSJgFJ3RjukrfqSHWthS1d4o8fhHy\nKJKEnirE5hHqB50dafXrBfgZdaOs3C6ppRIePFe2o4vUEapMTCHFw0woQR8Ah4/R\nn7Z9G9Ln+0Cinmy0nbIDiZJ+pgLAXCOWBfDUzcOjDGKvcpoZharA07c0q1/5ojzO\n4F0Fh4g/BUmtrASwHfcIbjHyCSr1j/3Iz883iy07gJY5Yhiuaqmp0o0f9fgHkG53\n2xCU1owmACqaIBNQMukvXRDtB2GJMuKa/asTZDP6R5re+iXs7+s9ohcRRAKGyAyc\nYKIQKcaA+6M8T7/G+TPHZX6HJWqJJiYB+EC2ERblpvq9TPlLguEWcmvjbVc31nyq\nSDoO3ncFWKFmVsbQPTbP+pKUmlLfJwtb5XqxNR5GEXSwVv4I7IqBmJz1MmRafnBZ\ng0FJUtH668GnldO20XbnSVBr820F5SISMXVwCXDXEvGwwiB8Lt8PvqzXnGIFDAu3\nDlQI5sxSqpPVWSyw08ppKT2Tpmy8adiBotLfaCFl2VTHwOae48X2dMPBvQARAQAB\ntDFGZWRvcmEgKDMwKSA8ZmVkb3JhLTMwLXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQI4BBMBAgAiBQJbbqxnAhsPBgsJCAcDAgYVCAIJCgsEFgIDAQIeAQIXgAAK\nCRDvPBEfz8ZZudTnD/9170LL3nyTVUCFmBjT9wZ4gYnpwtKVPa/pKnxbbS+Bmmac\ng9TrT9pZbqOHrNJLiZ3Zx1Hp+8uxr3Lo6kbYwImLhkOEDrf4aP17HfQ6VYFbQZI8\nf79OFxWJ7si9+3gfzeh9UYFEqOQfzIjLWFyfnas0OnV/P+RMQ1Zr+vPRqO7AR2va\nN9wg+Xl7157dhXPCGYnGMNSoxCbpRs0JNlzvJMuAea5nTTznRaJZtK/xKsqLn51D\nK07k9MHVFXakOH8QtMCUglbwfTfIpO5YRq5imxlWbqsYWVQy1WGJFyW6hWC0+RcJ\nOx5zGtOfi4/dN+xJ+ibnbyvy/il7Qm+vyFhCYqIPyS5m2UVJUuao3eApE38k78/o\n8aQOTnFQZ+U1Sw+6woFTxjqRQBXlQm2+7Bt3bqGATg4sXXWPbmwdL87Ic+mxn/ml\nSMfQux/5k6iAu1kQhwkO2YJn9eII6HIPkW+2m5N1JsUyJQe4cbtZE5Yh3TRA0dm7\n+zoBRfCXkOW4krchbgww/ptVmzMMP7GINJdROrJnsGl5FVeid9qHzV7aZycWSma7\nCxBYB1J8HCbty5NjtD6XMYRrMLxXugvX6Q4NPPH+2NKjzX4SIDejS6JjgrP3KA3O\npMuo7ZHMfveBngv8yP+ZD/1sS6l+dfExvdaJdOdgFCnp4p3gPbw5+Lv70HrMjA==\n=BfZ/\n-----END PGP PUBLIC KEY BLOCK-----\n",
+                  "checksum": "sha256:9f596e18f585bee30ac41c11fb11a83ed6b11d5b341c1cb56ca4015d7717cb97"
+                }
+              ],
+              "packages": [
+                "dnf",
+                "dosfstools",
+                "e2fsprogs",
+                "grub2-pc",
+                "policycoreutils",
+                "qemu-img",
+                "systemd",
+                "tar"
+              ],
+              "releasever": "30",
+              "basearch": "x86_64",
+              "module_platform_id": "platform:f30"
+            }
+          }
+        ]
+      },
+      "runner": "org.osbuild.fedora30"
+    },
+    "stages": [
+      {
+        "name": "org.osbuild.dnf",
+        "options": {
+          "repos": [
+            {
+              "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-30&arch=x86_64",
+              "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBFturGcBEACv0xBo91V2n0uEC2vh69ywCiSyvUgN/AQH8EZpCVtM7NyjKgKm\nbbY4G3R0M3ir1xXmvUDvK0493/qOiFrjkplvzXFTGpPTi0ypqGgxc5d0ohRA1M75\nL+0AIlXoOgHQ358/c4uO8X0JAA1NYxCkAW1KSJgFJ3RjukrfqSHWthS1d4o8fhHy\nKJKEnirE5hHqB50dafXrBfgZdaOs3C6ppRIePFe2o4vUEapMTCHFw0woQR8Ah4/R\nn7Z9G9Ln+0Cinmy0nbIDiZJ+pgLAXCOWBfDUzcOjDGKvcpoZharA07c0q1/5ojzO\n4F0Fh4g/BUmtrASwHfcIbjHyCSr1j/3Iz883iy07gJY5Yhiuaqmp0o0f9fgHkG53\n2xCU1owmACqaIBNQMukvXRDtB2GJMuKa/asTZDP6R5re+iXs7+s9ohcRRAKGyAyc\nYKIQKcaA+6M8T7/G+TPHZX6HJWqJJiYB+EC2ERblpvq9TPlLguEWcmvjbVc31nyq\nSDoO3ncFWKFmVsbQPTbP+pKUmlLfJwtb5XqxNR5GEXSwVv4I7IqBmJz1MmRafnBZ\ng0FJUtH668GnldO20XbnSVBr820F5SISMXVwCXDXEvGwwiB8Lt8PvqzXnGIFDAu3\nDlQI5sxSqpPVWSyw08ppKT2Tpmy8adiBotLfaCFl2VTHwOae48X2dMPBvQARAQAB\ntDFGZWRvcmEgKDMwKSA8ZmVkb3JhLTMwLXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQI4BBMBAgAiBQJbbqxnAhsPBgsJCAcDAgYVCAIJCgsEFgIDAQIeAQIXgAAK\nCRDvPBEfz8ZZudTnD/9170LL3nyTVUCFmBjT9wZ4gYnpwtKVPa/pKnxbbS+Bmmac\ng9TrT9pZbqOHrNJLiZ3Zx1Hp+8uxr3Lo6kbYwImLhkOEDrf4aP17HfQ6VYFbQZI8\nf79OFxWJ7si9+3gfzeh9UYFEqOQfzIjLWFyfnas0OnV/P+RMQ1Zr+vPRqO7AR2va\nN9wg+Xl7157dhXPCGYnGMNSoxCbpRs0JNlzvJMuAea5nTTznRaJZtK/xKsqLn51D\nK07k9MHVFXakOH8QtMCUglbwfTfIpO5YRq5imxlWbqsYWVQy1WGJFyW6hWC0+RcJ\nOx5zGtOfi4/dN+xJ+ibnbyvy/il7Qm+vyFhCYqIPyS5m2UVJUuao3eApE38k78/o\n8aQOTnFQZ+U1Sw+6woFTxjqRQBXlQm2+7Bt3bqGATg4sXXWPbmwdL87Ic+mxn/ml\nSMfQux/5k6iAu1kQhwkO2YJn9eII6HIPkW+2m5N1JsUyJQe4cbtZE5Yh3TRA0dm7\n+zoBRfCXkOW4krchbgww/ptVmzMMP7GINJdROrJnsGl5FVeid9qHzV7aZycWSma7\nCxBYB1J8HCbty5NjtD6XMYRrMLxXugvX6Q4NPPH+2NKjzX4SIDejS6JjgrP3KA3O\npMuo7ZHMfveBngv8yP+ZD/1sS6l+dfExvdaJdOdgFCnp4p3gPbw5+Lv70HrMjA==\n=BfZ/\n-----END PGP PUBLIC KEY BLOCK-----\n",
+              "checksum": "sha256:9f596e18f585bee30ac41c11fb11a83ed6b11d5b341c1cb56ca4015d7717cb97"
+            }
+          ],
+          "packages": [
+            "@anaconda-tools",
+            "chrony",
+            "firewalld",
+            "kernel",
+            "langpacks-en",
+            "openssh-server",
+            "policycoreutils",
+            "selinux-policy-targeted"
+          ],
+          "exclude_packages": [
+            "dracut-config-rescue"
+          ],
+          "releasever": "30",
+          "basearch": "x86_64",
+          "module_platform_id": "platform:f30"
+        }
+      },
+      {
+        "name": "org.osbuild.locale",
+        "options": {
+          "language": "en_US"
+        }
+      },
+      {
+        "name": "org.osbuild.grub2",
+        "options": {
+          "root_fs_uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
+          "kernel_opts": "ro biosdevname=0 net.ifnames=0",
+          "legacy": true
+        }
+      },
+      {
+        "name": "org.osbuild.systemd",
+        "options": {
+          "enabled_services": [
+            "sshd"
+          ],
+          "disabled_services": [
+            "auditd"
+          ]
+        }
+      },
+      {
+        "name": "org.osbuild.users",
+        "options": {
+          "users": {
+            "redhat": {
+              "groups": [
+                "wheel"
+              ],
+              "password": "$6$IR7O7z56ouB/OInP$.hscD6dQqPQGwMuQ.idumixSHI/JEyaUfiCAHVSpGO/iNLEvvVZVOQL23zBzQbc2.yJ25xAZD75H0tXqKJpEE/",
+              "key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC61wMCjOSHwbVb4VfVyl5sn497qW4PsdQ7Ty7aD6wDNZ/QjjULkDV/yW5WjDlDQ7UqFH0Sr7vywjqDizUAqK7zM5FsUKsUXWHWwg/ehKg8j9xKcMv11AkFoUoujtfAujnKODkk58XSA9whPr7qcw3vPrmog680pnMSzf9LC7J6kXfs6lkoKfBh9VnlxusCrw2yg0qI1fHAZBLPx7mW6+me71QZsS6sVz8v8KXyrXsKTdnF50FjzHcK9HXDBtSJS5wA3fkcRYymJe0o6WMWNdgSRVpoSiWaHHmFgdMUJaYoCfhXzyl7LtNb3Q+Sveg+tJK7JaRXBLMUllOlJ6ll5Hod root@localhost"
+            }
+          }
+        }
+      },
+      {
+        "name": "org.osbuild.selinux",
+        "options": {
+          "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
+        }
+      },
+      {
+        "name": "org.osbuild.fix-bls",
+        "options": {}
+      }
+    ],
+    "assembler": {
+      "name": "org.osbuild.tar",
+      "options": {
+        "filename": "root.tar.xz"
+      }
+    }
+  }
+}

--- a/test/cases/rhel82_groups.json
+++ b/test/cases/rhel82_groups.json
@@ -1,0 +1,143 @@
+{
+  "compose": {
+    "output-format": "tar",
+    "distro": "rhel-8.2",
+    "arch": "x86_64",
+    "checksums": {
+      "baseos": "sha256:3ce6f4ffa7d05b81fec2ba5a1c4917b351231c3433f2f5eed86ed5f8f97168a1",
+      "appstream": "sha256:662e1dc0e465dd5e8efec9f42ef24ac9fd8418294254c3c98ea0342d6e903aed"
+    },
+    "filename": "root.tar.xz",
+    "blueprint": {
+      "groups": [
+        {
+          "name": "anaconda-tools"
+        }
+      ],
+      "customizations": {
+        "user": [
+          {
+            "name": "redhat",
+            "key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC61wMCjOSHwbVb4VfVyl5sn497qW4PsdQ7Ty7aD6wDNZ/QjjULkDV/yW5WjDlDQ7UqFH0Sr7vywjqDizUAqK7zM5FsUKsUXWHWwg/ehKg8j9xKcMv11AkFoUoujtfAujnKODkk58XSA9whPr7qcw3vPrmog680pnMSzf9LC7J6kXfs6lkoKfBh9VnlxusCrw2yg0qI1fHAZBLPx7mW6+me71QZsS6sVz8v8KXyrXsKTdnF50FjzHcK9HXDBtSJS5wA3fkcRYymJe0o6WMWNdgSRVpoSiWaHHmFgdMUJaYoCfhXzyl7LtNb3Q+Sveg+tJK7JaRXBLMUllOlJ6ll5Hod"
+          }
+        ]
+      }
+    }
+  },
+  "pipeline": {
+    "build": {
+      "pipeline": {
+        "stages": [
+          {
+            "name": "org.osbuild.dnf",
+            "options": {
+              "repos": [
+                {
+                  "baseurl": "http://download-ipv4.eng.brq.redhat.com/rhel-8/nightly/RHEL-8/RHEL-8.2.0-20191213.n.1/compose/BaseOS/x86_64/os",
+                  "checksum": "sha256:3ce6f4ffa7d05b81fec2ba5a1c4917b351231c3433f2f5eed86ed5f8f97168a1"
+                },
+                {
+                  "baseurl": "http://download-ipv4.eng.brq.redhat.com/rhel-8/nightly/RHEL-8/RHEL-8.2.0-20191213.n.1/compose/AppStream/x86_64/os",
+                  "checksum": "sha256:662e1dc0e465dd5e8efec9f42ef24ac9fd8418294254c3c98ea0342d6e903aed"
+                }
+              ],
+              "packages": [
+                "dnf",
+                "dosfstools",
+                "dracut-config-generic",
+                "e2fsprogs",
+                "glibc",
+                "grub2-pc",
+                "policycoreutils",
+                "python36",
+                "qemu-img",
+                "systemd",
+                "tar",
+                "xfsprogs"
+              ],
+              "releasever": "8",
+              "basearch": "x86_64",
+              "module_platform_id": "platform:el8"
+            }
+          }
+        ]
+      },
+      "runner": "org.osbuild.rhel82"
+    },
+    "stages": [
+      {
+        "name": "org.osbuild.dnf",
+        "options": {
+          "repos": [
+            {
+              "baseurl": "http://download-ipv4.eng.brq.redhat.com/rhel-8/nightly/RHEL-8/RHEL-8.2.0-20191213.n.1/compose/BaseOS/x86_64/os",
+              "checksum": "sha256:3ce6f4ffa7d05b81fec2ba5a1c4917b351231c3433f2f5eed86ed5f8f97168a1"
+            },
+            {
+              "baseurl": "http://download-ipv4.eng.brq.redhat.com/rhel-8/nightly/RHEL-8/RHEL-8.2.0-20191213.n.1/compose/AppStream/x86_64/os",
+              "checksum": "sha256:662e1dc0e465dd5e8efec9f42ef24ac9fd8418294254c3c98ea0342d6e903aed"
+            }
+          ],
+          "packages": [
+            "@anaconda-tools",
+            "chrony",
+            "dracut-config-generic",
+            "firewalld",
+            "kernel",
+            "langpacks-en",
+            "policycoreutils",
+            "selinux-policy-targeted"
+          ],
+          "exclude_packages": [
+            "dracut-config-rescue",
+            "timedatex"
+          ],
+          "releasever": "8",
+          "basearch": "x86_64",
+          "module_platform_id": "platform:el8"
+        }
+      },
+      {
+        "name": "org.osbuild.fix-bls",
+        "options": {}
+      },
+      {
+        "name": "org.osbuild.grub2",
+        "options": {
+          "root_fs_uuid": "0bd700f8-090f-4556-b797-b340297ea1bd",
+          "kernel_opts": "ro net.ifnames=0",
+          "legacy": true
+        }
+      },
+      {
+        "name": "org.osbuild.locale",
+        "options": {
+          "language": "en_US"
+        }
+      },
+      {
+        "name": "org.osbuild.users",
+        "options": {
+          "users": {
+            "redhat": {
+              "key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC61wMCjOSHwbVb4VfVyl5sn497qW4PsdQ7Ty7aD6wDNZ/QjjULkDV/yW5WjDlDQ7UqFH0Sr7vywjqDizUAqK7zM5FsUKsUXWHWwg/ehKg8j9xKcMv11AkFoUoujtfAujnKODkk58XSA9whPr7qcw3vPrmog680pnMSzf9LC7J6kXfs6lkoKfBh9VnlxusCrw2yg0qI1fHAZBLPx7mW6+me71QZsS6sVz8v8KXyrXsKTdnF50FjzHcK9HXDBtSJS5wA3fkcRYymJe0o6WMWNdgSRVpoSiWaHHmFgdMUJaYoCfhXzyl7LtNb3Q+Sveg+tJK7JaRXBLMUllOlJ6ll5Hod"
+            }
+          }
+        }
+      },
+      {
+        "name": "org.osbuild.selinux",
+        "options": {
+          "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
+        }
+      }
+    ],
+    "assembler": {
+      "name": "org.osbuild.tar",
+      "options": {
+        "filename": "root.tar.xz",
+        "compression": "xz"
+      }
+    }
+  }
+}


### PR DESCRIPTION
When group names are passed on to dnf, they must be prefixed with an
ampersand, or they are treated as a regular package, potentially
causing the build to fail.

Add a testcase to verify this behavior.

This resolves rhbz#1784035.

Signed-off-by: Tom Gundersen <teg@jklm.no>