### PR TITLE
Switch blueprint commit to use a random SHA-1

### DIFF
--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -28,3 +28,13 @@ func TestBumpVersion(t *testing.T) {
 		}
 	}
 }
+
+func TestRandomSHA1String(t *testing.T) {
+	hash, err := randomSHA1String()
+	if err != nil {
+		t.Fatalf("RandomSHA1String failed: %s", err)
+	}
+	if len(hash) != 40 {
+		t.Fatalf("RandomSHA1String failed: hash is not 40 characters")
+	}
+}


### PR DESCRIPTION
Generating a SHA-1 based on time is not safe. A collision can easily be
generated, and if parallel operations are used they will eventually
collide. This reads random bytes and uses them for the SHA-1 hash. It
will return an error if the rand.Read() fails.