### PR TITLE
Fix blueprint commit ordering and add blueprint tag support

### DIFF
--- a/internal/weldr/api.go
+++ b/internal/weldr/api.go
@@ -1117,13 +1117,14 @@ func (api *API) blueprintsChangesHandler(writer http.ResponseWriter, request *ht
 			name = name[1:]
 		}
 		bpChanges := api.store.GetBlueprintChanges(name)
+		// Reverse the changes, newest first
+		reversed := make([]blueprint.Change, 0, len(bpChanges))
+		for i := len(bpChanges) - 1; i >= 0; i-- {
+			reversed = append(reversed, bpChanges[i])
+		}
 		if bpChanges != nil {
-			// Sort the changes by Timestamp, descending
-			sort.Slice(bpChanges, func(i, j int) bool {
-				return bpChanges[i].Timestamp > bpChanges[j].Timestamp
-			})
 			change := change{
-				Changes: bpChanges,
+				Changes: reversed,
 				Name:    name,
 				Total:   len(bpChanges),
 			}

--- a/internal/weldr/api.go
+++ b/internal/weldr/api.go
@@ -84,6 +84,7 @@ func New(rpmmd rpmmd.RPMMD, arch string, distro distro.Distro, logger *log.Logge
 	api.router.POST("/api/v:version/blueprints/new", api.blueprintsNewHandler)
 	api.router.POST("/api/v:version/blueprints/workspace", api.blueprintsWorkspaceHandler)
 	api.router.POST("/api/v:version/blueprints/undo/:blueprint/:commit", api.blueprintUndoHandler)
+	api.router.POST("/api/v:version/blueprints/tag/:blueprint", api.blueprintsTagHandler)
 	api.router.DELETE("/api/v:version/blueprints/delete/:blueprint", api.blueprintDeleteHandler)
 	api.router.DELETE("/api/v:version/blueprints/workspace/:blueprint", api.blueprintDeleteWorkspaceHandler)
 
@@ -1275,6 +1276,24 @@ func (api *API) blueprintDeleteWorkspaceHandler(writer http.ResponseWriter, requ
 	}
 
 	api.store.DeleteBlueprintFromWorkspace(params.ByName("blueprint"))
+	statusResponseOK(writer)
+}
+
+// blueprintsTagHandler tags the current blueprint commit as a new revision
+func (api *API) blueprintsTagHandler(writer http.ResponseWriter, request *http.Request, params httprouter.Params) {
+	if !verifyRequestVersion(writer, params, 0) {
+		return
+	}
+
+	err := api.store.TagBlueprint(params.ByName("blueprint"))
+	if err != nil {
+		errors := responseError{
+			ID:  "BlueprintsError",
+			Msg: err.Error(),
+		}
+		statusResponseError(writer, http.StatusBadRequest, errors)
+		return
+	}
 	statusResponseOK(writer)
 }
 


### PR DESCRIPTION
In the process of adding tests I discovered that the tag route was unimplemented, and that the blueprint commits were un-ordered. This PR builds on my test PR #261 and should not be merged until that one is.