### PR TITLE
rpmmd: fix LoadRepositories in case no valid path is provided

### DIFF
--- a/internal/rpmmd/repository.go
+++ b/internal/rpmmd/repository.go
@@ -136,6 +136,9 @@ func LoadRepositories(confPaths []string, distro string) (map[string][]RepoConfi
 			return nil, err
 		}
 	}
+	if err != nil {
+		return nil, &RepositoryError{"LoadRepositories failed: none of the provided paths contain distro configuration"}
+	}
 	defer f.Close()
 
 	var repos map[string][]RepoConfig


### PR DESCRIPTION
The LoadRepositories function interates over a list of paths and expects
to find a distro configuration in one of them. The case when no path
with valid configuration is found was not handled. This patch introduces
the check.