### PR TITLE
Add a proper development VM setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ __pycache__
 
 /*.tar.gz
 /*.src.rpm
+
+/.vagrant

--- a/Makefile
+++ b/Makefile
@@ -83,3 +83,20 @@ check-working-directory:
 	  echo "Uncommited changes, refusing (Use git add . && git commit or git stash to clean your working directory)."; \
 	  exit 1; \
 	fi
+
+.PHONY: vm-provision
+vm-provision:
+	vagrant destroy -f
+	tools/make-osbuild-rpm
+	vagrant up
+	rm -rf .build
+
+.PHONY: vm-install
+vm-install: rpm
+	vagrant rsync
+	vagrant ssh -c "sudo dnf remove -y golang-github-osbuild-composer*; sudo dnf install -y /vagrant/output/x86_64/*.rpm"
+
+.PHONY: vm-test
+vm-test:
+	vagrant rsync
+	vagrant ssh -c "sudo systemctl start osbuild-composer.socket && sudo /vagrant/tools/run-tests"

--- a/README.md
+++ b/README.md
@@ -60,3 +60,46 @@ Please refer to the [lorax-composer](https://github.com/weldr/lorax)'s documenat
 ## Testing
 
 See [test/README.md](test/README.md)
+
+## Running the development VM
+Unfortunately, you cannot run osbuild-composer in a container due to the fact that osbuild requires /dev to be able to create loop devices. Therefore, we have the following vm setup.
+
+
+### Prerequisites
+You need to have vagrant and rpm build tools installed:
+```
+sudo dnf install -y rpm-build 'dnf-command(builddep)' vagrant
+```
+
+Next, you need to install build dependencies of osbuild and osbuild-composer by running the following command inside the cloned osbuild-composer repository:
+
+```
+wget https://raw.githubusercontent.com/osbuild/osbuild-composer/master/golang-github-osbuild-composer.spec
+sudo dnf builddep -y osbuild.spec golang-github-osbuild-osbuild.composer.spec
+rm osbuild.spec
+```
+
+### Provisioning the VM
+The following command will provision a VM with osbuild and cockpit-composer installed. Cockpit-composer and its dependencies are installed from the repositories, osbuild is installed from rpms built on your local machine from the current master branch.
+```
+make vm-provision
+``` 
+
+*Note: This command will delete any previous vagrant VMs created in this directory.*
+
+### Installing osbuild-composer from source
+The following command will install osbuild-composer from your local git checkout. Firstly, rpms are locally built, then they are rsynced to the VM and finally they're installed in the VM.
+```
+make vm-install
+```
+
+### Running tests inside the VM
+After the VM is provisioned and osbuild-composer is installed, you can run the integration test suite using the following command:
+```
+make vm-test
+```
+### Accessing the VM
+You have two options to access the VM:
+
+1) Using ssh, just run `vagrant ssh`
+2) Using cockpit, go to http://localhost:9091 and log in as admin/foobar 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -25,7 +25,6 @@ Vagrant.configure("2") do |config|
   # :-O what the sed?!
   config.vm.provision "shell", inline: <<-SHELL
     dnf install /vagrant/output/x86_64/*.rpm -y && \
-    sed -i 's|31|30|' /etc/os-release && \
     systemctl start osbuild-composer.socket && \
     pushd /usr/libexec/osbuild-composer && \
     su vagrant -c /usr/libexec/tests/osbuild-composer/osbuild-tests

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,33 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# You can use this file to easily run integration test. In order to run them,
+# build RPM using `make rpm` and then run `vagrant up`. If all went just fine,
+# you can run `vagrant destroy` to clean up the VM.
+#
+# If anything went wrong, you can `vagrant ssh` into the machine and try to
+# tweak the tests by hand there, or you can fix them locally and run `vagrant
+# rsync-auto` to sync new RPMs, then ssh into the machine, 
+# `dnf remove 'golang-github-osbuild-composer-*'`, log out of the machine, and
+# run `vagrant provision` (yes, it was not intended for this use case, but works
+# just fine).
+
+Vagrant.configure("2") do |config|
+  config.vm.box = "fedora/31-cloud-base"
+
+  # This is needed for dnf, without all the RAM OOM killer will kill it during
+  # depsolving :)
+  config.vm.provider :libvirt do |libvirt|
+    libvirt.memory = 4096
+    libvirt.cpus = 2
+  end
+
+  # :-O what the sed?!
+  config.vm.provision "shell", inline: <<-SHELL
+    dnf install /vagrant/output/x86_64/*.rpm -y && \
+    sed -i 's|31|30|' /etc/os-release && \
+    systemctl start osbuild-composer.socket && \
+    pushd /usr/libexec/osbuild-composer && \
+    su vagrant -c /usr/libexec/tests/osbuild-composer/osbuild-tests
+  SHELL
+end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,32 +1,28 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
-# You can use this file to easily run integration test. In order to run them,
-# build RPM using `make rpm` and then run `vagrant up`. If all went just fine,
-# you can run `vagrant destroy` to clean up the VM.
-#
-# If anything went wrong, you can `vagrant ssh` into the machine and try to
-# tweak the tests by hand there, or you can fix them locally and run `vagrant
-# rsync-auto` to sync new RPMs, then ssh into the machine, 
-# `dnf remove 'golang-github-osbuild-composer-*'`, log out of the machine, and
-# run `vagrant provision` (yes, it was not intended for this use case, but works
-# just fine).
-
 Vagrant.configure("2") do |config|
   config.vm.box = "fedora/31-cloud-base"
+  config.vm.network "forwarded_port", guest: 9090, host: 9091
 
   # This is needed for dnf, without all the RAM OOM killer will kill it during
   # depsolving :)
   config.vm.provider :libvirt do |libvirt|
-    libvirt.memory = 4096
+    libvirt.memory = 2048
     libvirt.cpus = 2
   end
 
-  # :-O what the sed?!
   config.vm.provision "shell", inline: <<-SHELL
-    dnf install /vagrant/output/x86_64/*.rpm -y && \
-    systemctl start osbuild-composer.socket && \
-    pushd /usr/libexec/osbuild-composer && \
-    su vagrant -c /usr/libexec/tests/osbuild-composer/osbuild-tests
+    set -e
+
+    # add admin account with foobar password to be able to log in to cockpit
+    # (inspired by cockpit repository)
+    getent passwd admin >/dev/null || useradd -c Administrator -G wheel admin
+    echo foobar | passwd --stdin admin
+
+    dnf upgrade -y
+    dnf install -y cockpit-composer /vagrant/.build/*.rpm
+
+    systemctl enable --now cockpit.socket
   SHELL
 end

--- a/tools/make-osbuild-rpm
+++ b/tools/make-osbuild-rpm
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+set -e
+
+rm -rf .build
+mkdir .build
+
+BUILDDIR=$(mktemp -d -t osbuild-rpm-XXXXXXXXXX)
+
+git clone https://github.com/osbuild/osbuild.git "${BUILDDIR}"
+pushd "$BUILDDIR"
+
+make rpm
+
+popd
+
+cp "${BUILDDIR}"/output/noarch/*.rpm .build
+rm -rf "${BUILDDIR}"

--- a/tools/run-tests
+++ b/tools/run-tests
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+cd /usr/libexec/osbuild-composer/ || exit
+
+results=
+
+for f in /usr/libexec/tests/osbuild-composer/*; do
+  testname="$(basename "$f")"
+  echo Running "$testname"
+  "$f"
+  result=$?
+  if [ $result -eq 0 ]; then
+    results="${results}[SUCCESS] $testname\n"
+  else
+    results="${results}[FAILURE] $testname\n"
+  fi
+done
+
+echo
+echo Test results overview:
+echo -en "$results"


### PR DESCRIPTION
I'm tired of me and other people not knowing how to properly run osbuild-composer when developing it. A lot of people don't like running code-under-development on their local machine especially when parts of it are running with superuser privileges. To solve this issue I took Martin's Vagrant PR (#234) and turned it into a proper development VM setup. I consider this PR as good enough to be merged but it's mostly just MVP - it can be expanded by a lot.

### Quick example
Run:
```
make vm-provision vm-install vm-test
```

This command will provision the VM, build and install osbuild-composer and run all the integration tests.


### How it works
I added three targets to Makefile which enable a user to provision the VM, install osbuild-composer from source to it and finally run the integration tests. I tried to document the process as much as possible in the README.

### Technical details
Osbuild is installed from the upstream master branch. The RPM is built locally using `make rpm`. Osbuild-composer is installed from the HEAD of local checkout. The RPM is also built locally using `make rpm`.

### Notes
- building osbuild and osbuild-composer rpms in koji would be nice. The downside is that is slower and requires additional setup (kerberos login), this might be bad for open source project. There's also an option to build the rpms locally with mock.
- testing multiple fedora versions. Switch to mock/koji to build the rpms is must have here. Also, I'm not sure how to deal with it using Vagrant, we might want to switch to use plain qemu for it.
- testing RHEL. Switch to mock/brew is required. Vagrant boxes might be problem as well, we can use plain qemu here as well.
- testing multiarch. Imho not possible/viable.
- why Vagrant was used if it's not flexible enough to deal with multiple Fedora versions and RHEL?
  Because it makes things easier - by default it can transfer files to the VM using rsync and provides a simple way to log in it using ssh. Also it very easily manages port redirects and state (downloading the box and spinning up the VM). We can switch to something more flexible later but it will require more setup.
- how does this relate to the current CI effort?
The CI effort uses ansible to provision the VM, we can reuse the playbooks with some modifications to provision the development VM. We can also reuse the scripts to build the RPMs. In my opinion this is enough to create environment as close to the "official CI environment" as possible.
- osbuild from master?
As discussed earlier we should stick to some version of osbuild. @teg recently did some work in building osbuild from specific commit. Once the required parts are merged, it should be possible to use it in this PR.
- multi-machine integration tests. These are required for multiarch, which is imho not possible/viable as stated previously. The only other thing that requires multiple machines is the remote worker. This might be tricky but it's definitely doable.