### PR TITLE
rpmmd: pass in cache directory explicitly

### DIFF
--- a/cmd/osbuild-composer/main.go
+++ b/cmd/osbuild-composer/main.go
@@ -7,6 +7,7 @@ import (
 	"github.com/osbuild/osbuild-composer/internal/rcm"
 	"io/ioutil"
 	"log"
+	"path"
 	"os"
 
 	"github.com/osbuild/osbuild-composer/internal/common"
@@ -73,7 +74,12 @@ func main() {
 	weldrListener := composerListeners[0]
 	jobListener := composerListeners[1]
 
-	rpm := rpmmd.NewRPMMD()
+	cacheDirectory, ok := os.LookupEnv("CACHE_DIRECTORY")
+	if !ok {
+		log.Fatal("CACHE_DIRECTORY is not set. Is the service file missing CacheDirectory=?")
+	}
+
+	rpm := rpmmd.NewRPMMD(path.Join(cacheDirectory, "rpmmd"))
 	distros := distro.NewRegistry([]string{"/etc/osbuild-composer", "/usr/share/osbuild-composer"})
 
 	distribution, err := distros.FromHost()

--- a/cmd/osbuild-dnf-json-tests/main.go
+++ b/cmd/osbuild-dnf-json-tests/main.go
@@ -57,7 +57,7 @@ func TestFetchChecksum(quiet bool, dir string) {
 	if !quiet {
 		log.Println("Running TestFetchChecksum on:", dir)
 	}
-	rpmMetadata := rpmmd.NewRPMMD()
+	rpmMetadata := rpmmd.NewRPMMD(path.Join(dir, "rpmmd"))
 	_, c, err := rpmMetadata.FetchMetadata([]rpmmd.RepoConfig{repoCfg}, "platform:f31")
 	if err != nil {
 		log.Panic("Failed to fetch checksum:", err)

--- a/cmd/osbuild-pipeline/main.go
+++ b/cmd/osbuild-pipeline/main.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"path"
 
 	"github.com/osbuild/osbuild-composer/internal/common"
 
@@ -87,7 +88,12 @@ func main() {
 	}
 	packages = append(pkgs, packages...)
 
-	rpmmd := rpmmd.NewRPMMD()
+	home, err := os.UserHomeDir()
+	if err != nil {
+		panic("os.UserHomeDir(): " + err.Error())
+	}
+
+	rpmmd := rpmmd.NewRPMMD(path.Join(home, ".cache/osbuild-composer/rpmmd"))
 	packageSpecs, checksums, err := rpmmd.Depsolve(packages, exclude_pkgs, d.Repositories(archArg), d.ModulePlatformID(), false)
 	if err != nil {
 		panic("Could not depsolve: " + err.Error())


### PR DESCRIPTION
rpmmd looked at the CACHE_DIRECTORY environment variable to set a path
for the dnf repository cache.  Aside from being a smelly thing to do
from a library, this breaks osbuild-pipeline and osbuild-dnf-json-tests,
which don't run as systemd services and thus don't have CACHE_DIRECTORY
set.

Explicitly pass the cache directory to rpmmd. Keep using a path based on
CACHE_DIRECTORY for osbuild-composer. Use the user's `.cache` directory
for osbuild-pipeline and a temporary directory for the tests.