### PR TITLE
weldr/api: add missing compose/cancel route

### DIFF
--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -461,6 +461,24 @@ func (s *Store) PushCompose(composeID uuid.UUID, bp *blueprint.Blueprint, checks
 	return nil
 }
 
+func (s *Store) CancelCompose(id uuid.UUID) error {
+	return s.change(func() error {
+		compose, exists := s.Composes[id]
+
+		if !exists {
+			return &NotFoundError{}
+		}
+
+		if compose.QueueStatus != "WAITING" && compose.QueueStatus != "RUNNING" {
+			return &InvalidRequestError{fmt.Sprintf("Compose %s is not in WAITING or RUNNING.", id)}
+		}
+
+		delete(s.Composes, id)
+
+		return nil
+	})
+}
+
 func (s *Store) DeleteCompose(id uuid.UUID) error {
 	return s.change(func() error {
 		compose, exists := s.Composes[id]


### PR DESCRIPTION
This was accidentally left out. It is the same as the delete route,
except that it works in the WAITING or RUNNING states rather than
FINISHED or FAILED, and it takes a single UUID, rather than a list.

Resolves rhbz#1783991.

Signed-off-by: Tom Gundersen <teg@jklm.no>