### PR TITLE
First part of the porting the current ./test/run test suite to Go

### DIFF
--- a/cmd/osbuild-composer/main.go
+++ b/cmd/osbuild-composer/main.go
@@ -8,8 +8,8 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
-	"runtime"
 
+	"github.com/osbuild/osbuild-composer/internal/common"
 	"github.com/osbuild/osbuild-composer/internal/distro"
 	"github.com/osbuild/osbuild-composer/internal/jobqueue"
 	"github.com/osbuild/osbuild-composer/internal/rpmmd"
@@ -18,20 +18,6 @@ import (
 
 	"github.com/coreos/go-systemd/activation"
 )
-
-func currentArch() string {
-	if runtime.GOARCH == "amd64" {
-		return "x86_64"
-	} else if runtime.GOARCH == "arm64" {
-		return "aarch64"
-	} else if runtime.GOARCH == "ppc64le" {
-		return "ppc64le"
-	} else if runtime.GOARCH == "s390x" {
-		return "s390x"
-	} else {
-		panic("unsupported architecture")
-	}
-}
 
 type connectionConfig struct {
 	CACertFile     string
@@ -103,7 +89,7 @@ func main() {
 	store := store.New(&stateDir, distribution, *distros)
 
 	jobAPI := jobqueue.New(logger, store)
-	weldrAPI := weldr.New(rpm, currentArch(), distribution, logger, store)
+	weldrAPI := weldr.New(rpm, common.CurrentArch(), distribution, logger, store)
 
 	go jobAPI.Serve(jobListener)
 

--- a/cmd/osbuild-image-tests/osbuild-image-tests.go
+++ b/cmd/osbuild-image-tests/osbuild-image-tests.go
@@ -1,0 +1,265 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"github.com/google/go-cmp/cmp"
+	"github.com/osbuild/osbuild-composer/internal/common"
+	"github.com/osbuild/osbuild-composer/internal/distro"
+	"io"
+	"io/ioutil"
+	"log"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+type testcaseStruct struct {
+	Compose struct {
+		Distro   string
+		Arch     string
+		Filename string
+	}
+	Pipeline  json.RawMessage
+	ImageInfo json.RawMessage `json:"image-info"`
+}
+
+// runOsbuild runs osbuild with the specified pipeline and store.
+func runOsbuild(pipeline []byte, store string) (string, error) {
+	cmd := exec.Command(
+		"osbuild",
+		"--store", store,
+		"--json",
+		"-",
+	)
+
+	cmd.Stderr = os.Stderr
+	cmd.Stdin = bytes.NewReader(pipeline)
+	var outBuffer bytes.Buffer
+	cmd.Stdout = &outBuffer
+
+	log.Print("[osbuild] running")
+	err := cmd.Run()
+
+	if err != nil {
+		log.Print("[osbuild] failed")
+		if _, ok := err.(*exec.ExitError); ok {
+			return "", fmt.Errorf("running osbuild failed: %s", outBuffer.String())
+		}
+		return "", fmt.Errorf("running osbuild failed from an unexpected reason: %v", err)
+	}
+
+	log.Print("[osbuild] succeeded")
+
+	var result struct {
+		OutputID string `json:"output_id"`
+	}
+
+	err = json.NewDecoder(&outBuffer).Decode(&result)
+	if err != nil {
+		return "", fmt.Errorf("cannot decode osbuild output: %v", err)
+	}
+
+	return result.OutputID, nil
+}
+
+// extractXZ extracts an xz archive, it's just a simple wrapper around unxz(1).
+func extractXZ(archivePath string) error {
+	cmd := exec.Command("unxz", archivePath)
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("cannot extract xz archive: %v", err)
+	}
+
+	return nil
+}
+
+// splitExtension returns a file extension as the second return value and
+// the rest as the first return value.
+// The functionality should be the same as Python splitext's
+func splitExtension(path string) (string, string) {
+	ex := filepath.Ext(path)
+	base := strings.TrimSuffix(path, ex)
+
+	return base, ex
+}
+
+// testImageInfo runs image-info on image specified by imageImage and
+// compares the result with expected image info
+func testImageInfo(imagePath string, rawImageInfoExpected []byte) error {
+	var imageInfoExpected interface{}
+	err := json.Unmarshal(rawImageInfoExpected, &imageInfoExpected)
+	if err != nil {
+		return fmt.Errorf("cannot decode expected image info: %v", err)
+	}
+
+	cmd := exec.Command("/usr/libexec/osbuild-composer/image-info", imagePath)
+	cmd.Stderr = os.Stderr
+	reader, writer := io.Pipe()
+	cmd.Stdout = writer
+
+	err = cmd.Start()
+	if err != nil {
+		return fmt.Errorf("image-info cannot start: %v", err)
+	}
+
+	var imageInfoGot interface{}
+	err = json.NewDecoder(reader).Decode(&imageInfoGot)
+	if err != nil {
+		return fmt.Errorf("decoding image-info output failed: %v", err)
+	}
+
+	err = cmd.Wait()
+	if err != nil {
+		return fmt.Errorf("running image-info failed: %v", err)
+	}
+
+	if diff := cmp.Diff(imageInfoExpected, imageInfoGot); diff != "" {
+		return fmt.Errorf("image info differs:\n%s", diff)
+	}
+
+	return nil
+}
+
+// testImage performs a series of tests specified in the testcase
+// on an image
+func testImage(testcase testcaseStruct, imagePath string) error {
+	if testcase.ImageInfo != nil {
+		log.Print("[image info sub-test] running")
+		err := testImageInfo(imagePath, testcase.ImageInfo)
+		if err != nil {
+			log.Print("[image info sub-test] failed")
+			return err
+		}
+		log.Print("[image info sub-test] succeeded")
+	} else {
+		log.Print("[image info sub-test] not defined, skipping")
+	}
+
+	return nil
+}
+
+// runTestcase builds the pipeline specified in the testcase and then it
+// tests the result
+func runTestcase(testcase testcaseStruct) error {
+	store, err := ioutil.TempDir("/var/tmp", "osbuild-image-tests-")
+	if err != nil {
+		return fmt.Errorf("cannot create temporary store: %v", err)
+	}
+	defer func() {
+		err := os.RemoveAll(store)
+		if err != nil {
+			log.Printf("cannot remove temporary store: %v\n", err)
+		}
+	}()
+
+	outputID, err := runOsbuild(testcase.Pipeline, store)
+	if err != nil {
+		return err
+	}
+
+	imagePath := fmt.Sprintf("%s/refs/%s/%s", store, outputID, testcase.Compose.Filename)
+
+	// if the result is xz archive, extract it
+	base, ex := splitExtension(imagePath)
+	if ex == ".xz" {
+		if err := extractXZ(imagePath); err != nil {
+			return err
+		}
+		imagePath = base
+	}
+
+	return testImage(testcase, imagePath)
+}
+
+// getAllCases returns paths to all testcases in the testcase directory
+func getAllCases() ([]string, error) {
+	const casesDirectory = "/usr/share/tests/osbuild-composer/cases"
+	cases, err := ioutil.ReadDir(casesDirectory)
+	if err != nil {
+		return nil, fmt.Errorf("cannot list test cases: %v", err)
+	}
+
+	casesPaths := []string{}
+	for _, c := range cases {
+		if c.IsDir() {
+			continue
+		}
+
+		casePath := fmt.Sprintf("%s/%s", casesDirectory, c.Name())
+		casesPaths = append(casesPaths, casePath)
+	}
+
+	return casesPaths, nil
+}
+
+// runTests opens, parses and runs all the specified testcases
+func runTests(cases []string) error {
+	for _, path := range cases {
+		f, err := os.Open(path)
+		if err != nil {
+			return fmt.Errorf("%s: cannot open test case: %v", path, err)
+		}
+
+		var testcase testcaseStruct
+		err = json.NewDecoder(f).Decode(&testcase)
+		if err != nil {
+			return fmt.Errorf("%s: cannot decode test case: %v", path, err)
+		}
+
+		currentArch := common.CurrentArch()
+		if testcase.Compose.Arch != currentArch {
+			log.Printf("%s: skipping, the required arch is %s, the current arch is %s", path, testcase.Compose.Arch, currentArch)
+			continue
+		}
+
+		hostDistroName, err := distro.GetHostDistroName()
+		if err != nil {
+			return fmt.Errorf("cannot get host distro name: %v", err)
+		}
+
+		// TODO: forge distro name for now
+		if strings.HasPrefix(hostDistroName, "fedora") {
+			hostDistroName = "fedora-30"
+		}
+
+		if testcase.Compose.Distro != hostDistroName {
+			log.Printf("%s: skipping, the required distro is %s, the host distro is %s", path, testcase.Compose.Distro, hostDistroName)
+			continue
+		}
+
+		log.Printf("%s: RUNNING", path)
+
+		err = runTestcase(testcase)
+		if err != nil {
+			log.Printf("%s: FAILURE\nReason: %v", path, err)
+		} else {
+			log.Printf("%s: SUCCESS", path)
+		}
+
+	}
+
+	return nil
+}
+
+func main() {
+	flag.Parse()
+	cases := flag.Args()
+
+	// if no cases were specified, run the default set
+	if len(cases) == 0 {
+		var err error
+		cases, err = getAllCases()
+		if err != nil {
+			log.Fatalf("searching for testcases failed: %v", err)
+		}
+	}
+
+	err := runTests(cases)
+
+	if err != nil {
+		log.Fatalf("error occured while running tests: %v", err)
+	}
+}

--- a/golang-github-osbuild-composer.spec
+++ b/golang-github-osbuild-composer.spec
@@ -68,6 +68,7 @@ export GOFLAGS=-mod=vendor
 %gobuild -o _bin/osbuild-worker %{goipath}/cmd/osbuild-worker
 %gobuild -o _bin/osbuild-tests %{goipath}/cmd/osbuild-tests
 %gobuild -o _bin/osbuild-dnf-json-tests %{goipath}/cmd/osbuild-dnf-json-tests
+%gobuild -o _bin/osbuild-image-tests %{goipath}/cmd/osbuild-image-tests
 
 %install
 install -m 0755 -vd                                         %{buildroot}%{_libexecdir}/osbuild-composer
@@ -78,9 +79,14 @@ install -m 0755 -vp dnf-json                                %{buildroot}%{_libex
 install -m 0755 -vd                                         %{buildroot}%{_libexecdir}/tests/osbuild-composer
 install -m 0755 -vp _bin/osbuild-tests                      %{buildroot}%{_libexecdir}/tests/osbuild-composer/
 install -m 0755 -vp _bin/osbuild-dnf-json-tests             %{buildroot}%{_libexecdir}/tests/osbuild-composer/
+install -m 0755 -vp _bin/osbuild-image-tests                %{buildroot}%{_libexecdir}/tests/osbuild-composer/
+install -m 0755 -vp tools/image-info                        %{buildroot}%{_libexecdir}/osbuild-composer/
 
 install -m 0755 -vd                                         %{buildroot}%{_datadir}/osbuild-composer/repositories
 install -m 0644 -vp repositories/*                          %{buildroot}%{_datadir}/osbuild-composer/repositories/
+
+install -m 0755 -vd                                         %{buildroot}%{_datadir}/tests/osbuild-composer/cases
+install -m 0644 -vp test/cases/*                            %{buildroot}%{_datadir}/tests/osbuild-composer/cases/
 
 install -m 0755 -vd                                         %{buildroot}%{_unitdir}
 install -m 0644 -vp distribution/*.{service,socket}         %{buildroot}%{_unitdir}/
@@ -141,8 +147,9 @@ Requires:	createrepo_c
 Integration tests to be run on a pristine-dedicated system to test the osbuild-composer package.
 
 %files tests
-%{_libexecdir}/tests/osbuild-composer/osbuild-tests
-%{_libexecdir}/tests/osbuild-composer/osbuild-dnf-json-tests
+%{_libexecdir}/tests/osbuild-composer/*
+%{_datadir}/tests/osbuild-composer/*
+%{_libexecdir}/osbuild-composer/image-info
 
 %package worker
 Summary:	The worker for osbuild-composer

--- a/internal/common/helpers.go
+++ b/internal/common/helpers.go
@@ -1,0 +1,17 @@
+package common
+
+import "runtime"
+
+func CurrentArch() string {
+	if runtime.GOARCH == "amd64" {
+		return "x86_64"
+	} else if runtime.GOARCH == "arm64" {
+		return "aarch64"
+	} else if runtime.GOARCH == "ppc64le" {
+		return "ppc64le"
+	} else if runtime.GOARCH == "s390x" {
+		return "s390x"
+	} else {
+		panic("unsupported architecture")
+	}
+}

--- a/internal/distro/distro.go
+++ b/internal/distro/distro.go
@@ -126,18 +126,10 @@ func (r *Registry) GetDistro(name string) Distro {
 }
 
 func (r *Registry) FromHost() (Distro, error) {
-	f, err := os.Open("/etc/os-release")
+	name, err := GetHostDistroName()
 	if err != nil {
 		return nil, err
 	}
-	defer f.Close()
-
-	osrelease, err := readOSRelease(f)
-	if err != nil {
-		return nil, err
-	}
-
-	name := osrelease["ID"] + "-" + osrelease["VERSION_ID"]
 
 	d := r.GetDistro(name)
 	if d == nil {
@@ -145,6 +137,21 @@ func (r *Registry) FromHost() (Distro, error) {
 	}
 
 	return d, nil
+}
+
+func GetHostDistroName() (string, error) {
+	f, err := os.Open("/etc/os-release")
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+	osrelease, err := readOSRelease(f)
+	if err != nil {
+		return "", err
+	}
+
+	name := osrelease["ID"] + "-" + osrelease["VERSION_ID"]
+	return name, nil
 }
 
 func readOSRelease(r io.Reader) (map[string]string, error) {


### PR DESCRIPTION
Image info tests are running, therefore I think it's time for reviewing. Please note that this is meant to be a part of the integration test suite (therefore run on a pristine Fedora VM, not on Travis CI).

Changes from the Python version:
1) osbuild is called from `PATH`, not from the submodule.
2) `--arches` argument is gone. Instead only the tests for the current arch are run.
  Go's `flag` package doesn't support arguments with multiple values, therefore I just dropped it for now. We can revisit this later.
3) `--distros` argument is gone. Instead only the tests for the host distro are run.
  The same reason as the previous point, we can also revisit this later.
4) `--cases` argument is now a positional argument. (`osbuild-image-tests CASES... `), when no `CASES` are given, all the tests are run
5) For diffing the actual output from `image-info` and the expected output Go's `cmp` library is now used. I think this approach is much simpler (no need for two temporary files) and I even like its output more.