### PR TITLE
osbuild-pipeline: improve CLI interface

### DIFF
--- a/internal/common/types.go
+++ b/internal/common/types.go
@@ -37,6 +37,23 @@ func marshalHelper(input int, mapping map[string]int, errorMessage string) ([]by
 	return nil, &CustomJsonConversionError{fmt.Sprintf("%d %s", input, errorMessage)}
 }
 
+func listHelper(mapping map[string]int) []string {
+	ret := make([]string, 0)
+	for k,_ := range mapping {
+		ret = append(ret, k)
+	}
+	return ret
+}
+
+func existsHelper(mapping map[string]int, testedValue string) bool {
+	for k, _ := range mapping {
+		if k == testedValue {
+			return true
+		}
+	}
+	return false
+}
+
 // Architecture represents one of the supported CPU architectures available for images
 // produced by osbuild-composer. It is represented as an integer because if it
 // was a string it would unmarshal from JSON just fine even in case that the architecture
@@ -70,6 +87,14 @@ func getArchMapping() map[string]int {
 		"s390x":   int(S390x),
 	}
 	return mapping
+}
+
+func ListArchitectures() []string {
+	return listHelper(getArchMapping())
+}
+
+func ArchitectureExists(testedArch string) bool {
+	return existsHelper(getArchMapping(), testedArch)
 }
 
 // UnmarshalJSON is a custom unmarshaling function to limit the set of allowed values
@@ -151,6 +176,15 @@ func getDistributionMapping() map[string]int {
 		"rhel-8.2":  int(RHEL82),
 	}
 	return mapping
+}
+
+
+func ListDistributions() []string {
+	return listHelper(getDistributionMapping())
+}
+
+func DistributionExists(testedDistro string) bool {
+	return existsHelper(getDistributionMapping(), testedDistro)
 }
 
 func (distro Distribution) UnmarshalJSON(data []byte) error {


### PR DESCRIPTION
In the current state, osbuild-pipeline exits with random golang error, such as goroutine failed, which is not at all helpful. This PR introduces CLI arguments validation and helful error messages that use the newly introduced types so that we don't waste time guessing what was the right way to invoke this tool.

note about image types:
Image type validation is not in place because we want to rethink the names and the newly created types are different from what we currently use in `distro` package