### PR TITLE
spec: move worker-related service units to worker sub-package

### DIFF
--- a/golang-github-osbuild-composer.spec
+++ b/golang-github-osbuild-composer.spec
@@ -122,9 +122,7 @@ export GOPATH=$PWD/_build:%{gopath}
 %{_datadir}/osbuild-composer/
 %{_unitdir}/osbuild-composer.service
 %{_unitdir}/osbuild-composer.socket
-%{_unitdir}/osbuild-remote-worker@.service
 %{_unitdir}/osbuild-remote-worker.socket
-%{_unitdir}/osbuild-worker@.service
 %{_sysusersdir}/osbuild-composer.conf
 
 %package rcm
@@ -161,6 +159,8 @@ The worker for osbuild-composer
 
 %files worker
 %{_libexecdir}/osbuild-composer/osbuild-worker
+%{_unitdir}/osbuild-worker@.service
+%{_unitdir}/osbuild-remote-worker@.service
 
 %post worker
 %systemd_post osbuild-worker@.service osbuild-remote-worker@.service


### PR DESCRIPTION
Prior this commit installing the worker sub-packages shows the following
warning:

Failed to preset unit: Unit file osbuild-worker@.service does not exist.

Moving the unit file to the sub-package fixes it.