### PR TITLE
blueprint: add default version

### DIFF
--- a/internal/blueprint/blueprint.go
+++ b/internal/blueprint/blueprint.go
@@ -65,6 +65,9 @@ func (b *Blueprint) Initialize() error {
 	if b.Groups == nil {
 		b.Groups = []Group{}
 	}
+	if b.Version == "" {
+		b.Version = "0.0.0"
+	}
 	// Return an error if the version is not valid
 	_, err := semver.NewVersion(b.Version)
 	if err != nil {

--- a/internal/blueprint/blueprint_test.go
+++ b/internal/blueprint/blueprint_test.go
@@ -42,7 +42,7 @@ func TestBlueprintInitialize(t *testing.T) {
 		NewBlueprint  Blueprint
 		ExpectedError bool
 	}{
-		{Blueprint{Name: "bp-test-1", Description: "Empty version", Version: ""}, true},
+		{Blueprint{Name: "bp-test-1", Description: "Empty version", Version: ""}, false},
 		{Blueprint{Name: "bp-test-2", Description: "Invalid version 1", Version: "0"}, true},
 		{Blueprint{Name: "bp-test-2", Description: "Invalid version 2", Version: "0.0"}, true},
 		{Blueprint{Name: "bp-test-3", Description: "Invalid version 3", Version: "0.0.0.0"}, true},

--- a/internal/weldr/api_test.go
+++ b/internal/weldr/api_test.go
@@ -71,6 +71,7 @@ func TestBlueprintsNew(t *testing.T) {
 		ExpectedStatus int
 		ExpectedJSON   string
 	}{
+		{"POST", "/api/v0/blueprints/new", `{"name":"test","description":"Test","packages":[],"version":""}`, http.StatusOK, `{"status":true}`},
 		{"POST", "/api/v0/blueprints/new", `{"name":"test","description":"Test","packages":[{"name":"httpd","version":"2.4.*"}],"version":"0.0.0"}`, http.StatusOK, `{"status":true}`},
 	}
 


### PR DESCRIPTION
If the user creates a new blueprint with no version specified, the blueprint struct uses "0.0.0" as the default version. Blueprint tests for a blueprint with an empty version now expect no error.