### PR TITLE
jobqueue: remove unused compose import

### DIFF
--- a/internal/jobqueue/job.go
+++ b/internal/jobqueue/job.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"os/exec"
 
-	"github.com/osbuild/osbuild-composer/internal/compose"
 	"github.com/osbuild/osbuild-composer/internal/osbuild"
 
 	"github.com/google/uuid"


### PR DESCRIPTION
In jobqueue/job internal/compose was imported. This imported is unused and osbuild-composer fails to build. The import is now removed.