### PR TITLE
Add a linter to this project

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,32 @@
+name: Lint
+
+# NOTE(mhayden): Restricting branches prevents jobs from being doubled since
+# a push to a pull request triggers two events.
+on:
+  pull_request:
+    branches:
+      - "*"
+  push:
+    branches:
+      - master
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: Set up Go 1.13
+        uses: actions/setup-go@v1
+        with:
+          go-version: 1.13
+        id: go
+
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v1
+
+      - name: Install golangci-lint
+        run: curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b $(go env GOPATH)/bin v1.23.7
+
+      - name: Run golangci-lint
+        run: $(go env GOPATH)/bin/golangci-lint run

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,3 +1,9 @@
+linters-settings:
+  govet:
+    disable:
+      - shadow # default value recommended by golangci
+      - composites
+
 issues:
   # Maximum issues count per one linter. Set to 0 to disable. Default is 50.
   max-issues-per-linter: 0

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,6 @@
+issues:
+  # Maximum issues count per one linter. Set to 0 to disable. Default is 50.
+  max-issues-per-linter: 0
+
+  # Maximum count of issues with the same text. Set to 0 to disable. Default is 3.
+  max-same-issues: 0

--- a/cmd/osbuild-composer/main.go
+++ b/cmd/osbuild-composer/main.go
@@ -91,7 +91,10 @@ func main() {
 	jobAPI := jobqueue.New(logger, store)
 	weldrAPI := weldr.New(rpm, common.CurrentArch(), distribution, logger, store)
 
-	go jobAPI.Serve(jobListener)
+	go func() {
+		err := jobAPI.Serve(jobListener)
+		common.PanicOnError(err)
+	}()
 
 	// Optionally run RCM API as well as Weldr API
 	if rcmApiListeners, exists := listeners["osbuild-rcm.socket"]; exists {
@@ -124,9 +127,16 @@ func main() {
 			}
 
 			listener := tls.NewListener(listener, tlsConfig)
-			go jobAPI.Serve(listener)
+			go func() {
+				err := jobAPI.Serve(listener)
+				common.PanicOnError(err)
+			}()
 		}
 	}
 
-	weldrAPI.Serve(weldrListener)
+	go func() {
+		err := weldrAPI.Serve(weldrListener)
+		common.PanicOnError(err)
+	}()
+
 }

