### PR TITLE
spec: fix osbuild version dependency

### DIFF
--- a/golang-github-osbuild-composer.spec
+++ b/golang-github-osbuild-composer.spec
@@ -37,7 +37,7 @@ BuildRequires:  golang(github.com/google/go-cmp/cmp)
 
 Requires: golang-github-osbuild-composer-worker
 Requires: systemd
-Requires: osbuild>=7
+Requires: osbuild >= 7
 
 Provides: osbuild-composer
 Provides: lorax-composer


### PR DESCRIPTION
There needs to be a space, otherwise it does not work
```
[root@6440f5c897a2 osbuild-composer]# rpm -q osbuild
osbuild-7-1.fc31.noarch
[root@6440f5c897a2 osbuild-composer]# dnf install output/x86_64/*.rpm
Last metadata expiration check: 2:36:56 ago on Thu Feb 20 11:46:09 2020.
Error:
 Problem 1: conflicting requests
  - nothing provides osbuild>=7 needed by golang-github-osbuild-composer-5-1.fc31.x86_64
 Problem 2: package golang-github-osbuild-composer-tests-5-1.fc31.x86_64 requires osbuild-composer, but none of the providers can be installed
  - conflicting requests
  - nothing provides osbuild>=7 needed by golang-github-osbuild-composer-5-1.fc31.x86_64
(try to add '--skip-broken' to skip uninstallable packages)
```