### PR TITLE
api: Add TOML support for workspace POST

### DIFF
--- a/internal/weldr/api.go
+++ b/internal/weldr/api.go
@@ -1126,21 +1126,29 @@ func (api *API) blueprintsWorkspaceHandler(writer http.ResponseWriter, request *
 	}
 
 	contentType := request.Header["Content-Type"]
-	if len(contentType) != 1 || contentType[0] != "application/json" {
+	if len(contentType) == 0 {
 		errors := responseError{
 			ID:  "BlueprintsError",
-			Msg: "'blueprint must be json'",
+			Msg: "missing Content-Type header",
 		}
 		statusResponseError(writer, http.StatusBadRequest, errors)
 		return
 	}
 
 	var blueprint blueprint.Blueprint
-	err := json.NewDecoder(request.Body).Decode(&blueprint)
+	var err error
+	if contentType[0] == "application/json" {
+		err = json.NewDecoder(request.Body).Decode(&blueprint)
+	} else if contentType[0] == "text/x-toml" {
+		_, err = toml.DecodeReader(request.Body, &blueprint)
+	} else {
+		err = errors.New("blueprint must be in json or toml format")
+	}
+
 	if err != nil {
 		errors := responseError{
 			ID:  "BlueprintsError",
-			Msg: "400 Bad Request: The browser (or proxy) sent a request that this server could not understand.",
+			Msg: "400 Bad Request: The browser (or proxy) sent a request that this server could not understand: " + err.Error(),
 		}
 		statusResponseError(writer, http.StatusBadRequest, errors)
 		return
@@ -1249,7 +1257,7 @@ func (api *API) composeHandler(writer http.ResponseWriter, request *http.Request
 	bp := api.store.GetBlueprintCommitted(cr.BlueprintName)
 
 	size := cr.Size
-	
+
 	// Microsoft Azure requires vhd images to be rounded up to the nearest MB
 	if cr.ComposeType == "vhd" && size%MegaByte != 0 {
 		size = (size/MegaByte + 1) * MegaByte

--- a/internal/weldr/api_test.go
+++ b/internal/weldr/api_test.go
@@ -101,7 +101,7 @@ version = "2.4.*"`
 	}
 }
 
-func TestBlueprintsWorkspace(t *testing.T) {
+func TestBlueprintsWorkspaceJSON(t *testing.T) {
 	var cases = []struct {
 		Method         string
 		Path           string
@@ -116,6 +116,29 @@ func TestBlueprintsWorkspace(t *testing.T) {
 		api, _ := createWeldrAPI(rpmmd_mock.BaseFixture)
 		test.SendHTTP(api, true, "POST", "/api/v0/blueprints/new", `{"name":"test","description":"Test","packages":[{"name":"httpd","version":"2.4.*"}],"version":"0.0.0"}`)
 		test.TestRoute(t, api, true, c.Method, c.Path, c.Body, c.ExpectedStatus, c.ExpectedJSON)
+	}
+}
+
+func TestBlueprintsWorkspaceTOML(t *testing.T) {
+	blueprint := `
+name = "test"
+description = "Test"
+version = "0.0.0"
+
+[[packages]]
+name = "httpd"
+version = "2.4.*"`
+
+	req := httptest.NewRequest("POST", "/api/v0/blueprints/workspace", bytes.NewReader([]byte(blueprint)))
+	req.Header.Set("Content-Type", "text/x-toml")
+	recorder := httptest.NewRecorder()
+
+	api, _ := createWeldrAPI(rpmmd_mock.BaseFixture)
+	api.ServeHTTP(recorder, req)
+
+	r := recorder.Result()
+	if r.StatusCode != http.StatusOK {
+		t.Fatalf("unexpected status %v", r.StatusCode)
 	}
 }
 


### PR DESCRIPTION
composer-cli pushes blueprints to the workspace using TOML not JSON.
This also adds a test.