### PR TITLE
Transfer logs from worker to composer using API instead of filesystem

### DIFF
--- a/cmd/osbuild-worker/main.go
+++ b/cmd/osbuild-worker/main.go
@@ -90,17 +90,10 @@ func handleJob(client *ComposerClient) error {
 	}
 
 	fmt.Printf("Running job %s\n", job.ID.String())
-	image, result, err, errs := job.Run()
+	image, result, err := job.Run()
 	if err != nil {
 		log.Printf("  Job failed: %v", err)
 		return client.UpdateJob(job, "FAILED", nil, result)
-	}
-
-	for _, err := range errs {
-		if err != nil {
-			log.Printf("  Job target error: %v", err)
-			return client.UpdateJob(job, "FAILED", nil, result)
-		}
 	}
 
 	return client.UpdateJob(job, "FINISHED", image, result)

--- a/internal/common/compose_result.go
+++ b/internal/common/compose_result.go
@@ -1,4 +1,4 @@
-package weldr
+package common
 
 import (
 	"encoding/json"
@@ -34,7 +34,7 @@ type ComposeResult struct {
 	Success bool `json:"success"`
 }
 
-func (cr *ComposeResult) WriteLog(writer io.Writer) {
+func (cr *ComposeResult) Write(writer io.Writer) {
 	if cr.Build == nil && len(cr.Stages) == 0 && cr.Assembler == nil {
 		fmt.Fprintf(writer, "The compose result is empty.\n")
 	}

--- a/internal/jobqueue/api.go
+++ b/internal/jobqueue/api.go
@@ -93,10 +93,10 @@ func (api *API) addJobHandler(writer http.ResponseWriter, request *http.Request,
 
 	writer.WriteHeader(http.StatusCreated)
 	json.NewEncoder(writer).Encode(Job{
-		ID: nextJob.ComposeID,
-		Distro: nextJob.Distro,
-		Pipeline: nextJob.Pipeline,
-		Targets: nextJob.Targets,
+		ID:         nextJob.ComposeID,
+		Distro:     nextJob.Distro,
+		Pipeline:   nextJob.Pipeline,
+		Targets:    nextJob.Targets,
 		OutputType: nextJob.OutputType,
 	})
 }
@@ -121,7 +121,7 @@ func (api *API) updateJobHandler(writer http.ResponseWriter, request *http.Reque
 		return
 	}
 
-	err = api.store.UpdateCompose(id, body.Status, body.Image)
+	err = api.store.UpdateCompose(id, body.Status, body.Image, body.Result)
 	if err != nil {
 		switch err.(type) {
 		case *store.NotFoundError:

--- a/internal/weldr/api.go
+++ b/internal/weldr/api.go
@@ -22,6 +22,7 @@ import (
 	"github.com/julienschmidt/httprouter"
 
 	"github.com/osbuild/osbuild-composer/internal/blueprint"
+	"github.com/osbuild/osbuild-composer/internal/common"
 	"github.com/osbuild/osbuild-composer/internal/distro"
 	"github.com/osbuild/osbuild-composer/internal/rpmmd"
 	"github.com/osbuild/osbuild-composer/internal/store"
@@ -1249,7 +1250,7 @@ func (api *API) composeHandler(writer http.ResponseWriter, request *http.Request
 	bp := api.store.GetBlueprintCommitted(cr.BlueprintName)
 
 	size := cr.Size
-	
+
 	// Microsoft Azure requires vhd images to be rounded up to the nearest MB
 	if cr.ComposeType == "vhd" && size%MegaByte != 0 {
 		size = (size/MegaByte + 1) * MegaByte
@@ -1603,7 +1604,7 @@ func (api *API) composeLogsHandler(writer http.ResponseWriter, request *http.Req
 		return
 	}
 
-	var result ComposeResult
+	var result common.ComposeResult
 	err = json.NewDecoder(resultReader).Decode(&result)
 	if err != nil {
 		errors := responseError{
@@ -1623,7 +1624,7 @@ func (api *API) composeLogsHandler(writer http.ResponseWriter, request *http.Req
 
 	// tar format needs to contain file size before the actual file content, therefore the intermediate buffer
 	var fileContents bytes.Buffer
-	result.WriteLog(&fileContents)
+	result.Write(&fileContents)
 
 	header := &tar.Header{
 		Name: "logs/osbuild.log",
@@ -1688,7 +1689,7 @@ func (api *API) composeLogHandler(writer http.ResponseWriter, request *http.Requ
 		return
 	}
 
-	var result ComposeResult
+	var result common.ComposeResult
 	err = json.NewDecoder(resultReader).Decode(&result)
 	if err != nil {
 		errors := responseError{
@@ -1701,7 +1702,7 @@ func (api *API) composeLogHandler(writer http.ResponseWriter, request *http.Requ
 
 	resultReader.Close()
 
-	result.WriteLog(writer)
+	result.Write(writer)
 }
 
 func (api *API) composeFinishedHandler(writer http.ResponseWriter, request *http.Request, params httprouter.Params) {


### PR DESCRIPTION
This is needed in order to implement remote workers.