### PR TITLE
tests: Build all available image types during integration test

### DIFF
--- a/cmd/osbuild-tests/main.go
+++ b/cmd/osbuild-tests/main.go
@@ -60,7 +60,14 @@ func main() {
 	runComposerCLI(false, "status", "show")
 
 	// Full integration tests
+	testCompose("ami")
+	testCompose("ext4-filesystem")
+	testCompose("openstack")
+	testCompose("partitioned-disk")
 	testCompose("qcow2")
+	testCompose("tar")
+	testCompose("vhd")
+	testCompose("vmdk")
 }
 
 func testCompose(outputType string) {


### PR DESCRIPTION
comparing to lorax-composer test suite only ext4-filesystem and partitioned-disk are built without asserting anything other than the build succeeds. For the rest of the images we usually try to
boot them and verify the resulting VM works somehow.

@teg I've tried this locally and it works for me although it makes the entire test suite take longer. Please review.

