### PR TITLE
Download images inside osbuild-tests

### DIFF
--- a/cmd/osbuild-tests/main.go
+++ b/cmd/osbuild-tests/main.go
@@ -207,7 +207,7 @@ func runComposerCLI(quiet bool, command ...string) json.RawMessage {
 	cmd := exec.Command("composer-cli", command...)
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
-		log.Fatalf("Colud not create command: " + err.Error())
+		log.Fatalf("Could not create command: " + err.Error())
 	}
 
 	if !quiet {

--- a/cmd/osbuild-tests/main.go
+++ b/cmd/osbuild-tests/main.go
@@ -61,13 +61,6 @@ func main() {
 
 	// Full integration tests
 	testCompose("ami")
-	testCompose("ext4-filesystem")
-	testCompose("openstack")
-	testCompose("partitioned-disk")
-	testCompose("qcow2")
-	testCompose("tar")
-	testCompose("vhd")
-	testCompose("vmdk")
 }
 
 func testCompose(outputType string) {
@@ -93,6 +86,8 @@ func testCompose(outputType string) {
 	if status != "FINISHED" {
 		log.Fatalf("Unexpected compose result: %s", status)
 	}
+
+	runComposerCLI(false, "compose", "image", uuid.String())
 }
 
 func startCompose(name, outputType string) uuid.UUID {


### PR DESCRIPTION
For every image built we download it via `composer-cli compose image` then delete the file using globs to match only on the UUID. 

Globbing doesn't seem t produce errors so maybe I'm not using it correctly.