### PR TITLE
packit: fix srpm build

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -29,3 +29,6 @@ jobs:
     trigger: release
     metadata:
       dist-git-branch: f31
+actions:
+  # workaround for https://github.com/packit-service/packit/issues/641
+  fix-spec-file: make fix-spec

--- a/Makefile
+++ b/Makefile
@@ -52,3 +52,8 @@ check-working-directory:
 	  echo "Uncommited changes, refusing (Use git add . && git commit or git stash to clean your working directory)."; \
 	  exit 1; \
 	fi
+
+# workaround for https://github.com/packit-service/packit/issues/641
+fix-spec:
+	sed -i "s/\(Version:\s*\)[0-9]\+/\\1$(PACKIT_PROJECT_VERSION)/" golang-github-osbuild-composer.spec
+	sed -i "s/\(Source0:\s*\).\+/\\1$(PACKIT_PROJECT_ARCHIVE)/" golang-github-osbuild-composer.spec


### PR DESCRIPTION
Prior to this commit packit was building srpm with wrong spec file:
The version field in the spec wasn't updated with version expected
by packit.

This commit introduces a workaround which modifies the spec file using
packit action.

In addition, the following issue was created at packit's upstream:
https://github.com/packit-service/packit/issues/641

After this PR is merged, it's possible to turn on packit for this repository, which should fix issues like this: https://github.com/osbuild/osbuild-composer/pull/177 . Proof that this PR fixes the packit: https://github.com/ondrejbudai/osbuild-composer/pull/3

This PR is draft, I'm waiting for packit upstream, maybe that's not packit fault but an issue in our specfile.