### PR TITLE
Add coveralls.io coverage reports to the unit tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,19 +13,22 @@ matrix:
       language: go
       go: 1.12.x
       env: GO111MODULE=on # needed even for Go 1.12
-      script: go test -v ./...
+      before_install: go get github.com/mattn/goveralls
+      script: $GOPATH/bin/goveralls -show -v -service=travis-ci
     - name: unit-tests
       arch: arm64
       language: go
       go: 1.12.x
       env: GO111MODULE=on # needed even for Go 1.12
-      script: go test -v ./...
+      before_install: go get github.com/mattn/goveralls
+      script: $GOPATH/bin/goveralls -show -v -service=travis-ci
     - name: unit-tests
       arch: s390x
       language: go
       go: 1.12.x
       env: GO111MODULE=on # needed even for Go 1.12
-      script: go test -v ./...
+      before_install: go get github.com/mattn/goveralls
+      script: $GOPATH/bin/goveralls -show -v -service=travis-ci
     - name: image-test-empty-blueprint
       arch: amd64
       language: python


### PR DESCRIPTION
This uses the goveralls project to run the tests and push the results to
coveralls.io