### PR TITLE
Makefile: use spec file from HEAD to make rpm

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ RPM_TARBALL=rpmbuild/SOURCES/osbuild-composer-$(COMMIT).tar.gz
 
 $(RPM_SPECFILE):
 	mkdir -p $(CURDIR)/rpmbuild/SPECS
-	echo "%global commit $(COMMIT)" | cat - golang-github-osbuild-composer.spec > $(RPM_SPECFILE)
+	(echo "%global commit $(COMMIT)"; git show HEAD:golang-github-osbuild-composer.spec) > $(RPM_SPECFILE)
 
 $(RPM_TARBALL):
 	mkdir -p $(CURDIR)/rpmbuild/SOURCES


### PR DESCRIPTION
The spec file in the current working directory might have changes. When
building rpms with the commit hash in the version, they ought to be
built with the spec file from that hash as well.