### PR TITLE
distro: use fedora-30 as hostname for all fedora versions

### DIFF
--- a/internal/distro/distro.go
+++ b/internal/distro/distro.go
@@ -82,7 +82,12 @@ func (r *Registry) FromHost() (Distro, error) {
 		return nil, err
 	}
 
-	name := osrelease["ID"] + "-" + osrelease["VERSION_ID"]
+	name := osrelease["ID"]
+	if name == "fedora" {
+		name = name + "-30"
+	} else {
+		name = name + "-" + osrelease["VERSION_ID"]
+	}
 
 	d := r.GetDistro(name)
 	if d == nil {


### PR DESCRIPTION
Osbuild-composer will not run on fedora versions other than fedora 30. For instance, osbuild-composer will get fedora 31's distro name as fedora-31 and will crash because it is an unkown distro. But, fedora 31 is able to build fedora 30 images. So, I changed the FromHost function so all versions of fedora will use the distro name of fedora-30 and osbuild-composer will be able to run on them and build fedora 30 images.