### PR TITLE
Change ownership of the output directory immediately

### DIFF
--- a/internal/jobqueue/job.go
+++ b/internal/jobqueue/job.go
@@ -119,6 +119,13 @@ func (job *Job) Run() (*store.Image, error, []error) {
 				continue
 			}
 
+			// Make sure the directory ownership is correct, even if there are errors later
+			err = runCommand("chown", "_osbuild-composer:_osbuild-composer", options.Location)
+			if err != nil {
+				r = append(r, err)
+				continue
+			}
+
 			jobFile, err := os.Create(options.Location + "/result.json")
 			if err != nil {
 				r = append(r, err)


### PR DESCRIPTION
Otherwise if there is an error creating result.json or if the Run
command failed it will remain owned by root.root and cannot be deleted
via the API.

Closes #204