--- a/cmd/osbuild-tests/main.go
+++ b/cmd/osbuild-tests/main.go
@@ -96,7 +96,7 @@ func startCompose(name, outputType string) uuid.UUID {
 	if err != nil {
 		log.Fatalf("Unexpected reply: " + err.Error())
 	}
-	if reply.Status != true {
+	if !reply.Status {
 		log.Fatalf("Unexpected status %v", reply.Status)
 	}
 
@@ -123,7 +123,7 @@ func deleteCompose(id uuid.UUID) {
 	if len(reply.IDs) != 1 {
 		log.Fatalf("Unexpected number of UUIDs returned: %d", len(reply.IDs))
 	}
-	if reply.IDs[0].Status != true {
+	if !reply.IDs[0].Status {
 		log.Fatalf("Unexpected status %v", reply.IDs[0].Status)
 	}
 }
@@ -174,7 +174,7 @@ func pushBlueprint(bp *blueprint.Blueprint) {
 	if err != nil {
 		log.Fatalf("Unexpected reply: " + err.Error())
 	}
-	if reply.Status != true {
+	if !reply.Status {
 		log.Fatalf("Unexpected status %v", reply.Status)
 	}
 }
@@ -188,7 +188,7 @@ func deleteBlueprint(bp *blueprint.Blueprint) {
 	if err != nil {
 		log.Fatalf("Unexpected reply: " + err.Error())
 	}
-	if reply.Status != true {
+	if !reply.Status {
 		log.Fatalf("Unexpected status %v", reply.Status)
 	}
 }

--- a/cmd/osbuild-tests/main.go
+++ b/cmd/osbuild-tests/main.go
@@ -205,7 +205,10 @@ func runComposerCLI(quiet bool, command ...string) json.RawMessage {
 		log.Printf("$ composer-cli %s\n", strings.Join(command, " "))
 	}
 
-	cmd.Start()
+	err = cmd.Start()
+	if err != nil {
+		log.Fatalf("Could not start command: %v", err)
+	}
 
 	var result json.RawMessage
 

--- a/cmd/osbuild-worker/main.go
+++ b/cmd/osbuild-worker/main.go
@@ -100,7 +100,10 @@ func (c *ComposerClient) AddJob() (*jobqueue.Job, error) {
 	}
 
 	var b bytes.Buffer
-	json.NewEncoder(&b).Encode(request{})
+	err := json.NewEncoder(&b).Encode(request{})
+	if err != nil {
+		return nil, err
+	}
 	response, err := c.client.Post(c.createURL("/job-queue/v1/jobs"), "application/json", &b)
 	if err != nil {
 		return nil, err
@@ -124,7 +127,10 @@ func (c *ComposerClient) AddJob() (*jobqueue.Job, error) {
 
 func (c *ComposerClient) UpdateJob(job *jobqueue.Job, status common.ImageBuildState, result *common.ComposeResult) error {
 	var b bytes.Buffer
-	json.NewEncoder(&b).Encode(&jobqueue.JobStatus{status, result})
+	err := json.NewEncoder(&b).Encode(&jobqueue.JobStatus{status, result})
+	if err != nil {
+		return err
+	}
 	urlPath := fmt.Sprintf("/job-queue/v1/jobs/%s/builds/%d", job.ID.String(), job.ImageBuildID)
 	url := c.createURL(urlPath)
 	req, err := http.NewRequest("PATCH", url, &b)

--- a/cmd/osbuild-worker/main.go
+++ b/cmd/osbuild-worker/main.go
@@ -110,7 +110,7 @@ func (c *ComposerClient) AddJob() (*jobqueue.Job, error) {
 	if response.StatusCode != http.StatusCreated {
 		rawR, _ := ioutil.ReadAll(response.Body)
 		r := string(rawR)
-		return nil, errors.New(fmt.Sprintf("couldn't create job, got %d: %s", response.StatusCode, r))
+		return nil, fmt.Errorf("couldn't create job, got %d: %s", response.StatusCode, r)
 	}
 
 	job := &jobqueue.Job{}

--- a/internal/blueprint/blueprint_test.go
+++ b/internal/blueprint/blueprint_test.go
@@ -78,7 +78,10 @@ func TestBumpVersion(t *testing.T) {
 
 	for _, c := range cases {
 		bp := c.NewBlueprint
-		bp.Initialize()
+		err := bp.Initialize()
+		if err != nil {
+			panic(err)
+		}
 
 		bp.BumpVersion(c.OldVersion)
 		if bp.Version != c.ExpectedVersion {

--- a/internal/common/compose_result.go
+++ b/internal/common/compose_result.go
@@ -34,7 +34,7 @@ type ComposeResult struct {
 	Success bool `json:"success"`
 }
 
-func (cr *ComposeResult) Write(writer io.Writer) {
+func (cr *ComposeResult) Write(writer io.Writer) error {
 	if cr.Build == nil && len(cr.Stages) == 0 && cr.Assembler == nil {
 		fmt.Fprintf(writer, "The compose result is empty.\n")
 	}
@@ -46,7 +46,10 @@ func (cr *ComposeResult) Write(writer io.Writer) {
 			fmt.Fprintf(writer, "Stage %s\n", stage.Name)
 			enc := json.NewEncoder(writer)
 			enc.SetIndent("", "  ")
-			enc.Encode(stage.Options)
+			err := enc.Encode(stage.Options)
+			if err != nil {
+				return err
+			}
 			fmt.Fprintf(writer, "\nOutput:\n%s\n", stage.Output)
 		}
 	}
@@ -57,7 +60,10 @@ func (cr *ComposeResult) Write(writer io.Writer) {
 			fmt.Fprintf(writer, "Stage: %s\n", stage.Name)
 			enc := json.NewEncoder(writer)
 			enc.SetIndent("", "  ")
-			enc.Encode(stage.Options)
+			err := enc.Encode(stage.Options)
+			if err != nil {
+				return err
+			}
 			fmt.Fprintf(writer, "\nOutput:\n%s\n", stage.Output)
 		}
 	}
@@ -66,7 +72,12 @@ func (cr *ComposeResult) Write(writer io.Writer) {
 		fmt.Fprintf(writer, "Assembler %s:\n", cr.Assembler.Name)
 		enc := json.NewEncoder(writer)
 		enc.SetIndent("", "  ")
-		enc.Encode(cr.Assembler.Options)
+		err := enc.Encode(cr.Assembler.Options)
+		if err != nil {
+			return err
+		}
 		fmt.Fprintf(writer, "\nOutput:\n%s\n", cr.Assembler.Output)
 	}
+
+	return nil
 }

--- a/internal/common/helpers.go
+++ b/internal/common/helpers.go
@@ -15,3 +15,9 @@ func CurrentArch() string {
 		panic("unsupported architecture")
 	}
 }
+
+func PanicOnError(err error) {
+	if err != nil {
+		panic(err)
+	}
+}

--- a/internal/common/types.go
+++ b/internal/common/types.go
@@ -57,7 +57,7 @@ func marshalHelper(input int, mapping map[string]int, errorMessage string) ([]by
 // See unmarshalHelper for introduction. This helper can create a list of possible values of a single type.
 func listHelper(mapping map[string]int) []string {
 	ret := make([]string, 0)
-	for k, _ := range mapping {
+	for k := range mapping {
 		ret = append(ret, k)
 	}
 	return ret
@@ -65,7 +65,7 @@ func listHelper(mapping map[string]int) []string {
 
 // See unmarshalHelper for introduction. With this helper one can make sure a value exists in a set of existing values.
 func existsHelper(mapping map[string]int, testedValue string) bool {
-	for k, _ := range mapping {
+	for k := range mapping {
 		if k == testedValue {
 			return true
 		}

--- a/internal/jobqueue/api.go
+++ b/internal/jobqueue/api.go
@@ -74,7 +74,10 @@ func statusResponseError(writer http.ResponseWriter, code int, errors ...string)
 	writer.WriteHeader(code)
 
 	for _, err := range errors {
-		writer.Write([]byte(err))
+		_, e := writer.Write([]byte(err))
+		if e != nil {
+			panic(e)
+		}
 	}
 }
 

--- a/internal/jobqueue/job.go
+++ b/internal/jobqueue/job.go
@@ -175,10 +175,3 @@ func (job *Job) Run(uploader LocalTargetUploader) (*common.ComposeResult, error)
 
 	return &result, nil
 }
-
-func runCommand(command string, params ...string) error {
-	cp := exec.Command(command, params...)
-	cp.Stderr = os.Stderr
-	cp.Stdout = os.Stdout
-	return cp.Run()
-}

--- a/internal/osbuild/source_test.go
+++ b/internal/osbuild/source_test.go
@@ -86,7 +86,7 @@ func TestSource_UnmarshalJSON(t *testing.T) {
 			if err != nil {
 				t.Errorf("Could not marshal source: %v", err)
 			}
-			if bytes.Compare(gotBytes, tt.args.data) != 0 {
+			if !bytes.Equal(gotBytes, tt.args.data) {
 				t.Errorf("Expected '%v', got '%v'", string(tt.args.data), string(gotBytes))
 			}
 			if !reflect.DeepEqual(&gotSources, sources) {

--- a/internal/osbuild/stage_test.go
+++ b/internal/osbuild/stage_test.go
@@ -285,7 +285,7 @@ func TestStage_UnmarshalJSON(t *testing.T) {
 			if err != nil {
 				t.Errorf("Could not marshal stage: %v", err)
 			}
-			if bytes.Compare(gotBytes, tt.args.data) != 0 {
+			if !bytes.Equal(gotBytes, tt.args.data) {
 				t.Errorf("Expected `%v`, got `%v`", string(tt.args.data), string(gotBytes))
 			}
 			if !reflect.DeepEqual(&gotStage, stage) {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -243,7 +243,10 @@ func randomSHA1String() (string, error) {
 	} else if n != 20 {
 		return "", errors.New("randomSHA1String: short read from rand")
 	}
-	hash.Write(data)
+	_, err = hash.Write(data)
+	if err != nil {
+		return "", err
+	}
 	return hex.EncodeToString(hash.Sum(nil)), nil
 }
 

--- a/internal/upload/awsupload/awsupload_test.go
+++ b/internal/upload/awsupload/awsupload_test.go
@@ -109,10 +109,13 @@ func TestAWS_S3Upload(t *testing.T) {
 	// Delete the object from S3 after the test is finished
 	defer func() {
 		s := s3.New(sess)
-		s.DeleteObject(&s3.DeleteObjectInput{
+		_, err := s.DeleteObject(&s3.DeleteObjectInput{
 			Bucket: &bucket,
 			Key:    &s3Key,
 		})
+		if err != nil {
+			panic(err)
+		}
 	}()
 
 	// Set up temporary file for downloaded

--- a/internal/upload/azure/azure.go
+++ b/internal/upload/azure/azure.go
@@ -151,7 +151,7 @@ func UploadImage(credentials Credentials, metadata ImageMetadata, fileName strin
 	var blobChecksum []byte = props.ContentMD5()
 	var fileChecksum []byte = imageFileHash.Sum(nil)
 
-	if bytes.Compare(blobChecksum, fileChecksum) != 0 {
+	if !bytes.Equal(blobChecksum, fileChecksum) {
 		return &errorString{"error during image upload. the image seems to be corrupted"}
 	}
 

--- a/internal/upload/azure/azure_test.go
+++ b/internal/upload/azure/azure_test.go
@@ -59,10 +59,11 @@ func TestAzure_FileUpload(t *testing.T) {
 	handleErrors(t, err)
 
 	h := md5.New()
-	io.Copy(h, f)
+	_, err = io.Copy(h, f)
 	handleErrors(t, err)
 	imageChecksum := h.Sum(nil)
-	f.Close()
+	err = f.Close()
+	handleErrors(t, err)
 
 	credentials := Credentials{
 		StorageAccount:   storageAccount,
@@ -99,7 +100,8 @@ func TestAzure_FileUpload(t *testing.T) {
 	handleErrors(t, err)
 	blobData := &bytes.Buffer{}
 	reader := get.Body(azblob.RetryReaderOptions{})
-	blobData.ReadFrom(reader)
+	_, err = blobData.ReadFrom(reader)
+	handleErrors(t, err)
 	reader.Close() // The client must close the response body when finished with it
 	blobBytes := blobData.Bytes()
 	blobChecksum := md5.Sum(blobBytes)

--- a/internal/upload/azure/azure_test.go
+++ b/internal/upload/azure/azure_test.go
@@ -110,7 +110,7 @@ func TestAzure_FileUpload(t *testing.T) {
 	_, _ = blobURL.Delete(ctx, azblob.DeleteSnapshotsOptionInclude, azblob.BlobAccessConditions{})
 	_ = os.Remove(fileName)
 
-	if bytes.Compare(imageChecksum, blobChecksum[:]) != 0 {
+	if !bytes.Equal(imageChecksum, blobChecksum[:]) {
 		t.Fatalf("Checksums do not match! Local file: %x, cloud blob: %x", imageChecksum, blobChecksum[:])
 	}
 

--- a/internal/weldr/api.go
+++ b/internal/weldr/api.go
@@ -614,7 +614,7 @@ func (api *API) modulesInfoHandler(writer http.ResponseWriter, request *http.Req
 	packageInfos := foundPackages.ToPackageInfos()
 
 	if modulesRequested {
-		for i, _ := range packageInfos {
+		for i := range packageInfos {
 			err := packageInfos[i].FillDependencies(api.rpmmd, api.distro.Repositories(api.arch), api.distro.ModulePlatformID())
 			if err != nil {
 				errors := responseError{

--- a/internal/weldr/api.go
+++ b/internal/weldr/api.go
@@ -1847,10 +1847,7 @@ func (api *API) composeFailedHandler(writer http.ResponseWriter, request *http.R
 }
 
 func (api *API) fetchPackageList() (rpmmd.PackageList, error) {
-	var repos []rpmmd.RepoConfig
-	for _, repo := range api.distro.Repositories(api.arch) {
-		repos = append(repos, repo)
-	}
+	repos := api.distro.Repositories(api.arch)
 	for _, source := range api.store.GetAllSources() {
 		repos = append(repos, source.RepoConfig())
 	}
@@ -1871,10 +1868,7 @@ func getPkgNameGlob(pkg blueprint.Package) string {
 }
 
 func (api *API) depsolveBlueprint(bp *blueprint.Blueprint, outputType, arch string, clean bool) ([]rpmmd.PackageSpec, []rpmmd.PackageSpec, map[string]string, error) {
-	var repos []rpmmd.RepoConfig
-	for _, repo := range api.distro.Repositories(api.arch) {
-		repos = append(repos, repo)
-	}
+	repos := api.distro.Repositories(api.arch)
 	for _, source := range api.store.GetAllSources() {
 		repos = append(repos, source.RepoConfig())
 	}

--- a/internal/weldr/api_test.go
+++ b/internal/weldr/api_test.go
@@ -593,7 +593,10 @@ func TestComposeLogs(t *testing.T) {
 
 		var buffer bytes.Buffer
 
-		io.Copy(&buffer, tr)
+		_, err = io.Copy(&buffer, tr)
+		if err != nil {
+			t.Errorf("cannot copy untar result: %v", err)
+		}
 
 		if buffer.String() != c.ExpectedFileContent {
 			t.Errorf("%s: expected log content: %s, but got: %s", c.Path, c.ExpectedFileContent, buffer.String())

--- a/internal/weldr/api_test.go
+++ b/internal/weldr/api_test.go
@@ -484,7 +484,7 @@ func TestComposeDelete(t *testing.T) {
 
 		idsInStore := []string{}
 
-		for id, _ := range s.Composes {
+		for id := range s.Composes {
 			idsInStore = append(idsInStore, id.String())
 		}
 


### PR DESCRIPTION
I would like to introduce linting of our Go code in the project. I think this could help us to detect some errors before the merge button is pressed. I chose golangci-lint as our linter as it's a popular project used by many big projects (podman, openshift), and it aggregates multiple Go linters so more errors can be caught. To demonstrate its functionality, I run it on the current master. Then, I chose one example for each error type. The results are here:

### errcheck (45 cases)
```
errcheck in cmd/osbuild-tests/main.go:
Error return value of `cmd.Start` is not checked:
	cmd.Start()
```

There are 45 cases of unchecked errors in our code. It's surely annoying to do the check every time (in some cases god bless exceptions) but without any checking of errors we will never know about them. I think we should always react - if it's clearly programming mistake, let's panic. If it's something minor, pass it to the caller or log it. However, never let it escape!

### gosimple/S1002 (4 cases)
```
gosimple in cmd/osbuild-tests/main.go:
S1002: should omit comparison to bool constant, can be simplified to `!reply.Status`:
	if reply.Status != true {
```

A stylistic thing, I think it makes reading code easier.

### gosimple/S1004 (4 cases)
```
gosimple in internal/osbuild/source_test.go:
S1004: should use !bytes.Equal(gotBytes, tt.args.data) instead:
			if bytes.Compare(gotBytes, tt.args.data) != 0 {
```

I think this is very reasonable.

### gosimple/S1005 (3 cases)
```
gosimple in internal/common/types.go:
S1005: should omit value from range; this loop is equivalent to `for k := range ...`:
	for k, _ := range mapping {
```

This might be a bit annoying, I'm not sure about it but I decided to fix it, there are just 3 cases.

### gosimple/S1011 (2 cases)
```
gosimple in internal/weldr/api.go:
S1011: should replace loop with `repos = append(repos, api.distro.Repositories(api.arch)...)`:
	for _, repo := range api.distro.Repositories(api.arch) {
```

Very reasonable.

### gosimple/S1028 (1 case)
```
gosimple in cmd/osbuild-worker/main.go:
S1028: should use fmt.Errorf(...) instead of errors.New(fmt.Sprintf(...)):
		return nil, errors.New(fmt.Sprintf("couldn't create job, got %d: %s", response.StatusCode, r))
```

Nice catch, gosimple is trying to teach you how to use Go more efficiently.

### govet/composites (22 cases)
```
govet in internal/distro/fedora30/distro.go:
composites: `github.com/osbuild/osbuild-composer/internal/osbuild.ChronyStageOptions` composite literal uses unkeyed fields:
		p.AddStage(osbuild.NewChronyStage(&osbuild.ChronyStageOptions{ntpServers}))
```

According to govet it should be:
```
        p.AddStage(osbuild.NewChronyStage(&osbuild.ChronyStageOptions{Timeservers: ntpServers}))
```
This rule is about not specifying the names of fields when initializing structs. I decided to **turn it off**, I think in a lot of cases it's actually better to omit a field name, so the code can be shorter and easier to read.

### ineffassign (1 case)
```
ineffassign in internal/weldr/api.go:
ineffectual assignment to `err`:
	packages, checksums, err := api.rpmmd.Depsolve(...)
	if err != nil {
		return nil, nil, nil, err
	}

	buildPackages := []rpmmd.PackageSpec{}
	if outputType != "" {
		buildSpecs, err := api.distro.BuildPackages(arch)
		if err != nil {
			return nil, nil, nil, err
		}
		buildPackages, _, err = api.rpmmd.Depsolve(...) <<< HERE IS THE ERROR
	}

	return packages, buildPackages, checksums, err
```

This is a rather interesting catch. One might think that the error from the last depsolve gets returned by the last return statement. However, that's not true! `buildSpecs, err := api.distro.BuildPackage(arch)` creates a new `err` variable which shadows the one from outer scope. Therefore, the depsolve error is just thrown away when the if block is left, and `err` with the value of `nil` is returned.

Another example from the past (I fixed it when firstly playing with linting):

```
ineffassign in internal/distro/fedora30/distro.go:
ineffectual assignment to `enabledServices`:
        enabledServices = append(enabledServices, s.Enabled...)
        enabledServices = append(disabledServices, s.Disabled...)
```

Yeah, this is a clear bug!

### deadcode (1 case)
```
deadcode in internal/jobqueue/job.go:
`runCommand` is unused (deadcode):
    func runCommand(command string, params ...string) error {
```

It's nice not to have any dead code, right?

## Full log
https://gist.github.com/ondrejbudai/5697c4ace57ec5024d48f1a30c55bfc4

## Can you lint the past?
Yes, you can! I decided it would be awesome to lint not only the current master but every commit in the master branch. Surprisingly for me, the code in many commits cannot be built (and therefore linted). Fair amount of PRs have broken code prior the last commit. Is that bad? I don't know.

Overall, the results were better than expected - I didn't find any other kind of errors than those currently in master. There were about 8 cases of `ineffassign`, many of them clear bugs. Now, we will be able to detect them with proper linting on CI! Otherwise, nothing major appeared, apparently we are great coders!

## Outcome of this PR
- I created Github workflow with golangci-lint
- I fixed all the errors or turn off the violated rule

  In the end I decided only to turn off the `govet/composites` rule because I find it a bit annoying.

  The error handling - yeah, it's not fun, but I think it's worth catching as many errors as possible and not letting them escape. With the `common.PanicError()` helper it's not that bad.

I'm open to discussions! Also, we may want to squash all those fix commits, I just want to be able to revert a fix simply if requested.

