### PR TITLE
osbuild-composer: fix number of listeners check

### DIFF
--- a/cmd/osbuild-composer/main.go
+++ b/cmd/osbuild-composer/main.go
@@ -42,7 +42,7 @@ func main() {
 		log.Fatalf("Could not get listening sockets: " + err.Error())
 	}
 
-	if len(listeners) != 2 || len(listeners) != 3 {
+	if len(listeners) != 2 && len(listeners) != 3 {
 		log.Fatalf("Unexpected number of listening sockets (%d), expected 2 or 3", len(listeners))
 	}
 


### PR DESCRIPTION
Osbuild-composer expects two or three listeners and fails if there is an unexpected number of listening sockets. Checking if there are not two or if there are not three listeners always returns true even if there are the desired number of listeners. Therefore, osbuild-composer always crashes. The check now only crashes if there are a number of listeners other than 2 or 3.