### PR TITLE
api/jobqueue: return 500 error when updating job unexpectedly failed

### DIFF
--- a/internal/jobqueue/api.go
+++ b/internal/jobqueue/api.go
@@ -132,6 +132,8 @@ func (api *API) updateJobHandler(writer http.ResponseWriter, request *http.Reque
 			statusResponseError(writer, http.StatusBadRequest, err.Error())
 		case *store.InvalidRequestError:
 			statusResponseError(writer, http.StatusBadRequest, err.Error())
+		default:
+			statusResponseError(writer, http.StatusInternalServerError, err.Error())
 		}
 		return
 	}


### PR DESCRIPTION
Prior this commit these errors would just disappear.