### PR TITLE
osbuild-tests: run compose tests in a temporary directory

### DIFF
--- a/cmd/osbuild-tests/main.go
+++ b/cmd/osbuild-tests/main.go
@@ -82,6 +82,11 @@ func testCompose(outputType string) {
 	pushBlueprint(&bp)
 	defer deleteBlueprint(&bp)
 
+	runComposerCLI(false, "blueprints", "save", "empty")
+	if _, err := os.Stat("empty.toml"); os.IsNotExist(err) {
+		log.Fatalf("empty.toml doesn not exist: %v", err)
+	}
+
 	uuid := startCompose("empty", outputType)
 	defer deleteCompose(uuid)
 	status := waitForCompose(uuid)


### PR DESCRIPTION
Some `composer-cli` commands operate on the current directory, for
example saving blueprints or images. Add the `TemporaryWorkDir` type,
which helps changing to a temporary working directory and cleaning
everything up after.

The alternative would have been to pass a working directory to all calls
of `runComposerCLI`, but that seemed like it would require a lot of
change, which I didn't deem worth for testing code.