### PR TITLE
fix composer immediately exiting

### DIFF
--- a/cmd/osbuild-composer/main.go
+++ b/cmd/osbuild-composer/main.go
@@ -134,9 +134,7 @@ func main() {
 		}
 	}
 
-	go func() {
-		err := weldrAPI.Serve(weldrListener)
-		common.PanicOnError(err)
-	}()
+	err = weldrAPI.Serve(weldrListener)
+	common.PanicOnError(err)
 
 }


### PR DESCRIPTION
I broke it in d7cbc22d, there shouldn't be a goroutine.