### PR TITLE
store: fix compose state handling on restart

### DIFF
--- a/internal/weldr/api_test.go
+++ b/internal/weldr/api_test.go
@@ -345,6 +345,13 @@ func TestCompose(t *testing.T) {
 			break
 		}
 
+		if compose.Pipeline == nil {
+			t.Fatalf("%s: the compose in the store did not contain a blueprint", c.Path)
+		} else {
+			// TODO: find some (reasonable) way to verify the contents of the pipeline
+			compose.Pipeline = nil
+		}
+
 		if diff := cmp.Diff(compose, *c.ExpectedCompose, test.IgnoreDates(), test.IgnoreUuids(), test.Ignore("Targets.Options.Location")); diff != "" {
 			t.Errorf("%s: compose in store isn't the same as expected, diff:\n%s", c.Path, diff)
 		}


### PR DESCRIPTION
When restarting composer, we were not handling the compose states
correctly.

This resolves that as follows:
 * any running composes are marked as failed,
 * any waiting composes are put back in the pending jobs queue

As a consequence of needing the ability to reinitialize the job
queue, we must include the depsolved pipeline in the compose object.
This is the correct thing to do, as the semantics we currently
adhere to is that pipelines are depsolved when the compose is
started (and restarting composer should not affect this by for
instance re-depsolve the pipeline).

Resolves rhbz#1784062.

Signed-off-by: Tom Gundersen <teg@jklm.no>