### PR TITLE
distribution: set CACHE_DIRECTORY in the .service file

### DIFF
--- a/distribution/osbuild-composer.service
+++ b/distribution/osbuild-composer.service
@@ -13,5 +13,8 @@ WorkingDirectory=/usr/libexec/osbuild-composer/
 User=_osbuild-composer
 Restart=on-failure
 
+# systemd >= 240 sets this, but osbuild-composer runs on earlier versions
+Environment="CACHE_DIRECTORY=/var/cache/osbuild-composer"
+
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
systemd >= 240 sets this variable to `/var/cache/` + the value of
CacheDirectory. osbuild-composer must run on earlier versions though
(specifically RHEL 8.2).