### PR TITLE
Allow for user defined image size

### DIFF
--- a/cmd/osbuild-pipeline/main.go
+++ b/cmd/osbuild-pipeline/main.go
@@ -58,7 +58,7 @@ func main() {
 		panic(err.Error())
 	}
 
-	pipeline, err := d.Pipeline(blueprint, nil, checksums, archArg, format)
+	pipeline, err := d.Pipeline(blueprint, nil, checksums, archArg, format, 0)
 	if err != nil {
 		panic(err.Error())
 	}

--- a/internal/distro/distro.go
+++ b/internal/distro/distro.go
@@ -34,7 +34,7 @@ type Distro interface {
 	// Returns an osbuild pipeline that generates an image in the given
 	// output format with all packages and customizations specified in the
 	// given blueprint.
-	Pipeline(b *blueprint.Blueprint, additionalRepos []rpmmd.RepoConfig, checksums map[string]string, outputArchitecture, outputFormat string) (*pipeline.Pipeline, error)
+	Pipeline(b *blueprint.Blueprint, additionalRepos []rpmmd.RepoConfig, checksums map[string]string, outputArchitecture, outputFormat string, size uint64) (*pipeline.Pipeline, error)
 
 	// Returns a osbuild runner that can be used on this distro.
 	Runner() string

--- a/internal/distro/distro_test.go
+++ b/internal/distro/distro_test.go
@@ -48,7 +48,7 @@ func TestDistro_Pipeline(t *testing.T) {
 				t.Errorf("unknown distro: %v", tt.Compose.Distro)
 				return
 			}
-			got, err := d.Pipeline(tt.Compose.Blueprint, nil, tt.Compose.Checksums, tt.Compose.Arch, tt.Compose.OutputFormat)
+			got, err := d.Pipeline(tt.Compose.Blueprint, nil, tt.Compose.Checksums, tt.Compose.Arch, tt.Compose.OutputFormat, 0)
 			if (err != nil) != (tt.Pipeline == nil) {
 				t.Errorf("distro.Pipeline() error = %v", err)
 				return

--- a/internal/distro/test/distro.go
+++ b/internal/distro/test/distro.go
@@ -42,7 +42,7 @@ func (d *TestDistro) FilenameFromType(outputFormat string) (string, string, erro
 	}
 }
 
-func (d *TestDistro) Pipeline(b *blueprint.Blueprint, additionalRepos []rpmmd.RepoConfig, checksums map[string]string, outputArch, outputFormat string) (*pipeline.Pipeline, error) {
+func (d *TestDistro) Pipeline(b *blueprint.Blueprint, additionalRepos []rpmmd.RepoConfig, checksums map[string]string, outputArch, outputFormat string, size uint64) (*pipeline.Pipeline, error) {
 	if outputFormat == "test_output" && outputArch == "test_arch" {
 		return &pipeline.Pipeline{}, nil
 	} else {

--- a/internal/jobqueue/api_test.go
+++ b/internal/jobqueue/api_test.go
@@ -45,7 +45,7 @@ func TestCreate(t *testing.T) {
 	store := store.New(nil, distro)
 	api := jobqueue.New(nil, store)
 
-	err := store.PushCompose(id, &blueprint.Blueprint{}, map[string]string{"test-repo": "test:foo"}, "test_arch", "test_output", nil)
+	err := store.PushCompose(id, &blueprint.Blueprint{}, map[string]string{"test-repo": "test:foo"}, "test_arch", "test_output", 0, nil)
 	if err != nil {
 		t.Fatalf("error pushing compose: %v", err)
 	}
@@ -61,7 +61,7 @@ func testUpdateTransition(t *testing.T, from, to string, expectedStatus int) {
 	api := jobqueue.New(nil, store)
 
 	if from != "VOID" {
-		err := store.PushCompose(id, &blueprint.Blueprint{}, map[string]string{"test": "test:foo"}, "test_arch", "test_output", nil)
+		err := store.PushCompose(id, &blueprint.Blueprint{}, map[string]string{"test": "test:foo"}, "test_arch", "test_output", 0, nil)
 		if err != nil {
 			t.Fatalf("error pushing compose: %v", err)
 		}

--- a/internal/pipeline/tar_assembler.go
+++ b/internal/pipeline/tar_assembler.go
@@ -6,6 +6,7 @@ package pipeline
 // compression type, and stores the output with the given filename.
 type TarAssemblerOptions struct {
 	Filename    string `json:"filename"`
+	Size        uint64 `json:"size"`
 	Compression string `json:"compression,omitempty"`
 }
 
@@ -13,9 +14,10 @@ func (TarAssemblerOptions) isAssemblerOptions() {}
 
 // NewTarAssemblerOptions creates a new TarAssemblerOptions object, with the
 // mandatory options set.
-func NewTarAssemblerOptions(filename string) *TarAssemblerOptions {
+func NewTarAssemblerOptions(filename string, size uint64) *TarAssemblerOptions {
 	return &TarAssemblerOptions{
 		Filename: filename,
+		Size:     size,
 	}
 }
 

--- a/internal/rcm/api.go
+++ b/internal/rcm/api.go
@@ -129,7 +129,7 @@ func (api *API) submit(writer http.ResponseWriter, request *http.Request, _ http
 	// Push the requested compose to the store
 	composeUUID := uuid.New()
 	// nil is used as an upload target, because LocalTarget is already used in the PushCompose function
-	err = api.store.PushCompose(composeUUID, &blueprint.Blueprint{}, make(map[string]string), composeRequest.Architectures[0], composeRequest.ImageTypes[0], nil)
+	err = api.store.PushCompose(composeUUID, &blueprint.Blueprint{}, make(map[string]string), composeRequest.Architectures[0], composeRequest.ImageTypes[0], 0, nil)
 	if err != nil {
 		if api.logger != nil {
 			api.logger.Println("RCM API failed to push compose:", err)

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -463,7 +463,7 @@ func (s *Store) PushCompose(composeID uuid.UUID, bp *blueprint.Blueprint, checks
 		repos = append(repos, source.RepoConfig())
 	}
 
-	pipeline, err := s.distro.Pipeline(bp, repos, checksums, arch, composeType)
+	pipeline, err := s.distro.Pipeline(bp, repos, checksums, arch, composeType, 0)
 	if err != nil {
 		return err
 	}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -443,7 +443,7 @@ func (s *Store) GetComposeResult(id uuid.UUID) (io.ReadCloser, error) {
 	return os.Open(*s.stateDir + "/outputs/" + id.String() + "/result.json")
 }
 
-func (s *Store) PushCompose(composeID uuid.UUID, bp *blueprint.Blueprint, checksums map[string]string, arch, composeType string, uploadTarget *target.Target) error {
+func (s *Store) PushCompose(composeID uuid.UUID, bp *blueprint.Blueprint, checksums map[string]string, arch, composeType string, size uint64, uploadTarget *target.Target) error {
 	targets := []*target.Target{}
 
 	if s.stateDir != nil {
@@ -463,7 +463,7 @@ func (s *Store) PushCompose(composeID uuid.UUID, bp *blueprint.Blueprint, checks
 		repos = append(repos, source.RepoConfig())
 	}
 
-	pipeline, err := s.distro.Pipeline(bp, repos, checksums, arch, composeType, 0)
+	pipeline, err := s.distro.Pipeline(bp, repos, checksums, arch, composeType, size)
 	if err != nil {
 		return err
 	}

--- a/internal/weldr/api.go
+++ b/internal/weldr/api.go
@@ -1257,7 +1257,7 @@ func (api *API) composeHandler(writer http.ResponseWriter, request *http.Request
 			return
 		}
 
-		err = api.store.PushCompose(reply.BuildID, bp, checksums, api.arch, cr.ComposeType, uploadTarget)
+		err = api.store.PushCompose(reply.BuildID, bp, checksums, api.arch, cr.ComposeType, 0, uploadTarget)
 
 		// TODO: we should probably do some kind of blueprint validation in future
 		// for now, let's just 500 and bail out

--- a/test/cases/ami_empty_blueprint.json
+++ b/test/cases/ami_empty_blueprint.json
@@ -130,7 +130,7 @@
       "options": {
         "format": "raw.xz",
         "filename": "image.raw.xz",
-        "size": 3222274048,
+        "size": 6442450944,
         "ptuuid": "0x14fc63d2",
         "pttype": "mbr",
         "partitions": [
@@ -599,7 +599,7 @@
         "fstype": "ext4",
         "label": null,
         "partuuid": "14fc63d2-01",
-        "size": 3221225472,
+        "size": 6441402368,
         "start": 1048576,
         "type": "83",
         "uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac"

--- a/test/cases/disk_empty_blueprint.json
+++ b/test/cases/disk_empty_blueprint.json
@@ -115,7 +115,7 @@
       "options": {
         "format": "raw",
         "filename": "disk.img",
-        "size": 3222274048,
+        "size": 2147483648,
         "ptuuid": "0x14fc63d2",
         "pttype": "mbr",
         "partitions": [
@@ -549,7 +549,7 @@
         "fstype": "ext4",
         "label": null,
         "partuuid": "14fc63d2-01",
-        "size": 3221225472,
+        "size": 2146435072,
         "start": 1048576,
         "type": "83",
         "uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac"

--- a/test/cases/disk_local_boot.json
+++ b/test/cases/disk_local_boot.json
@@ -168,7 +168,7 @@
       "options": {
         "format": "raw",
         "filename": "disk.img",
-        "size": 3222274048,
+        "size": 2147483648,
         "ptuuid": "0x14fc63d2",
         "pttype": "mbr",
         "partitions": [

--- a/test/cases/ext4_empty_blueprint.json
+++ b/test/cases/ext4_empty_blueprint.json
@@ -99,7 +99,7 @@
       "options": {
         "filename": "filesystem.img",
         "root_fs_uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
-        "size": 3222274048
+        "size": 2147483648
       }
     }
   },

--- a/test/cases/ext4_local_boot.json
+++ b/test/cases/ext4_local_boot.json
@@ -153,7 +153,7 @@
       "options": {
         "filename": "filesystem.img",
         "root_fs_uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
-        "size": 3222274048
+        "size": 2147483648
       }
     }
   }

--- a/test/cases/openstack_empty_blueprint.json
+++ b/test/cases/openstack_empty_blueprint.json
@@ -119,7 +119,7 @@
       "options": {
         "format": "qcow2",
         "filename": "disk.qcow2",
-        "size": 3222274048,
+        "size": 2147483648,
         "ptuuid": "0x14fc63d2",
         "pttype": "mbr",
         "partitions": [
@@ -605,7 +605,7 @@
         "fstype": "ext4",
         "label": null,
         "partuuid": "14fc63d2-01",
-        "size": 3221225472,
+        "size": 2146435072,
         "start": 1048576,
         "type": "83",
         "uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac"

--- a/test/cases/openstack_local_boot.json
+++ b/test/cases/openstack_local_boot.json
@@ -169,7 +169,7 @@
       "options": {
         "format": "qcow2",
         "filename": "disk.qcow2",
-        "size": 3222274048,
+        "size": 2147483648,
         "ptuuid": "0x14fc63d2",
         "pttype": "mbr",
         "partitions": [

--- a/test/cases/qcow2_empty_blueprint.json
+++ b/test/cases/qcow2_empty_blueprint.json
@@ -120,7 +120,7 @@
       "options": {
         "format": "qcow2",
         "filename": "disk.qcow2",
-        "size": 3222274048,
+        "size": 2147483648,
         "ptuuid": "0x14fc63d2",
         "pttype": "mbr",
         "partitions": [
@@ -581,7 +581,7 @@
         "fstype": "ext4",
         "label": null,
         "partuuid": "14fc63d2-01",
-        "size": 3221225472,
+        "size": 2146435072,
         "start": 1048576,
         "type": "83",
         "uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac"

--- a/test/cases/qcow2_local_boot.json
+++ b/test/cases/qcow2_local_boot.json
@@ -170,7 +170,7 @@
       "options": {
         "format": "qcow2",
         "filename": "disk.qcow2",
-        "size": 3222274048,
+        "size": 2147483648,
         "ptuuid": "0x14fc63d2",
         "pttype": "mbr",
         "partitions": [

--- a/test/cases/rhel82_ext4_filesystem.json
+++ b/test/cases/rhel82_ext4_filesystem.json
@@ -131,7 +131,7 @@
       "options": {
         "filename": "filesystem.img",
         "root_fs_uuid": "0bd700f8-090f-4556-b797-b340297ea1bd",
-        "size": 3221225472,
+        "size": 2147483648,
         "fs_type": "xfs"
       }
     }

--- a/test/cases/rhel82_openstack.json
+++ b/test/cases/rhel82_openstack.json
@@ -129,7 +129,7 @@
       "options": {
         "format": "qcow2",
         "filename": "disk.qcow2",
-        "size": 3221225472,
+        "size": 2147483648,
         "ptuuid": "0x14fc63d2",
         "pttype": "mbr",
         "partitions": [

--- a/test/cases/rhel82_partitioned_disk.json
+++ b/test/cases/rhel82_partitioned_disk.json
@@ -146,7 +146,7 @@
         "format": "raw",
         "filename": "disk.img",
         "ptuuid": "0x14fc63d2",
-        "size": 3221225472,
+        "size": 2147483648,
         "ptuuid": "0x14fc63d2",
         "pttype": "mbr",
         "partitions": [

--- a/test/cases/rhel82_qcow2.json
+++ b/test/cases/rhel82_qcow2.json
@@ -185,7 +185,7 @@
       "options": {
         "format": "qcow2",
         "filename": "disk.qcow2",
-        "size": 3221225472,
+        "size": 2147483648,
         "ptuuid": "0x14fc63d2",
         "pttype": "mbr",
         "partitions": [

--- a/test/cases/rhel82_vhd.json
+++ b/test/cases/rhel82_vhd.json
@@ -144,7 +144,7 @@
       "options": {
         "format": "vpc",
         "filename": "disk.vhd",
-        "size": 3221225472,
+        "size": 2147483648,
         "ptuuid": "0x14fc63d2",
         "pttype": "mbr",
         "partitions": [

--- a/test/cases/rhel82_vmdk.json
+++ b/test/cases/rhel82_vmdk.json
@@ -149,7 +149,7 @@
       "options": {
         "format": "vmdk",
         "filename": "disk.vmdk",
-        "size": 3221225472,
+        "size": 2147483648,
         "ptuuid": "0x14fc63d2",
         "pttype": "mbr",
         "partitions": [

--- a/test/cases/vhd_empty_blueprint.json
+++ b/test/cases/vhd_empty_blueprint.json
@@ -134,7 +134,7 @@
       "options": {
         "format": "vpc",
         "filename": "disk.vhd",
-        "size": 3222274048,
+        "size": 2147483648,
         "ptuuid": "0x14fc63d2",
         "pttype": "mbr",
         "partitions": [
@@ -578,7 +578,7 @@
         "fstype": "ext4",
         "label": null,
         "partuuid": "14fc63d2-01",
-        "size": 3221225472,
+        "size": 2146435072,
         "start": 1048576,
         "type": "83",
         "uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac"

--- a/test/cases/vhd_local_boot.json
+++ b/test/cases/vhd_local_boot.json
@@ -168,7 +168,7 @@
       "options": {
         "format": "qcow2",
         "filename": "disk.vhd",
-        "size": 3222274048,
+        "size": 2147483648,
         "ptuuid": "0x14fc63d2",
         "pttype": "mbr",
         "partitions": [

--- a/test/cases/vmdk_empty_blueprint.json
+++ b/test/cases/vmdk_empty_blueprint.json
@@ -116,7 +116,7 @@
       "options": {
         "format": "vmdk",
         "filename": "disk.vmdk",
-        "size": 3222274048,
+        "size": 2147483648,
         "ptuuid": "0x14fc63d2",
         "pttype": "mbr",
         "partitions": [
@@ -566,7 +566,7 @@
         "fstype": "ext4",
         "label": null,
         "partuuid": "14fc63d2-01",
-        "size": 3221225472,
+        "size": 2146435072,
         "start": 1048576,
         "type": "83",
         "uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac"

--- a/test/cases/vmdk_local_boot.json
+++ b/test/cases/vmdk_local_boot.json
@@ -166,7 +166,7 @@
       "options": {
         "format": "vmdk",
         "filename": "disk.vmdk",
-        "size": 3222274048,
+        "size": 2147483648,
         "ptuuid": "0x14fc63d2",
         "pttype": "mbr",
         "partitions": [


### PR DESCRIPTION
When starting a compose users can pass in an image size. The resulting image will then be of this size. If no image size is passed a default size will be used. 