### PR TITLE
spec: remove lorax-composer provide

### DIFF
--- a/golang-github-osbuild-composer.spec
+++ b/golang-github-osbuild-composer.spec
@@ -41,7 +41,6 @@ Requires: systemd
 Requires: osbuild >= 7
 
 Provides: osbuild-composer
-Provides: lorax-composer
 
 %description
 %{common_description}


### PR DESCRIPTION
We're not fully compatible with lorax-composer's API yet, and we don't
provide lorax-composer's systemd unit files.

As a result, cockpit-composer's integration tests fail, because `dnf
install lorax-composer` on Fedora can result in installing
osbuild-composer in some cases.