### PR TITLE
dnf-json: always specify a cache directory

### DIFF
--- a/distribution/osbuild-composer.service
+++ b/distribution/osbuild-composer.service
@@ -7,6 +7,7 @@ Wants=osbuild-worker@1.service
 [Service]
 Type=simple
 ExecStart=/usr/libexec/osbuild-composer/osbuild-composer
+CacheDirectory=osbuild-composer
 StateDirectory=osbuild-composer
 WorkingDirectory=/usr/libexec/osbuild-composer/
 User=_osbuild-composer

--- a/distribution/osbuild-worker@.service
+++ b/distribution/osbuild-worker@.service
@@ -7,7 +7,6 @@ After=multi-user.target osbuild-composer.socket
 Type=simple
 PrivateTmp=true
 ExecStart=/usr/libexec/osbuild-composer/osbuild-worker
-CacheDirectory=osbuild-composer
 Restart=on-failure
 RestartSec=10s
 CPUSchedulingPolicy=batch

--- a/dnf-json
+++ b/dnf-json
@@ -43,8 +43,7 @@ def create_base(repos, module_platform_id, persistdir, cachedir, clean=False):
     base.conf.module_platform_id = module_platform_id
     base.conf.config_file_path = "/dev/null"
     base.conf.persistdir = persistdir
-    if cachedir:
-        base.conf.cachedir = cachedir
+    base.conf.cachedir = cachedir
 
     if clean:
         shutil.rmtree(base.conf.cachedir, ignore_errors=True)
@@ -90,7 +89,7 @@ command = call["command"]
 arguments = call["arguments"]
 repos = arguments.get("repos", {})
 clean = arguments.get("clean", False)
-cachedir = arguments.get("cachedir", None)
+cachedir = arguments["cachedir"]
 module_platform_id = arguments["module_platform_id"]
 
 with tempfile.TemporaryDirectory() as persistdir:

--- a/internal/rpmmd/repository.go
+++ b/internal/rpmmd/repository.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"os"
 	"os/exec"
+	"path"
 	"sort"
 	"time"
 
@@ -216,8 +217,9 @@ func NewRPMMD() RPMMD {
 func (*rpmmdImpl) FetchMetadata(repos []RepoConfig, modulePlatformID string) (PackageList, map[string]string, error) {
 	var arguments = struct {
 		Repos            []RepoConfig `json:"repos"`
+		CacheDir         string       `json:"cachedir"`
 		ModulePlatformID string       `json:"module_platform_id"`
-	}{repos, modulePlatformID}
+	}{repos, path.Join(os.Getenv("CACHE_DIRECTORY"), "rpmmd"), modulePlatformID}
 	var reply struct {
 		Checksums map[string]string `json:"checksums"`
 		Packages  PackageList       `json:"packages"`
@@ -234,9 +236,10 @@ func (*rpmmdImpl) Depsolve(specs, excludeSpecs []string, repos []RepoConfig, mod
 		PackageSpecs     []string     `json:"package-specs"`
 		ExcludSpecs      []string     `json:"exclude-specs"`
 		Repos            []RepoConfig `json:"repos"`
+		CacheDir         string       `json:"cachedir"`
 		ModulePlatformID string       `json:"module_platform_id"`
 		Clean            bool         `json:"clean,omitempty"`
-	}{specs, excludeSpecs, repos, modulePlatformID, clean}
+	}{specs, excludeSpecs, repos, path.Join(os.Getenv("CACHE_DIRECTORY"), "rpmmd"), modulePlatformID, clean}
 	var reply struct {
 		Checksums    map[string]string `json:"checksums"`
 		Dependencies []PackageSpec     `json:"dependencies"`


### PR DESCRIPTION
dnf does not behave well when we don't specify a cache directory. Use /var/cache/osbuild-composer/rpmmd, as we did at one point in the past. Let systemd create the cache directory and set up the right user/group permissions for us.

This should avoid lots of stale cache directories around as reported by @msehnout.

I cherry-picked a patch from #198, to (hopefully) avoid a merge conflict.