### PR TITLE
[WIP] POC: Rewrite dnf-json integration tests for go test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ __pycache__
 
 /osbuild-composer
 /osbuild-worker
+/osbuild-weldr-tests
 /osbuild-pipeline
 /osbuild-upload-azure
 /osbuild-upload-aws

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ build:
 	go build -o osbuild-upload-aws ./cmd/osbuild-upload-aws/
 	go build -o osbuild-tests ./cmd/osbuild-tests/
 	go build -o osbuild-weldr-tests ./cmd/osbuild-weldr-tests/
-	go build -o osbuild-dnf-json-tests ./cmd/osbuild-dnf-json-tests/
+	go test -c -o osbuild-dnf-json-tests ./cmd/osbuild-dnf-json-tests/main_test.go
 	go build -o osbuild-rcm-tests ./cmd/osbuild-rcm-tests/
 
 .PHONY: install

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/google/uuid v1.1.1
 	github.com/julienschmidt/httprouter v1.2.0
 	github.com/pkg/errors v0.9.1 // indirect
-	github.com/stretchr/testify v1.4.0 // indirect
+	github.com/stretchr/testify v1.4.0
 	golang.org/x/net v0.0.0-20200202094626-16171245cfb2 // indirect
 	golang.org/x/sys v0.0.0-20200212091648-12a6c2dcc1e4 // indirect
 )

--- a/golang-github-osbuild-composer.spec
+++ b/golang-github-osbuild-composer.spec
@@ -1,4 +1,6 @@
 %global goipath         github.com/osbuild/osbuild-composer
+# workaround for https://pagure.io/go-rpm-macros/pull-request/23
+%define gotest_co(c:o:) GO111MODULE=off go test %{gotestflags} -ldflags "${LDFLAGS:-}%{?currentgoldflags} -extldflags '%{gotestextldflags}'" %{?**};
 
 Version:        7
 
@@ -68,7 +70,7 @@ export GOFLAGS=-mod=vendor
 %gobuild -o _bin/osbuild-worker %{goipath}/cmd/osbuild-worker
 %gobuild -o _bin/osbuild-tests %{goipath}/cmd/osbuild-tests
 %gobuild -o _bin/osbuild-weldr-tests %{goipath}/cmd/osbuild-weldr-tests
-%gobuild -o _bin/osbuild-dnf-json-tests %{goipath}/cmd/osbuild-dnf-json-tests
+%gotest_co -c -o _bin/osbuild-dnf-json-tests %{goipath}/cmd/osbuild-dnf-json-tests
 %gobuild -o _bin/osbuild-image-tests %{goipath}/cmd/osbuild-image-tests
 
 %install


### PR DESCRIPTION
Rewrites the file so that it can be discovered by `go test` and so we can use asserts as well. This makes it more common to what is there in the golang eco system wrt writing test suites.

We can still produce a binary that can be executed to run the test. We can also discover/execute tests on the fly via go test (currently fails b/c it can't find the dnf-json command). 

I've git a snag when building the binary for inclusion in RPM though:
- There is a %gotest macro for RPM but it doesn't accept any options so I can't pass (-c (compile, don't execute) and -o)
- With the current workaround rpmbuild failed with 
```
error: Missing build-id in /root/osbuild-composer/rpmbuild/BUILDROOT/golang-github-osbuild-composer-6-1.20200305git46ea9cc.fc31.x86_64/usr/libexec/tests/osbuild-composer/osbuild-dnf-json-tests
```

@teg, @msehnout can you please take a look.