### PR TITLE
image-types: start describing image types

### DIFF
--- a/image-types/README.md
+++ b/image-types/README.md
@@ -1,0 +1,8 @@
+# OSBuild Composer Image Types
+
+This directory contains high-level descriptions of all image types that
+*osbuild-composer* generates, grouped by operating system.
+
+Each of them contains a short description of the purpose and intended use case
+of the image type, and any peculiarities that make this image type differ from
+a standard installation.

--- a/image-types/rhel8/README.md
+++ b/image-types/rhel8/README.md
@@ -1,0 +1,21 @@
+# Red Hat Enterprise Linux 8
+
+Owner: *None*
+
+*osbuild-composer* can create [Red Hat Enterprise Linux 8][rhel] images.
+
+## Architectures
+
+RHEL supports `x86_64`, `aarch64`, `ppc64le`, and `s390x`.
+
+## Partitioning and Booting
+
+The default file system is `xfs` on one bootable partition.
+
+## Packages
+
+By default, these images are created by installing the `@Core` group and the
+`kernel` package.
+
+
+[rhel]: https://access.redhat.com/products/red-hat-enterprise-linux

--- a/image-types/rhel8/amazon-ec2.md
+++ b/image-types/rhel8/amazon-ec2.md
@@ -1,0 +1,48 @@
+# Amazon EC2 Image
+
+Owner: *None*
+
+This image is meant to be used in [Amazon Elastic Compute Cloud (EC2)][ec2], a
+popular cloud computing platform. It has to follow Amazon’s
+[guidelines][guidelines] and [requirements][requirements] for shared AMIs.
+
+## File Format
+
+EC2 uses Amazon Machine Images (AMIs) internally, which can only be created
+inside EC2. An image in a standard format (ova, vmdk, vhd/x, or raw) must be
+imported from S3 storage. *osbuild-composer* generates this image type in the
+VHDX format, because it is fairly modern, widely used, and uses less space than
+RAW images.
+
+The default image size is 6 GB.
+
+## Architectures
+
+Limited to `x86_64` and `aarch64`, because those are available on EC2.
+
+## Partitioning and Booting
+
+The image specifies partitions with a MBR partition table, because that is
+required by EC2. It contains one bootable partition formatted with RHEL's
+default file system `xfs`.
+
+## Packages
+
+`cloud-init` is included in this image, because it is required by EC2.
+
+EC2 doesn't require any specialized firmware. Thus, in order to keep the
+resulting image size small, all `-firmware` packages are excluded. An exception
+is the `linux-firmware` package, which cannot be excluded because the `kernel`
+package depends on it.
+
+`dracut-config-rescue` is excluded from the image, because the boot loader
+entry it provides is broken.
+
+## Kernel Command Line
+
+`ro console=ttyS0,115200n8 console=tty0 net.ifnames=0 rd.blacklist=nouveau nvme_core.io_timeout=4294967295 crashkernel=auto`
+
+
+[ec2]: https://aws.amazon.com/ec2
+[guidelines]: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/building-shared-amis.html
+[requirements]: https://docs.aws.amazon.com/vm-import/latest/userguide/vmie_prereqs.html

--- a/image-types/rhel8/openstack.md
+++ b/image-types/rhel8/openstack.md
@@ -1,0 +1,31 @@
+# OpenStack Image
+
+Owner: *None*
+
+This image is meant to be run in an OpenStack environment. It has to conform to
+OpenStack’s [image requirements][requirements].
+
+## File Format
+
+This image is OpenStack's native file format is qcow2.
+
+The default image size is 2 GB.
+
+## Partitioning and Booting
+
+The generated images contain one bootable partition formatted with RHEL's
+default file system `xfs`.
+
+## Software
+
+`cloud-init` is included in this image, because it is required by OpenStack.
+
+`dracut-config-rescue` is excluded from the image, because the boot loader
+entry it provides is broken.
+
+## Kernel Command Line
+
+`ro net.ifnames=0`
+
+
+[requirements]: https://docs.openstack.org/image-guide/openstack-images.html


### PR DESCRIPTION
This is the start to document the image types that osbuild-composer
produces on a higher level than the code in the `distro` package.

The idea is to document the purpose for each of the image types as well
as the reasons why deviating from a standard install is necessary.

This is a draft. Want to get feedback if this is generally going in the right direction before fleshing it out further. That's why I requested reviews from *all the people* :tada: 