### PR TITLE
Fix osbuild-pipeline creating pipelines with an image size of 0

### DIFF
--- a/cmd/osbuild-pipeline/main.go
+++ b/cmd/osbuild-pipeline/main.go
@@ -102,7 +102,8 @@ func main() {
 		panic("Could not depsolve build packages: " + err.Error())
 	}
 
-	pipeline, err := d.Pipeline(blueprint, nil, packageSpecs, buildPackageSpecs, checksums, archArg, imageType, 0)
+	size := d.GetSizeForOutputType(imageType, 0)
+	pipeline, err := d.Pipeline(blueprint, nil, packageSpecs, buildPackageSpecs, checksums, archArg, imageType, size)
 	if err != nil {
 		panic(err.Error())
 	}


### PR DESCRIPTION
When creating a pipeline with the default image size, the size should no longer be set to 0. Instead, the size is fetched using the distro function GetSizeForOutputType which can return the default image size
for a given image type. This size can then be passed into the pipeline.