### PR TITLE
Add tcp and tls support to worker API

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,15 +27,18 @@ install:
 	cp distribution/*.socket /etc/systemd/system/
 	systemctl daemon-reload
 
+.PHONY: tarball
 tarball:
 	git archive --prefix=$(PACKAGE_NAME)-$(VERSION)/ --format=tar.gz HEAD > $(PACKAGE_NAME)-$(VERSION).tar.gz
 
+.PHONY: srpm
 srpm: golang-github-$(PACKAGE_NAME).spec check-working-directory tarball
 	/usr/bin/rpmbuild -bs \
 	  --define "_sourcedir $(CURDIR)" \
 	  --define "_srcrpmdir $(CURDIR)" \
 	  golang-github-$(PACKAGE_NAME).spec
 
+.PHONY: rpm
 rpm: golang-github-$(PACKAGE_NAME).spec check-working-directory tarball 
 	- rm -r "`pwd`/output"
 	mkdir -p "`pwd`/output"
@@ -51,6 +54,7 @@ rpm: golang-github-$(PACKAGE_NAME).spec check-working-directory tarball
 	rm -r "`pwd`/rpmbuild"
 	rm -r "`pwd`/build"
 
+.PHONY: check-working-directory
 check-working-directory:
 	@if [ "`git status --porcelain --untracked-files=no | wc -l`" != "0" ]; then \
 	  echo "Uncommited changes, refusing (Use git add . && git commit or git stash to clean your working directory)."; \

--- a/distribution/osbuild-remote-worker.socket
+++ b/distribution/osbuild-remote-worker.socket
@@ -1,0 +1,9 @@
+[Unit]
+Description=OSBuild Composer API sockets
+
+[Socket]
+Service=osbuild-composer.service
+ListenStream=8700
+
+[Install]
+WantedBy=sockets.target

--- a/distribution/osbuild-remote-worker@.service
+++ b/distribution/osbuild-remote-worker@.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=OSBuild Composer Remote Worker (%i)
+After=multi-user.target
+
+[Service]
+Type=simple
+PrivateTmp=true
+ExecStart=/usr/libexec/osbuild-composer/osbuild-worker --remote %i
+CacheDirectory=osbuild-composer
+Restart=on-failure
+RestartSec=10s
+CPUSchedulingPolicy=batch
+IOSchedulingClass=idle

--- a/distribution/osbuild-worker@.service
+++ b/distribution/osbuild-worker@.service
@@ -6,7 +6,7 @@ After=multi-user.target osbuild-composer.socket
 [Service]
 Type=simple
 PrivateTmp=true
-ExecStart=/usr/libexec/osbuild-composer/osbuild-worker -C /var/lib/osbuild
+ExecStart=/usr/libexec/osbuild-composer/osbuild-worker
 CacheDirectory=osbuild-composer
 Restart=on-failure
 RestartSec=10s

--- a/golang-github-osbuild-composer.spec
+++ b/golang-github-osbuild-composer.spec
@@ -35,6 +35,7 @@ BuildRequires:  golang(github.com/gobwas/glob)
 BuildRequires:  golang(github.com/google/go-cmp/cmp)
 %endif
 
+Requires: golang-github-osbuild-composer-worker
 Requires: systemd
 Requires: osbuild>=7
 
@@ -98,18 +99,19 @@ export GOPATH=$PWD/_build:%{gopath}
 %endif
 
 %post
-%systemd_post osbuild-composer.service osbuild-composer.socket osbuild-worker@.service
+%systemd_post osbuild-composer.service osbuild-composer.socket osbuild-remote-worker.socket
 
 %preun
-%systemd_preun osbuild-composer.service osbuild-composer.socket osbuild-worker@.service
+%systemd_preun osbuild-composer.service osbuild-composer.socket osbuild-remote-worker.socket
 
 %postun
-%systemd_postun_with_restart osbuild-composer.service osbuild-composer.socket osbuild-worker@.service
+%systemd_postun_with_restart osbuild-composer.service osbuild-composer.socket osbuild-remote-worker.socket
 
 %files
 %license LICENSE
 %doc README.md
-%{_libexecdir}/osbuild-composer/
+%{_libexecdir}/osbuild-composer/osbuild-composer
+%{_libexecdir}/osbuild-composer/dnf-json
 %{_datadir}/osbuild-composer/
 %{_unitdir}/*.{service,socket}
 %{_sysusersdir}/osbuild-composer.conf
@@ -126,6 +128,26 @@ Integration tests to be run on a pristine-dedicated system to test the osbuild-c
 %files tests
 %{_libexecdir}/tests/osbuild-composer/osbuild-tests
 %{_libexecdir}/tests/osbuild-composer/osbuild-dnf-json-tests
+
+%package worker
+Summary:	The worker for osbuild-composer
+Requires:   systemd
+Requires:   osbuild
+
+%description worker
+The worker for osbuild-composer
+
+%files worker
+%{_libexecdir}/osbuild-composer/osbuild-worker
+
+%post worker
+%systemd_post osbuild-worker@.service osbuild-remote-worker@.service
+
+%preun worker
+%systemd_preun osbuild-worker@.service osbuild-remote-worker@.service
+
+%postun worker
+%systemd_postun_with_restart osbuild-worker@.service osbuild-remote-worker@.service
 
 %changelog
 * Sun Dec 1 11:00:00 CEST 2019 Ondrej Budai <obudai@redhat.com> - 4-1


### PR DESCRIPTION
Several decision I made which we might discuss:
- configuration is passed in composer and worker as command line arguments. This is the easiest options but there might be some security concerns.
- socket activation is used even with tcp (systemd supports it). I'm not sure if that's what we want.

TODO:
- tests - we need some kind of integration tests for worker/composer.
- disabling local target in the case of a remote worker