### PR TITLE
weldr: ensure passing valid `package-specs` to dnf-json

### DIFF
--- a/internal/weldr/api.go
+++ b/internal/weldr/api.go
@@ -1878,7 +1878,7 @@ func (api *API) depsolveBlueprint(bp *blueprint.Blueprint, outputType, arch stri
 	for _, source := range api.store.GetAllSources() {
 		repos = append(repos, source.RepoConfig())
 	}
-	var specs []string
+	var specs []string = []string{}
 	for _, pkg := range bp.Packages {
 		specs = append(specs, getPkgNameGlob(pkg))
 	}


### PR DESCRIPTION
If no packages are included in a blueprint, the slice remains `nil`,
which translates to `null` in json. Always initialize the slice by
pointing it to an empty array.