### PR TITLE
Upload images from worker to compose using jobqueue API

### DIFF
--- a/cmd/osbuild-worker/main.go
+++ b/cmd/osbuild-worker/main.go
@@ -56,8 +56,9 @@ func (c *ComposerClient) AddJob() (*jobqueue.Job, error) {
 
 func (c *ComposerClient) UpdateJob(job *jobqueue.Job, status common.ImageBuildState, result *common.ComposeResult) error {
 	var b bytes.Buffer
-	json.NewEncoder(&b).Encode(&jobqueue.JobStatus{status, job.ImageBuildID, result})
-	req, err := http.NewRequest("PATCH", "http://localhost/job-queue/v1/jobs/"+job.ID.String(), &b)
+	json.NewEncoder(&b).Encode(&jobqueue.JobStatus{status, result})
+	url := fmt.Sprintf("http://localhost/job-queue/v1/jobs/%s/builds/%d", job.ID.String(), job.ImageBuildID)
+	req, err := http.NewRequest("PATCH", url, &b)
 	if err != nil {
 		return err
 	}

--- a/internal/compose/compose.go
+++ b/internal/compose/compose.go
@@ -71,14 +71,14 @@ func (ib *ImageBuild) DeepCopy() ImageBuild {
 	}
 }
 
-func (ib *ImageBuild) GetLocalTarget() *target.LocalTargetOptions {
+func (ib *ImageBuild) HasLocalTarget() bool {
 	for _, t := range ib.Targets {
-		if localTarget, ok := t.Options.(*target.LocalTargetOptions); ok {
-			return localTarget
+		if _, ok := t.Options.(*target.LocalTargetOptions); ok {
+			return true
 		}
 	}
 
-	return nil
+	return false
 }
 
 // A Compose represent the task of building a set of images from a single blueprint.

--- a/internal/compose/compose.go
+++ b/internal/compose/compose.go
@@ -71,6 +71,16 @@ func (ib *ImageBuild) DeepCopy() ImageBuild {
 	}
 }
 
+func (ib *ImageBuild) GetLocalTarget() *target.LocalTargetOptions {
+	for _, t := range ib.Targets {
+		if localTarget, ok := t.Options.(*target.LocalTargetOptions); ok {
+			return localTarget
+		}
+	}
+
+	return nil
+}
+
 // A Compose represent the task of building a set of images from a single blueprint.
 // It contains all the information necessary to generate the inputs for the job, as
 // well as the job's state.

--- a/internal/jobqueue/api.go
+++ b/internal/jobqueue/api.go
@@ -70,6 +70,10 @@ func statusResponseOK(writer http.ResponseWriter) {
 
 func statusResponseError(writer http.ResponseWriter, code int, errors ...string) {
 	writer.WriteHeader(code)
+
+	for _, err := range errors {
+		writer.Write([]byte(err))
+	}
 }
 
 func (api *API) addJobHandler(writer http.ResponseWriter, request *http.Request, _ httprouter.Params) {

--- a/internal/jobqueue/api.go
+++ b/internal/jobqueue/api.go
@@ -94,12 +94,12 @@ func (api *API) addJobHandler(writer http.ResponseWriter, request *http.Request,
 	writer.WriteHeader(http.StatusCreated)
 	// FIXME: handle or comment this possible error
 	_ = json.NewEncoder(writer).Encode(Job{
-		ID: nextJob.ComposeID,
+		ID:           nextJob.ComposeID,
 		ImageBuildID: nextJob.ImageBuildID,
-		Distro: nextJob.Distro,
-		Pipeline: nextJob.Pipeline,
-		Targets: nextJob.Targets,
-		OutputType: nextJob.ImageType,
+		Distro:       nextJob.Distro,
+		Pipeline:     nextJob.Pipeline,
+		Targets:      nextJob.Targets,
+		OutputType:   nextJob.ImageType,
 	})
 }
 
@@ -123,7 +123,7 @@ func (api *API) updateJobHandler(writer http.ResponseWriter, request *http.Reque
 		return
 	}
 
-	err = api.store.UpdateImageBuildInCompose(id, body.ImageBuildID, body.Status, body.Image, body.Result)
+	err = api.store.UpdateImageBuildInCompose(id, body.ImageBuildID, body.Status, body.Result)
 	if err != nil {
 		switch err.(type) {
 		case *store.NotFoundError:

--- a/internal/jobqueue/api_test.go
+++ b/internal/jobqueue/api_test.go
@@ -25,11 +25,11 @@ func TestBasic(t *testing.T) {
 		// Create job with invalid body
 		{"POST", "/job-queue/v1/jobs", ``, http.StatusBadRequest, `invalid request: EOF`},
 		// Update job with invalid ID
-		{"PATCH", "/job-queue/v1/jobs/foo", `{"status":"RUNNING"}`, http.StatusBadRequest, `invalid compose id: invalid UUID length: 3`},
+		{"PATCH", "/job-queue/v1/jobs/foo/builds/0", `{"status":"RUNNING"}`, http.StatusBadRequest, `invalid compose id: invalid UUID length: 3`},
 		// Update job that does not exist, with invalid body
-		{"PATCH", "/job-queue/v1/jobs/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", ``, http.StatusBadRequest, `invalid status: EOF`},
+		{"PATCH", "/job-queue/v1/jobs/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa/builds/0", ``, http.StatusBadRequest, `invalid status: EOF`},
 		// Update job that does not exist
-		{"PATCH", "/job-queue/v1/jobs/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", `{"image_build_id": 0, "status":"RUNNING"}`, http.StatusNotFound, `compose does not exist`},
+		{"PATCH", "/job-queue/v1/jobs/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa/builds/0", `{"status":"RUNNING"}`, http.StatusNotFound, `compose does not exist`},
 	}
 
 	for _, c := range cases {
@@ -72,12 +72,12 @@ func testUpdateTransition(t *testing.T, from, to string, expectedStatus int, exp
 		if from != "WAITING" {
 			test.SendHTTP(api, false, "POST", "/job-queue/v1/jobs", `{}`)
 			if from != "RUNNING" {
-				test.SendHTTP(api, false, "PATCH", "/job-queue/v1/jobs/ffffffff-ffff-ffff-ffff-ffffffffffff", `{"status":"`+from+`"}`)
+				test.SendHTTP(api, false, "PATCH", "/job-queue/v1/jobs/ffffffff-ffff-ffff-ffff-ffffffffffff/builds/0", `{"status":"`+from+`"}`)
 			}
 		}
 	}
 
-	test.TestNonJsonRoute(t, api, false, "PATCH", "/job-queue/v1/jobs/ffffffff-ffff-ffff-ffff-ffffffffffff", `{"status":"`+to+`"}`, expectedStatus, expectedResponse)
+	test.TestNonJsonRoute(t, api, false, "PATCH", "/job-queue/v1/jobs/ffffffff-ffff-ffff-ffff-ffffffffffff/builds/0", `{"status":"`+to+`"}`, expectedStatus, expectedResponse)
 }
 
 func TestUpdate(t *testing.T) {

--- a/internal/jobqueue/job.go
+++ b/internal/jobqueue/job.go
@@ -26,9 +26,8 @@ type Job struct {
 }
 
 type JobStatus struct {
-	Status       common.ImageBuildState `json:"status"`
-	ImageBuildID int                    `json:"image_build_id"`
-	Result       *common.ComposeResult  `json:"result"`
+	Status common.ImageBuildState `json:"status"`
+	Result *common.ComposeResult  `json:"result"`
 }
 
 type TargetsError struct {

--- a/internal/jobqueue/local_target_uploader.go
+++ b/internal/jobqueue/local_target_uploader.go
@@ -1,0 +1,7 @@
+package jobqueue
+
+import "io"
+
+type LocalTargetUploader interface {
+	UploadImage(job *Job, reader io.Reader) error
+}

--- a/internal/mocks/rpmmd/fixtures.go
+++ b/internal/mocks/rpmmd/fixtures.go
@@ -75,9 +75,7 @@ func createBaseStoreFixture() *store.Store {
 		ImageName: "localimage",
 		Created:   date,
 		Status:    common.IBWaiting,
-		Options: &target.LocalTargetOptions{
-			Location: "/tmp/localimage",
-		},
+		Options:   &target.LocalTargetOptions{},
 	}
 
 	var awsTarget = &target.Target{

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -683,7 +683,7 @@ func (s *Store) PopJob() Job {
 }
 
 // UpdateImageBuildInCompose sets the status and optionally also the final image.
-func (s *Store) UpdateImageBuildInCompose(composeID uuid.UUID, imageBuildID int, status common.ImageBuildState, image *compose.Image, result *common.ComposeResult) error {
+func (s *Store) UpdateImageBuildInCompose(composeID uuid.UUID, imageBuildID int, status common.ImageBuildState, result *common.ComposeResult) error {
 	return s.change(func() error {
 		// Check that the compose exists
 		currentCompose, exists := s.Composes[composeID]
@@ -717,9 +717,6 @@ func (s *Store) UpdateImageBuildInCompose(composeID uuid.UUID, imageBuildID int,
 		// In case the image build is done, store the time and possibly also the image
 		if status == common.IBFinished || status == common.IBFailed {
 			currentCompose.ImageBuilds[imageBuildID].JobFinished = time.Now()
-			if status == common.IBFinished {
-				currentCompose.ImageBuilds[imageBuildID].Image = image
-			}
 		}
 
 		s.Composes[composeID] = currentCompose

--- a/internal/target/local_target.go
+++ b/internal/target/local_target.go
@@ -1,7 +1,6 @@
 package target
 
 type LocalTargetOptions struct {
-	Location string `json:"location"`
 }
 
 func (LocalTargetOptions) isTargetOptions() {}

--- a/internal/weldr/api.go
+++ b/internal/weldr/api.go
@@ -1522,9 +1522,7 @@ func (api *API) composeInfoHandler(writer http.ResponseWriter, request *http.Req
 	// 1st build is considered
 	reply.ComposeType, _ = compose.ImageBuilds[0].ImageType.ToCompatString()
 	reply.QueueStatus = compose.GetState().ToString()
-	if compose.ImageBuilds[0].Image != nil {
-		reply.ImageSize = compose.ImageBuilds[0].Size
-	}
+	reply.ImageSize = compose.ImageBuilds[0].Size
 
 	if isRequestVersionAtLeast(params, 1) {
 		reply.Uploads = TargetsToUploadResponses(compose.ImageBuilds[0].Targets)

--- a/internal/weldr/api.go
+++ b/internal/weldr/api.go
@@ -1652,7 +1652,7 @@ func (api *API) composeLogsHandler(writer http.ResponseWriter, request *http.Req
 		return
 	}
 
-	resultReader, err := api.store.GetComposeResult(id)
+	resultReader, err := api.store.GetImageBuildResult(id, 0)
 
 	if err != nil {
 		errors := responseError{
@@ -1737,7 +1737,7 @@ func (api *API) composeLogHandler(writer http.ResponseWriter, request *http.Requ
 		return
 	}
 
-	resultReader, err := api.store.GetComposeResult(id)
+	resultReader, err := api.store.GetImageBuildResult(id, 0)
 
 	if err != nil {
 		errors := responseError{

--- a/internal/weldr/compose.go
+++ b/internal/weldr/compose.go
@@ -4,7 +4,6 @@ import (
 	"github.com/google/uuid"
 	"github.com/osbuild/osbuild-composer/internal/common"
 	"github.com/osbuild/osbuild-composer/internal/compose"
-	"log"
 	"sort"
 )
 
@@ -13,7 +12,7 @@ type ComposeEntry struct {
 	Blueprint   string                 `json:"blueprint"`
 	Version     string                 `json:"version"`
 	ComposeType common.ImageType       `json:"compose_type"`
-	ImageSize   uint64                 `json:"image_size"`
+	ImageSize   uint64                 `json:"image_size"` // This is user-provided image size, not actual file size
 	QueueStatus common.ImageBuildState `json:"queue_status"`
 	JobCreated  float64                `json:"job_created"`
 	JobStarted  float64                `json:"job_started,omitempty"`
@@ -43,13 +42,7 @@ func composeToComposeEntry(id uuid.UUID, compose compose.Compose, includeUploads
 		composeEntry.JobStarted = float64(compose.ImageBuilds[0].JobStarted.UnixNano()) / 1000000000
 
 	case common.IBFinished:
-		if compose.ImageBuilds[0].Image != nil {
-			composeEntry.ImageSize = compose.ImageBuilds[0].Size
-		} else {
-			log.Printf("finished compose with id %s has nil image\n", id.String())
-			composeEntry.ImageSize = 0
-		}
-
+		composeEntry.ImageSize = compose.ImageBuilds[0].Size
 		composeEntry.JobCreated = float64(compose.ImageBuilds[0].JobCreated.UnixNano()) / 1000000000
 		composeEntry.JobStarted = float64(compose.ImageBuilds[0].JobStarted.UnixNano()) / 1000000000
 		composeEntry.JobFinished = float64(compose.ImageBuilds[0].JobFinished.UnixNano()) / 1000000000


### PR DESCRIPTION
This PR grew bigger than I originally though but honestly, **I love it**. Things changed:

1) Images from worker to composer are now transported using jobqueue API. This enables us to implement remote workers (should be just fairly simple rebase of my existing PR).
2) `LocalTarget.Location` field is no more. The store is now responsible for managing all the build artifacts and keeping track of their locations. The LocalTarget's now only denoting if there's an image for an image build.
3) `Compose.Image` is no more. We can calculate its values when they are needed, no need to store them redundantly.
4) osbuild results and images are now stored per image build instead of per compose. This was TODO from #221 and it made sense to me to implement it in this PR.