### PR TITLE
Restructure test-cases

### DIFF
--- a/cmd/osbuild-image-tests/osbuild-image-tests.go
+++ b/cmd/osbuild-image-tests/osbuild-image-tests.go
@@ -5,9 +5,6 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"github.com/google/go-cmp/cmp"
-	"github.com/osbuild/osbuild-composer/internal/common"
-	"github.com/osbuild/osbuild-composer/internal/distro"
 	"io"
 	"io/ioutil"
 	"log"
@@ -15,6 +12,10 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/osbuild/osbuild-composer/internal/common"
+	"github.com/osbuild/osbuild-composer/internal/distro"
 )
 
 type testcaseStruct struct {
@@ -23,12 +24,12 @@ type testcaseStruct struct {
 		Arch     string
 		Filename string
 	}
-	Pipeline  json.RawMessage
+	Manifest  json.RawMessage
 	ImageInfo json.RawMessage `json:"image-info"`
 }
 
-// runOsbuild runs osbuild with the specified pipeline and store.
-func runOsbuild(pipeline []byte, store string) (string, error) {
+// runOsbuild runs osbuild with the specified manifest and store.
+func runOsbuild(manifest []byte, store string) (string, error) {
 	cmd := exec.Command(
 		"osbuild",
 		"--store", store,
@@ -37,7 +38,7 @@ func runOsbuild(pipeline []byte, store string) (string, error) {
 	)
 
 	cmd.Stderr = os.Stderr
-	cmd.Stdin = bytes.NewReader(pipeline)
+	cmd.Stdin = bytes.NewReader(manifest)
 	var outBuffer bytes.Buffer
 	cmd.Stdout = &outBuffer
 
@@ -155,7 +156,7 @@ func runTestcase(testcase testcaseStruct) error {
 		}
 	}()
 
-	outputID, err := runOsbuild(testcase.Pipeline, store)
+	outputID, err := runOsbuild(testcase.Manifest, store)
 	if err != nil {
 		return err
 	}

--- a/internal/distro/distro.go
+++ b/internal/distro/distro.go
@@ -55,15 +55,6 @@ type Distro interface {
 	// Returns the build packages for a given output architecture
 	BuildPackages(outputArchitecture string) ([]string, error)
 
-	// Returns an osbuild pipeline that generates an image in the given
-	// output format with all packages and customizations specified in the
-	// given blueprint.
-	Pipeline(b *blueprint.Blueprint, additionalRepos []rpmmd.RepoConfig, packageSpecs, buildPackageSpecs []rpmmd.PackageSpec, checksums map[string]string, outputArchitecture, outputFormat string, size uint64) (*osbuild.Pipeline, error)
-
-	// Returns an osbuild sources object that is required for building the
-	// corresponding pipeline containing the given packages.
-	Sources(packages []rpmmd.PackageSpec) *osbuild.Sources
-
 	// Returns an osbuild manifest, containing the sources and pipeline necessary
 	// to generates an image in the given output format with all packages and
 	// customizations specified in the given blueprint.

--- a/internal/distro/distro_test.go
+++ b/internal/distro/distro_test.go
@@ -21,7 +21,7 @@ func TestDistro_Pipeline(t *testing.T) {
 		t.Errorf("Could not read pipelines directory '%s': %v", pipelinePath, err)
 	}
 	for _, fileInfo := range fileInfos {
-		type compose struct {
+		type composeRequest struct {
 			Distro       string               `json:"distro"`
 			Arch         string               `json:"arch"`
 			OutputFormat string               `json:"output-format"`
@@ -33,9 +33,9 @@ func TestDistro_Pipeline(t *testing.T) {
 			Checksums     map[string]string   `json:"checksums"`
 		}
 		var tt struct {
-			Compose  *compose          `json:"compose"`
-			RpmMD    *rpmMD            `json:"rpmmd"`
-			Pipeline *osbuild.Pipeline `json:"pipeline,omitempty"`
+			ComposeRequest *composeRequest   `json:"compose-request"`
+			RpmMD          *rpmMD            `json:"rpmmd"`
+			Pipeline       *osbuild.Pipeline `json:"pipeline,omitempty"`
 		}
 		file, err := ioutil.ReadFile(pipelinePath + fileInfo.Name())
 		if err != nil {
@@ -45,28 +45,28 @@ func TestDistro_Pipeline(t *testing.T) {
 		if err != nil {
 			t.Errorf("Colud not parse test-case '%s': %v", fileInfo.Name(), err)
 		}
-		if tt.Compose == nil || tt.Compose.Blueprint == nil {
+		if tt.ComposeRequest == nil || tt.ComposeRequest.Blueprint == nil {
 			t.Logf("Skipping '%s'.", fileInfo.Name())
 			continue
 		}
-		t.Run(tt.Compose.OutputFormat, func(t *testing.T) {
+		t.Run(tt.ComposeRequest.OutputFormat, func(t *testing.T) {
 			distros, err := distro.NewDefaultRegistry([]string{"../.."})
 			if err != nil {
 				t.Fatal(err)
 			}
-			d := distros.GetDistro(tt.Compose.Distro)
+			d := distros.GetDistro(tt.ComposeRequest.Distro)
 			if d == nil {
-				t.Errorf("unknown distro: %v", tt.Compose.Distro)
+				t.Errorf("unknown distro: %v", tt.ComposeRequest.Distro)
 				return
 			}
-			size := d.GetSizeForOutputType(tt.Compose.OutputFormat, 0)
-			got, err := d.Pipeline(tt.Compose.Blueprint,
+			size := d.GetSizeForOutputType(tt.ComposeRequest.OutputFormat, 0)
+			got, err := d.Pipeline(tt.ComposeRequest.Blueprint,
 				nil,
 				tt.RpmMD.Packages,
 				tt.RpmMD.BuildPackages,
 				tt.RpmMD.Checksums,
-				tt.Compose.Arch,
-				tt.Compose.OutputFormat,
+				tt.ComposeRequest.Arch,
+				tt.ComposeRequest.OutputFormat,
 				size)
 			if (err != nil) != (tt.Pipeline == nil) {
 				t.Errorf("distro.Pipeline() error = %v", err)

--- a/internal/distro/distro_test.go
+++ b/internal/distro/distro_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/osbuild/osbuild-composer/internal/blueprint"
 	"github.com/osbuild/osbuild-composer/internal/distro"
 	"github.com/osbuild/osbuild-composer/internal/osbuild"
+	"github.com/osbuild/osbuild-composer/internal/rpmmd"
 )
 
 func TestDistro_Pipeline(t *testing.T) {
@@ -27,7 +28,9 @@ func TestDistro_Pipeline(t *testing.T) {
 			Blueprint    *blueprint.Blueprint `json:"blueprint"`
 		}
 		type rpmMD struct {
-			Checksums map[string]string `json:"checksums"`
+			BuildPackages []rpmmd.PackageSpec `json:"build-packages"`
+			Packages      []rpmmd.PackageSpec `json:"packages"`
+			Checksums     map[string]string   `json:"checksums"`
 		}
 		var tt struct {
 			Compose  *compose          `json:"compose"`
@@ -57,7 +60,14 @@ func TestDistro_Pipeline(t *testing.T) {
 				return
 			}
 			size := d.GetSizeForOutputType(tt.Compose.OutputFormat, 0)
-			got, err := d.Pipeline(tt.Compose.Blueprint, nil, nil, nil, tt.RpmMD.Checksums, tt.Compose.Arch, tt.Compose.OutputFormat, size)
+			got, err := d.Pipeline(tt.Compose.Blueprint,
+				nil,
+				tt.RpmMD.Packages,
+				tt.RpmMD.BuildPackages,
+				tt.RpmMD.Checksums,
+				tt.Compose.Arch,
+				tt.Compose.OutputFormat,
+				size)
 			if (err != nil) != (tt.Pipeline == nil) {
 				t.Errorf("distro.Pipeline() error = %v", err)
 				return

--- a/internal/distro/distro_test.go
+++ b/internal/distro/distro_test.go
@@ -24,11 +24,14 @@ func TestDistro_Pipeline(t *testing.T) {
 			Distro       string               `json:"distro"`
 			Arch         string               `json:"arch"`
 			OutputFormat string               `json:"output-format"`
-			Checksums    map[string]string    `json:"checksums"`
 			Blueprint    *blueprint.Blueprint `json:"blueprint"`
+		}
+		type rpmMD struct {
+			Checksums map[string]string `json:"checksums"`
 		}
 		var tt struct {
 			Compose  *compose          `json:"compose"`
+			RpmMD    *rpmMD            `json:"rpmmd"`
 			Pipeline *osbuild.Pipeline `json:"pipeline,omitempty"`
 		}
 		file, err := ioutil.ReadFile(pipelinePath + fileInfo.Name())
@@ -54,7 +57,7 @@ func TestDistro_Pipeline(t *testing.T) {
 				return
 			}
 			size := d.GetSizeForOutputType(tt.Compose.OutputFormat, 0)
-			got, err := d.Pipeline(tt.Compose.Blueprint, nil, nil, nil, tt.Compose.Checksums, tt.Compose.Arch, tt.Compose.OutputFormat, size)
+			got, err := d.Pipeline(tt.Compose.Blueprint, nil, nil, nil, tt.RpmMD.Checksums, tt.Compose.Arch, tt.Compose.OutputFormat, size)
 			if (err != nil) != (tt.Pipeline == nil) {
 				t.Errorf("distro.Pipeline() error = %v", err)
 				return

--- a/internal/distro/distro_test.go
+++ b/internal/distro/distro_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/osbuild/osbuild-composer/internal/rpmmd"
 )
 
-func TestDistro_Pipeline(t *testing.T) {
+func TestDistro_Manifest(t *testing.T) {
 	pipelinePath := "../../test/cases/"
 	fileInfos, err := ioutil.ReadDir(pipelinePath)
 	if err != nil {
@@ -35,7 +35,7 @@ func TestDistro_Pipeline(t *testing.T) {
 		var tt struct {
 			ComposeRequest *composeRequest   `json:"compose-request"`
 			RpmMD          *rpmMD            `json:"rpmmd"`
-			Pipeline       *osbuild.Pipeline `json:"pipeline,omitempty"`
+			Manifest       *osbuild.Manifest `json:"manifest,omitempty"`
 		}
 		file, err := ioutil.ReadFile(pipelinePath + fileInfo.Name())
 		if err != nil {
@@ -60,7 +60,7 @@ func TestDistro_Pipeline(t *testing.T) {
 				return
 			}
 			size := d.GetSizeForOutputType(tt.ComposeRequest.OutputFormat, 0)
-			got, err := d.Pipeline(tt.ComposeRequest.Blueprint,
+			got, err := d.Manifest(tt.ComposeRequest.Blueprint,
 				nil,
 				tt.RpmMD.Packages,
 				tt.RpmMD.BuildPackages,
@@ -68,15 +68,15 @@ func TestDistro_Pipeline(t *testing.T) {
 				tt.ComposeRequest.Arch,
 				tt.ComposeRequest.OutputFormat,
 				size)
-			if (err != nil) != (tt.Pipeline == nil) {
-				t.Errorf("distro.Pipeline() error = %v", err)
+			if (err != nil) != (tt.Manifest == nil) {
+				t.Errorf("distro.Manifest() error = %v", err)
 				return
 			}
-			if tt.Pipeline != nil {
-				if !reflect.DeepEqual(got, tt.Pipeline) {
+			if tt.Manifest != nil {
+				if !reflect.DeepEqual(got, tt.Manifest) {
 					// Without this the "difference" is just a list of pointers.
 					gotJson, _ := json.Marshal(got)
-					fileJson, _ := json.Marshal(tt.Pipeline)
+					fileJson, _ := json.Marshal(tt.Manifest)
 					t.Errorf("d.Pipeline() =\n%v,\nwant =\n%v", string(gotJson), string(fileJson))
 				}
 			}

--- a/internal/distro/distro_test.go
+++ b/internal/distro/distro_test.go
@@ -39,11 +39,11 @@ func TestDistro_Pipeline(t *testing.T) {
 		}
 		file, err := ioutil.ReadFile(pipelinePath + fileInfo.Name())
 		if err != nil {
-			t.Errorf("Colud not read test-case '%s': %v", fileInfo.Name(), err)
+			t.Errorf("Could not read test-case '%s': %v", fileInfo.Name(), err)
 		}
 		err = json.Unmarshal([]byte(file), &tt)
 		if err != nil {
-			t.Errorf("Colud not parse test-case '%s': %v", fileInfo.Name(), err)
+			t.Errorf("Could not parse test-case '%s': %v", fileInfo.Name(), err)
 		}
 		if tt.ComposeRequest == nil || tt.ComposeRequest.Blueprint == nil {
 			t.Logf("Skipping '%s'.", fileInfo.Name())

--- a/internal/distro/fedora30/distro.go
+++ b/internal/distro/fedora30/distro.go
@@ -386,7 +386,7 @@ func (r *Fedora30) BuildPackages(outputArchitecture string) ([]string, error) {
 	return append(r.buildPackages, arch.BuildPackages...), nil
 }
 
-func (r *Fedora30) Pipeline(b *blueprint.Blueprint, additionalRepos []rpmmd.RepoConfig, packageSpecs, buildPackageSpecs []rpmmd.PackageSpec, checksums map[string]string, outputArchitecture, outputFormat string, size uint64) (*osbuild.Pipeline, error) {
+func (r *Fedora30) pipeline(b *blueprint.Blueprint, additionalRepos []rpmmd.RepoConfig, packageSpecs, buildPackageSpecs []rpmmd.PackageSpec, checksums map[string]string, outputArchitecture, outputFormat string, size uint64) (*osbuild.Pipeline, error) {
 	output, exists := r.outputs[outputFormat]
 	if !exists {
 		return nil, errors.New("invalid output format: " + outputFormat)
@@ -469,18 +469,18 @@ func (r *Fedora30) Pipeline(b *blueprint.Blueprint, additionalRepos []rpmmd.Repo
 	return p, nil
 }
 
-func (r *Fedora30) Sources(packages []rpmmd.PackageSpec) *osbuild.Sources {
+func (r *Fedora30) sources(packages []rpmmd.PackageSpec) *osbuild.Sources {
 	return &osbuild.Sources{}
 }
 
 func (r *Fedora30) Manifest(b *blueprint.Blueprint, additionalRepos []rpmmd.RepoConfig, packageSpecs, buildPackageSpecs []rpmmd.PackageSpec, checksums map[string]string, outputArchitecture, outputFormat string, size uint64) (*osbuild.Manifest, error) {
-	pipeline, err := r.Pipeline(b, additionalRepos, packageSpecs, buildPackageSpecs, checksums, outputArchitecture, outputFormat, size)
+	pipeline, err := r.pipeline(b, additionalRepos, packageSpecs, buildPackageSpecs, checksums, outputArchitecture, outputFormat, size)
 	if err != nil {
 		return nil, err
 	}
 
 	return &osbuild.Manifest{
-		Sources:  *r.Sources(append(packageSpecs, buildPackageSpecs...)),
+		Sources:  *r.sources(append(packageSpecs, buildPackageSpecs...)),
 		Pipeline: *pipeline,
 	}, nil
 }

--- a/internal/distro/fedora31/distro.go
+++ b/internal/distro/fedora31/distro.go
@@ -386,7 +386,7 @@ func (r *Fedora31) BuildPackages(outputArchitecture string) ([]string, error) {
 	return append(r.buildPackages, arch.BuildPackages...), nil
 }
 
-func (r *Fedora31) Pipeline(b *blueprint.Blueprint, additionalRepos []rpmmd.RepoConfig, packageSpecs, buildPackageSpecs []rpmmd.PackageSpec, checksums map[string]string, outputArchitecture, outputFormat string, size uint64) (*osbuild.Pipeline, error) {
+func (r *Fedora31) pipeline(b *blueprint.Blueprint, additionalRepos []rpmmd.RepoConfig, packageSpecs, buildPackageSpecs []rpmmd.PackageSpec, checksums map[string]string, outputArchitecture, outputFormat string, size uint64) (*osbuild.Pipeline, error) {
 	output, exists := r.outputs[outputFormat]
 	if !exists {
 		return nil, errors.New("invalid output format: " + outputFormat)
@@ -469,18 +469,18 @@ func (r *Fedora31) Pipeline(b *blueprint.Blueprint, additionalRepos []rpmmd.Repo
 	return p, nil
 }
 
-func (r *Fedora31) Sources(packages []rpmmd.PackageSpec) *osbuild.Sources {
+func (r *Fedora31) sources(packages []rpmmd.PackageSpec) *osbuild.Sources {
 	return &osbuild.Sources{}
 }
 
 func (r *Fedora31) Manifest(b *blueprint.Blueprint, additionalRepos []rpmmd.RepoConfig, packageSpecs, buildPackageSpecs []rpmmd.PackageSpec, checksums map[string]string, outputArchitecture, outputFormat string, size uint64) (*osbuild.Manifest, error) {
-	pipeline, err := r.Pipeline(b, additionalRepos, packageSpecs, buildPackageSpecs, checksums, outputArchitecture, outputFormat, size)
+	pipeline, err := r.pipeline(b, additionalRepos, packageSpecs, buildPackageSpecs, checksums, outputArchitecture, outputFormat, size)
 	if err != nil {
 		return nil, err
 	}
 
 	return &osbuild.Manifest{
-		Sources:  *r.Sources(append(packageSpecs, buildPackageSpecs...)),
+		Sources:  *r.sources(append(packageSpecs, buildPackageSpecs...)),
 		Pipeline: *pipeline,
 	}, nil
 }

--- a/internal/distro/fedora32/distro.go
+++ b/internal/distro/fedora32/distro.go
@@ -386,7 +386,7 @@ func (r *Fedora32) BuildPackages(outputArchitecture string) ([]string, error) {
 	return append(r.buildPackages, arch.BuildPackages...), nil
 }
 
-func (r *Fedora32) Pipeline(b *blueprint.Blueprint, additionalRepos []rpmmd.RepoConfig, packageSpecs, buildPackageSpecs []rpmmd.PackageSpec, checksums map[string]string, outputArchitecture, outputFormat string, size uint64) (*osbuild.Pipeline, error) {
+func (r *Fedora32) pipeline(b *blueprint.Blueprint, additionalRepos []rpmmd.RepoConfig, packageSpecs, buildPackageSpecs []rpmmd.PackageSpec, checksums map[string]string, outputArchitecture, outputFormat string, size uint64) (*osbuild.Pipeline, error) {
 	output, exists := r.outputs[outputFormat]
 	if !exists {
 		return nil, errors.New("invalid output format: " + outputFormat)
@@ -469,18 +469,18 @@ func (r *Fedora32) Pipeline(b *blueprint.Blueprint, additionalRepos []rpmmd.Repo
 	return p, nil
 }
 
-func (r *Fedora32) Sources(packages []rpmmd.PackageSpec) *osbuild.Sources {
+func (r *Fedora32) sources(packages []rpmmd.PackageSpec) *osbuild.Sources {
 	return &osbuild.Sources{}
 }
 
 func (r *Fedora32) Manifest(b *blueprint.Blueprint, additionalRepos []rpmmd.RepoConfig, packageSpecs, buildPackageSpecs []rpmmd.PackageSpec, checksums map[string]string, outputArchitecture, outputFormat string, size uint64) (*osbuild.Manifest, error) {
-	pipeline, err := r.Pipeline(b, additionalRepos, packageSpecs, buildPackageSpecs, checksums, outputArchitecture, outputFormat, size)
+	pipeline, err := r.pipeline(b, additionalRepos, packageSpecs, buildPackageSpecs, checksums, outputArchitecture, outputFormat, size)
 	if err != nil {
 		return nil, err
 	}
 
 	return &osbuild.Manifest{
-		Sources:  *r.Sources(append(packageSpecs, buildPackageSpecs...)),
+		Sources:  *r.sources(append(packageSpecs, buildPackageSpecs...)),
 		Pipeline: *pipeline,
 	}, nil
 }

--- a/internal/distro/fedoratest/distro.go
+++ b/internal/distro/fedoratest/distro.go
@@ -63,7 +63,7 @@ func (d *FedoraTestDistro) BuildPackages(outputArchitecture string) ([]string, e
 	return nil, nil
 }
 
-func (d *FedoraTestDistro) Pipeline(b *blueprint.Blueprint, additionalRepos []rpmmd.RepoConfig, buildPackages, basePackages []rpmmd.PackageSpec, checksums map[string]string, outputArch, outputFormat string, size uint64) (*osbuild.Pipeline, error) {
+func (d *FedoraTestDistro) pipeline(b *blueprint.Blueprint, additionalRepos []rpmmd.RepoConfig, buildPackages, basePackages []rpmmd.PackageSpec, checksums map[string]string, outputArch, outputFormat string, size uint64) (*osbuild.Pipeline, error) {
 	if outputFormat == "qcow2" && outputArch == "x86_64" {
 		return &osbuild.Pipeline{}, nil
 	} else {
@@ -71,18 +71,18 @@ func (d *FedoraTestDistro) Pipeline(b *blueprint.Blueprint, additionalRepos []rp
 	}
 }
 
-func (r *FedoraTestDistro) Sources(packages []rpmmd.PackageSpec) *osbuild.Sources {
+func (r *FedoraTestDistro) sources(packages []rpmmd.PackageSpec) *osbuild.Sources {
 	return &osbuild.Sources{}
 }
 
 func (r *FedoraTestDistro) Manifest(b *blueprint.Blueprint, additionalRepos []rpmmd.RepoConfig, packageSpecs, buildPackageSpecs []rpmmd.PackageSpec, checksums map[string]string, outputArchitecture, outputFormat string, size uint64) (*osbuild.Manifest, error) {
-	pipeline, err := r.Pipeline(b, additionalRepos, packageSpecs, buildPackageSpecs, checksums, outputArchitecture, outputFormat, size)
+	pipeline, err := r.pipeline(b, additionalRepos, packageSpecs, buildPackageSpecs, checksums, outputArchitecture, outputFormat, size)
 	if err != nil {
 		return nil, err
 	}
 
 	return &osbuild.Manifest{
-		Sources:  *r.Sources(append(packageSpecs, buildPackageSpecs...)),
+		Sources:  *r.sources(append(packageSpecs, buildPackageSpecs...)),
 		Pipeline: *pipeline,
 	}, nil
 }

--- a/internal/distro/rhel81/distro.go
+++ b/internal/distro/rhel81/distro.go
@@ -525,7 +525,7 @@ func (r *RHEL81) BuildPackages(outputArchitecture string) ([]string, error) {
 	return append(r.buildPackages, arch.BuildPackages...), nil
 }
 
-func (r *RHEL81) Pipeline(b *blueprint.Blueprint, additionalRepos []rpmmd.RepoConfig, packageSpecs, buildPackageSpecs []rpmmd.PackageSpec, checksums map[string]string, outputArchitecture, outputFormat string, size uint64) (*osbuild.Pipeline, error) {
+func (r *RHEL81) pipeline(b *blueprint.Blueprint, additionalRepos []rpmmd.RepoConfig, packageSpecs, buildPackageSpecs []rpmmd.PackageSpec, checksums map[string]string, outputArchitecture, outputFormat string, size uint64) (*osbuild.Pipeline, error) {
 	output, exists := r.outputs[outputFormat]
 	if !exists {
 		return nil, errors.New("invalid output format: " + outputFormat)
@@ -612,18 +612,18 @@ func (r *RHEL81) Pipeline(b *blueprint.Blueprint, additionalRepos []rpmmd.RepoCo
 	return p, nil
 }
 
-func (r *RHEL81) Sources(packages []rpmmd.PackageSpec) *osbuild.Sources {
+func (r *RHEL81) sources(packages []rpmmd.PackageSpec) *osbuild.Sources {
 	return &osbuild.Sources{}
 }
 
 func (r *RHEL81) Manifest(b *blueprint.Blueprint, additionalRepos []rpmmd.RepoConfig, packageSpecs, buildPackageSpecs []rpmmd.PackageSpec, checksums map[string]string, outputArchitecture, outputFormat string, size uint64) (*osbuild.Manifest, error) {
-	pipeline, err := r.Pipeline(b, additionalRepos, packageSpecs, buildPackageSpecs, checksums, outputArchitecture, outputFormat, size)
+	pipeline, err := r.pipeline(b, additionalRepos, packageSpecs, buildPackageSpecs, checksums, outputArchitecture, outputFormat, size)
 	if err != nil {
 		return nil, err
 	}
 
 	return &osbuild.Manifest{
-		Sources:  *r.Sources(append(packageSpecs, buildPackageSpecs...)),
+		Sources:  *r.sources(append(packageSpecs, buildPackageSpecs...)),
 		Pipeline: *pipeline,
 	}, nil
 }

--- a/internal/distro/rhel82/distro.go
+++ b/internal/distro/rhel82/distro.go
@@ -525,7 +525,7 @@ func (r *RHEL82) BuildPackages(outputArchitecture string) ([]string, error) {
 	return append(r.buildPackages, arch.BuildPackages...), nil
 }
 
-func (r *RHEL82) Pipeline(b *blueprint.Blueprint, additionalRepos []rpmmd.RepoConfig, packageSpecs, buildPackageSpecs []rpmmd.PackageSpec, checksums map[string]string, outputArchitecture, outputFormat string, size uint64) (*osbuild.Pipeline, error) {
+func (r *RHEL82) pipeline(b *blueprint.Blueprint, additionalRepos []rpmmd.RepoConfig, packageSpecs, buildPackageSpecs []rpmmd.PackageSpec, checksums map[string]string, outputArchitecture, outputFormat string, size uint64) (*osbuild.Pipeline, error) {
 	output, exists := r.outputs[outputFormat]
 	if !exists {
 		return nil, errors.New("invalid output format: " + outputFormat)
@@ -612,18 +612,18 @@ func (r *RHEL82) Pipeline(b *blueprint.Blueprint, additionalRepos []rpmmd.RepoCo
 	return p, nil
 }
 
-func (r *RHEL82) Sources(packages []rpmmd.PackageSpec) *osbuild.Sources {
+func (r *RHEL82) sources(packages []rpmmd.PackageSpec) *osbuild.Sources {
 	return &osbuild.Sources{}
 }
 
 func (r *RHEL82) Manifest(b *blueprint.Blueprint, additionalRepos []rpmmd.RepoConfig, packageSpecs, buildPackageSpecs []rpmmd.PackageSpec, checksums map[string]string, outputArchitecture, outputFormat string, size uint64) (*osbuild.Manifest, error) {
-	pipeline, err := r.Pipeline(b, additionalRepos, packageSpecs, buildPackageSpecs, checksums, outputArchitecture, outputFormat, size)
+	pipeline, err := r.pipeline(b, additionalRepos, packageSpecs, buildPackageSpecs, checksums, outputArchitecture, outputFormat, size)
 	if err != nil {
 		return nil, err
 	}
 
 	return &osbuild.Manifest{
-		Sources:  *r.Sources(append(packageSpecs, buildPackageSpecs...)),
+		Sources:  *r.sources(append(packageSpecs, buildPackageSpecs...)),
 		Pipeline: *pipeline,
 	}, nil
 }

--- a/internal/distro/test/distro.go
+++ b/internal/distro/test/distro.go
@@ -55,7 +55,7 @@ func (d *TestDistro) BuildPackages(outputArchitecture string) ([]string, error) 
 	return nil, nil
 }
 
-func (d *TestDistro) Pipeline(b *blueprint.Blueprint, additionalRepos []rpmmd.RepoConfig, packageSpecs, buildPackageSpecs []rpmmd.PackageSpec, checksums map[string]string, outputArch, outputFormat string, size uint64) (*osbuild.Pipeline, error) {
+func (d *TestDistro) pipeline(b *blueprint.Blueprint, additionalRepos []rpmmd.RepoConfig, packageSpecs, buildPackageSpecs []rpmmd.PackageSpec, checksums map[string]string, outputArch, outputFormat string, size uint64) (*osbuild.Pipeline, error) {
 	if outputFormat == "test_output" && outputArch == "test_arch" {
 		return &osbuild.Pipeline{}, nil
 	}
@@ -63,18 +63,18 @@ func (d *TestDistro) Pipeline(b *blueprint.Blueprint, additionalRepos []rpmmd.Re
 	return nil, errors.New("invalid output format or arch: " + outputFormat + " @ " + outputArch)
 }
 
-func (d *TestDistro) Sources(packages []rpmmd.PackageSpec) *osbuild.Sources {
+func (d *TestDistro) sources(packages []rpmmd.PackageSpec) *osbuild.Sources {
 	return &osbuild.Sources{}
 }
 
 func (r *TestDistro) Manifest(b *blueprint.Blueprint, additionalRepos []rpmmd.RepoConfig, packageSpecs, buildPackageSpecs []rpmmd.PackageSpec, checksums map[string]string, outputArchitecture, outputFormat string, size uint64) (*osbuild.Manifest, error) {
-	pipeline, err := r.Pipeline(b, additionalRepos, packageSpecs, buildPackageSpecs, checksums, outputArchitecture, outputFormat, size)
+	pipeline, err := r.pipeline(b, additionalRepos, packageSpecs, buildPackageSpecs, checksums, outputArchitecture, outputFormat, size)
 	if err != nil {
 		return nil, err
 	}
 
 	return &osbuild.Manifest{
-		Sources:  *r.Sources(append(packageSpecs, buildPackageSpecs...)),
+		Sources:  *r.sources(append(packageSpecs, buildPackageSpecs...)),
 		Pipeline: *pipeline,
 	}, nil
 }

--- a/test/cases/ami_empty_blueprint.json
+++ b/test/cases/ami_empty_blueprint.json
@@ -5,12 +5,14 @@
   "compose": {
     "distro": "fedora-30",
     "arch": "x86_64",
-    "checksums": {
-      "fedora": "sha256:9f596e18f585bee30ac41c11fb11a83ed6b11d5b341c1cb56ca4015d7717cb97"
-    },
     "filename": "image.raw.xz",
     "output-format": "ami",
     "blueprint": {}
+  },
+  "rpmmd": {
+    "checksums": {
+      "fedora": "sha256:9f596e18f585bee30ac41c11fb11a83ed6b11d5b341c1cb56ca4015d7717cb97"
+    }
   },
   "pipeline": {
     "build": {

--- a/test/cases/ami_empty_blueprint.json
+++ b/test/cases/ami_empty_blueprint.json
@@ -14,138 +14,141 @@
       "fedora": "sha256:9f596e18f585bee30ac41c11fb11a83ed6b11d5b341c1cb56ca4015d7717cb97"
     }
   },
-  "pipeline": {
-    "build": {
-      "pipeline": {
-        "stages": [
-          {
-            "name": "org.osbuild.dnf",
-            "options": {
-              "repos": [
-                {
-                  "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-30&arch=x86_64",
-                  "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBFturGcBEACv0xBo91V2n0uEC2vh69ywCiSyvUgN/AQH8EZpCVtM7NyjKgKm\nbbY4G3R0M3ir1xXmvUDvK0493/qOiFrjkplvzXFTGpPTi0ypqGgxc5d0ohRA1M75\nL+0AIlXoOgHQ358/c4uO8X0JAA1NYxCkAW1KSJgFJ3RjukrfqSHWthS1d4o8fhHy\nKJKEnirE5hHqB50dafXrBfgZdaOs3C6ppRIePFe2o4vUEapMTCHFw0woQR8Ah4/R\nn7Z9G9Ln+0Cinmy0nbIDiZJ+pgLAXCOWBfDUzcOjDGKvcpoZharA07c0q1/5ojzO\n4F0Fh4g/BUmtrASwHfcIbjHyCSr1j/3Iz883iy07gJY5Yhiuaqmp0o0f9fgHkG53\n2xCU1owmACqaIBNQMukvXRDtB2GJMuKa/asTZDP6R5re+iXs7+s9ohcRRAKGyAyc\nYKIQKcaA+6M8T7/G+TPHZX6HJWqJJiYB+EC2ERblpvq9TPlLguEWcmvjbVc31nyq\nSDoO3ncFWKFmVsbQPTbP+pKUmlLfJwtb5XqxNR5GEXSwVv4I7IqBmJz1MmRafnBZ\ng0FJUtH668GnldO20XbnSVBr820F5SISMXVwCXDXEvGwwiB8Lt8PvqzXnGIFDAu3\nDlQI5sxSqpPVWSyw08ppKT2Tpmy8adiBotLfaCFl2VTHwOae48X2dMPBvQARAQAB\ntDFGZWRvcmEgKDMwKSA8ZmVkb3JhLTMwLXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQI4BBMBAgAiBQJbbqxnAhsPBgsJCAcDAgYVCAIJCgsEFgIDAQIeAQIXgAAK\nCRDvPBEfz8ZZudTnD/9170LL3nyTVUCFmBjT9wZ4gYnpwtKVPa/pKnxbbS+Bmmac\ng9TrT9pZbqOHrNJLiZ3Zx1Hp+8uxr3Lo6kbYwImLhkOEDrf4aP17HfQ6VYFbQZI8\nf79OFxWJ7si9+3gfzeh9UYFEqOQfzIjLWFyfnas0OnV/P+RMQ1Zr+vPRqO7AR2va\nN9wg+Xl7157dhXPCGYnGMNSoxCbpRs0JNlzvJMuAea5nTTznRaJZtK/xKsqLn51D\nK07k9MHVFXakOH8QtMCUglbwfTfIpO5YRq5imxlWbqsYWVQy1WGJFyW6hWC0+RcJ\nOx5zGtOfi4/dN+xJ+ibnbyvy/il7Qm+vyFhCYqIPyS5m2UVJUuao3eApE38k78/o\n8aQOTnFQZ+U1Sw+6woFTxjqRQBXlQm2+7Bt3bqGATg4sXXWPbmwdL87Ic+mxn/ml\nSMfQux/5k6iAu1kQhwkO2YJn9eII6HIPkW+2m5N1JsUyJQe4cbtZE5Yh3TRA0dm7\n+zoBRfCXkOW4krchbgww/ptVmzMMP7GINJdROrJnsGl5FVeid9qHzV7aZycWSma7\nCxBYB1J8HCbty5NjtD6XMYRrMLxXugvX6Q4NPPH+2NKjzX4SIDejS6JjgrP3KA3O\npMuo7ZHMfveBngv8yP+ZD/1sS6l+dfExvdaJdOdgFCnp4p3gPbw5+Lv70HrMjA==\n=BfZ/\n-----END PGP PUBLIC KEY BLOCK-----\n",
-                  "checksum": "sha256:9f596e18f585bee30ac41c11fb11a83ed6b11d5b341c1cb56ca4015d7717cb97"
-                }
-              ],
-              "packages": [
-                "dnf",
-                "dosfstools",
-                "e2fsprogs",
-                "grub2-pc",
-                "policycoreutils",
-                "qemu-img",
-                "systemd",
-                "tar"
-              ],
-              "releasever": "30",
-              "basearch": "x86_64",
-              "module_platform_id": "platform:f30"
+  "manifest": {
+    "sources": {},
+    "pipeline": {
+      "build": {
+        "pipeline": {
+          "stages": [
+            {
+              "name": "org.osbuild.dnf",
+              "options": {
+                "repos": [
+                  {
+                    "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-30&arch=x86_64",
+                    "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBFturGcBEACv0xBo91V2n0uEC2vh69ywCiSyvUgN/AQH8EZpCVtM7NyjKgKm\nbbY4G3R0M3ir1xXmvUDvK0493/qOiFrjkplvzXFTGpPTi0ypqGgxc5d0ohRA1M75\nL+0AIlXoOgHQ358/c4uO8X0JAA1NYxCkAW1KSJgFJ3RjukrfqSHWthS1d4o8fhHy\nKJKEnirE5hHqB50dafXrBfgZdaOs3C6ppRIePFe2o4vUEapMTCHFw0woQR8Ah4/R\nn7Z9G9Ln+0Cinmy0nbIDiZJ+pgLAXCOWBfDUzcOjDGKvcpoZharA07c0q1/5ojzO\n4F0Fh4g/BUmtrASwHfcIbjHyCSr1j/3Iz883iy07gJY5Yhiuaqmp0o0f9fgHkG53\n2xCU1owmACqaIBNQMukvXRDtB2GJMuKa/asTZDP6R5re+iXs7+s9ohcRRAKGyAyc\nYKIQKcaA+6M8T7/G+TPHZX6HJWqJJiYB+EC2ERblpvq9TPlLguEWcmvjbVc31nyq\nSDoO3ncFWKFmVsbQPTbP+pKUmlLfJwtb5XqxNR5GEXSwVv4I7IqBmJz1MmRafnBZ\ng0FJUtH668GnldO20XbnSVBr820F5SISMXVwCXDXEvGwwiB8Lt8PvqzXnGIFDAu3\nDlQI5sxSqpPVWSyw08ppKT2Tpmy8adiBotLfaCFl2VTHwOae48X2dMPBvQARAQAB\ntDFGZWRvcmEgKDMwKSA8ZmVkb3JhLTMwLXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQI4BBMBAgAiBQJbbqxnAhsPBgsJCAcDAgYVCAIJCgsEFgIDAQIeAQIXgAAK\nCRDvPBEfz8ZZudTnD/9170LL3nyTVUCFmBjT9wZ4gYnpwtKVPa/pKnxbbS+Bmmac\ng9TrT9pZbqOHrNJLiZ3Zx1Hp+8uxr3Lo6kbYwImLhkOEDrf4aP17HfQ6VYFbQZI8\nf79OFxWJ7si9+3gfzeh9UYFEqOQfzIjLWFyfnas0OnV/P+RMQ1Zr+vPRqO7AR2va\nN9wg+Xl7157dhXPCGYnGMNSoxCbpRs0JNlzvJMuAea5nTTznRaJZtK/xKsqLn51D\nK07k9MHVFXakOH8QtMCUglbwfTfIpO5YRq5imxlWbqsYWVQy1WGJFyW6hWC0+RcJ\nOx5zGtOfi4/dN+xJ+ibnbyvy/il7Qm+vyFhCYqIPyS5m2UVJUuao3eApE38k78/o\n8aQOTnFQZ+U1Sw+6woFTxjqRQBXlQm2+7Bt3bqGATg4sXXWPbmwdL87Ic+mxn/ml\nSMfQux/5k6iAu1kQhwkO2YJn9eII6HIPkW+2m5N1JsUyJQe4cbtZE5Yh3TRA0dm7\n+zoBRfCXkOW4krchbgww/ptVmzMMP7GINJdROrJnsGl5FVeid9qHzV7aZycWSma7\nCxBYB1J8HCbty5NjtD6XMYRrMLxXugvX6Q4NPPH+2NKjzX4SIDejS6JjgrP3KA3O\npMuo7ZHMfveBngv8yP+ZD/1sS6l+dfExvdaJdOdgFCnp4p3gPbw5+Lv70HrMjA==\n=BfZ/\n-----END PGP PUBLIC KEY BLOCK-----\n",
+                    "checksum": "sha256:9f596e18f585bee30ac41c11fb11a83ed6b11d5b341c1cb56ca4015d7717cb97"
+                  }
+                ],
+                "packages": [
+                  "dnf",
+                  "dosfstools",
+                  "e2fsprogs",
+                  "grub2-pc",
+                  "policycoreutils",
+                  "qemu-img",
+                  "systemd",
+                  "tar"
+                ],
+                "releasever": "30",
+                "basearch": "x86_64",
+                "module_platform_id": "platform:f30"
+              }
             }
+          ]
+        },
+        "runner": "org.osbuild.fedora30"
+      },
+      "stages": [
+        {
+          "name": "org.osbuild.dnf",
+          "options": {
+            "repos": [
+              {
+                "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-30&arch=x86_64",
+                "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBFturGcBEACv0xBo91V2n0uEC2vh69ywCiSyvUgN/AQH8EZpCVtM7NyjKgKm\nbbY4G3R0M3ir1xXmvUDvK0493/qOiFrjkplvzXFTGpPTi0ypqGgxc5d0ohRA1M75\nL+0AIlXoOgHQ358/c4uO8X0JAA1NYxCkAW1KSJgFJ3RjukrfqSHWthS1d4o8fhHy\nKJKEnirE5hHqB50dafXrBfgZdaOs3C6ppRIePFe2o4vUEapMTCHFw0woQR8Ah4/R\nn7Z9G9Ln+0Cinmy0nbIDiZJ+pgLAXCOWBfDUzcOjDGKvcpoZharA07c0q1/5ojzO\n4F0Fh4g/BUmtrASwHfcIbjHyCSr1j/3Iz883iy07gJY5Yhiuaqmp0o0f9fgHkG53\n2xCU1owmACqaIBNQMukvXRDtB2GJMuKa/asTZDP6R5re+iXs7+s9ohcRRAKGyAyc\nYKIQKcaA+6M8T7/G+TPHZX6HJWqJJiYB+EC2ERblpvq9TPlLguEWcmvjbVc31nyq\nSDoO3ncFWKFmVsbQPTbP+pKUmlLfJwtb5XqxNR5GEXSwVv4I7IqBmJz1MmRafnBZ\ng0FJUtH668GnldO20XbnSVBr820F5SISMXVwCXDXEvGwwiB8Lt8PvqzXnGIFDAu3\nDlQI5sxSqpPVWSyw08ppKT2Tpmy8adiBotLfaCFl2VTHwOae48X2dMPBvQARAQAB\ntDFGZWRvcmEgKDMwKSA8ZmVkb3JhLTMwLXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQI4BBMBAgAiBQJbbqxnAhsPBgsJCAcDAgYVCAIJCgsEFgIDAQIeAQIXgAAK\nCRDvPBEfz8ZZudTnD/9170LL3nyTVUCFmBjT9wZ4gYnpwtKVPa/pKnxbbS+Bmmac\ng9TrT9pZbqOHrNJLiZ3Zx1Hp+8uxr3Lo6kbYwImLhkOEDrf4aP17HfQ6VYFbQZI8\nf79OFxWJ7si9+3gfzeh9UYFEqOQfzIjLWFyfnas0OnV/P+RMQ1Zr+vPRqO7AR2va\nN9wg+Xl7157dhXPCGYnGMNSoxCbpRs0JNlzvJMuAea5nTTznRaJZtK/xKsqLn51D\nK07k9MHVFXakOH8QtMCUglbwfTfIpO5YRq5imxlWbqsYWVQy1WGJFyW6hWC0+RcJ\nOx5zGtOfi4/dN+xJ+ibnbyvy/il7Qm+vyFhCYqIPyS5m2UVJUuao3eApE38k78/o\n8aQOTnFQZ+U1Sw+6woFTxjqRQBXlQm2+7Bt3bqGATg4sXXWPbmwdL87Ic+mxn/ml\nSMfQux/5k6iAu1kQhwkO2YJn9eII6HIPkW+2m5N1JsUyJQe4cbtZE5Yh3TRA0dm7\n+zoBRfCXkOW4krchbgww/ptVmzMMP7GINJdROrJnsGl5FVeid9qHzV7aZycWSma7\nCxBYB1J8HCbty5NjtD6XMYRrMLxXugvX6Q4NPPH+2NKjzX4SIDejS6JjgrP3KA3O\npMuo7ZHMfveBngv8yP+ZD/1sS6l+dfExvdaJdOdgFCnp4p3gPbw5+Lv70HrMjA==\n=BfZ/\n-----END PGP PUBLIC KEY BLOCK-----\n",
+                "checksum": "sha256:9f596e18f585bee30ac41c11fb11a83ed6b11d5b341c1cb56ca4015d7717cb97"
+              }
+            ],
+            "packages": [
+              "@Core",
+              "checkpolicy",
+              "chrony",
+              "cloud-init",
+              "grub2-pc",
+              "kernel",
+              "langpacks-en",
+              "libxcrypt-compat",
+              "net-tools",
+              "selinux-policy-targeted",
+              "xfsprogs"
+            ],
+            "exclude_packages": [
+              "dracut-config-rescue"
+            ],
+            "releasever": "30",
+            "basearch": "x86_64",
+            "module_platform_id": "platform:f30"
           }
-        ]
-      },
-      "runner": "org.osbuild.fedora30"
-    },
-    "stages": [
-      {
-        "name": "org.osbuild.dnf",
-        "options": {
-          "repos": [
-            {
-              "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-30&arch=x86_64",
-              "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBFturGcBEACv0xBo91V2n0uEC2vh69ywCiSyvUgN/AQH8EZpCVtM7NyjKgKm\nbbY4G3R0M3ir1xXmvUDvK0493/qOiFrjkplvzXFTGpPTi0ypqGgxc5d0ohRA1M75\nL+0AIlXoOgHQ358/c4uO8X0JAA1NYxCkAW1KSJgFJ3RjukrfqSHWthS1d4o8fhHy\nKJKEnirE5hHqB50dafXrBfgZdaOs3C6ppRIePFe2o4vUEapMTCHFw0woQR8Ah4/R\nn7Z9G9Ln+0Cinmy0nbIDiZJ+pgLAXCOWBfDUzcOjDGKvcpoZharA07c0q1/5ojzO\n4F0Fh4g/BUmtrASwHfcIbjHyCSr1j/3Iz883iy07gJY5Yhiuaqmp0o0f9fgHkG53\n2xCU1owmACqaIBNQMukvXRDtB2GJMuKa/asTZDP6R5re+iXs7+s9ohcRRAKGyAyc\nYKIQKcaA+6M8T7/G+TPHZX6HJWqJJiYB+EC2ERblpvq9TPlLguEWcmvjbVc31nyq\nSDoO3ncFWKFmVsbQPTbP+pKUmlLfJwtb5XqxNR5GEXSwVv4I7IqBmJz1MmRafnBZ\ng0FJUtH668GnldO20XbnSVBr820F5SISMXVwCXDXEvGwwiB8Lt8PvqzXnGIFDAu3\nDlQI5sxSqpPVWSyw08ppKT2Tpmy8adiBotLfaCFl2VTHwOae48X2dMPBvQARAQAB\ntDFGZWRvcmEgKDMwKSA8ZmVkb3JhLTMwLXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQI4BBMBAgAiBQJbbqxnAhsPBgsJCAcDAgYVCAIJCgsEFgIDAQIeAQIXgAAK\nCRDvPBEfz8ZZudTnD/9170LL3nyTVUCFmBjT9wZ4gYnpwtKVPa/pKnxbbS+Bmmac\ng9TrT9pZbqOHrNJLiZ3Zx1Hp+8uxr3Lo6kbYwImLhkOEDrf4aP17HfQ6VYFbQZI8\nf79OFxWJ7si9+3gfzeh9UYFEqOQfzIjLWFyfnas0OnV/P+RMQ1Zr+vPRqO7AR2va\nN9wg+Xl7157dhXPCGYnGMNSoxCbpRs0JNlzvJMuAea5nTTznRaJZtK/xKsqLn51D\nK07k9MHVFXakOH8QtMCUglbwfTfIpO5YRq5imxlWbqsYWVQy1WGJFyW6hWC0+RcJ\nOx5zGtOfi4/dN+xJ+ibnbyvy/il7Qm+vyFhCYqIPyS5m2UVJUuao3eApE38k78/o\n8aQOTnFQZ+U1Sw+6woFTxjqRQBXlQm2+7Bt3bqGATg4sXXWPbmwdL87Ic+mxn/ml\nSMfQux/5k6iAu1kQhwkO2YJn9eII6HIPkW+2m5N1JsUyJQe4cbtZE5Yh3TRA0dm7\n+zoBRfCXkOW4krchbgww/ptVmzMMP7GINJdROrJnsGl5FVeid9qHzV7aZycWSma7\nCxBYB1J8HCbty5NjtD6XMYRrMLxXugvX6Q4NPPH+2NKjzX4SIDejS6JjgrP3KA3O\npMuo7ZHMfveBngv8yP+ZD/1sS6l+dfExvdaJdOdgFCnp4p3gPbw5+Lv70HrMjA==\n=BfZ/\n-----END PGP PUBLIC KEY BLOCK-----\n",
-              "checksum": "sha256:9f596e18f585bee30ac41c11fb11a83ed6b11d5b341c1cb56ca4015d7717cb97"
-            }
-          ],
-          "packages": [
-            "@Core",
-            "checkpolicy",
-            "chrony",
-            "cloud-init",
-            "grub2-pc",
-            "kernel",
-            "langpacks-en",
-            "libxcrypt-compat",
-            "net-tools",
-            "selinux-policy-targeted",
-            "xfsprogs"
-          ],
-          "exclude_packages": [
-            "dracut-config-rescue"
-          ],
-          "releasever": "30",
-          "basearch": "x86_64",
-          "module_platform_id": "platform:f30"
+        },
+        {
+          "name": "org.osbuild.fix-bls",
+          "options": {}
+        },
+        {
+          "name": "org.osbuild.locale",
+          "options": {
+            "language": "en_US"
+          }
+        },
+        {
+          "name": "org.osbuild.fstab",
+          "options": {
+            "filesystems": [
+              {
+                "uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
+                "vfs_type": "ext4",
+                "path": "/",
+                "options": "defaults",
+                "freq": 1,
+                "passno": 1
+              }
+            ]
+          }
+        },
+        {
+          "name": "org.osbuild.grub2",
+          "options": {
+            "root_fs_uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
+            "kernel_opts": "ro no_timer_check console=ttyS0,115200n8 console=tty1 biosdevname=0 net.ifnames=0 console=ttyS0,115200",
+            "legacy": true
+          }
+        },
+        {
+          "name": "org.osbuild.systemd",
+          "options": {
+            "enabled_services": [
+              "cloud-init.service"
+            ]
+          }
+        },
+        {
+          "name": "org.osbuild.selinux",
+          "options": {
+            "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
+          }
         }
-      },
-      {
-        "name": "org.osbuild.fix-bls",
-        "options": {}
-      },
-      {
-        "name": "org.osbuild.locale",
+      ],
+      "assembler": {
+        "name": "org.osbuild.qemu",
         "options": {
-          "language": "en_US"
-        }
-      },
-      {
-        "name": "org.osbuild.fstab",
-        "options": {
-          "filesystems": [
+          "format": "raw.xz",
+          "filename": "image.raw.xz",
+          "size": 6442450944,
+          "ptuuid": "0x14fc63d2",
+          "pttype": "mbr",
+          "partitions": [
             {
-              "uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
-              "vfs_type": "ext4",
-              "path": "/",
-              "options": "defaults",
-              "freq": 1,
-              "passno": 1
+              "start": 2048,
+              "bootable": true,
+              "filesystem": {
+                "type": "ext4",
+                "uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
+                "mountpoint": "/"
+              }
             }
           ]
         }
-      },
-      {
-        "name": "org.osbuild.grub2",
-        "options": {
-          "root_fs_uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
-          "kernel_opts": "ro no_timer_check console=ttyS0,115200n8 console=tty1 biosdevname=0 net.ifnames=0 console=ttyS0,115200",
-          "legacy": true
-        }
-      },
-      {
-        "name": "org.osbuild.systemd",
-        "options": {
-          "enabled_services": [
-            "cloud-init.service"
-          ]
-        }
-      },
-      {
-        "name": "org.osbuild.selinux",
-        "options": {
-          "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
-        }
-      }
-    ],
-    "assembler": {
-      "name": "org.osbuild.qemu",
-      "options": {
-        "format": "raw.xz",
-        "filename": "image.raw.xz",
-        "size": 6442450944,
-        "ptuuid": "0x14fc63d2",
-        "pttype": "mbr",
-        "partitions": [
-          {
-            "start": 2048,
-            "bootable": true,
-            "filesystem": {
-              "type": "ext4",
-              "uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
-              "mountpoint": "/"
-            }
-          }
-        ]
       }
     }
   },

--- a/test/cases/ami_empty_blueprint.json
+++ b/test/cases/ami_empty_blueprint.json
@@ -2,7 +2,7 @@
   "boot": {
     "type": "qemu-extract"
   },
-  "compose": {
+  "compose-request": {
     "distro": "fedora-30",
     "arch": "x86_64",
     "filename": "image.raw.xz",

--- a/test/cases/disk_empty_blueprint.json
+++ b/test/cases/disk_empty_blueprint.json
@@ -11,126 +11,129 @@
       "fedora": "sha256:9f596e18f585bee30ac41c11fb11a83ed6b11d5b341c1cb56ca4015d7717cb97"
     }
   },
-  "pipeline": {
-    "build": {
-      "pipeline": {
-        "stages": [
-          {
-            "name": "org.osbuild.dnf",
-            "options": {
-              "repos": [
-                {
-                  "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-30&arch=x86_64",
-                  "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBFturGcBEACv0xBo91V2n0uEC2vh69ywCiSyvUgN/AQH8EZpCVtM7NyjKgKm\nbbY4G3R0M3ir1xXmvUDvK0493/qOiFrjkplvzXFTGpPTi0ypqGgxc5d0ohRA1M75\nL+0AIlXoOgHQ358/c4uO8X0JAA1NYxCkAW1KSJgFJ3RjukrfqSHWthS1d4o8fhHy\nKJKEnirE5hHqB50dafXrBfgZdaOs3C6ppRIePFe2o4vUEapMTCHFw0woQR8Ah4/R\nn7Z9G9Ln+0Cinmy0nbIDiZJ+pgLAXCOWBfDUzcOjDGKvcpoZharA07c0q1/5ojzO\n4F0Fh4g/BUmtrASwHfcIbjHyCSr1j/3Iz883iy07gJY5Yhiuaqmp0o0f9fgHkG53\n2xCU1owmACqaIBNQMukvXRDtB2GJMuKa/asTZDP6R5re+iXs7+s9ohcRRAKGyAyc\nYKIQKcaA+6M8T7/G+TPHZX6HJWqJJiYB+EC2ERblpvq9TPlLguEWcmvjbVc31nyq\nSDoO3ncFWKFmVsbQPTbP+pKUmlLfJwtb5XqxNR5GEXSwVv4I7IqBmJz1MmRafnBZ\ng0FJUtH668GnldO20XbnSVBr820F5SISMXVwCXDXEvGwwiB8Lt8PvqzXnGIFDAu3\nDlQI5sxSqpPVWSyw08ppKT2Tpmy8adiBotLfaCFl2VTHwOae48X2dMPBvQARAQAB\ntDFGZWRvcmEgKDMwKSA8ZmVkb3JhLTMwLXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQI4BBMBAgAiBQJbbqxnAhsPBgsJCAcDAgYVCAIJCgsEFgIDAQIeAQIXgAAK\nCRDvPBEfz8ZZudTnD/9170LL3nyTVUCFmBjT9wZ4gYnpwtKVPa/pKnxbbS+Bmmac\ng9TrT9pZbqOHrNJLiZ3Zx1Hp+8uxr3Lo6kbYwImLhkOEDrf4aP17HfQ6VYFbQZI8\nf79OFxWJ7si9+3gfzeh9UYFEqOQfzIjLWFyfnas0OnV/P+RMQ1Zr+vPRqO7AR2va\nN9wg+Xl7157dhXPCGYnGMNSoxCbpRs0JNlzvJMuAea5nTTznRaJZtK/xKsqLn51D\nK07k9MHVFXakOH8QtMCUglbwfTfIpO5YRq5imxlWbqsYWVQy1WGJFyW6hWC0+RcJ\nOx5zGtOfi4/dN+xJ+ibnbyvy/il7Qm+vyFhCYqIPyS5m2UVJUuao3eApE38k78/o\n8aQOTnFQZ+U1Sw+6woFTxjqRQBXlQm2+7Bt3bqGATg4sXXWPbmwdL87Ic+mxn/ml\nSMfQux/5k6iAu1kQhwkO2YJn9eII6HIPkW+2m5N1JsUyJQe4cbtZE5Yh3TRA0dm7\n+zoBRfCXkOW4krchbgww/ptVmzMMP7GINJdROrJnsGl5FVeid9qHzV7aZycWSma7\nCxBYB1J8HCbty5NjtD6XMYRrMLxXugvX6Q4NPPH+2NKjzX4SIDejS6JjgrP3KA3O\npMuo7ZHMfveBngv8yP+ZD/1sS6l+dfExvdaJdOdgFCnp4p3gPbw5+Lv70HrMjA==\n=BfZ/\n-----END PGP PUBLIC KEY BLOCK-----\n",
-                  "checksum": "sha256:9f596e18f585bee30ac41c11fb11a83ed6b11d5b341c1cb56ca4015d7717cb97"
-                }
-              ],
-              "packages": [
-                "dnf",
-                "dosfstools",
-                "e2fsprogs",
-                "grub2-pc",
-                "policycoreutils",
-                "qemu-img",
-                "systemd",
-                "tar"
-              ],
-              "releasever": "30",
-              "basearch": "x86_64",
-              "module_platform_id": "platform:f30"
+  "manifest": {
+    "sources": {},
+    "pipeline": {
+      "build": {
+        "pipeline": {
+          "stages": [
+            {
+              "name": "org.osbuild.dnf",
+              "options": {
+                "repos": [
+                  {
+                    "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-30&arch=x86_64",
+                    "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBFturGcBEACv0xBo91V2n0uEC2vh69ywCiSyvUgN/AQH8EZpCVtM7NyjKgKm\nbbY4G3R0M3ir1xXmvUDvK0493/qOiFrjkplvzXFTGpPTi0ypqGgxc5d0ohRA1M75\nL+0AIlXoOgHQ358/c4uO8X0JAA1NYxCkAW1KSJgFJ3RjukrfqSHWthS1d4o8fhHy\nKJKEnirE5hHqB50dafXrBfgZdaOs3C6ppRIePFe2o4vUEapMTCHFw0woQR8Ah4/R\nn7Z9G9Ln+0Cinmy0nbIDiZJ+pgLAXCOWBfDUzcOjDGKvcpoZharA07c0q1/5ojzO\n4F0Fh4g/BUmtrASwHfcIbjHyCSr1j/3Iz883iy07gJY5Yhiuaqmp0o0f9fgHkG53\n2xCU1owmACqaIBNQMukvXRDtB2GJMuKa/asTZDP6R5re+iXs7+s9ohcRRAKGyAyc\nYKIQKcaA+6M8T7/G+TPHZX6HJWqJJiYB+EC2ERblpvq9TPlLguEWcmvjbVc31nyq\nSDoO3ncFWKFmVsbQPTbP+pKUmlLfJwtb5XqxNR5GEXSwVv4I7IqBmJz1MmRafnBZ\ng0FJUtH668GnldO20XbnSVBr820F5SISMXVwCXDXEvGwwiB8Lt8PvqzXnGIFDAu3\nDlQI5sxSqpPVWSyw08ppKT2Tpmy8adiBotLfaCFl2VTHwOae48X2dMPBvQARAQAB\ntDFGZWRvcmEgKDMwKSA8ZmVkb3JhLTMwLXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQI4BBMBAgAiBQJbbqxnAhsPBgsJCAcDAgYVCAIJCgsEFgIDAQIeAQIXgAAK\nCRDvPBEfz8ZZudTnD/9170LL3nyTVUCFmBjT9wZ4gYnpwtKVPa/pKnxbbS+Bmmac\ng9TrT9pZbqOHrNJLiZ3Zx1Hp+8uxr3Lo6kbYwImLhkOEDrf4aP17HfQ6VYFbQZI8\nf79OFxWJ7si9+3gfzeh9UYFEqOQfzIjLWFyfnas0OnV/P+RMQ1Zr+vPRqO7AR2va\nN9wg+Xl7157dhXPCGYnGMNSoxCbpRs0JNlzvJMuAea5nTTznRaJZtK/xKsqLn51D\nK07k9MHVFXakOH8QtMCUglbwfTfIpO5YRq5imxlWbqsYWVQy1WGJFyW6hWC0+RcJ\nOx5zGtOfi4/dN+xJ+ibnbyvy/il7Qm+vyFhCYqIPyS5m2UVJUuao3eApE38k78/o\n8aQOTnFQZ+U1Sw+6woFTxjqRQBXlQm2+7Bt3bqGATg4sXXWPbmwdL87Ic+mxn/ml\nSMfQux/5k6iAu1kQhwkO2YJn9eII6HIPkW+2m5N1JsUyJQe4cbtZE5Yh3TRA0dm7\n+zoBRfCXkOW4krchbgww/ptVmzMMP7GINJdROrJnsGl5FVeid9qHzV7aZycWSma7\nCxBYB1J8HCbty5NjtD6XMYRrMLxXugvX6Q4NPPH+2NKjzX4SIDejS6JjgrP3KA3O\npMuo7ZHMfveBngv8yP+ZD/1sS6l+dfExvdaJdOdgFCnp4p3gPbw5+Lv70HrMjA==\n=BfZ/\n-----END PGP PUBLIC KEY BLOCK-----\n",
+                    "checksum": "sha256:9f596e18f585bee30ac41c11fb11a83ed6b11d5b341c1cb56ca4015d7717cb97"
+                  }
+                ],
+                "packages": [
+                  "dnf",
+                  "dosfstools",
+                  "e2fsprogs",
+                  "grub2-pc",
+                  "policycoreutils",
+                  "qemu-img",
+                  "systemd",
+                  "tar"
+                ],
+                "releasever": "30",
+                "basearch": "x86_64",
+                "module_platform_id": "platform:f30"
+              }
             }
+          ]
+        },
+        "runner": "org.osbuild.fedora30"
+      },
+      "stages": [
+        {
+          "name": "org.osbuild.dnf",
+          "options": {
+            "repos": [
+              {
+                "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-30&arch=x86_64",
+                "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBFturGcBEACv0xBo91V2n0uEC2vh69ywCiSyvUgN/AQH8EZpCVtM7NyjKgKm\nbbY4G3R0M3ir1xXmvUDvK0493/qOiFrjkplvzXFTGpPTi0ypqGgxc5d0ohRA1M75\nL+0AIlXoOgHQ358/c4uO8X0JAA1NYxCkAW1KSJgFJ3RjukrfqSHWthS1d4o8fhHy\nKJKEnirE5hHqB50dafXrBfgZdaOs3C6ppRIePFe2o4vUEapMTCHFw0woQR8Ah4/R\nn7Z9G9Ln+0Cinmy0nbIDiZJ+pgLAXCOWBfDUzcOjDGKvcpoZharA07c0q1/5ojzO\n4F0Fh4g/BUmtrASwHfcIbjHyCSr1j/3Iz883iy07gJY5Yhiuaqmp0o0f9fgHkG53\n2xCU1owmACqaIBNQMukvXRDtB2GJMuKa/asTZDP6R5re+iXs7+s9ohcRRAKGyAyc\nYKIQKcaA+6M8T7/G+TPHZX6HJWqJJiYB+EC2ERblpvq9TPlLguEWcmvjbVc31nyq\nSDoO3ncFWKFmVsbQPTbP+pKUmlLfJwtb5XqxNR5GEXSwVv4I7IqBmJz1MmRafnBZ\ng0FJUtH668GnldO20XbnSVBr820F5SISMXVwCXDXEvGwwiB8Lt8PvqzXnGIFDAu3\nDlQI5sxSqpPVWSyw08ppKT2Tpmy8adiBotLfaCFl2VTHwOae48X2dMPBvQARAQAB\ntDFGZWRvcmEgKDMwKSA8ZmVkb3JhLTMwLXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQI4BBMBAgAiBQJbbqxnAhsPBgsJCAcDAgYVCAIJCgsEFgIDAQIeAQIXgAAK\nCRDvPBEfz8ZZudTnD/9170LL3nyTVUCFmBjT9wZ4gYnpwtKVPa/pKnxbbS+Bmmac\ng9TrT9pZbqOHrNJLiZ3Zx1Hp+8uxr3Lo6kbYwImLhkOEDrf4aP17HfQ6VYFbQZI8\nf79OFxWJ7si9+3gfzeh9UYFEqOQfzIjLWFyfnas0OnV/P+RMQ1Zr+vPRqO7AR2va\nN9wg+Xl7157dhXPCGYnGMNSoxCbpRs0JNlzvJMuAea5nTTznRaJZtK/xKsqLn51D\nK07k9MHVFXakOH8QtMCUglbwfTfIpO5YRq5imxlWbqsYWVQy1WGJFyW6hWC0+RcJ\nOx5zGtOfi4/dN+xJ+ibnbyvy/il7Qm+vyFhCYqIPyS5m2UVJUuao3eApE38k78/o\n8aQOTnFQZ+U1Sw+6woFTxjqRQBXlQm2+7Bt3bqGATg4sXXWPbmwdL87Ic+mxn/ml\nSMfQux/5k6iAu1kQhwkO2YJn9eII6HIPkW+2m5N1JsUyJQe4cbtZE5Yh3TRA0dm7\n+zoBRfCXkOW4krchbgww/ptVmzMMP7GINJdROrJnsGl5FVeid9qHzV7aZycWSma7\nCxBYB1J8HCbty5NjtD6XMYRrMLxXugvX6Q4NPPH+2NKjzX4SIDejS6JjgrP3KA3O\npMuo7ZHMfveBngv8yP+ZD/1sS6l+dfExvdaJdOdgFCnp4p3gPbw5+Lv70HrMjA==\n=BfZ/\n-----END PGP PUBLIC KEY BLOCK-----\n",
+                "checksum": "sha256:9f596e18f585bee30ac41c11fb11a83ed6b11d5b341c1cb56ca4015d7717cb97"
+              }
+            ],
+            "packages": [
+              "@core",
+              "chrony",
+              "firewalld",
+              "grub2-pc",
+              "kernel",
+              "langpacks-en",
+              "selinux-policy-targeted"
+            ],
+            "exclude_packages": [
+              "dracut-config-rescue"
+            ],
+            "releasever": "30",
+            "basearch": "x86_64",
+            "module_platform_id": "platform:f30"
           }
-        ]
-      },
-      "runner": "org.osbuild.fedora30"
-    },
-    "stages": [
-      {
-        "name": "org.osbuild.dnf",
-        "options": {
-          "repos": [
-            {
-              "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-30&arch=x86_64",
-              "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBFturGcBEACv0xBo91V2n0uEC2vh69ywCiSyvUgN/AQH8EZpCVtM7NyjKgKm\nbbY4G3R0M3ir1xXmvUDvK0493/qOiFrjkplvzXFTGpPTi0ypqGgxc5d0ohRA1M75\nL+0AIlXoOgHQ358/c4uO8X0JAA1NYxCkAW1KSJgFJ3RjukrfqSHWthS1d4o8fhHy\nKJKEnirE5hHqB50dafXrBfgZdaOs3C6ppRIePFe2o4vUEapMTCHFw0woQR8Ah4/R\nn7Z9G9Ln+0Cinmy0nbIDiZJ+pgLAXCOWBfDUzcOjDGKvcpoZharA07c0q1/5ojzO\n4F0Fh4g/BUmtrASwHfcIbjHyCSr1j/3Iz883iy07gJY5Yhiuaqmp0o0f9fgHkG53\n2xCU1owmACqaIBNQMukvXRDtB2GJMuKa/asTZDP6R5re+iXs7+s9ohcRRAKGyAyc\nYKIQKcaA+6M8T7/G+TPHZX6HJWqJJiYB+EC2ERblpvq9TPlLguEWcmvjbVc31nyq\nSDoO3ncFWKFmVsbQPTbP+pKUmlLfJwtb5XqxNR5GEXSwVv4I7IqBmJz1MmRafnBZ\ng0FJUtH668GnldO20XbnSVBr820F5SISMXVwCXDXEvGwwiB8Lt8PvqzXnGIFDAu3\nDlQI5sxSqpPVWSyw08ppKT2Tpmy8adiBotLfaCFl2VTHwOae48X2dMPBvQARAQAB\ntDFGZWRvcmEgKDMwKSA8ZmVkb3JhLTMwLXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQI4BBMBAgAiBQJbbqxnAhsPBgsJCAcDAgYVCAIJCgsEFgIDAQIeAQIXgAAK\nCRDvPBEfz8ZZudTnD/9170LL3nyTVUCFmBjT9wZ4gYnpwtKVPa/pKnxbbS+Bmmac\ng9TrT9pZbqOHrNJLiZ3Zx1Hp+8uxr3Lo6kbYwImLhkOEDrf4aP17HfQ6VYFbQZI8\nf79OFxWJ7si9+3gfzeh9UYFEqOQfzIjLWFyfnas0OnV/P+RMQ1Zr+vPRqO7AR2va\nN9wg+Xl7157dhXPCGYnGMNSoxCbpRs0JNlzvJMuAea5nTTznRaJZtK/xKsqLn51D\nK07k9MHVFXakOH8QtMCUglbwfTfIpO5YRq5imxlWbqsYWVQy1WGJFyW6hWC0+RcJ\nOx5zGtOfi4/dN+xJ+ibnbyvy/il7Qm+vyFhCYqIPyS5m2UVJUuao3eApE38k78/o\n8aQOTnFQZ+U1Sw+6woFTxjqRQBXlQm2+7Bt3bqGATg4sXXWPbmwdL87Ic+mxn/ml\nSMfQux/5k6iAu1kQhwkO2YJn9eII6HIPkW+2m5N1JsUyJQe4cbtZE5Yh3TRA0dm7\n+zoBRfCXkOW4krchbgww/ptVmzMMP7GINJdROrJnsGl5FVeid9qHzV7aZycWSma7\nCxBYB1J8HCbty5NjtD6XMYRrMLxXugvX6Q4NPPH+2NKjzX4SIDejS6JjgrP3KA3O\npMuo7ZHMfveBngv8yP+ZD/1sS6l+dfExvdaJdOdgFCnp4p3gPbw5+Lv70HrMjA==\n=BfZ/\n-----END PGP PUBLIC KEY BLOCK-----\n",
-              "checksum": "sha256:9f596e18f585bee30ac41c11fb11a83ed6b11d5b341c1cb56ca4015d7717cb97"
-            }
-          ],
-          "packages": [
-            "@core",
-            "chrony",
-            "firewalld",
-            "grub2-pc",
-            "kernel",
-            "langpacks-en",
-            "selinux-policy-targeted"
-          ],
-          "exclude_packages": [
-            "dracut-config-rescue"
-          ],
-          "releasever": "30",
-          "basearch": "x86_64",
-          "module_platform_id": "platform:f30"
+        },
+        {
+          "name": "org.osbuild.fix-bls",
+          "options": {}
+        },
+        {
+          "name": "org.osbuild.locale",
+          "options": {
+            "language": "en_US"
+          }
+        },
+        {
+          "name": "org.osbuild.fstab",
+          "options": {
+            "filesystems": [
+              {
+                "uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
+                "vfs_type": "ext4",
+                "path": "/",
+                "options": "defaults",
+                "freq": 1,
+                "passno": 1
+              }
+            ]
+          }
+        },
+        {
+          "name": "org.osbuild.grub2",
+          "options": {
+            "root_fs_uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
+            "kernel_opts": "ro biosdevname=0 net.ifnames=0",
+            "legacy": true
+          }
+        },
+        {
+          "name": "org.osbuild.selinux",
+          "options": {
+            "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
+          }
         }
-      },
-      {
-        "name": "org.osbuild.fix-bls",
-        "options": {}
-      },
-      {
-        "name": "org.osbuild.locale",
+      ],
+      "assembler": {
+        "name": "org.osbuild.qemu",
         "options": {
-          "language": "en_US"
-        }
-      },
-      {
-        "name": "org.osbuild.fstab",
-        "options": {
-          "filesystems": [
+          "format": "raw",
+          "filename": "disk.img",
+          "size": 2147483648,
+          "ptuuid": "0x14fc63d2",
+          "pttype": "mbr",
+          "partitions": [
             {
-              "uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
-              "vfs_type": "ext4",
-              "path": "/",
-              "options": "defaults",
-              "freq": 1,
-              "passno": 1
+              "start": 2048,
+              "bootable": true,
+              "filesystem": {
+                "type": "ext4",
+                "uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
+                "mountpoint": "/"
+              }
             }
           ]
         }
-      },
-      {
-        "name": "org.osbuild.grub2",
-        "options": {
-          "root_fs_uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
-          "kernel_opts": "ro biosdevname=0 net.ifnames=0",
-          "legacy": true
-        }
-      },
-      {
-        "name": "org.osbuild.selinux",
-        "options": {
-          "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
-        }
-      }
-    ],
-    "assembler": {
-      "name": "org.osbuild.qemu",
-      "options": {
-        "format": "raw",
-        "filename": "disk.img",
-        "size": 2147483648,
-        "ptuuid": "0x14fc63d2",
-        "pttype": "mbr",
-        "partitions": [
-          {
-            "start": 2048,
-            "bootable": true,
-            "filesystem": {
-              "type": "ext4",
-              "uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
-              "mountpoint": "/"
-            }
-          }
-        ]
       }
     }
   },

--- a/test/cases/disk_empty_blueprint.json
+++ b/test/cases/disk_empty_blueprint.json
@@ -1,5 +1,5 @@
 {
-  "compose": {
+  "compose-request": {
     "distro": "fedora-30",
     "arch": "x86_64",
     "output-format": "partitioned-disk",

--- a/test/cases/disk_empty_blueprint.json
+++ b/test/cases/disk_empty_blueprint.json
@@ -2,12 +2,14 @@
   "compose": {
     "distro": "fedora-30",
     "arch": "x86_64",
-    "checksums": {
-      "fedora": "sha256:9f596e18f585bee30ac41c11fb11a83ed6b11d5b341c1cb56ca4015d7717cb97"
-    },
     "output-format": "partitioned-disk",
     "filename": "disk.img",
     "blueprint": {}
+  },
+  "rpmmd": {
+    "checksums": {
+      "fedora": "sha256:9f596e18f585bee30ac41c11fb11a83ed6b11d5b341c1cb56ca4015d7717cb97"
+    }
   },
   "pipeline": {
     "build": {

--- a/test/cases/disk_local_boot.json
+++ b/test/cases/disk_local_boot.json
@@ -2,7 +2,7 @@
   "boot": {
     "type": "nspawn"
   },
-  "compose": {
+  "compose-request": {
     "distro": "fedora-30",
     "arch": "x86_64",
     "output-format": "partitioned-disk",

--- a/test/cases/disk_local_boot.json
+++ b/test/cases/disk_local_boot.json
@@ -37,6 +37,11 @@
       }
     }
   },
+  "rpmmd": {
+    "checksums": {
+      "fedora": "sha256:9f596e18f585bee30ac41c11fb11a83ed6b11d5b341c1cb56ca4015d7717cb97"
+    }
+  },
   "pipeline": {
     "build": {
       "pipeline": {

--- a/test/cases/disk_local_boot.json
+++ b/test/cases/disk_local_boot.json
@@ -42,151 +42,154 @@
       "fedora": "sha256:9f596e18f585bee30ac41c11fb11a83ed6b11d5b341c1cb56ca4015d7717cb97"
     }
   },
-  "pipeline": {
-    "build": {
-      "pipeline": {
-        "stages": [
-          {
-            "name": "org.osbuild.dnf",
-            "options": {
-              "repos": [
-                {
-                  "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-30&arch=x86_64",
-                  "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBFturGcBEACv0xBo91V2n0uEC2vh69ywCiSyvUgN/AQH8EZpCVtM7NyjKgKm\nbbY4G3R0M3ir1xXmvUDvK0493/qOiFrjkplvzXFTGpPTi0ypqGgxc5d0ohRA1M75\nL+0AIlXoOgHQ358/c4uO8X0JAA1NYxCkAW1KSJgFJ3RjukrfqSHWthS1d4o8fhHy\nKJKEnirE5hHqB50dafXrBfgZdaOs3C6ppRIePFe2o4vUEapMTCHFw0woQR8Ah4/R\nn7Z9G9Ln+0Cinmy0nbIDiZJ+pgLAXCOWBfDUzcOjDGKvcpoZharA07c0q1/5ojzO\n4F0Fh4g/BUmtrASwHfcIbjHyCSr1j/3Iz883iy07gJY5Yhiuaqmp0o0f9fgHkG53\n2xCU1owmACqaIBNQMukvXRDtB2GJMuKa/asTZDP6R5re+iXs7+s9ohcRRAKGyAyc\nYKIQKcaA+6M8T7/G+TPHZX6HJWqJJiYB+EC2ERblpvq9TPlLguEWcmvjbVc31nyq\nSDoO3ncFWKFmVsbQPTbP+pKUmlLfJwtb5XqxNR5GEXSwVv4I7IqBmJz1MmRafnBZ\ng0FJUtH668GnldO20XbnSVBr820F5SISMXVwCXDXEvGwwiB8Lt8PvqzXnGIFDAu3\nDlQI5sxSqpPVWSyw08ppKT2Tpmy8adiBotLfaCFl2VTHwOae48X2dMPBvQARAQAB\ntDFGZWRvcmEgKDMwKSA8ZmVkb3JhLTMwLXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQI4BBMBAgAiBQJbbqxnAhsPBgsJCAcDAgYVCAIJCgsEFgIDAQIeAQIXgAAK\nCRDvPBEfz8ZZudTnD/9170LL3nyTVUCFmBjT9wZ4gYnpwtKVPa/pKnxbbS+Bmmac\ng9TrT9pZbqOHrNJLiZ3Zx1Hp+8uxr3Lo6kbYwImLhkOEDrf4aP17HfQ6VYFbQZI8\nf79OFxWJ7si9+3gfzeh9UYFEqOQfzIjLWFyfnas0OnV/P+RMQ1Zr+vPRqO7AR2va\nN9wg+Xl7157dhXPCGYnGMNSoxCbpRs0JNlzvJMuAea5nTTznRaJZtK/xKsqLn51D\nK07k9MHVFXakOH8QtMCUglbwfTfIpO5YRq5imxlWbqsYWVQy1WGJFyW6hWC0+RcJ\nOx5zGtOfi4/dN+xJ+ibnbyvy/il7Qm+vyFhCYqIPyS5m2UVJUuao3eApE38k78/o\n8aQOTnFQZ+U1Sw+6woFTxjqRQBXlQm2+7Bt3bqGATg4sXXWPbmwdL87Ic+mxn/ml\nSMfQux/5k6iAu1kQhwkO2YJn9eII6HIPkW+2m5N1JsUyJQe4cbtZE5Yh3TRA0dm7\n+zoBRfCXkOW4krchbgww/ptVmzMMP7GINJdROrJnsGl5FVeid9qHzV7aZycWSma7\nCxBYB1J8HCbty5NjtD6XMYRrMLxXugvX6Q4NPPH+2NKjzX4SIDejS6JjgrP3KA3O\npMuo7ZHMfveBngv8yP+ZD/1sS6l+dfExvdaJdOdgFCnp4p3gPbw5+Lv70HrMjA==\n=BfZ/\n-----END PGP PUBLIC KEY BLOCK-----\n",
-                  "checksum": "sha256:9f596e18f585bee30ac41c11fb11a83ed6b11d5b341c1cb56ca4015d7717cb97"
-                }
-              ],
-              "packages": [
-                "dnf",
-                "dosfstools",
-                "e2fsprogs",
-                "grub2-pc",
-                "policycoreutils",
-                "qemu-img",
-                "systemd",
-                "tar"
-              ],
-              "releasever": "30",
-              "basearch": "x86_64",
-              "module_platform_id": "platform:f30"
+  "manifest": {
+    "sources": {},
+    "pipeline": {
+      "build": {
+        "pipeline": {
+          "stages": [
+            {
+              "name": "org.osbuild.dnf",
+              "options": {
+                "repos": [
+                  {
+                    "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-30&arch=x86_64",
+                    "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBFturGcBEACv0xBo91V2n0uEC2vh69ywCiSyvUgN/AQH8EZpCVtM7NyjKgKm\nbbY4G3R0M3ir1xXmvUDvK0493/qOiFrjkplvzXFTGpPTi0ypqGgxc5d0ohRA1M75\nL+0AIlXoOgHQ358/c4uO8X0JAA1NYxCkAW1KSJgFJ3RjukrfqSHWthS1d4o8fhHy\nKJKEnirE5hHqB50dafXrBfgZdaOs3C6ppRIePFe2o4vUEapMTCHFw0woQR8Ah4/R\nn7Z9G9Ln+0Cinmy0nbIDiZJ+pgLAXCOWBfDUzcOjDGKvcpoZharA07c0q1/5ojzO\n4F0Fh4g/BUmtrASwHfcIbjHyCSr1j/3Iz883iy07gJY5Yhiuaqmp0o0f9fgHkG53\n2xCU1owmACqaIBNQMukvXRDtB2GJMuKa/asTZDP6R5re+iXs7+s9ohcRRAKGyAyc\nYKIQKcaA+6M8T7/G+TPHZX6HJWqJJiYB+EC2ERblpvq9TPlLguEWcmvjbVc31nyq\nSDoO3ncFWKFmVsbQPTbP+pKUmlLfJwtb5XqxNR5GEXSwVv4I7IqBmJz1MmRafnBZ\ng0FJUtH668GnldO20XbnSVBr820F5SISMXVwCXDXEvGwwiB8Lt8PvqzXnGIFDAu3\nDlQI5sxSqpPVWSyw08ppKT2Tpmy8adiBotLfaCFl2VTHwOae48X2dMPBvQARAQAB\ntDFGZWRvcmEgKDMwKSA8ZmVkb3JhLTMwLXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQI4BBMBAgAiBQJbbqxnAhsPBgsJCAcDAgYVCAIJCgsEFgIDAQIeAQIXgAAK\nCRDvPBEfz8ZZudTnD/9170LL3nyTVUCFmBjT9wZ4gYnpwtKVPa/pKnxbbS+Bmmac\ng9TrT9pZbqOHrNJLiZ3Zx1Hp+8uxr3Lo6kbYwImLhkOEDrf4aP17HfQ6VYFbQZI8\nf79OFxWJ7si9+3gfzeh9UYFEqOQfzIjLWFyfnas0OnV/P+RMQ1Zr+vPRqO7AR2va\nN9wg+Xl7157dhXPCGYnGMNSoxCbpRs0JNlzvJMuAea5nTTznRaJZtK/xKsqLn51D\nK07k9MHVFXakOH8QtMCUglbwfTfIpO5YRq5imxlWbqsYWVQy1WGJFyW6hWC0+RcJ\nOx5zGtOfi4/dN+xJ+ibnbyvy/il7Qm+vyFhCYqIPyS5m2UVJUuao3eApE38k78/o\n8aQOTnFQZ+U1Sw+6woFTxjqRQBXlQm2+7Bt3bqGATg4sXXWPbmwdL87Ic+mxn/ml\nSMfQux/5k6iAu1kQhwkO2YJn9eII6HIPkW+2m5N1JsUyJQe4cbtZE5Yh3TRA0dm7\n+zoBRfCXkOW4krchbgww/ptVmzMMP7GINJdROrJnsGl5FVeid9qHzV7aZycWSma7\nCxBYB1J8HCbty5NjtD6XMYRrMLxXugvX6Q4NPPH+2NKjzX4SIDejS6JjgrP3KA3O\npMuo7ZHMfveBngv8yP+ZD/1sS6l+dfExvdaJdOdgFCnp4p3gPbw5+Lv70HrMjA==\n=BfZ/\n-----END PGP PUBLIC KEY BLOCK-----\n",
+                    "checksum": "sha256:9f596e18f585bee30ac41c11fb11a83ed6b11d5b341c1cb56ca4015d7717cb97"
+                  }
+                ],
+                "packages": [
+                  "dnf",
+                  "dosfstools",
+                  "e2fsprogs",
+                  "grub2-pc",
+                  "policycoreutils",
+                  "qemu-img",
+                  "systemd",
+                  "tar"
+                ],
+                "releasever": "30",
+                "basearch": "x86_64",
+                "module_platform_id": "platform:f30"
+              }
+            }
+          ]
+        },
+        "runner": "org.osbuild.fedora30"
+      },
+      "stages": [
+        {
+          "name": "org.osbuild.dnf",
+          "options": {
+            "repos": [
+              {
+                "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-30&arch=x86_64",
+                "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBFturGcBEACv0xBo91V2n0uEC2vh69ywCiSyvUgN/AQH8EZpCVtM7NyjKgKm\nbbY4G3R0M3ir1xXmvUDvK0493/qOiFrjkplvzXFTGpPTi0ypqGgxc5d0ohRA1M75\nL+0AIlXoOgHQ358/c4uO8X0JAA1NYxCkAW1KSJgFJ3RjukrfqSHWthS1d4o8fhHy\nKJKEnirE5hHqB50dafXrBfgZdaOs3C6ppRIePFe2o4vUEapMTCHFw0woQR8Ah4/R\nn7Z9G9Ln+0Cinmy0nbIDiZJ+pgLAXCOWBfDUzcOjDGKvcpoZharA07c0q1/5ojzO\n4F0Fh4g/BUmtrASwHfcIbjHyCSr1j/3Iz883iy07gJY5Yhiuaqmp0o0f9fgHkG53\n2xCU1owmACqaIBNQMukvXRDtB2GJMuKa/asTZDP6R5re+iXs7+s9ohcRRAKGyAyc\nYKIQKcaA+6M8T7/G+TPHZX6HJWqJJiYB+EC2ERblpvq9TPlLguEWcmvjbVc31nyq\nSDoO3ncFWKFmVsbQPTbP+pKUmlLfJwtb5XqxNR5GEXSwVv4I7IqBmJz1MmRafnBZ\ng0FJUtH668GnldO20XbnSVBr820F5SISMXVwCXDXEvGwwiB8Lt8PvqzXnGIFDAu3\nDlQI5sxSqpPVWSyw08ppKT2Tpmy8adiBotLfaCFl2VTHwOae48X2dMPBvQARAQAB\ntDFGZWRvcmEgKDMwKSA8ZmVkb3JhLTMwLXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQI4BBMBAgAiBQJbbqxnAhsPBgsJCAcDAgYVCAIJCgsEFgIDAQIeAQIXgAAK\nCRDvPBEfz8ZZudTnD/9170LL3nyTVUCFmBjT9wZ4gYnpwtKVPa/pKnxbbS+Bmmac\ng9TrT9pZbqOHrNJLiZ3Zx1Hp+8uxr3Lo6kbYwImLhkOEDrf4aP17HfQ6VYFbQZI8\nf79OFxWJ7si9+3gfzeh9UYFEqOQfzIjLWFyfnas0OnV/P+RMQ1Zr+vPRqO7AR2va\nN9wg+Xl7157dhXPCGYnGMNSoxCbpRs0JNlzvJMuAea5nTTznRaJZtK/xKsqLn51D\nK07k9MHVFXakOH8QtMCUglbwfTfIpO5YRq5imxlWbqsYWVQy1WGJFyW6hWC0+RcJ\nOx5zGtOfi4/dN+xJ+ibnbyvy/il7Qm+vyFhCYqIPyS5m2UVJUuao3eApE38k78/o\n8aQOTnFQZ+U1Sw+6woFTxjqRQBXlQm2+7Bt3bqGATg4sXXWPbmwdL87Ic+mxn/ml\nSMfQux/5k6iAu1kQhwkO2YJn9eII6HIPkW+2m5N1JsUyJQe4cbtZE5Yh3TRA0dm7\n+zoBRfCXkOW4krchbgww/ptVmzMMP7GINJdROrJnsGl5FVeid9qHzV7aZycWSma7\nCxBYB1J8HCbty5NjtD6XMYRrMLxXugvX6Q4NPPH+2NKjzX4SIDejS6JjgrP3KA3O\npMuo7ZHMfveBngv8yP+ZD/1sS6l+dfExvdaJdOdgFCnp4p3gPbw5+Lv70HrMjA==\n=BfZ/\n-----END PGP PUBLIC KEY BLOCK-----\n",
+                "checksum": "sha256:9f596e18f585bee30ac41c11fb11a83ed6b11d5b341c1cb56ca4015d7717cb97"
+              }
+            ],
+            "packages": [
+              "@core",
+              "chrony",
+              "firewalld",
+              "grub2-pc",
+              "kernel",
+              "langpacks-en",
+              "selinux-policy-targeted"
+            ],
+            "exclude_packages": [
+              "dracut-config-rescue"
+            ],
+            "releasever": "30",
+            "basearch": "x86_64",
+            "module_platform_id": "platform:f30"
+          }
+        },
+        {
+          "name": "org.osbuild.locale",
+          "options": {
+            "language": "en_US"
+          }
+        },
+        {
+          "name": "org.osbuild.fstab",
+          "options": {
+            "filesystems": [
+              {
+                "uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
+                "vfs_type": "ext4",
+                "path": "/",
+                "options": "defaults",
+                "freq": 1,
+                "passno": 1
+              }
+            ]
+          }
+        },
+        {
+          "name": "org.osbuild.grub2",
+          "options": {
+            "root_fs_uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
+            "kernel_opts": "ro biosdevname=0 net.ifnames=0",
+            "legacy": true
+          }
+        },
+        {
+          "name": "org.osbuild.systemd",
+          "options": {
+            "enabled_services": [
+              "sshd"
+            ],
+            "disabled_services": [
+              "auditd"
+            ]
+          }
+        },
+        {
+          "name": "org.osbuild.users",
+          "options": {
+            "users": {
+              "redhat": {
+                "groups": [
+                  "wheel"
+                ],
+                "password": "$6$IR7O7z56ouB/OInP$.hscD6dQqPQGwMuQ.idumixSHI/JEyaUfiCAHVSpGO/iNLEvvVZVOQL23zBzQbc2.yJ25xAZD75H0tXqKJpEE/",
+                "key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC61wMCjOSHwbVb4VfVyl5sn497qW4PsdQ7Ty7aD6wDNZ/QjjULkDV/yW5WjDlDQ7UqFH0Sr7vywjqDizUAqK7zM5FsUKsUXWHWwg/ehKg8j9xKcMv11AkFoUoujtfAujnKODkk58XSA9whPr7qcw3vPrmog680pnMSzf9LC7J6kXfs6lkoKfBh9VnlxusCrw2yg0qI1fHAZBLPx7mW6+me71QZsS6sVz8v8KXyrXsKTdnF50FjzHcK9HXDBtSJS5wA3fkcRYymJe0o6WMWNdgSRVpoSiWaHHmFgdMUJaYoCfhXzyl7LtNb3Q+Sveg+tJK7JaRXBLMUllOlJ6ll5Hod root@localhost"
+              }
             }
           }
-        ]
-      },
-      "runner": "org.osbuild.fedora30"
-    },
-    "stages": [
-      {
-        "name": "org.osbuild.dnf",
-        "options": {
-          "repos": [
-            {
-              "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-30&arch=x86_64",
-              "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBFturGcBEACv0xBo91V2n0uEC2vh69ywCiSyvUgN/AQH8EZpCVtM7NyjKgKm\nbbY4G3R0M3ir1xXmvUDvK0493/qOiFrjkplvzXFTGpPTi0ypqGgxc5d0ohRA1M75\nL+0AIlXoOgHQ358/c4uO8X0JAA1NYxCkAW1KSJgFJ3RjukrfqSHWthS1d4o8fhHy\nKJKEnirE5hHqB50dafXrBfgZdaOs3C6ppRIePFe2o4vUEapMTCHFw0woQR8Ah4/R\nn7Z9G9Ln+0Cinmy0nbIDiZJ+pgLAXCOWBfDUzcOjDGKvcpoZharA07c0q1/5ojzO\n4F0Fh4g/BUmtrASwHfcIbjHyCSr1j/3Iz883iy07gJY5Yhiuaqmp0o0f9fgHkG53\n2xCU1owmACqaIBNQMukvXRDtB2GJMuKa/asTZDP6R5re+iXs7+s9ohcRRAKGyAyc\nYKIQKcaA+6M8T7/G+TPHZX6HJWqJJiYB+EC2ERblpvq9TPlLguEWcmvjbVc31nyq\nSDoO3ncFWKFmVsbQPTbP+pKUmlLfJwtb5XqxNR5GEXSwVv4I7IqBmJz1MmRafnBZ\ng0FJUtH668GnldO20XbnSVBr820F5SISMXVwCXDXEvGwwiB8Lt8PvqzXnGIFDAu3\nDlQI5sxSqpPVWSyw08ppKT2Tpmy8adiBotLfaCFl2VTHwOae48X2dMPBvQARAQAB\ntDFGZWRvcmEgKDMwKSA8ZmVkb3JhLTMwLXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQI4BBMBAgAiBQJbbqxnAhsPBgsJCAcDAgYVCAIJCgsEFgIDAQIeAQIXgAAK\nCRDvPBEfz8ZZudTnD/9170LL3nyTVUCFmBjT9wZ4gYnpwtKVPa/pKnxbbS+Bmmac\ng9TrT9pZbqOHrNJLiZ3Zx1Hp+8uxr3Lo6kbYwImLhkOEDrf4aP17HfQ6VYFbQZI8\nf79OFxWJ7si9+3gfzeh9UYFEqOQfzIjLWFyfnas0OnV/P+RMQ1Zr+vPRqO7AR2va\nN9wg+Xl7157dhXPCGYnGMNSoxCbpRs0JNlzvJMuAea5nTTznRaJZtK/xKsqLn51D\nK07k9MHVFXakOH8QtMCUglbwfTfIpO5YRq5imxlWbqsYWVQy1WGJFyW6hWC0+RcJ\nOx5zGtOfi4/dN+xJ+ibnbyvy/il7Qm+vyFhCYqIPyS5m2UVJUuao3eApE38k78/o\n8aQOTnFQZ+U1Sw+6woFTxjqRQBXlQm2+7Bt3bqGATg4sXXWPbmwdL87Ic+mxn/ml\nSMfQux/5k6iAu1kQhwkO2YJn9eII6HIPkW+2m5N1JsUyJQe4cbtZE5Yh3TRA0dm7\n+zoBRfCXkOW4krchbgww/ptVmzMMP7GINJdROrJnsGl5FVeid9qHzV7aZycWSma7\nCxBYB1J8HCbty5NjtD6XMYRrMLxXugvX6Q4NPPH+2NKjzX4SIDejS6JjgrP3KA3O\npMuo7ZHMfveBngv8yP+ZD/1sS6l+dfExvdaJdOdgFCnp4p3gPbw5+Lv70HrMjA==\n=BfZ/\n-----END PGP PUBLIC KEY BLOCK-----\n",
-              "checksum": "sha256:9f596e18f585bee30ac41c11fb11a83ed6b11d5b341c1cb56ca4015d7717cb97"
-            }
-          ],
-          "packages": [
-            "@core",
-            "chrony",
-            "firewalld",
-            "grub2-pc",
-            "kernel",
-            "langpacks-en",
-            "selinux-policy-targeted"
-          ],
-          "exclude_packages": [
-            "dracut-config-rescue"
-          ],
-          "releasever": "30",
-          "basearch": "x86_64",
-          "module_platform_id": "platform:f30"
+        },
+        {
+          "name": "org.osbuild.selinux",
+          "options": {
+            "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
+          }
+        },
+        {
+          "name": "org.osbuild.fix-bls",
+          "options": {}
         }
-      },
-      {
-        "name": "org.osbuild.locale",
+      ],
+      "assembler": {
+        "name": "org.osbuild.qemu",
         "options": {
-          "language": "en_US"
-        }
-      },
-      {
-        "name": "org.osbuild.fstab",
-        "options": {
-          "filesystems": [
+          "format": "raw",
+          "filename": "disk.img",
+          "size": 2147483648,
+          "ptuuid": "0x14fc63d2",
+          "pttype": "mbr",
+          "partitions": [
             {
-              "uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
-              "vfs_type": "ext4",
-              "path": "/",
-              "options": "defaults",
-              "freq": 1,
-              "passno": 1
+              "start": 2048,
+              "bootable": true,
+              "filesystem": {
+                "type": "ext4",
+                "uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
+                "mountpoint": "/"
+              }
             }
           ]
         }
-      },
-      {
-        "name": "org.osbuild.grub2",
-        "options": {
-          "root_fs_uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
-          "kernel_opts": "ro biosdevname=0 net.ifnames=0",
-          "legacy": true
-        }
-      },
-      {
-        "name": "org.osbuild.systemd",
-        "options": {
-          "enabled_services": [
-            "sshd"
-          ],
-          "disabled_services": [
-            "auditd"
-          ]
-        }
-      },
-      {
-        "name": "org.osbuild.users",
-        "options": {
-          "users": {
-            "redhat": {
-              "groups": [
-                "wheel"
-              ],
-              "password": "$6$IR7O7z56ouB/OInP$.hscD6dQqPQGwMuQ.idumixSHI/JEyaUfiCAHVSpGO/iNLEvvVZVOQL23zBzQbc2.yJ25xAZD75H0tXqKJpEE/",
-              "key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC61wMCjOSHwbVb4VfVyl5sn497qW4PsdQ7Ty7aD6wDNZ/QjjULkDV/yW5WjDlDQ7UqFH0Sr7vywjqDizUAqK7zM5FsUKsUXWHWwg/ehKg8j9xKcMv11AkFoUoujtfAujnKODkk58XSA9whPr7qcw3vPrmog680pnMSzf9LC7J6kXfs6lkoKfBh9VnlxusCrw2yg0qI1fHAZBLPx7mW6+me71QZsS6sVz8v8KXyrXsKTdnF50FjzHcK9HXDBtSJS5wA3fkcRYymJe0o6WMWNdgSRVpoSiWaHHmFgdMUJaYoCfhXzyl7LtNb3Q+Sveg+tJK7JaRXBLMUllOlJ6ll5Hod root@localhost"
-            }
-          }
-        }
-      },
-      {
-        "name": "org.osbuild.selinux",
-        "options": {
-          "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
-        }
-      },
-      {
-        "name": "org.osbuild.fix-bls",
-        "options": {}
-      }
-    ],
-    "assembler": {
-      "name": "org.osbuild.qemu",
-      "options": {
-        "format": "raw",
-        "filename": "disk.img",
-        "size": 2147483648,
-        "ptuuid": "0x14fc63d2",
-        "pttype": "mbr",
-        "partitions": [
-          {
-            "start": 2048,
-            "bootable": true,
-            "filesystem": {
-              "type": "ext4",
-              "uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
-              "mountpoint": "/"
-            }
-          }
-        ]
       }
     }
   }

--- a/test/cases/ext4_empty_blueprint.json
+++ b/test/cases/ext4_empty_blueprint.json
@@ -1,5 +1,5 @@
 {
-  "compose": {
+  "compose-request": {
     "distro": "fedora-30",
     "arch": "x86_64",
     "output-format": "ext4-filesystem",

--- a/test/cases/ext4_empty_blueprint.json
+++ b/test/cases/ext4_empty_blueprint.json
@@ -2,12 +2,14 @@
   "compose": {
     "distro": "fedora-30",
     "arch": "x86_64",
-    "checksums": {
-      "fedora": "sha256:9f596e18f585bee30ac41c11fb11a83ed6b11d5b341c1cb56ca4015d7717cb97"
-    },
     "output-format": "ext4-filesystem",
     "filename": "filesystem.img",
     "blueprint": {}
+  },
+  "rpmmd": {
+    "checksums": {
+      "fedora": "sha256:9f596e18f585bee30ac41c11fb11a83ed6b11d5b341c1cb56ca4015d7717cb97"
+    }
   },
   "pipeline": {
     "build": {

--- a/test/cases/ext4_empty_blueprint.json
+++ b/test/cases/ext4_empty_blueprint.json
@@ -11,97 +11,100 @@
       "fedora": "sha256:9f596e18f585bee30ac41c11fb11a83ed6b11d5b341c1cb56ca4015d7717cb97"
     }
   },
-  "pipeline": {
-    "build": {
-      "pipeline": {
-        "stages": [
-          {
-            "name": "org.osbuild.dnf",
-            "options": {
-              "repos": [
-                {
-                  "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-30&arch=x86_64",
-                  "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBFturGcBEACv0xBo91V2n0uEC2vh69ywCiSyvUgN/AQH8EZpCVtM7NyjKgKm\nbbY4G3R0M3ir1xXmvUDvK0493/qOiFrjkplvzXFTGpPTi0ypqGgxc5d0ohRA1M75\nL+0AIlXoOgHQ358/c4uO8X0JAA1NYxCkAW1KSJgFJ3RjukrfqSHWthS1d4o8fhHy\nKJKEnirE5hHqB50dafXrBfgZdaOs3C6ppRIePFe2o4vUEapMTCHFw0woQR8Ah4/R\nn7Z9G9Ln+0Cinmy0nbIDiZJ+pgLAXCOWBfDUzcOjDGKvcpoZharA07c0q1/5ojzO\n4F0Fh4g/BUmtrASwHfcIbjHyCSr1j/3Iz883iy07gJY5Yhiuaqmp0o0f9fgHkG53\n2xCU1owmACqaIBNQMukvXRDtB2GJMuKa/asTZDP6R5re+iXs7+s9ohcRRAKGyAyc\nYKIQKcaA+6M8T7/G+TPHZX6HJWqJJiYB+EC2ERblpvq9TPlLguEWcmvjbVc31nyq\nSDoO3ncFWKFmVsbQPTbP+pKUmlLfJwtb5XqxNR5GEXSwVv4I7IqBmJz1MmRafnBZ\ng0FJUtH668GnldO20XbnSVBr820F5SISMXVwCXDXEvGwwiB8Lt8PvqzXnGIFDAu3\nDlQI5sxSqpPVWSyw08ppKT2Tpmy8adiBotLfaCFl2VTHwOae48X2dMPBvQARAQAB\ntDFGZWRvcmEgKDMwKSA8ZmVkb3JhLTMwLXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQI4BBMBAgAiBQJbbqxnAhsPBgsJCAcDAgYVCAIJCgsEFgIDAQIeAQIXgAAK\nCRDvPBEfz8ZZudTnD/9170LL3nyTVUCFmBjT9wZ4gYnpwtKVPa/pKnxbbS+Bmmac\ng9TrT9pZbqOHrNJLiZ3Zx1Hp+8uxr3Lo6kbYwImLhkOEDrf4aP17HfQ6VYFbQZI8\nf79OFxWJ7si9+3gfzeh9UYFEqOQfzIjLWFyfnas0OnV/P+RMQ1Zr+vPRqO7AR2va\nN9wg+Xl7157dhXPCGYnGMNSoxCbpRs0JNlzvJMuAea5nTTznRaJZtK/xKsqLn51D\nK07k9MHVFXakOH8QtMCUglbwfTfIpO5YRq5imxlWbqsYWVQy1WGJFyW6hWC0+RcJ\nOx5zGtOfi4/dN+xJ+ibnbyvy/il7Qm+vyFhCYqIPyS5m2UVJUuao3eApE38k78/o\n8aQOTnFQZ+U1Sw+6woFTxjqRQBXlQm2+7Bt3bqGATg4sXXWPbmwdL87Ic+mxn/ml\nSMfQux/5k6iAu1kQhwkO2YJn9eII6HIPkW+2m5N1JsUyJQe4cbtZE5Yh3TRA0dm7\n+zoBRfCXkOW4krchbgww/ptVmzMMP7GINJdROrJnsGl5FVeid9qHzV7aZycWSma7\nCxBYB1J8HCbty5NjtD6XMYRrMLxXugvX6Q4NPPH+2NKjzX4SIDejS6JjgrP3KA3O\npMuo7ZHMfveBngv8yP+ZD/1sS6l+dfExvdaJdOdgFCnp4p3gPbw5+Lv70HrMjA==\n=BfZ/\n-----END PGP PUBLIC KEY BLOCK-----\n",
-                  "checksum": "sha256:9f596e18f585bee30ac41c11fb11a83ed6b11d5b341c1cb56ca4015d7717cb97"
-                }
-              ],
-              "packages": [
-                "dnf",
-                "dosfstools",
-                "e2fsprogs",
-                "grub2-pc",
-                "policycoreutils",
-                "qemu-img",
-                "systemd",
-                "tar"
-              ],
-              "releasever": "30",
-              "basearch": "x86_64",
-              "module_platform_id": "platform:f30"
-            }
-          }
-        ]
-      },
-      "runner": "org.osbuild.fedora30"
-    },
-    "stages": [
-      {
-        "name": "org.osbuild.dnf",
-        "options": {
-          "repos": [
+  "manifest": {
+    "sources": {},
+    "pipeline": {
+      "build": {
+        "pipeline": {
+          "stages": [
             {
-              "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-30&arch=x86_64",
-              "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBFturGcBEACv0xBo91V2n0uEC2vh69ywCiSyvUgN/AQH8EZpCVtM7NyjKgKm\nbbY4G3R0M3ir1xXmvUDvK0493/qOiFrjkplvzXFTGpPTi0ypqGgxc5d0ohRA1M75\nL+0AIlXoOgHQ358/c4uO8X0JAA1NYxCkAW1KSJgFJ3RjukrfqSHWthS1d4o8fhHy\nKJKEnirE5hHqB50dafXrBfgZdaOs3C6ppRIePFe2o4vUEapMTCHFw0woQR8Ah4/R\nn7Z9G9Ln+0Cinmy0nbIDiZJ+pgLAXCOWBfDUzcOjDGKvcpoZharA07c0q1/5ojzO\n4F0Fh4g/BUmtrASwHfcIbjHyCSr1j/3Iz883iy07gJY5Yhiuaqmp0o0f9fgHkG53\n2xCU1owmACqaIBNQMukvXRDtB2GJMuKa/asTZDP6R5re+iXs7+s9ohcRRAKGyAyc\nYKIQKcaA+6M8T7/G+TPHZX6HJWqJJiYB+EC2ERblpvq9TPlLguEWcmvjbVc31nyq\nSDoO3ncFWKFmVsbQPTbP+pKUmlLfJwtb5XqxNR5GEXSwVv4I7IqBmJz1MmRafnBZ\ng0FJUtH668GnldO20XbnSVBr820F5SISMXVwCXDXEvGwwiB8Lt8PvqzXnGIFDAu3\nDlQI5sxSqpPVWSyw08ppKT2Tpmy8adiBotLfaCFl2VTHwOae48X2dMPBvQARAQAB\ntDFGZWRvcmEgKDMwKSA8ZmVkb3JhLTMwLXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQI4BBMBAgAiBQJbbqxnAhsPBgsJCAcDAgYVCAIJCgsEFgIDAQIeAQIXgAAK\nCRDvPBEfz8ZZudTnD/9170LL3nyTVUCFmBjT9wZ4gYnpwtKVPa/pKnxbbS+Bmmac\ng9TrT9pZbqOHrNJLiZ3Zx1Hp+8uxr3Lo6kbYwImLhkOEDrf4aP17HfQ6VYFbQZI8\nf79OFxWJ7si9+3gfzeh9UYFEqOQfzIjLWFyfnas0OnV/P+RMQ1Zr+vPRqO7AR2va\nN9wg+Xl7157dhXPCGYnGMNSoxCbpRs0JNlzvJMuAea5nTTznRaJZtK/xKsqLn51D\nK07k9MHVFXakOH8QtMCUglbwfTfIpO5YRq5imxlWbqsYWVQy1WGJFyW6hWC0+RcJ\nOx5zGtOfi4/dN+xJ+ibnbyvy/il7Qm+vyFhCYqIPyS5m2UVJUuao3eApE38k78/o\n8aQOTnFQZ+U1Sw+6woFTxjqRQBXlQm2+7Bt3bqGATg4sXXWPbmwdL87Ic+mxn/ml\nSMfQux/5k6iAu1kQhwkO2YJn9eII6HIPkW+2m5N1JsUyJQe4cbtZE5Yh3TRA0dm7\n+zoBRfCXkOW4krchbgww/ptVmzMMP7GINJdROrJnsGl5FVeid9qHzV7aZycWSma7\nCxBYB1J8HCbty5NjtD6XMYRrMLxXugvX6Q4NPPH+2NKjzX4SIDejS6JjgrP3KA3O\npMuo7ZHMfveBngv8yP+ZD/1sS6l+dfExvdaJdOdgFCnp4p3gPbw5+Lv70HrMjA==\n=BfZ/\n-----END PGP PUBLIC KEY BLOCK-----\n",
-              "checksum": "sha256:9f596e18f585bee30ac41c11fb11a83ed6b11d5b341c1cb56ca4015d7717cb97"
+              "name": "org.osbuild.dnf",
+              "options": {
+                "repos": [
+                  {
+                    "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-30&arch=x86_64",
+                    "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBFturGcBEACv0xBo91V2n0uEC2vh69ywCiSyvUgN/AQH8EZpCVtM7NyjKgKm\nbbY4G3R0M3ir1xXmvUDvK0493/qOiFrjkplvzXFTGpPTi0ypqGgxc5d0ohRA1M75\nL+0AIlXoOgHQ358/c4uO8X0JAA1NYxCkAW1KSJgFJ3RjukrfqSHWthS1d4o8fhHy\nKJKEnirE5hHqB50dafXrBfgZdaOs3C6ppRIePFe2o4vUEapMTCHFw0woQR8Ah4/R\nn7Z9G9Ln+0Cinmy0nbIDiZJ+pgLAXCOWBfDUzcOjDGKvcpoZharA07c0q1/5ojzO\n4F0Fh4g/BUmtrASwHfcIbjHyCSr1j/3Iz883iy07gJY5Yhiuaqmp0o0f9fgHkG53\n2xCU1owmACqaIBNQMukvXRDtB2GJMuKa/asTZDP6R5re+iXs7+s9ohcRRAKGyAyc\nYKIQKcaA+6M8T7/G+TPHZX6HJWqJJiYB+EC2ERblpvq9TPlLguEWcmvjbVc31nyq\nSDoO3ncFWKFmVsbQPTbP+pKUmlLfJwtb5XqxNR5GEXSwVv4I7IqBmJz1MmRafnBZ\ng0FJUtH668GnldO20XbnSVBr820F5SISMXVwCXDXEvGwwiB8Lt8PvqzXnGIFDAu3\nDlQI5sxSqpPVWSyw08ppKT2Tpmy8adiBotLfaCFl2VTHwOae48X2dMPBvQARAQAB\ntDFGZWRvcmEgKDMwKSA8ZmVkb3JhLTMwLXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQI4BBMBAgAiBQJbbqxnAhsPBgsJCAcDAgYVCAIJCgsEFgIDAQIeAQIXgAAK\nCRDvPBEfz8ZZudTnD/9170LL3nyTVUCFmBjT9wZ4gYnpwtKVPa/pKnxbbS+Bmmac\ng9TrT9pZbqOHrNJLiZ3Zx1Hp+8uxr3Lo6kbYwImLhkOEDrf4aP17HfQ6VYFbQZI8\nf79OFxWJ7si9+3gfzeh9UYFEqOQfzIjLWFyfnas0OnV/P+RMQ1Zr+vPRqO7AR2va\nN9wg+Xl7157dhXPCGYnGMNSoxCbpRs0JNlzvJMuAea5nTTznRaJZtK/xKsqLn51D\nK07k9MHVFXakOH8QtMCUglbwfTfIpO5YRq5imxlWbqsYWVQy1WGJFyW6hWC0+RcJ\nOx5zGtOfi4/dN+xJ+ibnbyvy/il7Qm+vyFhCYqIPyS5m2UVJUuao3eApE38k78/o\n8aQOTnFQZ+U1Sw+6woFTxjqRQBXlQm2+7Bt3bqGATg4sXXWPbmwdL87Ic+mxn/ml\nSMfQux/5k6iAu1kQhwkO2YJn9eII6HIPkW+2m5N1JsUyJQe4cbtZE5Yh3TRA0dm7\n+zoBRfCXkOW4krchbgww/ptVmzMMP7GINJdROrJnsGl5FVeid9qHzV7aZycWSma7\nCxBYB1J8HCbty5NjtD6XMYRrMLxXugvX6Q4NPPH+2NKjzX4SIDejS6JjgrP3KA3O\npMuo7ZHMfveBngv8yP+ZD/1sS6l+dfExvdaJdOdgFCnp4p3gPbw5+Lv70HrMjA==\n=BfZ/\n-----END PGP PUBLIC KEY BLOCK-----\n",
+                    "checksum": "sha256:9f596e18f585bee30ac41c11fb11a83ed6b11d5b341c1cb56ca4015d7717cb97"
+                  }
+                ],
+                "packages": [
+                  "dnf",
+                  "dosfstools",
+                  "e2fsprogs",
+                  "grub2-pc",
+                  "policycoreutils",
+                  "qemu-img",
+                  "systemd",
+                  "tar"
+                ],
+                "releasever": "30",
+                "basearch": "x86_64",
+                "module_platform_id": "platform:f30"
+              }
             }
-          ],
-          "packages": [
-            "chrony",
-            "firewalld",
-            "kernel",
-            "langpacks-en",
-            "policycoreutils",
-            "selinux-policy-targeted"
-          ],
-          "exclude_packages": [
-            "dracut-config-rescue"
-          ],
-          "releasever": "30",
-          "basearch": "x86_64",
-          "module_platform_id": "platform:f30"
+          ]
+        },
+        "runner": "org.osbuild.fedora30"
+      },
+      "stages": [
+        {
+          "name": "org.osbuild.dnf",
+          "options": {
+            "repos": [
+              {
+                "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-30&arch=x86_64",
+                "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBFturGcBEACv0xBo91V2n0uEC2vh69ywCiSyvUgN/AQH8EZpCVtM7NyjKgKm\nbbY4G3R0M3ir1xXmvUDvK0493/qOiFrjkplvzXFTGpPTi0ypqGgxc5d0ohRA1M75\nL+0AIlXoOgHQ358/c4uO8X0JAA1NYxCkAW1KSJgFJ3RjukrfqSHWthS1d4o8fhHy\nKJKEnirE5hHqB50dafXrBfgZdaOs3C6ppRIePFe2o4vUEapMTCHFw0woQR8Ah4/R\nn7Z9G9Ln+0Cinmy0nbIDiZJ+pgLAXCOWBfDUzcOjDGKvcpoZharA07c0q1/5ojzO\n4F0Fh4g/BUmtrASwHfcIbjHyCSr1j/3Iz883iy07gJY5Yhiuaqmp0o0f9fgHkG53\n2xCU1owmACqaIBNQMukvXRDtB2GJMuKa/asTZDP6R5re+iXs7+s9ohcRRAKGyAyc\nYKIQKcaA+6M8T7/G+TPHZX6HJWqJJiYB+EC2ERblpvq9TPlLguEWcmvjbVc31nyq\nSDoO3ncFWKFmVsbQPTbP+pKUmlLfJwtb5XqxNR5GEXSwVv4I7IqBmJz1MmRafnBZ\ng0FJUtH668GnldO20XbnSVBr820F5SISMXVwCXDXEvGwwiB8Lt8PvqzXnGIFDAu3\nDlQI5sxSqpPVWSyw08ppKT2Tpmy8adiBotLfaCFl2VTHwOae48X2dMPBvQARAQAB\ntDFGZWRvcmEgKDMwKSA8ZmVkb3JhLTMwLXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQI4BBMBAgAiBQJbbqxnAhsPBgsJCAcDAgYVCAIJCgsEFgIDAQIeAQIXgAAK\nCRDvPBEfz8ZZudTnD/9170LL3nyTVUCFmBjT9wZ4gYnpwtKVPa/pKnxbbS+Bmmac\ng9TrT9pZbqOHrNJLiZ3Zx1Hp+8uxr3Lo6kbYwImLhkOEDrf4aP17HfQ6VYFbQZI8\nf79OFxWJ7si9+3gfzeh9UYFEqOQfzIjLWFyfnas0OnV/P+RMQ1Zr+vPRqO7AR2va\nN9wg+Xl7157dhXPCGYnGMNSoxCbpRs0JNlzvJMuAea5nTTznRaJZtK/xKsqLn51D\nK07k9MHVFXakOH8QtMCUglbwfTfIpO5YRq5imxlWbqsYWVQy1WGJFyW6hWC0+RcJ\nOx5zGtOfi4/dN+xJ+ibnbyvy/il7Qm+vyFhCYqIPyS5m2UVJUuao3eApE38k78/o\n8aQOTnFQZ+U1Sw+6woFTxjqRQBXlQm2+7Bt3bqGATg4sXXWPbmwdL87Ic+mxn/ml\nSMfQux/5k6iAu1kQhwkO2YJn9eII6HIPkW+2m5N1JsUyJQe4cbtZE5Yh3TRA0dm7\n+zoBRfCXkOW4krchbgww/ptVmzMMP7GINJdROrJnsGl5FVeid9qHzV7aZycWSma7\nCxBYB1J8HCbty5NjtD6XMYRrMLxXugvX6Q4NPPH+2NKjzX4SIDejS6JjgrP3KA3O\npMuo7ZHMfveBngv8yP+ZD/1sS6l+dfExvdaJdOdgFCnp4p3gPbw5+Lv70HrMjA==\n=BfZ/\n-----END PGP PUBLIC KEY BLOCK-----\n",
+                "checksum": "sha256:9f596e18f585bee30ac41c11fb11a83ed6b11d5b341c1cb56ca4015d7717cb97"
+              }
+            ],
+            "packages": [
+              "chrony",
+              "firewalld",
+              "kernel",
+              "langpacks-en",
+              "policycoreutils",
+              "selinux-policy-targeted"
+            ],
+            "exclude_packages": [
+              "dracut-config-rescue"
+            ],
+            "releasever": "30",
+            "basearch": "x86_64",
+            "module_platform_id": "platform:f30"
+          }
+        },
+        {
+          "name": "org.osbuild.fix-bls",
+          "options": {}
+        },
+        {
+          "name": "org.osbuild.locale",
+          "options": {
+            "language": "en_US"
+          }
+        },
+        {
+          "name": "org.osbuild.grub2",
+          "options": {
+            "root_fs_uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
+            "kernel_opts": "ro biosdevname=0 net.ifnames=0",
+            "legacy": true
+          }
+        },
+        {
+          "name": "org.osbuild.selinux",
+          "options": {
+            "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
+          }
         }
-      },
-      {
-        "name": "org.osbuild.fix-bls",
-        "options": {}
-      },
-      {
-        "name": "org.osbuild.locale",
+      ],
+      "assembler": {
+        "name": "org.osbuild.rawfs",
         "options": {
-          "language": "en_US"
-        }
-      },
-      {
-        "name": "org.osbuild.grub2",
-        "options": {
+          "filename": "filesystem.img",
           "root_fs_uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
-          "kernel_opts": "ro biosdevname=0 net.ifnames=0",
-          "legacy": true
+          "size": 2147483648
         }
-      },
-      {
-        "name": "org.osbuild.selinux",
-        "options": {
-          "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
-        }
-      }
-    ],
-    "assembler": {
-      "name": "org.osbuild.rawfs",
-      "options": {
-        "filename": "filesystem.img",
-        "root_fs_uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
-        "size": 2147483648
       }
     }
   },

--- a/test/cases/ext4_local_boot.json
+++ b/test/cases/ext4_local_boot.json
@@ -42,123 +42,126 @@
       "fedora": "sha256:9f596e18f585bee30ac41c11fb11a83ed6b11d5b341c1cb56ca4015d7717cb97"
     }
   },
-  "pipeline": {
-    "build": {
-      "pipeline": {
-        "stages": [
-          {
-            "name": "org.osbuild.dnf",
-            "options": {
-              "repos": [
-                {
-                  "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-30&arch=x86_64",
-                  "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBFturGcBEACv0xBo91V2n0uEC2vh69ywCiSyvUgN/AQH8EZpCVtM7NyjKgKm\nbbY4G3R0M3ir1xXmvUDvK0493/qOiFrjkplvzXFTGpPTi0ypqGgxc5d0ohRA1M75\nL+0AIlXoOgHQ358/c4uO8X0JAA1NYxCkAW1KSJgFJ3RjukrfqSHWthS1d4o8fhHy\nKJKEnirE5hHqB50dafXrBfgZdaOs3C6ppRIePFe2o4vUEapMTCHFw0woQR8Ah4/R\nn7Z9G9Ln+0Cinmy0nbIDiZJ+pgLAXCOWBfDUzcOjDGKvcpoZharA07c0q1/5ojzO\n4F0Fh4g/BUmtrASwHfcIbjHyCSr1j/3Iz883iy07gJY5Yhiuaqmp0o0f9fgHkG53\n2xCU1owmACqaIBNQMukvXRDtB2GJMuKa/asTZDP6R5re+iXs7+s9ohcRRAKGyAyc\nYKIQKcaA+6M8T7/G+TPHZX6HJWqJJiYB+EC2ERblpvq9TPlLguEWcmvjbVc31nyq\nSDoO3ncFWKFmVsbQPTbP+pKUmlLfJwtb5XqxNR5GEXSwVv4I7IqBmJz1MmRafnBZ\ng0FJUtH668GnldO20XbnSVBr820F5SISMXVwCXDXEvGwwiB8Lt8PvqzXnGIFDAu3\nDlQI5sxSqpPVWSyw08ppKT2Tpmy8adiBotLfaCFl2VTHwOae48X2dMPBvQARAQAB\ntDFGZWRvcmEgKDMwKSA8ZmVkb3JhLTMwLXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQI4BBMBAgAiBQJbbqxnAhsPBgsJCAcDAgYVCAIJCgsEFgIDAQIeAQIXgAAK\nCRDvPBEfz8ZZudTnD/9170LL3nyTVUCFmBjT9wZ4gYnpwtKVPa/pKnxbbS+Bmmac\ng9TrT9pZbqOHrNJLiZ3Zx1Hp+8uxr3Lo6kbYwImLhkOEDrf4aP17HfQ6VYFbQZI8\nf79OFxWJ7si9+3gfzeh9UYFEqOQfzIjLWFyfnas0OnV/P+RMQ1Zr+vPRqO7AR2va\nN9wg+Xl7157dhXPCGYnGMNSoxCbpRs0JNlzvJMuAea5nTTznRaJZtK/xKsqLn51D\nK07k9MHVFXakOH8QtMCUglbwfTfIpO5YRq5imxlWbqsYWVQy1WGJFyW6hWC0+RcJ\nOx5zGtOfi4/dN+xJ+ibnbyvy/il7Qm+vyFhCYqIPyS5m2UVJUuao3eApE38k78/o\n8aQOTnFQZ+U1Sw+6woFTxjqRQBXlQm2+7Bt3bqGATg4sXXWPbmwdL87Ic+mxn/ml\nSMfQux/5k6iAu1kQhwkO2YJn9eII6HIPkW+2m5N1JsUyJQe4cbtZE5Yh3TRA0dm7\n+zoBRfCXkOW4krchbgww/ptVmzMMP7GINJdROrJnsGl5FVeid9qHzV7aZycWSma7\nCxBYB1J8HCbty5NjtD6XMYRrMLxXugvX6Q4NPPH+2NKjzX4SIDejS6JjgrP3KA3O\npMuo7ZHMfveBngv8yP+ZD/1sS6l+dfExvdaJdOdgFCnp4p3gPbw5+Lv70HrMjA==\n=BfZ/\n-----END PGP PUBLIC KEY BLOCK-----\n",
-                  "checksum": "sha256:9f596e18f585bee30ac41c11fb11a83ed6b11d5b341c1cb56ca4015d7717cb97"
-                }
-              ],
-              "packages": [
-                "dnf",
-                "dosfstools",
-                "e2fsprogs",
-                "grub2-pc",
-                "policycoreutils",
-                "qemu-img",
-                "systemd",
-                "tar"
-              ],
-              "releasever": "30",
-              "basearch": "x86_64",
-              "module_platform_id": "platform:f30"
-            }
-          }
-        ]
-      },
-      "runner": "org.osbuild.fedora30"
-    },
-    "stages": [
-      {
-        "name": "org.osbuild.dnf",
-        "options": {
-          "repos": [
+  "manifest": {
+    "sources": {},
+    "pipeline": {
+      "build": {
+        "pipeline": {
+          "stages": [
             {
-              "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-30&arch=x86_64",
-              "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBFturGcBEACv0xBo91V2n0uEC2vh69ywCiSyvUgN/AQH8EZpCVtM7NyjKgKm\nbbY4G3R0M3ir1xXmvUDvK0493/qOiFrjkplvzXFTGpPTi0ypqGgxc5d0ohRA1M75\nL+0AIlXoOgHQ358/c4uO8X0JAA1NYxCkAW1KSJgFJ3RjukrfqSHWthS1d4o8fhHy\nKJKEnirE5hHqB50dafXrBfgZdaOs3C6ppRIePFe2o4vUEapMTCHFw0woQR8Ah4/R\nn7Z9G9Ln+0Cinmy0nbIDiZJ+pgLAXCOWBfDUzcOjDGKvcpoZharA07c0q1/5ojzO\n4F0Fh4g/BUmtrASwHfcIbjHyCSr1j/3Iz883iy07gJY5Yhiuaqmp0o0f9fgHkG53\n2xCU1owmACqaIBNQMukvXRDtB2GJMuKa/asTZDP6R5re+iXs7+s9ohcRRAKGyAyc\nYKIQKcaA+6M8T7/G+TPHZX6HJWqJJiYB+EC2ERblpvq9TPlLguEWcmvjbVc31nyq\nSDoO3ncFWKFmVsbQPTbP+pKUmlLfJwtb5XqxNR5GEXSwVv4I7IqBmJz1MmRafnBZ\ng0FJUtH668GnldO20XbnSVBr820F5SISMXVwCXDXEvGwwiB8Lt8PvqzXnGIFDAu3\nDlQI5sxSqpPVWSyw08ppKT2Tpmy8adiBotLfaCFl2VTHwOae48X2dMPBvQARAQAB\ntDFGZWRvcmEgKDMwKSA8ZmVkb3JhLTMwLXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQI4BBMBAgAiBQJbbqxnAhsPBgsJCAcDAgYVCAIJCgsEFgIDAQIeAQIXgAAK\nCRDvPBEfz8ZZudTnD/9170LL3nyTVUCFmBjT9wZ4gYnpwtKVPa/pKnxbbS+Bmmac\ng9TrT9pZbqOHrNJLiZ3Zx1Hp+8uxr3Lo6kbYwImLhkOEDrf4aP17HfQ6VYFbQZI8\nf79OFxWJ7si9+3gfzeh9UYFEqOQfzIjLWFyfnas0OnV/P+RMQ1Zr+vPRqO7AR2va\nN9wg+Xl7157dhXPCGYnGMNSoxCbpRs0JNlzvJMuAea5nTTznRaJZtK/xKsqLn51D\nK07k9MHVFXakOH8QtMCUglbwfTfIpO5YRq5imxlWbqsYWVQy1WGJFyW6hWC0+RcJ\nOx5zGtOfi4/dN+xJ+ibnbyvy/il7Qm+vyFhCYqIPyS5m2UVJUuao3eApE38k78/o\n8aQOTnFQZ+U1Sw+6woFTxjqRQBXlQm2+7Bt3bqGATg4sXXWPbmwdL87Ic+mxn/ml\nSMfQux/5k6iAu1kQhwkO2YJn9eII6HIPkW+2m5N1JsUyJQe4cbtZE5Yh3TRA0dm7\n+zoBRfCXkOW4krchbgww/ptVmzMMP7GINJdROrJnsGl5FVeid9qHzV7aZycWSma7\nCxBYB1J8HCbty5NjtD6XMYRrMLxXugvX6Q4NPPH+2NKjzX4SIDejS6JjgrP3KA3O\npMuo7ZHMfveBngv8yP+ZD/1sS6l+dfExvdaJdOdgFCnp4p3gPbw5+Lv70HrMjA==\n=BfZ/\n-----END PGP PUBLIC KEY BLOCK-----\n",
-              "checksum": "sha256:9f596e18f585bee30ac41c11fb11a83ed6b11d5b341c1cb56ca4015d7717cb97"
+              "name": "org.osbuild.dnf",
+              "options": {
+                "repos": [
+                  {
+                    "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-30&arch=x86_64",
+                    "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBFturGcBEACv0xBo91V2n0uEC2vh69ywCiSyvUgN/AQH8EZpCVtM7NyjKgKm\nbbY4G3R0M3ir1xXmvUDvK0493/qOiFrjkplvzXFTGpPTi0ypqGgxc5d0ohRA1M75\nL+0AIlXoOgHQ358/c4uO8X0JAA1NYxCkAW1KSJgFJ3RjukrfqSHWthS1d4o8fhHy\nKJKEnirE5hHqB50dafXrBfgZdaOs3C6ppRIePFe2o4vUEapMTCHFw0woQR8Ah4/R\nn7Z9G9Ln+0Cinmy0nbIDiZJ+pgLAXCOWBfDUzcOjDGKvcpoZharA07c0q1/5ojzO\n4F0Fh4g/BUmtrASwHfcIbjHyCSr1j/3Iz883iy07gJY5Yhiuaqmp0o0f9fgHkG53\n2xCU1owmACqaIBNQMukvXRDtB2GJMuKa/asTZDP6R5re+iXs7+s9ohcRRAKGyAyc\nYKIQKcaA+6M8T7/G+TPHZX6HJWqJJiYB+EC2ERblpvq9TPlLguEWcmvjbVc31nyq\nSDoO3ncFWKFmVsbQPTbP+pKUmlLfJwtb5XqxNR5GEXSwVv4I7IqBmJz1MmRafnBZ\ng0FJUtH668GnldO20XbnSVBr820F5SISMXVwCXDXEvGwwiB8Lt8PvqzXnGIFDAu3\nDlQI5sxSqpPVWSyw08ppKT2Tpmy8adiBotLfaCFl2VTHwOae48X2dMPBvQARAQAB\ntDFGZWRvcmEgKDMwKSA8ZmVkb3JhLTMwLXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQI4BBMBAgAiBQJbbqxnAhsPBgsJCAcDAgYVCAIJCgsEFgIDAQIeAQIXgAAK\nCRDvPBEfz8ZZudTnD/9170LL3nyTVUCFmBjT9wZ4gYnpwtKVPa/pKnxbbS+Bmmac\ng9TrT9pZbqOHrNJLiZ3Zx1Hp+8uxr3Lo6kbYwImLhkOEDrf4aP17HfQ6VYFbQZI8\nf79OFxWJ7si9+3gfzeh9UYFEqOQfzIjLWFyfnas0OnV/P+RMQ1Zr+vPRqO7AR2va\nN9wg+Xl7157dhXPCGYnGMNSoxCbpRs0JNlzvJMuAea5nTTznRaJZtK/xKsqLn51D\nK07k9MHVFXakOH8QtMCUglbwfTfIpO5YRq5imxlWbqsYWVQy1WGJFyW6hWC0+RcJ\nOx5zGtOfi4/dN+xJ+ibnbyvy/il7Qm+vyFhCYqIPyS5m2UVJUuao3eApE38k78/o\n8aQOTnFQZ+U1Sw+6woFTxjqRQBXlQm2+7Bt3bqGATg4sXXWPbmwdL87Ic+mxn/ml\nSMfQux/5k6iAu1kQhwkO2YJn9eII6HIPkW+2m5N1JsUyJQe4cbtZE5Yh3TRA0dm7\n+zoBRfCXkOW4krchbgww/ptVmzMMP7GINJdROrJnsGl5FVeid9qHzV7aZycWSma7\nCxBYB1J8HCbty5NjtD6XMYRrMLxXugvX6Q4NPPH+2NKjzX4SIDejS6JjgrP3KA3O\npMuo7ZHMfveBngv8yP+ZD/1sS6l+dfExvdaJdOdgFCnp4p3gPbw5+Lv70HrMjA==\n=BfZ/\n-----END PGP PUBLIC KEY BLOCK-----\n",
+                    "checksum": "sha256:9f596e18f585bee30ac41c11fb11a83ed6b11d5b341c1cb56ca4015d7717cb97"
+                  }
+                ],
+                "packages": [
+                  "dnf",
+                  "dosfstools",
+                  "e2fsprogs",
+                  "grub2-pc",
+                  "policycoreutils",
+                  "qemu-img",
+                  "systemd",
+                  "tar"
+                ],
+                "releasever": "30",
+                "basearch": "x86_64",
+                "module_platform_id": "platform:f30"
+              }
             }
-          ],
-          "packages": [
-            "chrony",
-            "firewalld",
-            "kernel",
-            "langpacks-en",
-            "openssh-server",
-            "policycoreutils",
-            "selinux-policy-targeted"
-          ],
-          "exclude_packages": [
-            "dracut-config-rescue"
-          ],
-          "releasever": "30",
-          "basearch": "x86_64",
-          "module_platform_id": "platform:f30"
-        }
-      },
-      {
-        "name": "org.osbuild.locale",
-        "options": {
-          "language": "en_US"
-        }
-      },
-      {
-        "name": "org.osbuild.grub2",
-        "options": {
-          "root_fs_uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
-          "kernel_opts": "ro biosdevname=0 net.ifnames=0",
-          "legacy": true
-        }
-      },
-      {
-        "name": "org.osbuild.systemd",
-        "options": {
-          "enabled_services": [
-            "sshd"
-          ],
-          "disabled_services": [
-            "auditd"
           ]
-        }
+        },
+        "runner": "org.osbuild.fedora30"
       },
-      {
-        "name": "org.osbuild.users",
-        "options": {
-          "users": {
-            "redhat": {
-              "groups": [
-                "wheel"
-              ],
-              "password": "$6$IR7O7z56ouB/OInP$.hscD6dQqPQGwMuQ.idumixSHI/JEyaUfiCAHVSpGO/iNLEvvVZVOQL23zBzQbc2.yJ25xAZD75H0tXqKJpEE/",
-              "key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC61wMCjOSHwbVb4VfVyl5sn497qW4PsdQ7Ty7aD6wDNZ/QjjULkDV/yW5WjDlDQ7UqFH0Sr7vywjqDizUAqK7zM5FsUKsUXWHWwg/ehKg8j9xKcMv11AkFoUoujtfAujnKODkk58XSA9whPr7qcw3vPrmog680pnMSzf9LC7J6kXfs6lkoKfBh9VnlxusCrw2yg0qI1fHAZBLPx7mW6+me71QZsS6sVz8v8KXyrXsKTdnF50FjzHcK9HXDBtSJS5wA3fkcRYymJe0o6WMWNdgSRVpoSiWaHHmFgdMUJaYoCfhXzyl7LtNb3Q+Sveg+tJK7JaRXBLMUllOlJ6ll5Hod root@localhost"
+      "stages": [
+        {
+          "name": "org.osbuild.dnf",
+          "options": {
+            "repos": [
+              {
+                "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-30&arch=x86_64",
+                "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBFturGcBEACv0xBo91V2n0uEC2vh69ywCiSyvUgN/AQH8EZpCVtM7NyjKgKm\nbbY4G3R0M3ir1xXmvUDvK0493/qOiFrjkplvzXFTGpPTi0ypqGgxc5d0ohRA1M75\nL+0AIlXoOgHQ358/c4uO8X0JAA1NYxCkAW1KSJgFJ3RjukrfqSHWthS1d4o8fhHy\nKJKEnirE5hHqB50dafXrBfgZdaOs3C6ppRIePFe2o4vUEapMTCHFw0woQR8Ah4/R\nn7Z9G9Ln+0Cinmy0nbIDiZJ+pgLAXCOWBfDUzcOjDGKvcpoZharA07c0q1/5ojzO\n4F0Fh4g/BUmtrASwHfcIbjHyCSr1j/3Iz883iy07gJY5Yhiuaqmp0o0f9fgHkG53\n2xCU1owmACqaIBNQMukvXRDtB2GJMuKa/asTZDP6R5re+iXs7+s9ohcRRAKGyAyc\nYKIQKcaA+6M8T7/G+TPHZX6HJWqJJiYB+EC2ERblpvq9TPlLguEWcmvjbVc31nyq\nSDoO3ncFWKFmVsbQPTbP+pKUmlLfJwtb5XqxNR5GEXSwVv4I7IqBmJz1MmRafnBZ\ng0FJUtH668GnldO20XbnSVBr820F5SISMXVwCXDXEvGwwiB8Lt8PvqzXnGIFDAu3\nDlQI5sxSqpPVWSyw08ppKT2Tpmy8adiBotLfaCFl2VTHwOae48X2dMPBvQARAQAB\ntDFGZWRvcmEgKDMwKSA8ZmVkb3JhLTMwLXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQI4BBMBAgAiBQJbbqxnAhsPBgsJCAcDAgYVCAIJCgsEFgIDAQIeAQIXgAAK\nCRDvPBEfz8ZZudTnD/9170LL3nyTVUCFmBjT9wZ4gYnpwtKVPa/pKnxbbS+Bmmac\ng9TrT9pZbqOHrNJLiZ3Zx1Hp+8uxr3Lo6kbYwImLhkOEDrf4aP17HfQ6VYFbQZI8\nf79OFxWJ7si9+3gfzeh9UYFEqOQfzIjLWFyfnas0OnV/P+RMQ1Zr+vPRqO7AR2va\nN9wg+Xl7157dhXPCGYnGMNSoxCbpRs0JNlzvJMuAea5nTTznRaJZtK/xKsqLn51D\nK07k9MHVFXakOH8QtMCUglbwfTfIpO5YRq5imxlWbqsYWVQy1WGJFyW6hWC0+RcJ\nOx5zGtOfi4/dN+xJ+ibnbyvy/il7Qm+vyFhCYqIPyS5m2UVJUuao3eApE38k78/o\n8aQOTnFQZ+U1Sw+6woFTxjqRQBXlQm2+7Bt3bqGATg4sXXWPbmwdL87Ic+mxn/ml\nSMfQux/5k6iAu1kQhwkO2YJn9eII6HIPkW+2m5N1JsUyJQe4cbtZE5Yh3TRA0dm7\n+zoBRfCXkOW4krchbgww/ptVmzMMP7GINJdROrJnsGl5FVeid9qHzV7aZycWSma7\nCxBYB1J8HCbty5NjtD6XMYRrMLxXugvX6Q4NPPH+2NKjzX4SIDejS6JjgrP3KA3O\npMuo7ZHMfveBngv8yP+ZD/1sS6l+dfExvdaJdOdgFCnp4p3gPbw5+Lv70HrMjA==\n=BfZ/\n-----END PGP PUBLIC KEY BLOCK-----\n",
+                "checksum": "sha256:9f596e18f585bee30ac41c11fb11a83ed6b11d5b341c1cb56ca4015d7717cb97"
+              }
+            ],
+            "packages": [
+              "chrony",
+              "firewalld",
+              "kernel",
+              "langpacks-en",
+              "openssh-server",
+              "policycoreutils",
+              "selinux-policy-targeted"
+            ],
+            "exclude_packages": [
+              "dracut-config-rescue"
+            ],
+            "releasever": "30",
+            "basearch": "x86_64",
+            "module_platform_id": "platform:f30"
+          }
+        },
+        {
+          "name": "org.osbuild.locale",
+          "options": {
+            "language": "en_US"
+          }
+        },
+        {
+          "name": "org.osbuild.grub2",
+          "options": {
+            "root_fs_uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
+            "kernel_opts": "ro biosdevname=0 net.ifnames=0",
+            "legacy": true
+          }
+        },
+        {
+          "name": "org.osbuild.systemd",
+          "options": {
+            "enabled_services": [
+              "sshd"
+            ],
+            "disabled_services": [
+              "auditd"
+            ]
+          }
+        },
+        {
+          "name": "org.osbuild.users",
+          "options": {
+            "users": {
+              "redhat": {
+                "groups": [
+                  "wheel"
+                ],
+                "password": "$6$IR7O7z56ouB/OInP$.hscD6dQqPQGwMuQ.idumixSHI/JEyaUfiCAHVSpGO/iNLEvvVZVOQL23zBzQbc2.yJ25xAZD75H0tXqKJpEE/",
+                "key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC61wMCjOSHwbVb4VfVyl5sn497qW4PsdQ7Ty7aD6wDNZ/QjjULkDV/yW5WjDlDQ7UqFH0Sr7vywjqDizUAqK7zM5FsUKsUXWHWwg/ehKg8j9xKcMv11AkFoUoujtfAujnKODkk58XSA9whPr7qcw3vPrmog680pnMSzf9LC7J6kXfs6lkoKfBh9VnlxusCrw2yg0qI1fHAZBLPx7mW6+me71QZsS6sVz8v8KXyrXsKTdnF50FjzHcK9HXDBtSJS5wA3fkcRYymJe0o6WMWNdgSRVpoSiWaHHmFgdMUJaYoCfhXzyl7LtNb3Q+Sveg+tJK7JaRXBLMUllOlJ6ll5Hod root@localhost"
+              }
             }
           }
+        },
+        {
+          "name": "org.osbuild.selinux",
+          "options": {
+            "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
+          }
+        },
+        {
+          "name": "org.osbuild.fix-bls",
+          "options": {}
         }
-      },
-      {
-        "name": "org.osbuild.selinux",
+      ],
+      "assembler": {
+        "name": "org.osbuild.rawfs",
         "options": {
-          "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
+          "filename": "filesystem.img",
+          "root_fs_uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
+          "size": 2147483648
         }
-      },
-      {
-        "name": "org.osbuild.fix-bls",
-        "options": {}
-      }
-    ],
-    "assembler": {
-      "name": "org.osbuild.rawfs",
-      "options": {
-        "filename": "filesystem.img",
-        "root_fs_uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
-        "size": 2147483648
       }
     }
   }

--- a/test/cases/ext4_local_boot.json
+++ b/test/cases/ext4_local_boot.json
@@ -2,7 +2,7 @@
   "boot": {
     "type": "nspawn"
   },
-  "compose": {
+  "compose-request": {
     "distro": "fedora-30",
     "arch": "x86_64",
     "output-format": "ext4",

--- a/test/cases/ext4_local_boot.json
+++ b/test/cases/ext4_local_boot.json
@@ -37,6 +37,11 @@
       }
     }
   },
+  "rpmmd": {
+    "checksums": {
+      "fedora": "sha256:9f596e18f585bee30ac41c11fb11a83ed6b11d5b341c1cb56ca4015d7717cb97"
+    }
+  },
   "pipeline": {
     "build": {
       "pipeline": {

--- a/test/cases/groups_blueprint.json
+++ b/test/cases/groups_blueprint.json
@@ -41,6 +41,11 @@
       }
     }
   },
+  "rpmmd": {
+    "checksums": {
+      "fedora": "sha256:9f596e18f585bee30ac41c11fb11a83ed6b11d5b341c1cb56ca4015d7717cb97"
+    }
+  },
   "pipeline": {
     "build": {
       "pipeline": {

--- a/test/cases/groups_blueprint.json
+++ b/test/cases/groups_blueprint.json
@@ -2,7 +2,7 @@
   "boot": {
     "type": "nspawn-extract"
   },
-  "compose": {
+  "compose-request": {
     "output-format": "tar",
     "distro": "fedora-30",
     "arch": "x86_64",

--- a/test/cases/groups_blueprint.json
+++ b/test/cases/groups_blueprint.json
@@ -46,122 +46,125 @@
       "fedora": "sha256:9f596e18f585bee30ac41c11fb11a83ed6b11d5b341c1cb56ca4015d7717cb97"
     }
   },
-  "pipeline": {
-    "build": {
-      "pipeline": {
-        "stages": [
-          {
-            "name": "org.osbuild.dnf",
-            "options": {
-              "repos": [
-                {
-                  "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-30&arch=x86_64",
-                  "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBFturGcBEACv0xBo91V2n0uEC2vh69ywCiSyvUgN/AQH8EZpCVtM7NyjKgKm\nbbY4G3R0M3ir1xXmvUDvK0493/qOiFrjkplvzXFTGpPTi0ypqGgxc5d0ohRA1M75\nL+0AIlXoOgHQ358/c4uO8X0JAA1NYxCkAW1KSJgFJ3RjukrfqSHWthS1d4o8fhHy\nKJKEnirE5hHqB50dafXrBfgZdaOs3C6ppRIePFe2o4vUEapMTCHFw0woQR8Ah4/R\nn7Z9G9Ln+0Cinmy0nbIDiZJ+pgLAXCOWBfDUzcOjDGKvcpoZharA07c0q1/5ojzO\n4F0Fh4g/BUmtrASwHfcIbjHyCSr1j/3Iz883iy07gJY5Yhiuaqmp0o0f9fgHkG53\n2xCU1owmACqaIBNQMukvXRDtB2GJMuKa/asTZDP6R5re+iXs7+s9ohcRRAKGyAyc\nYKIQKcaA+6M8T7/G+TPHZX6HJWqJJiYB+EC2ERblpvq9TPlLguEWcmvjbVc31nyq\nSDoO3ncFWKFmVsbQPTbP+pKUmlLfJwtb5XqxNR5GEXSwVv4I7IqBmJz1MmRafnBZ\ng0FJUtH668GnldO20XbnSVBr820F5SISMXVwCXDXEvGwwiB8Lt8PvqzXnGIFDAu3\nDlQI5sxSqpPVWSyw08ppKT2Tpmy8adiBotLfaCFl2VTHwOae48X2dMPBvQARAQAB\ntDFGZWRvcmEgKDMwKSA8ZmVkb3JhLTMwLXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQI4BBMBAgAiBQJbbqxnAhsPBgsJCAcDAgYVCAIJCgsEFgIDAQIeAQIXgAAK\nCRDvPBEfz8ZZudTnD/9170LL3nyTVUCFmBjT9wZ4gYnpwtKVPa/pKnxbbS+Bmmac\ng9TrT9pZbqOHrNJLiZ3Zx1Hp+8uxr3Lo6kbYwImLhkOEDrf4aP17HfQ6VYFbQZI8\nf79OFxWJ7si9+3gfzeh9UYFEqOQfzIjLWFyfnas0OnV/P+RMQ1Zr+vPRqO7AR2va\nN9wg+Xl7157dhXPCGYnGMNSoxCbpRs0JNlzvJMuAea5nTTznRaJZtK/xKsqLn51D\nK07k9MHVFXakOH8QtMCUglbwfTfIpO5YRq5imxlWbqsYWVQy1WGJFyW6hWC0+RcJ\nOx5zGtOfi4/dN+xJ+ibnbyvy/il7Qm+vyFhCYqIPyS5m2UVJUuao3eApE38k78/o\n8aQOTnFQZ+U1Sw+6woFTxjqRQBXlQm2+7Bt3bqGATg4sXXWPbmwdL87Ic+mxn/ml\nSMfQux/5k6iAu1kQhwkO2YJn9eII6HIPkW+2m5N1JsUyJQe4cbtZE5Yh3TRA0dm7\n+zoBRfCXkOW4krchbgww/ptVmzMMP7GINJdROrJnsGl5FVeid9qHzV7aZycWSma7\nCxBYB1J8HCbty5NjtD6XMYRrMLxXugvX6Q4NPPH+2NKjzX4SIDejS6JjgrP3KA3O\npMuo7ZHMfveBngv8yP+ZD/1sS6l+dfExvdaJdOdgFCnp4p3gPbw5+Lv70HrMjA==\n=BfZ/\n-----END PGP PUBLIC KEY BLOCK-----\n",
-                  "checksum": "sha256:9f596e18f585bee30ac41c11fb11a83ed6b11d5b341c1cb56ca4015d7717cb97"
-                }
-              ],
-              "packages": [
-                "dnf",
-                "dosfstools",
-                "e2fsprogs",
-                "grub2-pc",
-                "policycoreutils",
-                "qemu-img",
-                "systemd",
-                "tar"
-              ],
-              "releasever": "30",
-              "basearch": "x86_64",
-              "module_platform_id": "platform:f30"
-            }
-          }
-        ]
-      },
-      "runner": "org.osbuild.fedora30"
-    },
-    "stages": [
-      {
-        "name": "org.osbuild.dnf",
-        "options": {
-          "repos": [
+  "manifest": {
+    "sources": {},
+    "pipeline": {
+      "build": {
+        "pipeline": {
+          "stages": [
             {
-              "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-30&arch=x86_64",
-              "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBFturGcBEACv0xBo91V2n0uEC2vh69ywCiSyvUgN/AQH8EZpCVtM7NyjKgKm\nbbY4G3R0M3ir1xXmvUDvK0493/qOiFrjkplvzXFTGpPTi0ypqGgxc5d0ohRA1M75\nL+0AIlXoOgHQ358/c4uO8X0JAA1NYxCkAW1KSJgFJ3RjukrfqSHWthS1d4o8fhHy\nKJKEnirE5hHqB50dafXrBfgZdaOs3C6ppRIePFe2o4vUEapMTCHFw0woQR8Ah4/R\nn7Z9G9Ln+0Cinmy0nbIDiZJ+pgLAXCOWBfDUzcOjDGKvcpoZharA07c0q1/5ojzO\n4F0Fh4g/BUmtrASwHfcIbjHyCSr1j/3Iz883iy07gJY5Yhiuaqmp0o0f9fgHkG53\n2xCU1owmACqaIBNQMukvXRDtB2GJMuKa/asTZDP6R5re+iXs7+s9ohcRRAKGyAyc\nYKIQKcaA+6M8T7/G+TPHZX6HJWqJJiYB+EC2ERblpvq9TPlLguEWcmvjbVc31nyq\nSDoO3ncFWKFmVsbQPTbP+pKUmlLfJwtb5XqxNR5GEXSwVv4I7IqBmJz1MmRafnBZ\ng0FJUtH668GnldO20XbnSVBr820F5SISMXVwCXDXEvGwwiB8Lt8PvqzXnGIFDAu3\nDlQI5sxSqpPVWSyw08ppKT2Tpmy8adiBotLfaCFl2VTHwOae48X2dMPBvQARAQAB\ntDFGZWRvcmEgKDMwKSA8ZmVkb3JhLTMwLXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQI4BBMBAgAiBQJbbqxnAhsPBgsJCAcDAgYVCAIJCgsEFgIDAQIeAQIXgAAK\nCRDvPBEfz8ZZudTnD/9170LL3nyTVUCFmBjT9wZ4gYnpwtKVPa/pKnxbbS+Bmmac\ng9TrT9pZbqOHrNJLiZ3Zx1Hp+8uxr3Lo6kbYwImLhkOEDrf4aP17HfQ6VYFbQZI8\nf79OFxWJ7si9+3gfzeh9UYFEqOQfzIjLWFyfnas0OnV/P+RMQ1Zr+vPRqO7AR2va\nN9wg+Xl7157dhXPCGYnGMNSoxCbpRs0JNlzvJMuAea5nTTznRaJZtK/xKsqLn51D\nK07k9MHVFXakOH8QtMCUglbwfTfIpO5YRq5imxlWbqsYWVQy1WGJFyW6hWC0+RcJ\nOx5zGtOfi4/dN+xJ+ibnbyvy/il7Qm+vyFhCYqIPyS5m2UVJUuao3eApE38k78/o\n8aQOTnFQZ+U1Sw+6woFTxjqRQBXlQm2+7Bt3bqGATg4sXXWPbmwdL87Ic+mxn/ml\nSMfQux/5k6iAu1kQhwkO2YJn9eII6HIPkW+2m5N1JsUyJQe4cbtZE5Yh3TRA0dm7\n+zoBRfCXkOW4krchbgww/ptVmzMMP7GINJdROrJnsGl5FVeid9qHzV7aZycWSma7\nCxBYB1J8HCbty5NjtD6XMYRrMLxXugvX6Q4NPPH+2NKjzX4SIDejS6JjgrP3KA3O\npMuo7ZHMfveBngv8yP+ZD/1sS6l+dfExvdaJdOdgFCnp4p3gPbw5+Lv70HrMjA==\n=BfZ/\n-----END PGP PUBLIC KEY BLOCK-----\n",
-              "checksum": "sha256:9f596e18f585bee30ac41c11fb11a83ed6b11d5b341c1cb56ca4015d7717cb97"
+              "name": "org.osbuild.dnf",
+              "options": {
+                "repos": [
+                  {
+                    "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-30&arch=x86_64",
+                    "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBFturGcBEACv0xBo91V2n0uEC2vh69ywCiSyvUgN/AQH8EZpCVtM7NyjKgKm\nbbY4G3R0M3ir1xXmvUDvK0493/qOiFrjkplvzXFTGpPTi0ypqGgxc5d0ohRA1M75\nL+0AIlXoOgHQ358/c4uO8X0JAA1NYxCkAW1KSJgFJ3RjukrfqSHWthS1d4o8fhHy\nKJKEnirE5hHqB50dafXrBfgZdaOs3C6ppRIePFe2o4vUEapMTCHFw0woQR8Ah4/R\nn7Z9G9Ln+0Cinmy0nbIDiZJ+pgLAXCOWBfDUzcOjDGKvcpoZharA07c0q1/5ojzO\n4F0Fh4g/BUmtrASwHfcIbjHyCSr1j/3Iz883iy07gJY5Yhiuaqmp0o0f9fgHkG53\n2xCU1owmACqaIBNQMukvXRDtB2GJMuKa/asTZDP6R5re+iXs7+s9ohcRRAKGyAyc\nYKIQKcaA+6M8T7/G+TPHZX6HJWqJJiYB+EC2ERblpvq9TPlLguEWcmvjbVc31nyq\nSDoO3ncFWKFmVsbQPTbP+pKUmlLfJwtb5XqxNR5GEXSwVv4I7IqBmJz1MmRafnBZ\ng0FJUtH668GnldO20XbnSVBr820F5SISMXVwCXDXEvGwwiB8Lt8PvqzXnGIFDAu3\nDlQI5sxSqpPVWSyw08ppKT2Tpmy8adiBotLfaCFl2VTHwOae48X2dMPBvQARAQAB\ntDFGZWRvcmEgKDMwKSA8ZmVkb3JhLTMwLXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQI4BBMBAgAiBQJbbqxnAhsPBgsJCAcDAgYVCAIJCgsEFgIDAQIeAQIXgAAK\nCRDvPBEfz8ZZudTnD/9170LL3nyTVUCFmBjT9wZ4gYnpwtKVPa/pKnxbbS+Bmmac\ng9TrT9pZbqOHrNJLiZ3Zx1Hp+8uxr3Lo6kbYwImLhkOEDrf4aP17HfQ6VYFbQZI8\nf79OFxWJ7si9+3gfzeh9UYFEqOQfzIjLWFyfnas0OnV/P+RMQ1Zr+vPRqO7AR2va\nN9wg+Xl7157dhXPCGYnGMNSoxCbpRs0JNlzvJMuAea5nTTznRaJZtK/xKsqLn51D\nK07k9MHVFXakOH8QtMCUglbwfTfIpO5YRq5imxlWbqsYWVQy1WGJFyW6hWC0+RcJ\nOx5zGtOfi4/dN+xJ+ibnbyvy/il7Qm+vyFhCYqIPyS5m2UVJUuao3eApE38k78/o\n8aQOTnFQZ+U1Sw+6woFTxjqRQBXlQm2+7Bt3bqGATg4sXXWPbmwdL87Ic+mxn/ml\nSMfQux/5k6iAu1kQhwkO2YJn9eII6HIPkW+2m5N1JsUyJQe4cbtZE5Yh3TRA0dm7\n+zoBRfCXkOW4krchbgww/ptVmzMMP7GINJdROrJnsGl5FVeid9qHzV7aZycWSma7\nCxBYB1J8HCbty5NjtD6XMYRrMLxXugvX6Q4NPPH+2NKjzX4SIDejS6JjgrP3KA3O\npMuo7ZHMfveBngv8yP+ZD/1sS6l+dfExvdaJdOdgFCnp4p3gPbw5+Lv70HrMjA==\n=BfZ/\n-----END PGP PUBLIC KEY BLOCK-----\n",
+                    "checksum": "sha256:9f596e18f585bee30ac41c11fb11a83ed6b11d5b341c1cb56ca4015d7717cb97"
+                  }
+                ],
+                "packages": [
+                  "dnf",
+                  "dosfstools",
+                  "e2fsprogs",
+                  "grub2-pc",
+                  "policycoreutils",
+                  "qemu-img",
+                  "systemd",
+                  "tar"
+                ],
+                "releasever": "30",
+                "basearch": "x86_64",
+                "module_platform_id": "platform:f30"
+              }
             }
-          ],
-          "packages": [
-            "@anaconda-tools",
-            "chrony",
-            "firewalld",
-            "kernel",
-            "langpacks-en",
-            "openssh-server",
-            "policycoreutils",
-            "selinux-policy-targeted"
-          ],
-          "exclude_packages": [
-            "dracut-config-rescue"
-          ],
-          "releasever": "30",
-          "basearch": "x86_64",
-          "module_platform_id": "platform:f30"
-        }
-      },
-      {
-        "name": "org.osbuild.locale",
-        "options": {
-          "language": "en_US"
-        }
-      },
-      {
-        "name": "org.osbuild.grub2",
-        "options": {
-          "root_fs_uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
-          "kernel_opts": "ro biosdevname=0 net.ifnames=0",
-          "legacy": true
-        }
-      },
-      {
-        "name": "org.osbuild.systemd",
-        "options": {
-          "enabled_services": [
-            "sshd"
-          ],
-          "disabled_services": [
-            "auditd"
           ]
-        }
+        },
+        "runner": "org.osbuild.fedora30"
       },
-      {
-        "name": "org.osbuild.users",
-        "options": {
-          "users": {
-            "redhat": {
-              "groups": [
-                "wheel"
-              ],
-              "password": "$6$IR7O7z56ouB/OInP$.hscD6dQqPQGwMuQ.idumixSHI/JEyaUfiCAHVSpGO/iNLEvvVZVOQL23zBzQbc2.yJ25xAZD75H0tXqKJpEE/",
-              "key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC61wMCjOSHwbVb4VfVyl5sn497qW4PsdQ7Ty7aD6wDNZ/QjjULkDV/yW5WjDlDQ7UqFH0Sr7vywjqDizUAqK7zM5FsUKsUXWHWwg/ehKg8j9xKcMv11AkFoUoujtfAujnKODkk58XSA9whPr7qcw3vPrmog680pnMSzf9LC7J6kXfs6lkoKfBh9VnlxusCrw2yg0qI1fHAZBLPx7mW6+me71QZsS6sVz8v8KXyrXsKTdnF50FjzHcK9HXDBtSJS5wA3fkcRYymJe0o6WMWNdgSRVpoSiWaHHmFgdMUJaYoCfhXzyl7LtNb3Q+Sveg+tJK7JaRXBLMUllOlJ6ll5Hod root@localhost"
+      "stages": [
+        {
+          "name": "org.osbuild.dnf",
+          "options": {
+            "repos": [
+              {
+                "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-30&arch=x86_64",
+                "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBFturGcBEACv0xBo91V2n0uEC2vh69ywCiSyvUgN/AQH8EZpCVtM7NyjKgKm\nbbY4G3R0M3ir1xXmvUDvK0493/qOiFrjkplvzXFTGpPTi0ypqGgxc5d0ohRA1M75\nL+0AIlXoOgHQ358/c4uO8X0JAA1NYxCkAW1KSJgFJ3RjukrfqSHWthS1d4o8fhHy\nKJKEnirE5hHqB50dafXrBfgZdaOs3C6ppRIePFe2o4vUEapMTCHFw0woQR8Ah4/R\nn7Z9G9Ln+0Cinmy0nbIDiZJ+pgLAXCOWBfDUzcOjDGKvcpoZharA07c0q1/5ojzO\n4F0Fh4g/BUmtrASwHfcIbjHyCSr1j/3Iz883iy07gJY5Yhiuaqmp0o0f9fgHkG53\n2xCU1owmACqaIBNQMukvXRDtB2GJMuKa/asTZDP6R5re+iXs7+s9ohcRRAKGyAyc\nYKIQKcaA+6M8T7/G+TPHZX6HJWqJJiYB+EC2ERblpvq9TPlLguEWcmvjbVc31nyq\nSDoO3ncFWKFmVsbQPTbP+pKUmlLfJwtb5XqxNR5GEXSwVv4I7IqBmJz1MmRafnBZ\ng0FJUtH668GnldO20XbnSVBr820F5SISMXVwCXDXEvGwwiB8Lt8PvqzXnGIFDAu3\nDlQI5sxSqpPVWSyw08ppKT2Tpmy8adiBotLfaCFl2VTHwOae48X2dMPBvQARAQAB\ntDFGZWRvcmEgKDMwKSA8ZmVkb3JhLTMwLXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQI4BBMBAgAiBQJbbqxnAhsPBgsJCAcDAgYVCAIJCgsEFgIDAQIeAQIXgAAK\nCRDvPBEfz8ZZudTnD/9170LL3nyTVUCFmBjT9wZ4gYnpwtKVPa/pKnxbbS+Bmmac\ng9TrT9pZbqOHrNJLiZ3Zx1Hp+8uxr3Lo6kbYwImLhkOEDrf4aP17HfQ6VYFbQZI8\nf79OFxWJ7si9+3gfzeh9UYFEqOQfzIjLWFyfnas0OnV/P+RMQ1Zr+vPRqO7AR2va\nN9wg+Xl7157dhXPCGYnGMNSoxCbpRs0JNlzvJMuAea5nTTznRaJZtK/xKsqLn51D\nK07k9MHVFXakOH8QtMCUglbwfTfIpO5YRq5imxlWbqsYWVQy1WGJFyW6hWC0+RcJ\nOx5zGtOfi4/dN+xJ+ibnbyvy/il7Qm+vyFhCYqIPyS5m2UVJUuao3eApE38k78/o\n8aQOTnFQZ+U1Sw+6woFTxjqRQBXlQm2+7Bt3bqGATg4sXXWPbmwdL87Ic+mxn/ml\nSMfQux/5k6iAu1kQhwkO2YJn9eII6HIPkW+2m5N1JsUyJQe4cbtZE5Yh3TRA0dm7\n+zoBRfCXkOW4krchbgww/ptVmzMMP7GINJdROrJnsGl5FVeid9qHzV7aZycWSma7\nCxBYB1J8HCbty5NjtD6XMYRrMLxXugvX6Q4NPPH+2NKjzX4SIDejS6JjgrP3KA3O\npMuo7ZHMfveBngv8yP+ZD/1sS6l+dfExvdaJdOdgFCnp4p3gPbw5+Lv70HrMjA==\n=BfZ/\n-----END PGP PUBLIC KEY BLOCK-----\n",
+                "checksum": "sha256:9f596e18f585bee30ac41c11fb11a83ed6b11d5b341c1cb56ca4015d7717cb97"
+              }
+            ],
+            "packages": [
+              "@anaconda-tools",
+              "chrony",
+              "firewalld",
+              "kernel",
+              "langpacks-en",
+              "openssh-server",
+              "policycoreutils",
+              "selinux-policy-targeted"
+            ],
+            "exclude_packages": [
+              "dracut-config-rescue"
+            ],
+            "releasever": "30",
+            "basearch": "x86_64",
+            "module_platform_id": "platform:f30"
+          }
+        },
+        {
+          "name": "org.osbuild.locale",
+          "options": {
+            "language": "en_US"
+          }
+        },
+        {
+          "name": "org.osbuild.grub2",
+          "options": {
+            "root_fs_uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
+            "kernel_opts": "ro biosdevname=0 net.ifnames=0",
+            "legacy": true
+          }
+        },
+        {
+          "name": "org.osbuild.systemd",
+          "options": {
+            "enabled_services": [
+              "sshd"
+            ],
+            "disabled_services": [
+              "auditd"
+            ]
+          }
+        },
+        {
+          "name": "org.osbuild.users",
+          "options": {
+            "users": {
+              "redhat": {
+                "groups": [
+                  "wheel"
+                ],
+                "password": "$6$IR7O7z56ouB/OInP$.hscD6dQqPQGwMuQ.idumixSHI/JEyaUfiCAHVSpGO/iNLEvvVZVOQL23zBzQbc2.yJ25xAZD75H0tXqKJpEE/",
+                "key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC61wMCjOSHwbVb4VfVyl5sn497qW4PsdQ7Ty7aD6wDNZ/QjjULkDV/yW5WjDlDQ7UqFH0Sr7vywjqDizUAqK7zM5FsUKsUXWHWwg/ehKg8j9xKcMv11AkFoUoujtfAujnKODkk58XSA9whPr7qcw3vPrmog680pnMSzf9LC7J6kXfs6lkoKfBh9VnlxusCrw2yg0qI1fHAZBLPx7mW6+me71QZsS6sVz8v8KXyrXsKTdnF50FjzHcK9HXDBtSJS5wA3fkcRYymJe0o6WMWNdgSRVpoSiWaHHmFgdMUJaYoCfhXzyl7LtNb3Q+Sveg+tJK7JaRXBLMUllOlJ6ll5Hod root@localhost"
+              }
             }
           }
+        },
+        {
+          "name": "org.osbuild.selinux",
+          "options": {
+            "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
+          }
+        },
+        {
+          "name": "org.osbuild.fix-bls",
+          "options": {}
         }
-      },
-      {
-        "name": "org.osbuild.selinux",
+      ],
+      "assembler": {
+        "name": "org.osbuild.tar",
         "options": {
-          "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
+          "filename": "root.tar.xz"
         }
-      },
-      {
-        "name": "org.osbuild.fix-bls",
-        "options": {}
-      }
-    ],
-    "assembler": {
-      "name": "org.osbuild.tar",
-      "options": {
-        "filename": "root.tar.xz"
       }
     }
   }

--- a/test/cases/openstack_empty_blueprint.json
+++ b/test/cases/openstack_empty_blueprint.json
@@ -1,5 +1,5 @@
 {
-  "compose": {
+  "compose-request": {
     "distro": "fedora-30",
     "arch": "x86_64",
     "output-format": "openstack",

--- a/test/cases/openstack_empty_blueprint.json
+++ b/test/cases/openstack_empty_blueprint.json
@@ -11,130 +11,133 @@
       "fedora": "sha256:9f596e18f585bee30ac41c11fb11a83ed6b11d5b341c1cb56ca4015d7717cb97"
     }
   },
-  "pipeline": {
-    "build": {
-      "pipeline": {
-        "stages": [
-          {
-            "name": "org.osbuild.dnf",
-            "options": {
-              "repos": [
-                {
-                  "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-30&arch=x86_64",
-                  "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBFturGcBEACv0xBo91V2n0uEC2vh69ywCiSyvUgN/AQH8EZpCVtM7NyjKgKm\nbbY4G3R0M3ir1xXmvUDvK0493/qOiFrjkplvzXFTGpPTi0ypqGgxc5d0ohRA1M75\nL+0AIlXoOgHQ358/c4uO8X0JAA1NYxCkAW1KSJgFJ3RjukrfqSHWthS1d4o8fhHy\nKJKEnirE5hHqB50dafXrBfgZdaOs3C6ppRIePFe2o4vUEapMTCHFw0woQR8Ah4/R\nn7Z9G9Ln+0Cinmy0nbIDiZJ+pgLAXCOWBfDUzcOjDGKvcpoZharA07c0q1/5ojzO\n4F0Fh4g/BUmtrASwHfcIbjHyCSr1j/3Iz883iy07gJY5Yhiuaqmp0o0f9fgHkG53\n2xCU1owmACqaIBNQMukvXRDtB2GJMuKa/asTZDP6R5re+iXs7+s9ohcRRAKGyAyc\nYKIQKcaA+6M8T7/G+TPHZX6HJWqJJiYB+EC2ERblpvq9TPlLguEWcmvjbVc31nyq\nSDoO3ncFWKFmVsbQPTbP+pKUmlLfJwtb5XqxNR5GEXSwVv4I7IqBmJz1MmRafnBZ\ng0FJUtH668GnldO20XbnSVBr820F5SISMXVwCXDXEvGwwiB8Lt8PvqzXnGIFDAu3\nDlQI5sxSqpPVWSyw08ppKT2Tpmy8adiBotLfaCFl2VTHwOae48X2dMPBvQARAQAB\ntDFGZWRvcmEgKDMwKSA8ZmVkb3JhLTMwLXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQI4BBMBAgAiBQJbbqxnAhsPBgsJCAcDAgYVCAIJCgsEFgIDAQIeAQIXgAAK\nCRDvPBEfz8ZZudTnD/9170LL3nyTVUCFmBjT9wZ4gYnpwtKVPa/pKnxbbS+Bmmac\ng9TrT9pZbqOHrNJLiZ3Zx1Hp+8uxr3Lo6kbYwImLhkOEDrf4aP17HfQ6VYFbQZI8\nf79OFxWJ7si9+3gfzeh9UYFEqOQfzIjLWFyfnas0OnV/P+RMQ1Zr+vPRqO7AR2va\nN9wg+Xl7157dhXPCGYnGMNSoxCbpRs0JNlzvJMuAea5nTTznRaJZtK/xKsqLn51D\nK07k9MHVFXakOH8QtMCUglbwfTfIpO5YRq5imxlWbqsYWVQy1WGJFyW6hWC0+RcJ\nOx5zGtOfi4/dN+xJ+ibnbyvy/il7Qm+vyFhCYqIPyS5m2UVJUuao3eApE38k78/o\n8aQOTnFQZ+U1Sw+6woFTxjqRQBXlQm2+7Bt3bqGATg4sXXWPbmwdL87Ic+mxn/ml\nSMfQux/5k6iAu1kQhwkO2YJn9eII6HIPkW+2m5N1JsUyJQe4cbtZE5Yh3TRA0dm7\n+zoBRfCXkOW4krchbgww/ptVmzMMP7GINJdROrJnsGl5FVeid9qHzV7aZycWSma7\nCxBYB1J8HCbty5NjtD6XMYRrMLxXugvX6Q4NPPH+2NKjzX4SIDejS6JjgrP3KA3O\npMuo7ZHMfveBngv8yP+ZD/1sS6l+dfExvdaJdOdgFCnp4p3gPbw5+Lv70HrMjA==\n=BfZ/\n-----END PGP PUBLIC KEY BLOCK-----\n",
-                  "checksum": "sha256:9f596e18f585bee30ac41c11fb11a83ed6b11d5b341c1cb56ca4015d7717cb97"
-                }
-              ],
-              "packages": [
-                "dnf",
-                "dosfstools",
-                "e2fsprogs",
-                "grub2-pc",
-                "policycoreutils",
-                "qemu-img",
-                "systemd",
-                "tar"
-              ],
-              "releasever": "30",
-              "basearch": "x86_64",
-              "module_platform_id": "platform:f30"
+  "manifest": {
+    "sources": {},
+    "pipeline": {
+      "build": {
+        "pipeline": {
+          "stages": [
+            {
+              "name": "org.osbuild.dnf",
+              "options": {
+                "repos": [
+                  {
+                    "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-30&arch=x86_64",
+                    "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBFturGcBEACv0xBo91V2n0uEC2vh69ywCiSyvUgN/AQH8EZpCVtM7NyjKgKm\nbbY4G3R0M3ir1xXmvUDvK0493/qOiFrjkplvzXFTGpPTi0ypqGgxc5d0ohRA1M75\nL+0AIlXoOgHQ358/c4uO8X0JAA1NYxCkAW1KSJgFJ3RjukrfqSHWthS1d4o8fhHy\nKJKEnirE5hHqB50dafXrBfgZdaOs3C6ppRIePFe2o4vUEapMTCHFw0woQR8Ah4/R\nn7Z9G9Ln+0Cinmy0nbIDiZJ+pgLAXCOWBfDUzcOjDGKvcpoZharA07c0q1/5ojzO\n4F0Fh4g/BUmtrASwHfcIbjHyCSr1j/3Iz883iy07gJY5Yhiuaqmp0o0f9fgHkG53\n2xCU1owmACqaIBNQMukvXRDtB2GJMuKa/asTZDP6R5re+iXs7+s9ohcRRAKGyAyc\nYKIQKcaA+6M8T7/G+TPHZX6HJWqJJiYB+EC2ERblpvq9TPlLguEWcmvjbVc31nyq\nSDoO3ncFWKFmVsbQPTbP+pKUmlLfJwtb5XqxNR5GEXSwVv4I7IqBmJz1MmRafnBZ\ng0FJUtH668GnldO20XbnSVBr820F5SISMXVwCXDXEvGwwiB8Lt8PvqzXnGIFDAu3\nDlQI5sxSqpPVWSyw08ppKT2Tpmy8adiBotLfaCFl2VTHwOae48X2dMPBvQARAQAB\ntDFGZWRvcmEgKDMwKSA8ZmVkb3JhLTMwLXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQI4BBMBAgAiBQJbbqxnAhsPBgsJCAcDAgYVCAIJCgsEFgIDAQIeAQIXgAAK\nCRDvPBEfz8ZZudTnD/9170LL3nyTVUCFmBjT9wZ4gYnpwtKVPa/pKnxbbS+Bmmac\ng9TrT9pZbqOHrNJLiZ3Zx1Hp+8uxr3Lo6kbYwImLhkOEDrf4aP17HfQ6VYFbQZI8\nf79OFxWJ7si9+3gfzeh9UYFEqOQfzIjLWFyfnas0OnV/P+RMQ1Zr+vPRqO7AR2va\nN9wg+Xl7157dhXPCGYnGMNSoxCbpRs0JNlzvJMuAea5nTTznRaJZtK/xKsqLn51D\nK07k9MHVFXakOH8QtMCUglbwfTfIpO5YRq5imxlWbqsYWVQy1WGJFyW6hWC0+RcJ\nOx5zGtOfi4/dN+xJ+ibnbyvy/il7Qm+vyFhCYqIPyS5m2UVJUuao3eApE38k78/o\n8aQOTnFQZ+U1Sw+6woFTxjqRQBXlQm2+7Bt3bqGATg4sXXWPbmwdL87Ic+mxn/ml\nSMfQux/5k6iAu1kQhwkO2YJn9eII6HIPkW+2m5N1JsUyJQe4cbtZE5Yh3TRA0dm7\n+zoBRfCXkOW4krchbgww/ptVmzMMP7GINJdROrJnsGl5FVeid9qHzV7aZycWSma7\nCxBYB1J8HCbty5NjtD6XMYRrMLxXugvX6Q4NPPH+2NKjzX4SIDejS6JjgrP3KA3O\npMuo7ZHMfveBngv8yP+ZD/1sS6l+dfExvdaJdOdgFCnp4p3gPbw5+Lv70HrMjA==\n=BfZ/\n-----END PGP PUBLIC KEY BLOCK-----\n",
+                    "checksum": "sha256:9f596e18f585bee30ac41c11fb11a83ed6b11d5b341c1cb56ca4015d7717cb97"
+                  }
+                ],
+                "packages": [
+                  "dnf",
+                  "dosfstools",
+                  "e2fsprogs",
+                  "grub2-pc",
+                  "policycoreutils",
+                  "qemu-img",
+                  "systemd",
+                  "tar"
+                ],
+                "releasever": "30",
+                "basearch": "x86_64",
+                "module_platform_id": "platform:f30"
+              }
             }
+          ]
+        },
+        "runner": "org.osbuild.fedora30"
+      },
+      "stages": [
+        {
+          "name": "org.osbuild.dnf",
+          "options": {
+            "repos": [
+              {
+                "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-30&arch=x86_64",
+                "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBFturGcBEACv0xBo91V2n0uEC2vh69ywCiSyvUgN/AQH8EZpCVtM7NyjKgKm\nbbY4G3R0M3ir1xXmvUDvK0493/qOiFrjkplvzXFTGpPTi0ypqGgxc5d0ohRA1M75\nL+0AIlXoOgHQ358/c4uO8X0JAA1NYxCkAW1KSJgFJ3RjukrfqSHWthS1d4o8fhHy\nKJKEnirE5hHqB50dafXrBfgZdaOs3C6ppRIePFe2o4vUEapMTCHFw0woQR8Ah4/R\nn7Z9G9Ln+0Cinmy0nbIDiZJ+pgLAXCOWBfDUzcOjDGKvcpoZharA07c0q1/5ojzO\n4F0Fh4g/BUmtrASwHfcIbjHyCSr1j/3Iz883iy07gJY5Yhiuaqmp0o0f9fgHkG53\n2xCU1owmACqaIBNQMukvXRDtB2GJMuKa/asTZDP6R5re+iXs7+s9ohcRRAKGyAyc\nYKIQKcaA+6M8T7/G+TPHZX6HJWqJJiYB+EC2ERblpvq9TPlLguEWcmvjbVc31nyq\nSDoO3ncFWKFmVsbQPTbP+pKUmlLfJwtb5XqxNR5GEXSwVv4I7IqBmJz1MmRafnBZ\ng0FJUtH668GnldO20XbnSVBr820F5SISMXVwCXDXEvGwwiB8Lt8PvqzXnGIFDAu3\nDlQI5sxSqpPVWSyw08ppKT2Tpmy8adiBotLfaCFl2VTHwOae48X2dMPBvQARAQAB\ntDFGZWRvcmEgKDMwKSA8ZmVkb3JhLTMwLXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQI4BBMBAgAiBQJbbqxnAhsPBgsJCAcDAgYVCAIJCgsEFgIDAQIeAQIXgAAK\nCRDvPBEfz8ZZudTnD/9170LL3nyTVUCFmBjT9wZ4gYnpwtKVPa/pKnxbbS+Bmmac\ng9TrT9pZbqOHrNJLiZ3Zx1Hp+8uxr3Lo6kbYwImLhkOEDrf4aP17HfQ6VYFbQZI8\nf79OFxWJ7si9+3gfzeh9UYFEqOQfzIjLWFyfnas0OnV/P+RMQ1Zr+vPRqO7AR2va\nN9wg+Xl7157dhXPCGYnGMNSoxCbpRs0JNlzvJMuAea5nTTznRaJZtK/xKsqLn51D\nK07k9MHVFXakOH8QtMCUglbwfTfIpO5YRq5imxlWbqsYWVQy1WGJFyW6hWC0+RcJ\nOx5zGtOfi4/dN+xJ+ibnbyvy/il7Qm+vyFhCYqIPyS5m2UVJUuao3eApE38k78/o\n8aQOTnFQZ+U1Sw+6woFTxjqRQBXlQm2+7Bt3bqGATg4sXXWPbmwdL87Ic+mxn/ml\nSMfQux/5k6iAu1kQhwkO2YJn9eII6HIPkW+2m5N1JsUyJQe4cbtZE5Yh3TRA0dm7\n+zoBRfCXkOW4krchbgww/ptVmzMMP7GINJdROrJnsGl5FVeid9qHzV7aZycWSma7\nCxBYB1J8HCbty5NjtD6XMYRrMLxXugvX6Q4NPPH+2NKjzX4SIDejS6JjgrP3KA3O\npMuo7ZHMfveBngv8yP+ZD/1sS6l+dfExvdaJdOdgFCnp4p3gPbw5+Lv70HrMjA==\n=BfZ/\n-----END PGP PUBLIC KEY BLOCK-----\n",
+                "checksum": "sha256:9f596e18f585bee30ac41c11fb11a83ed6b11d5b341c1cb56ca4015d7717cb97"
+              }
+            ],
+            "packages": [
+              "@Core",
+              "chrony",
+              "cloud-init",
+              "grub2-pc",
+              "kernel",
+              "langpacks-en",
+              "libdrm",
+              "qemu-guest-agent",
+              "selinux-policy-targeted",
+              "spice-vdagent",
+              "xen-libs"
+            ],
+            "exclude_packages": [
+              "dracut-config-rescue"
+            ],
+            "releasever": "30",
+            "basearch": "x86_64",
+            "module_platform_id": "platform:f30"
           }
-        ]
-      },
-      "runner": "org.osbuild.fedora30"
-    },
-    "stages": [
-      {
-        "name": "org.osbuild.dnf",
-        "options": {
-          "repos": [
-            {
-              "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-30&arch=x86_64",
-              "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBFturGcBEACv0xBo91V2n0uEC2vh69ywCiSyvUgN/AQH8EZpCVtM7NyjKgKm\nbbY4G3R0M3ir1xXmvUDvK0493/qOiFrjkplvzXFTGpPTi0ypqGgxc5d0ohRA1M75\nL+0AIlXoOgHQ358/c4uO8X0JAA1NYxCkAW1KSJgFJ3RjukrfqSHWthS1d4o8fhHy\nKJKEnirE5hHqB50dafXrBfgZdaOs3C6ppRIePFe2o4vUEapMTCHFw0woQR8Ah4/R\nn7Z9G9Ln+0Cinmy0nbIDiZJ+pgLAXCOWBfDUzcOjDGKvcpoZharA07c0q1/5ojzO\n4F0Fh4g/BUmtrASwHfcIbjHyCSr1j/3Iz883iy07gJY5Yhiuaqmp0o0f9fgHkG53\n2xCU1owmACqaIBNQMukvXRDtB2GJMuKa/asTZDP6R5re+iXs7+s9ohcRRAKGyAyc\nYKIQKcaA+6M8T7/G+TPHZX6HJWqJJiYB+EC2ERblpvq9TPlLguEWcmvjbVc31nyq\nSDoO3ncFWKFmVsbQPTbP+pKUmlLfJwtb5XqxNR5GEXSwVv4I7IqBmJz1MmRafnBZ\ng0FJUtH668GnldO20XbnSVBr820F5SISMXVwCXDXEvGwwiB8Lt8PvqzXnGIFDAu3\nDlQI5sxSqpPVWSyw08ppKT2Tpmy8adiBotLfaCFl2VTHwOae48X2dMPBvQARAQAB\ntDFGZWRvcmEgKDMwKSA8ZmVkb3JhLTMwLXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQI4BBMBAgAiBQJbbqxnAhsPBgsJCAcDAgYVCAIJCgsEFgIDAQIeAQIXgAAK\nCRDvPBEfz8ZZudTnD/9170LL3nyTVUCFmBjT9wZ4gYnpwtKVPa/pKnxbbS+Bmmac\ng9TrT9pZbqOHrNJLiZ3Zx1Hp+8uxr3Lo6kbYwImLhkOEDrf4aP17HfQ6VYFbQZI8\nf79OFxWJ7si9+3gfzeh9UYFEqOQfzIjLWFyfnas0OnV/P+RMQ1Zr+vPRqO7AR2va\nN9wg+Xl7157dhXPCGYnGMNSoxCbpRs0JNlzvJMuAea5nTTznRaJZtK/xKsqLn51D\nK07k9MHVFXakOH8QtMCUglbwfTfIpO5YRq5imxlWbqsYWVQy1WGJFyW6hWC0+RcJ\nOx5zGtOfi4/dN+xJ+ibnbyvy/il7Qm+vyFhCYqIPyS5m2UVJUuao3eApE38k78/o\n8aQOTnFQZ+U1Sw+6woFTxjqRQBXlQm2+7Bt3bqGATg4sXXWPbmwdL87Ic+mxn/ml\nSMfQux/5k6iAu1kQhwkO2YJn9eII6HIPkW+2m5N1JsUyJQe4cbtZE5Yh3TRA0dm7\n+zoBRfCXkOW4krchbgww/ptVmzMMP7GINJdROrJnsGl5FVeid9qHzV7aZycWSma7\nCxBYB1J8HCbty5NjtD6XMYRrMLxXugvX6Q4NPPH+2NKjzX4SIDejS6JjgrP3KA3O\npMuo7ZHMfveBngv8yP+ZD/1sS6l+dfExvdaJdOdgFCnp4p3gPbw5+Lv70HrMjA==\n=BfZ/\n-----END PGP PUBLIC KEY BLOCK-----\n",
-              "checksum": "sha256:9f596e18f585bee30ac41c11fb11a83ed6b11d5b341c1cb56ca4015d7717cb97"
-            }
-          ],
-          "packages": [
-            "@Core",
-            "chrony",
-            "cloud-init",
-            "grub2-pc",
-            "kernel",
-            "langpacks-en",
-            "libdrm",
-            "qemu-guest-agent",
-            "selinux-policy-targeted",
-            "spice-vdagent",
-            "xen-libs"
-          ],
-          "exclude_packages": [
-            "dracut-config-rescue"
-          ],
-          "releasever": "30",
-          "basearch": "x86_64",
-          "module_platform_id": "platform:f30"
+        },
+        {
+          "name": "org.osbuild.fix-bls",
+          "options": {}
+        },
+        {
+          "name": "org.osbuild.locale",
+          "options": {
+            "language": "en_US"
+          }
+        },
+        {
+          "name": "org.osbuild.fstab",
+          "options": {
+            "filesystems": [
+              {
+                "uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
+                "vfs_type": "ext4",
+                "path": "/",
+                "options": "defaults",
+                "freq": 1,
+                "passno": 1
+              }
+            ]
+          }
+        },
+        {
+          "name": "org.osbuild.grub2",
+          "options": {
+            "root_fs_uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
+            "kernel_opts": "ro biosdevname=0 net.ifnames=0",
+            "legacy": true
+          }
+        },
+        {
+          "name": "org.osbuild.selinux",
+          "options": {
+            "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
+          }
         }
-      },
-      {
-        "name": "org.osbuild.fix-bls",
-        "options": {}
-      },
-      {
-        "name": "org.osbuild.locale",
+      ],
+      "assembler": {
+        "name": "org.osbuild.qemu",
         "options": {
-          "language": "en_US"
-        }
-      },
-      {
-        "name": "org.osbuild.fstab",
-        "options": {
-          "filesystems": [
+          "format": "qcow2",
+          "filename": "disk.qcow2",
+          "size": 2147483648,
+          "ptuuid": "0x14fc63d2",
+          "pttype": "mbr",
+          "partitions": [
             {
-              "uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
-              "vfs_type": "ext4",
-              "path": "/",
-              "options": "defaults",
-              "freq": 1,
-              "passno": 1
+              "start": 2048,
+              "bootable": true,
+              "filesystem": {
+                "type": "ext4",
+                "uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
+                "mountpoint": "/"
+              }
             }
           ]
         }
-      },
-      {
-        "name": "org.osbuild.grub2",
-        "options": {
-          "root_fs_uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
-          "kernel_opts": "ro biosdevname=0 net.ifnames=0",
-          "legacy": true
-        }
-      },
-      {
-        "name": "org.osbuild.selinux",
-        "options": {
-          "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
-        }
-      }
-    ],
-    "assembler": {
-      "name": "org.osbuild.qemu",
-      "options": {
-        "format": "qcow2",
-        "filename": "disk.qcow2",
-        "size": 2147483648,
-        "ptuuid": "0x14fc63d2",
-        "pttype": "mbr",
-        "partitions": [
-          {
-            "start": 2048,
-            "bootable": true,
-            "filesystem": {
-              "type": "ext4",
-              "uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
-              "mountpoint": "/"
-            }
-          }
-        ]
       }
     }
   },

--- a/test/cases/openstack_empty_blueprint.json
+++ b/test/cases/openstack_empty_blueprint.json
@@ -2,12 +2,14 @@
   "compose": {
     "distro": "fedora-30",
     "arch": "x86_64",
-    "checksums": {
-      "fedora": "sha256:9f596e18f585bee30ac41c11fb11a83ed6b11d5b341c1cb56ca4015d7717cb97"
-    },
     "output-format": "openstack",
     "filename": "disk.qcow2",
     "blueprint": {}
+  },
+  "rpmmd": {
+    "checksums": {
+      "fedora": "sha256:9f596e18f585bee30ac41c11fb11a83ed6b11d5b341c1cb56ca4015d7717cb97"
+    }
   },
   "pipeline": {
     "build": {

--- a/test/cases/openstack_local_boot.json
+++ b/test/cases/openstack_local_boot.json
@@ -2,7 +2,7 @@
   "boot": {
     "type": "qemu"
   },
-  "compose": {
+  "compose-request": {
     "distro": "fedora-30",
     "arch": "x86_64",
     "output-format": "openstack",

--- a/test/cases/openstack_local_boot.json
+++ b/test/cases/openstack_local_boot.json
@@ -37,6 +37,11 @@
       }
     }
   },
+  "rpmmd": {
+    "checksums": {
+      "fedora": "sha256:9f596e18f585bee30ac41c11fb11a83ed6b11d5b341c1cb56ca4015d7717cb97"
+    }
+  },
   "pipeline": {
     "build": {
       "pipeline": {

--- a/test/cases/openstack_local_boot.json
+++ b/test/cases/openstack_local_boot.json
@@ -42,152 +42,155 @@
       "fedora": "sha256:9f596e18f585bee30ac41c11fb11a83ed6b11d5b341c1cb56ca4015d7717cb97"
     }
   },
-  "pipeline": {
-    "build": {
-      "pipeline": {
-        "stages": [
-          {
-            "name": "org.osbuild.dnf",
-            "options": {
-              "repos": [
-                {
-                  "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-30&arch=x86_64",
-                  "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBFturGcBEACv0xBo91V2n0uEC2vh69ywCiSyvUgN/AQH8EZpCVtM7NyjKgKm\nbbY4G3R0M3ir1xXmvUDvK0493/qOiFrjkplvzXFTGpPTi0ypqGgxc5d0ohRA1M75\nL+0AIlXoOgHQ358/c4uO8X0JAA1NYxCkAW1KSJgFJ3RjukrfqSHWthS1d4o8fhHy\nKJKEnirE5hHqB50dafXrBfgZdaOs3C6ppRIePFe2o4vUEapMTCHFw0woQR8Ah4/R\nn7Z9G9Ln+0Cinmy0nbIDiZJ+pgLAXCOWBfDUzcOjDGKvcpoZharA07c0q1/5ojzO\n4F0Fh4g/BUmtrASwHfcIbjHyCSr1j/3Iz883iy07gJY5Yhiuaqmp0o0f9fgHkG53\n2xCU1owmACqaIBNQMukvXRDtB2GJMuKa/asTZDP6R5re+iXs7+s9ohcRRAKGyAyc\nYKIQKcaA+6M8T7/G+TPHZX6HJWqJJiYB+EC2ERblpvq9TPlLguEWcmvjbVc31nyq\nSDoO3ncFWKFmVsbQPTbP+pKUmlLfJwtb5XqxNR5GEXSwVv4I7IqBmJz1MmRafnBZ\ng0FJUtH668GnldO20XbnSVBr820F5SISMXVwCXDXEvGwwiB8Lt8PvqzXnGIFDAu3\nDlQI5sxSqpPVWSyw08ppKT2Tpmy8adiBotLfaCFl2VTHwOae48X2dMPBvQARAQAB\ntDFGZWRvcmEgKDMwKSA8ZmVkb3JhLTMwLXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQI4BBMBAgAiBQJbbqxnAhsPBgsJCAcDAgYVCAIJCgsEFgIDAQIeAQIXgAAK\nCRDvPBEfz8ZZudTnD/9170LL3nyTVUCFmBjT9wZ4gYnpwtKVPa/pKnxbbS+Bmmac\ng9TrT9pZbqOHrNJLiZ3Zx1Hp+8uxr3Lo6kbYwImLhkOEDrf4aP17HfQ6VYFbQZI8\nf79OFxWJ7si9+3gfzeh9UYFEqOQfzIjLWFyfnas0OnV/P+RMQ1Zr+vPRqO7AR2va\nN9wg+Xl7157dhXPCGYnGMNSoxCbpRs0JNlzvJMuAea5nTTznRaJZtK/xKsqLn51D\nK07k9MHVFXakOH8QtMCUglbwfTfIpO5YRq5imxlWbqsYWVQy1WGJFyW6hWC0+RcJ\nOx5zGtOfi4/dN+xJ+ibnbyvy/il7Qm+vyFhCYqIPyS5m2UVJUuao3eApE38k78/o\n8aQOTnFQZ+U1Sw+6woFTxjqRQBXlQm2+7Bt3bqGATg4sXXWPbmwdL87Ic+mxn/ml\nSMfQux/5k6iAu1kQhwkO2YJn9eII6HIPkW+2m5N1JsUyJQe4cbtZE5Yh3TRA0dm7\n+zoBRfCXkOW4krchbgww/ptVmzMMP7GINJdROrJnsGl5FVeid9qHzV7aZycWSma7\nCxBYB1J8HCbty5NjtD6XMYRrMLxXugvX6Q4NPPH+2NKjzX4SIDejS6JjgrP3KA3O\npMuo7ZHMfveBngv8yP+ZD/1sS6l+dfExvdaJdOdgFCnp4p3gPbw5+Lv70HrMjA==\n=BfZ/\n-----END PGP PUBLIC KEY BLOCK-----\n",
-                  "checksum": "sha256:9f596e18f585bee30ac41c11fb11a83ed6b11d5b341c1cb56ca4015d7717cb97"
-                }
-              ],
-              "packages": [
-                "dnf",
-                "dosfstools",
-                "e2fsprogs",
-                "grub2-pc",
-                "policycoreutils",
-                "qemu-img",
-                "systemd",
-                "tar"
-              ],
-              "releasever": "30",
-              "basearch": "x86_64",
-              "module_platform_id": "platform:f30"
+  "manifest": {
+    "sources": {},
+    "pipeline": {
+      "build": {
+        "pipeline": {
+          "stages": [
+            {
+              "name": "org.osbuild.dnf",
+              "options": {
+                "repos": [
+                  {
+                    "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-30&arch=x86_64",
+                    "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBFturGcBEACv0xBo91V2n0uEC2vh69ywCiSyvUgN/AQH8EZpCVtM7NyjKgKm\nbbY4G3R0M3ir1xXmvUDvK0493/qOiFrjkplvzXFTGpPTi0ypqGgxc5d0ohRA1M75\nL+0AIlXoOgHQ358/c4uO8X0JAA1NYxCkAW1KSJgFJ3RjukrfqSHWthS1d4o8fhHy\nKJKEnirE5hHqB50dafXrBfgZdaOs3C6ppRIePFe2o4vUEapMTCHFw0woQR8Ah4/R\nn7Z9G9Ln+0Cinmy0nbIDiZJ+pgLAXCOWBfDUzcOjDGKvcpoZharA07c0q1/5ojzO\n4F0Fh4g/BUmtrASwHfcIbjHyCSr1j/3Iz883iy07gJY5Yhiuaqmp0o0f9fgHkG53\n2xCU1owmACqaIBNQMukvXRDtB2GJMuKa/asTZDP6R5re+iXs7+s9ohcRRAKGyAyc\nYKIQKcaA+6M8T7/G+TPHZX6HJWqJJiYB+EC2ERblpvq9TPlLguEWcmvjbVc31nyq\nSDoO3ncFWKFmVsbQPTbP+pKUmlLfJwtb5XqxNR5GEXSwVv4I7IqBmJz1MmRafnBZ\ng0FJUtH668GnldO20XbnSVBr820F5SISMXVwCXDXEvGwwiB8Lt8PvqzXnGIFDAu3\nDlQI5sxSqpPVWSyw08ppKT2Tpmy8adiBotLfaCFl2VTHwOae48X2dMPBvQARAQAB\ntDFGZWRvcmEgKDMwKSA8ZmVkb3JhLTMwLXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQI4BBMBAgAiBQJbbqxnAhsPBgsJCAcDAgYVCAIJCgsEFgIDAQIeAQIXgAAK\nCRDvPBEfz8ZZudTnD/9170LL3nyTVUCFmBjT9wZ4gYnpwtKVPa/pKnxbbS+Bmmac\ng9TrT9pZbqOHrNJLiZ3Zx1Hp+8uxr3Lo6kbYwImLhkOEDrf4aP17HfQ6VYFbQZI8\nf79OFxWJ7si9+3gfzeh9UYFEqOQfzIjLWFyfnas0OnV/P+RMQ1Zr+vPRqO7AR2va\nN9wg+Xl7157dhXPCGYnGMNSoxCbpRs0JNlzvJMuAea5nTTznRaJZtK/xKsqLn51D\nK07k9MHVFXakOH8QtMCUglbwfTfIpO5YRq5imxlWbqsYWVQy1WGJFyW6hWC0+RcJ\nOx5zGtOfi4/dN+xJ+ibnbyvy/il7Qm+vyFhCYqIPyS5m2UVJUuao3eApE38k78/o\n8aQOTnFQZ+U1Sw+6woFTxjqRQBXlQm2+7Bt3bqGATg4sXXWPbmwdL87Ic+mxn/ml\nSMfQux/5k6iAu1kQhwkO2YJn9eII6HIPkW+2m5N1JsUyJQe4cbtZE5Yh3TRA0dm7\n+zoBRfCXkOW4krchbgww/ptVmzMMP7GINJdROrJnsGl5FVeid9qHzV7aZycWSma7\nCxBYB1J8HCbty5NjtD6XMYRrMLxXugvX6Q4NPPH+2NKjzX4SIDejS6JjgrP3KA3O\npMuo7ZHMfveBngv8yP+ZD/1sS6l+dfExvdaJdOdgFCnp4p3gPbw5+Lv70HrMjA==\n=BfZ/\n-----END PGP PUBLIC KEY BLOCK-----\n",
+                    "checksum": "sha256:9f596e18f585bee30ac41c11fb11a83ed6b11d5b341c1cb56ca4015d7717cb97"
+                  }
+                ],
+                "packages": [
+                  "dnf",
+                  "dosfstools",
+                  "e2fsprogs",
+                  "grub2-pc",
+                  "policycoreutils",
+                  "qemu-img",
+                  "systemd",
+                  "tar"
+                ],
+                "releasever": "30",
+                "basearch": "x86_64",
+                "module_platform_id": "platform:f30"
+              }
+            }
+          ]
+        },
+        "runner": "org.osbuild.fedora30"
+      },
+      "stages": [
+        {
+          "name": "org.osbuild.dnf",
+          "options": {
+            "repos": [
+              {
+                "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-30&arch=x86_64",
+                "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBFturGcBEACv0xBo91V2n0uEC2vh69ywCiSyvUgN/AQH8EZpCVtM7NyjKgKm\nbbY4G3R0M3ir1xXmvUDvK0493/qOiFrjkplvzXFTGpPTi0ypqGgxc5d0ohRA1M75\nL+0AIlXoOgHQ358/c4uO8X0JAA1NYxCkAW1KSJgFJ3RjukrfqSHWthS1d4o8fhHy\nKJKEnirE5hHqB50dafXrBfgZdaOs3C6ppRIePFe2o4vUEapMTCHFw0woQR8Ah4/R\nn7Z9G9Ln+0Cinmy0nbIDiZJ+pgLAXCOWBfDUzcOjDGKvcpoZharA07c0q1/5ojzO\n4F0Fh4g/BUmtrASwHfcIbjHyCSr1j/3Iz883iy07gJY5Yhiuaqmp0o0f9fgHkG53\n2xCU1owmACqaIBNQMukvXRDtB2GJMuKa/asTZDP6R5re+iXs7+s9ohcRRAKGyAyc\nYKIQKcaA+6M8T7/G+TPHZX6HJWqJJiYB+EC2ERblpvq9TPlLguEWcmvjbVc31nyq\nSDoO3ncFWKFmVsbQPTbP+pKUmlLfJwtb5XqxNR5GEXSwVv4I7IqBmJz1MmRafnBZ\ng0FJUtH668GnldO20XbnSVBr820F5SISMXVwCXDXEvGwwiB8Lt8PvqzXnGIFDAu3\nDlQI5sxSqpPVWSyw08ppKT2Tpmy8adiBotLfaCFl2VTHwOae48X2dMPBvQARAQAB\ntDFGZWRvcmEgKDMwKSA8ZmVkb3JhLTMwLXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQI4BBMBAgAiBQJbbqxnAhsPBgsJCAcDAgYVCAIJCgsEFgIDAQIeAQIXgAAK\nCRDvPBEfz8ZZudTnD/9170LL3nyTVUCFmBjT9wZ4gYnpwtKVPa/pKnxbbS+Bmmac\ng9TrT9pZbqOHrNJLiZ3Zx1Hp+8uxr3Lo6kbYwImLhkOEDrf4aP17HfQ6VYFbQZI8\nf79OFxWJ7si9+3gfzeh9UYFEqOQfzIjLWFyfnas0OnV/P+RMQ1Zr+vPRqO7AR2va\nN9wg+Xl7157dhXPCGYnGMNSoxCbpRs0JNlzvJMuAea5nTTznRaJZtK/xKsqLn51D\nK07k9MHVFXakOH8QtMCUglbwfTfIpO5YRq5imxlWbqsYWVQy1WGJFyW6hWC0+RcJ\nOx5zGtOfi4/dN+xJ+ibnbyvy/il7Qm+vyFhCYqIPyS5m2UVJUuao3eApE38k78/o\n8aQOTnFQZ+U1Sw+6woFTxjqRQBXlQm2+7Bt3bqGATg4sXXWPbmwdL87Ic+mxn/ml\nSMfQux/5k6iAu1kQhwkO2YJn9eII6HIPkW+2m5N1JsUyJQe4cbtZE5Yh3TRA0dm7\n+zoBRfCXkOW4krchbgww/ptVmzMMP7GINJdROrJnsGl5FVeid9qHzV7aZycWSma7\nCxBYB1J8HCbty5NjtD6XMYRrMLxXugvX6Q4NPPH+2NKjzX4SIDejS6JjgrP3KA3O\npMuo7ZHMfveBngv8yP+ZD/1sS6l+dfExvdaJdOdgFCnp4p3gPbw5+Lv70HrMjA==\n=BfZ/\n-----END PGP PUBLIC KEY BLOCK-----\n",
+                "checksum": "sha256:9f596e18f585bee30ac41c11fb11a83ed6b11d5b341c1cb56ca4015d7717cb97"
+              }
+            ],
+            "packages": [
+              "@Core",
+              "chrony",
+              "cloud-init",
+              "grub2-pc",
+              "kernel",
+              "langpacks-en",
+              "libdrm",
+              "qemu-guest-agent",
+              "selinux-policy-targeted",
+              "spice-vdagent",
+              "xen-libs"
+            ],
+            "exclude_packages": [
+              "dracut-config-rescue"
+            ],
+            "releasever": "30",
+            "basearch": "x86_64",
+            "module_platform_id": "platform:f30"
+          }
+        },
+        {
+          "name": "org.osbuild.locale",
+          "options": {
+            "language": "en_US"
+          }
+        },
+        {
+          "name": "org.osbuild.fstab",
+          "options": {
+            "filesystems": [
+              {
+                "uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
+                "vfs_type": "ext4",
+                "path": "/",
+                "options": "defaults",
+                "freq": 1,
+                "passno": 1
+              }
+            ]
+          }
+        },
+        {
+          "name": "org.osbuild.grub2",
+          "options": {
+            "root_fs_uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
+            "kernel_opts": "ro biosdevname=0 net.ifnames=0",
+            "legacy": true
+          }
+        },
+        {
+          "name": "org.osbuild.systemd",
+          "options": {
+            "enabled_services": [
+              "sshd"
+            ]
+          }
+        },
+        {
+          "name": "org.osbuild.users",
+          "options": {
+            "users": {
+              "redhat": {
+                "groups": [
+                  "wheel"
+                ],
+                "password": "$6$IR7O7z56ouB/OInP$.hscD6dQqPQGwMuQ.idumixSHI/JEyaUfiCAHVSpGO/iNLEvvVZVOQL23zBzQbc2.yJ25xAZD75H0tXqKJpEE/",
+                "key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC61wMCjOSHwbVb4VfVyl5sn497qW4PsdQ7Ty7aD6wDNZ/QjjULkDV/yW5WjDlDQ7UqFH0Sr7vywjqDizUAqK7zM5FsUKsUXWHWwg/ehKg8j9xKcMv11AkFoUoujtfAujnKODkk58XSA9whPr7qcw3vPrmog680pnMSzf9LC7J6kXfs6lkoKfBh9VnlxusCrw2yg0qI1fHAZBLPx7mW6+me71QZsS6sVz8v8KXyrXsKTdnF50FjzHcK9HXDBtSJS5wA3fkcRYymJe0o6WMWNdgSRVpoSiWaHHmFgdMUJaYoCfhXzyl7LtNb3Q+Sveg+tJK7JaRXBLMUllOlJ6ll5Hod root@localhost"
+              }
             }
           }
-        ]
-      },
-      "runner": "org.osbuild.fedora30"
-    },
-    "stages": [
-      {
-        "name": "org.osbuild.dnf",
-        "options": {
-          "repos": [
-            {
-              "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-30&arch=x86_64",
-              "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBFturGcBEACv0xBo91V2n0uEC2vh69ywCiSyvUgN/AQH8EZpCVtM7NyjKgKm\nbbY4G3R0M3ir1xXmvUDvK0493/qOiFrjkplvzXFTGpPTi0ypqGgxc5d0ohRA1M75\nL+0AIlXoOgHQ358/c4uO8X0JAA1NYxCkAW1KSJgFJ3RjukrfqSHWthS1d4o8fhHy\nKJKEnirE5hHqB50dafXrBfgZdaOs3C6ppRIePFe2o4vUEapMTCHFw0woQR8Ah4/R\nn7Z9G9Ln+0Cinmy0nbIDiZJ+pgLAXCOWBfDUzcOjDGKvcpoZharA07c0q1/5ojzO\n4F0Fh4g/BUmtrASwHfcIbjHyCSr1j/3Iz883iy07gJY5Yhiuaqmp0o0f9fgHkG53\n2xCU1owmACqaIBNQMukvXRDtB2GJMuKa/asTZDP6R5re+iXs7+s9ohcRRAKGyAyc\nYKIQKcaA+6M8T7/G+TPHZX6HJWqJJiYB+EC2ERblpvq9TPlLguEWcmvjbVc31nyq\nSDoO3ncFWKFmVsbQPTbP+pKUmlLfJwtb5XqxNR5GEXSwVv4I7IqBmJz1MmRafnBZ\ng0FJUtH668GnldO20XbnSVBr820F5SISMXVwCXDXEvGwwiB8Lt8PvqzXnGIFDAu3\nDlQI5sxSqpPVWSyw08ppKT2Tpmy8adiBotLfaCFl2VTHwOae48X2dMPBvQARAQAB\ntDFGZWRvcmEgKDMwKSA8ZmVkb3JhLTMwLXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQI4BBMBAgAiBQJbbqxnAhsPBgsJCAcDAgYVCAIJCgsEFgIDAQIeAQIXgAAK\nCRDvPBEfz8ZZudTnD/9170LL3nyTVUCFmBjT9wZ4gYnpwtKVPa/pKnxbbS+Bmmac\ng9TrT9pZbqOHrNJLiZ3Zx1Hp+8uxr3Lo6kbYwImLhkOEDrf4aP17HfQ6VYFbQZI8\nf79OFxWJ7si9+3gfzeh9UYFEqOQfzIjLWFyfnas0OnV/P+RMQ1Zr+vPRqO7AR2va\nN9wg+Xl7157dhXPCGYnGMNSoxCbpRs0JNlzvJMuAea5nTTznRaJZtK/xKsqLn51D\nK07k9MHVFXakOH8QtMCUglbwfTfIpO5YRq5imxlWbqsYWVQy1WGJFyW6hWC0+RcJ\nOx5zGtOfi4/dN+xJ+ibnbyvy/il7Qm+vyFhCYqIPyS5m2UVJUuao3eApE38k78/o\n8aQOTnFQZ+U1Sw+6woFTxjqRQBXlQm2+7Bt3bqGATg4sXXWPbmwdL87Ic+mxn/ml\nSMfQux/5k6iAu1kQhwkO2YJn9eII6HIPkW+2m5N1JsUyJQe4cbtZE5Yh3TRA0dm7\n+zoBRfCXkOW4krchbgww/ptVmzMMP7GINJdROrJnsGl5FVeid9qHzV7aZycWSma7\nCxBYB1J8HCbty5NjtD6XMYRrMLxXugvX6Q4NPPH+2NKjzX4SIDejS6JjgrP3KA3O\npMuo7ZHMfveBngv8yP+ZD/1sS6l+dfExvdaJdOdgFCnp4p3gPbw5+Lv70HrMjA==\n=BfZ/\n-----END PGP PUBLIC KEY BLOCK-----\n",
-              "checksum": "sha256:9f596e18f585bee30ac41c11fb11a83ed6b11d5b341c1cb56ca4015d7717cb97"
-            }
-          ],
-          "packages": [
-            "@Core",
-            "chrony",
-            "cloud-init",
-            "grub2-pc",
-            "kernel",
-            "langpacks-en",
-            "libdrm",
-            "qemu-guest-agent",
-            "selinux-policy-targeted",
-            "spice-vdagent",
-            "xen-libs"
-          ],
-          "exclude_packages": [
-            "dracut-config-rescue"
-          ],
-          "releasever": "30",
-          "basearch": "x86_64",
-          "module_platform_id": "platform:f30"
+        },
+        {
+          "name": "org.osbuild.selinux",
+          "options": {
+            "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
+          }
+        },
+        {
+          "name": "org.osbuild.fix-bls",
+          "options": {}
         }
-      },
-      {
-        "name": "org.osbuild.locale",
+      ],
+      "assembler": {
+        "name": "org.osbuild.qemu",
         "options": {
-          "language": "en_US"
-        }
-      },
-      {
-        "name": "org.osbuild.fstab",
-        "options": {
-          "filesystems": [
+          "format": "qcow2",
+          "filename": "disk.qcow2",
+          "size": 2147483648,
+          "ptuuid": "0x14fc63d2",
+          "pttype": "mbr",
+          "partitions": [
             {
-              "uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
-              "vfs_type": "ext4",
-              "path": "/",
-              "options": "defaults",
-              "freq": 1,
-              "passno": 1
+              "start": 2048,
+              "bootable": true,
+              "filesystem": {
+                "type": "ext4",
+                "uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
+                "mountpoint": "/"
+              }
             }
           ]
         }
-      },
-      {
-        "name": "org.osbuild.grub2",
-        "options": {
-          "root_fs_uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
-          "kernel_opts": "ro biosdevname=0 net.ifnames=0",
-          "legacy": true
-        }
-      },
-      {
-        "name": "org.osbuild.systemd",
-        "options": {
-          "enabled_services": [
-            "sshd"
-          ]
-        }
-      },
-      {
-        "name": "org.osbuild.users",
-        "options": {
-          "users": {
-            "redhat": {
-              "groups": [
-                "wheel"
-              ],
-              "password": "$6$IR7O7z56ouB/OInP$.hscD6dQqPQGwMuQ.idumixSHI/JEyaUfiCAHVSpGO/iNLEvvVZVOQL23zBzQbc2.yJ25xAZD75H0tXqKJpEE/",
-              "key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC61wMCjOSHwbVb4VfVyl5sn497qW4PsdQ7Ty7aD6wDNZ/QjjULkDV/yW5WjDlDQ7UqFH0Sr7vywjqDizUAqK7zM5FsUKsUXWHWwg/ehKg8j9xKcMv11AkFoUoujtfAujnKODkk58XSA9whPr7qcw3vPrmog680pnMSzf9LC7J6kXfs6lkoKfBh9VnlxusCrw2yg0qI1fHAZBLPx7mW6+me71QZsS6sVz8v8KXyrXsKTdnF50FjzHcK9HXDBtSJS5wA3fkcRYymJe0o6WMWNdgSRVpoSiWaHHmFgdMUJaYoCfhXzyl7LtNb3Q+Sveg+tJK7JaRXBLMUllOlJ6ll5Hod root@localhost"
-            }
-          }
-        }
-      },
-      {
-        "name": "org.osbuild.selinux",
-        "options": {
-          "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
-        }
-      },
-      {
-        "name": "org.osbuild.fix-bls",
-        "options": {}
-      }
-    ],
-    "assembler": {
-      "name": "org.osbuild.qemu",
-      "options": {
-        "format": "qcow2",
-        "filename": "disk.qcow2",
-        "size": 2147483648,
-        "ptuuid": "0x14fc63d2",
-        "pttype": "mbr",
-        "partitions": [
-          {
-            "start": 2048,
-            "bootable": true,
-            "filesystem": {
-              "type": "ext4",
-              "uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
-              "mountpoint": "/"
-            }
-          }
-        ]
       }
     }
   }

--- a/test/cases/qcow2_empty_blueprint.json
+++ b/test/cases/qcow2_empty_blueprint.json
@@ -1,5 +1,5 @@
 {
-  "compose": {
+  "compose-request": {
     "distro": "fedora-30",
     "arch": "x86_64",
     "output-format": "qcow2",

--- a/test/cases/qcow2_empty_blueprint.json
+++ b/test/cases/qcow2_empty_blueprint.json
@@ -11,131 +11,134 @@
       "fedora": "sha256:9f596e18f585bee30ac41c11fb11a83ed6b11d5b341c1cb56ca4015d7717cb97"
     }
   },
-  "pipeline": {
-    "build": {
-      "pipeline": {
-        "stages": [
-          {
-            "name": "org.osbuild.dnf",
-            "options": {
-              "repos": [
-                {
-                  "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-30&arch=x86_64",
-                  "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBFturGcBEACv0xBo91V2n0uEC2vh69ywCiSyvUgN/AQH8EZpCVtM7NyjKgKm\nbbY4G3R0M3ir1xXmvUDvK0493/qOiFrjkplvzXFTGpPTi0ypqGgxc5d0ohRA1M75\nL+0AIlXoOgHQ358/c4uO8X0JAA1NYxCkAW1KSJgFJ3RjukrfqSHWthS1d4o8fhHy\nKJKEnirE5hHqB50dafXrBfgZdaOs3C6ppRIePFe2o4vUEapMTCHFw0woQR8Ah4/R\nn7Z9G9Ln+0Cinmy0nbIDiZJ+pgLAXCOWBfDUzcOjDGKvcpoZharA07c0q1/5ojzO\n4F0Fh4g/BUmtrASwHfcIbjHyCSr1j/3Iz883iy07gJY5Yhiuaqmp0o0f9fgHkG53\n2xCU1owmACqaIBNQMukvXRDtB2GJMuKa/asTZDP6R5re+iXs7+s9ohcRRAKGyAyc\nYKIQKcaA+6M8T7/G+TPHZX6HJWqJJiYB+EC2ERblpvq9TPlLguEWcmvjbVc31nyq\nSDoO3ncFWKFmVsbQPTbP+pKUmlLfJwtb5XqxNR5GEXSwVv4I7IqBmJz1MmRafnBZ\ng0FJUtH668GnldO20XbnSVBr820F5SISMXVwCXDXEvGwwiB8Lt8PvqzXnGIFDAu3\nDlQI5sxSqpPVWSyw08ppKT2Tpmy8adiBotLfaCFl2VTHwOae48X2dMPBvQARAQAB\ntDFGZWRvcmEgKDMwKSA8ZmVkb3JhLTMwLXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQI4BBMBAgAiBQJbbqxnAhsPBgsJCAcDAgYVCAIJCgsEFgIDAQIeAQIXgAAK\nCRDvPBEfz8ZZudTnD/9170LL3nyTVUCFmBjT9wZ4gYnpwtKVPa/pKnxbbS+Bmmac\ng9TrT9pZbqOHrNJLiZ3Zx1Hp+8uxr3Lo6kbYwImLhkOEDrf4aP17HfQ6VYFbQZI8\nf79OFxWJ7si9+3gfzeh9UYFEqOQfzIjLWFyfnas0OnV/P+RMQ1Zr+vPRqO7AR2va\nN9wg+Xl7157dhXPCGYnGMNSoxCbpRs0JNlzvJMuAea5nTTznRaJZtK/xKsqLn51D\nK07k9MHVFXakOH8QtMCUglbwfTfIpO5YRq5imxlWbqsYWVQy1WGJFyW6hWC0+RcJ\nOx5zGtOfi4/dN+xJ+ibnbyvy/il7Qm+vyFhCYqIPyS5m2UVJUuao3eApE38k78/o\n8aQOTnFQZ+U1Sw+6woFTxjqRQBXlQm2+7Bt3bqGATg4sXXWPbmwdL87Ic+mxn/ml\nSMfQux/5k6iAu1kQhwkO2YJn9eII6HIPkW+2m5N1JsUyJQe4cbtZE5Yh3TRA0dm7\n+zoBRfCXkOW4krchbgww/ptVmzMMP7GINJdROrJnsGl5FVeid9qHzV7aZycWSma7\nCxBYB1J8HCbty5NjtD6XMYRrMLxXugvX6Q4NPPH+2NKjzX4SIDejS6JjgrP3KA3O\npMuo7ZHMfveBngv8yP+ZD/1sS6l+dfExvdaJdOdgFCnp4p3gPbw5+Lv70HrMjA==\n=BfZ/\n-----END PGP PUBLIC KEY BLOCK-----\n",
-                  "checksum": "sha256:9f596e18f585bee30ac41c11fb11a83ed6b11d5b341c1cb56ca4015d7717cb97"
-                }
-              ],
-              "packages": [
-                "dnf",
-                "dosfstools",
-                "e2fsprogs",
-                "grub2-pc",
-                "policycoreutils",
-                "qemu-img",
-                "systemd",
-                "tar"
-              ],
-              "releasever": "30",
-              "basearch": "x86_64",
-              "module_platform_id": "platform:f30"
+  "manifest": {
+    "sources": {},
+    "pipeline": {
+      "build": {
+        "pipeline": {
+          "stages": [
+            {
+              "name": "org.osbuild.dnf",
+              "options": {
+                "repos": [
+                  {
+                    "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-30&arch=x86_64",
+                    "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBFturGcBEACv0xBo91V2n0uEC2vh69ywCiSyvUgN/AQH8EZpCVtM7NyjKgKm\nbbY4G3R0M3ir1xXmvUDvK0493/qOiFrjkplvzXFTGpPTi0ypqGgxc5d0ohRA1M75\nL+0AIlXoOgHQ358/c4uO8X0JAA1NYxCkAW1KSJgFJ3RjukrfqSHWthS1d4o8fhHy\nKJKEnirE5hHqB50dafXrBfgZdaOs3C6ppRIePFe2o4vUEapMTCHFw0woQR8Ah4/R\nn7Z9G9Ln+0Cinmy0nbIDiZJ+pgLAXCOWBfDUzcOjDGKvcpoZharA07c0q1/5ojzO\n4F0Fh4g/BUmtrASwHfcIbjHyCSr1j/3Iz883iy07gJY5Yhiuaqmp0o0f9fgHkG53\n2xCU1owmACqaIBNQMukvXRDtB2GJMuKa/asTZDP6R5re+iXs7+s9ohcRRAKGyAyc\nYKIQKcaA+6M8T7/G+TPHZX6HJWqJJiYB+EC2ERblpvq9TPlLguEWcmvjbVc31nyq\nSDoO3ncFWKFmVsbQPTbP+pKUmlLfJwtb5XqxNR5GEXSwVv4I7IqBmJz1MmRafnBZ\ng0FJUtH668GnldO20XbnSVBr820F5SISMXVwCXDXEvGwwiB8Lt8PvqzXnGIFDAu3\nDlQI5sxSqpPVWSyw08ppKT2Tpmy8adiBotLfaCFl2VTHwOae48X2dMPBvQARAQAB\ntDFGZWRvcmEgKDMwKSA8ZmVkb3JhLTMwLXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQI4BBMBAgAiBQJbbqxnAhsPBgsJCAcDAgYVCAIJCgsEFgIDAQIeAQIXgAAK\nCRDvPBEfz8ZZudTnD/9170LL3nyTVUCFmBjT9wZ4gYnpwtKVPa/pKnxbbS+Bmmac\ng9TrT9pZbqOHrNJLiZ3Zx1Hp+8uxr3Lo6kbYwImLhkOEDrf4aP17HfQ6VYFbQZI8\nf79OFxWJ7si9+3gfzeh9UYFEqOQfzIjLWFyfnas0OnV/P+RMQ1Zr+vPRqO7AR2va\nN9wg+Xl7157dhXPCGYnGMNSoxCbpRs0JNlzvJMuAea5nTTznRaJZtK/xKsqLn51D\nK07k9MHVFXakOH8QtMCUglbwfTfIpO5YRq5imxlWbqsYWVQy1WGJFyW6hWC0+RcJ\nOx5zGtOfi4/dN+xJ+ibnbyvy/il7Qm+vyFhCYqIPyS5m2UVJUuao3eApE38k78/o\n8aQOTnFQZ+U1Sw+6woFTxjqRQBXlQm2+7Bt3bqGATg4sXXWPbmwdL87Ic+mxn/ml\nSMfQux/5k6iAu1kQhwkO2YJn9eII6HIPkW+2m5N1JsUyJQe4cbtZE5Yh3TRA0dm7\n+zoBRfCXkOW4krchbgww/ptVmzMMP7GINJdROrJnsGl5FVeid9qHzV7aZycWSma7\nCxBYB1J8HCbty5NjtD6XMYRrMLxXugvX6Q4NPPH+2NKjzX4SIDejS6JjgrP3KA3O\npMuo7ZHMfveBngv8yP+ZD/1sS6l+dfExvdaJdOdgFCnp4p3gPbw5+Lv70HrMjA==\n=BfZ/\n-----END PGP PUBLIC KEY BLOCK-----\n",
+                    "checksum": "sha256:9f596e18f585bee30ac41c11fb11a83ed6b11d5b341c1cb56ca4015d7717cb97"
+                  }
+                ],
+                "packages": [
+                  "dnf",
+                  "dosfstools",
+                  "e2fsprogs",
+                  "grub2-pc",
+                  "policycoreutils",
+                  "qemu-img",
+                  "systemd",
+                  "tar"
+                ],
+                "releasever": "30",
+                "basearch": "x86_64",
+                "module_platform_id": "platform:f30"
+              }
             }
+          ]
+        },
+        "runner": "org.osbuild.fedora30"
+      },
+      "stages": [
+        {
+          "name": "org.osbuild.dnf",
+          "options": {
+            "repos": [
+              {
+                "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-30&arch=x86_64",
+                "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBFturGcBEACv0xBo91V2n0uEC2vh69ywCiSyvUgN/AQH8EZpCVtM7NyjKgKm\nbbY4G3R0M3ir1xXmvUDvK0493/qOiFrjkplvzXFTGpPTi0ypqGgxc5d0ohRA1M75\nL+0AIlXoOgHQ358/c4uO8X0JAA1NYxCkAW1KSJgFJ3RjukrfqSHWthS1d4o8fhHy\nKJKEnirE5hHqB50dafXrBfgZdaOs3C6ppRIePFe2o4vUEapMTCHFw0woQR8Ah4/R\nn7Z9G9Ln+0Cinmy0nbIDiZJ+pgLAXCOWBfDUzcOjDGKvcpoZharA07c0q1/5ojzO\n4F0Fh4g/BUmtrASwHfcIbjHyCSr1j/3Iz883iy07gJY5Yhiuaqmp0o0f9fgHkG53\n2xCU1owmACqaIBNQMukvXRDtB2GJMuKa/asTZDP6R5re+iXs7+s9ohcRRAKGyAyc\nYKIQKcaA+6M8T7/G+TPHZX6HJWqJJiYB+EC2ERblpvq9TPlLguEWcmvjbVc31nyq\nSDoO3ncFWKFmVsbQPTbP+pKUmlLfJwtb5XqxNR5GEXSwVv4I7IqBmJz1MmRafnBZ\ng0FJUtH668GnldO20XbnSVBr820F5SISMXVwCXDXEvGwwiB8Lt8PvqzXnGIFDAu3\nDlQI5sxSqpPVWSyw08ppKT2Tpmy8adiBotLfaCFl2VTHwOae48X2dMPBvQARAQAB\ntDFGZWRvcmEgKDMwKSA8ZmVkb3JhLTMwLXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQI4BBMBAgAiBQJbbqxnAhsPBgsJCAcDAgYVCAIJCgsEFgIDAQIeAQIXgAAK\nCRDvPBEfz8ZZudTnD/9170LL3nyTVUCFmBjT9wZ4gYnpwtKVPa/pKnxbbS+Bmmac\ng9TrT9pZbqOHrNJLiZ3Zx1Hp+8uxr3Lo6kbYwImLhkOEDrf4aP17HfQ6VYFbQZI8\nf79OFxWJ7si9+3gfzeh9UYFEqOQfzIjLWFyfnas0OnV/P+RMQ1Zr+vPRqO7AR2va\nN9wg+Xl7157dhXPCGYnGMNSoxCbpRs0JNlzvJMuAea5nTTznRaJZtK/xKsqLn51D\nK07k9MHVFXakOH8QtMCUglbwfTfIpO5YRq5imxlWbqsYWVQy1WGJFyW6hWC0+RcJ\nOx5zGtOfi4/dN+xJ+ibnbyvy/il7Qm+vyFhCYqIPyS5m2UVJUuao3eApE38k78/o\n8aQOTnFQZ+U1Sw+6woFTxjqRQBXlQm2+7Bt3bqGATg4sXXWPbmwdL87Ic+mxn/ml\nSMfQux/5k6iAu1kQhwkO2YJn9eII6HIPkW+2m5N1JsUyJQe4cbtZE5Yh3TRA0dm7\n+zoBRfCXkOW4krchbgww/ptVmzMMP7GINJdROrJnsGl5FVeid9qHzV7aZycWSma7\nCxBYB1J8HCbty5NjtD6XMYRrMLxXugvX6Q4NPPH+2NKjzX4SIDejS6JjgrP3KA3O\npMuo7ZHMfveBngv8yP+ZD/1sS6l+dfExvdaJdOdgFCnp4p3gPbw5+Lv70HrMjA==\n=BfZ/\n-----END PGP PUBLIC KEY BLOCK-----\n",
+                "checksum": "sha256:9f596e18f585bee30ac41c11fb11a83ed6b11d5b341c1cb56ca4015d7717cb97"
+              }
+            ],
+            "packages": [
+              "@Fedora Cloud Server",
+              "chrony",
+              "grub2-pc",
+              "kernel-core",
+              "langpacks-en",
+              "polkit",
+              "selinux-policy-targeted",
+              "systemd-udev"
+            ],
+            "exclude_packages": [
+              "dracut-config-rescue",
+              "etables",
+              "firewalld",
+              "gobject-introspection",
+              "plymouth"
+            ],
+            "releasever": "30",
+            "basearch": "x86_64",
+            "module_platform_id": "platform:f30"
           }
-        ]
-      },
-      "runner": "org.osbuild.fedora30"
-    },
-    "stages": [
-      {
-        "name": "org.osbuild.dnf",
-        "options": {
-          "repos": [
-            {
-              "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-30&arch=x86_64",
-              "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBFturGcBEACv0xBo91V2n0uEC2vh69ywCiSyvUgN/AQH8EZpCVtM7NyjKgKm\nbbY4G3R0M3ir1xXmvUDvK0493/qOiFrjkplvzXFTGpPTi0ypqGgxc5d0ohRA1M75\nL+0AIlXoOgHQ358/c4uO8X0JAA1NYxCkAW1KSJgFJ3RjukrfqSHWthS1d4o8fhHy\nKJKEnirE5hHqB50dafXrBfgZdaOs3C6ppRIePFe2o4vUEapMTCHFw0woQR8Ah4/R\nn7Z9G9Ln+0Cinmy0nbIDiZJ+pgLAXCOWBfDUzcOjDGKvcpoZharA07c0q1/5ojzO\n4F0Fh4g/BUmtrASwHfcIbjHyCSr1j/3Iz883iy07gJY5Yhiuaqmp0o0f9fgHkG53\n2xCU1owmACqaIBNQMukvXRDtB2GJMuKa/asTZDP6R5re+iXs7+s9ohcRRAKGyAyc\nYKIQKcaA+6M8T7/G+TPHZX6HJWqJJiYB+EC2ERblpvq9TPlLguEWcmvjbVc31nyq\nSDoO3ncFWKFmVsbQPTbP+pKUmlLfJwtb5XqxNR5GEXSwVv4I7IqBmJz1MmRafnBZ\ng0FJUtH668GnldO20XbnSVBr820F5SISMXVwCXDXEvGwwiB8Lt8PvqzXnGIFDAu3\nDlQI5sxSqpPVWSyw08ppKT2Tpmy8adiBotLfaCFl2VTHwOae48X2dMPBvQARAQAB\ntDFGZWRvcmEgKDMwKSA8ZmVkb3JhLTMwLXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQI4BBMBAgAiBQJbbqxnAhsPBgsJCAcDAgYVCAIJCgsEFgIDAQIeAQIXgAAK\nCRDvPBEfz8ZZudTnD/9170LL3nyTVUCFmBjT9wZ4gYnpwtKVPa/pKnxbbS+Bmmac\ng9TrT9pZbqOHrNJLiZ3Zx1Hp+8uxr3Lo6kbYwImLhkOEDrf4aP17HfQ6VYFbQZI8\nf79OFxWJ7si9+3gfzeh9UYFEqOQfzIjLWFyfnas0OnV/P+RMQ1Zr+vPRqO7AR2va\nN9wg+Xl7157dhXPCGYnGMNSoxCbpRs0JNlzvJMuAea5nTTznRaJZtK/xKsqLn51D\nK07k9MHVFXakOH8QtMCUglbwfTfIpO5YRq5imxlWbqsYWVQy1WGJFyW6hWC0+RcJ\nOx5zGtOfi4/dN+xJ+ibnbyvy/il7Qm+vyFhCYqIPyS5m2UVJUuao3eApE38k78/o\n8aQOTnFQZ+U1Sw+6woFTxjqRQBXlQm2+7Bt3bqGATg4sXXWPbmwdL87Ic+mxn/ml\nSMfQux/5k6iAu1kQhwkO2YJn9eII6HIPkW+2m5N1JsUyJQe4cbtZE5Yh3TRA0dm7\n+zoBRfCXkOW4krchbgww/ptVmzMMP7GINJdROrJnsGl5FVeid9qHzV7aZycWSma7\nCxBYB1J8HCbty5NjtD6XMYRrMLxXugvX6Q4NPPH+2NKjzX4SIDejS6JjgrP3KA3O\npMuo7ZHMfveBngv8yP+ZD/1sS6l+dfExvdaJdOdgFCnp4p3gPbw5+Lv70HrMjA==\n=BfZ/\n-----END PGP PUBLIC KEY BLOCK-----\n",
-              "checksum": "sha256:9f596e18f585bee30ac41c11fb11a83ed6b11d5b341c1cb56ca4015d7717cb97"
-            }
-          ],
-          "packages": [
-            "@Fedora Cloud Server",
-            "chrony",
-            "grub2-pc",
-            "kernel-core",
-            "langpacks-en",
-            "polkit",
-            "selinux-policy-targeted",
-            "systemd-udev"
-          ],
-          "exclude_packages": [
-            "dracut-config-rescue",
-            "etables",
-            "firewalld",
-            "gobject-introspection",
-            "plymouth"
-          ],
-          "releasever": "30",
-          "basearch": "x86_64",
-          "module_platform_id": "platform:f30"
+        },
+        {
+          "name": "org.osbuild.fix-bls",
+          "options": {}
+        },
+        {
+          "name": "org.osbuild.locale",
+          "options": {
+            "language": "en_US"
+          }
+        },
+        {
+          "name": "org.osbuild.fstab",
+          "options": {
+            "filesystems": [
+              {
+                "uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
+                "vfs_type": "ext4",
+                "path": "/",
+                "options": "defaults",
+                "freq": 1,
+                "passno": 1
+              }
+            ]
+          }
+        },
+        {
+          "name": "org.osbuild.grub2",
+          "options": {
+            "root_fs_uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
+            "kernel_opts": "ro biosdevname=0 net.ifnames=0",
+            "legacy": true
+          }
+        },
+        {
+          "name": "org.osbuild.selinux",
+          "options": {
+            "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
+          }
         }
-      },
-      {
-        "name": "org.osbuild.fix-bls",
-        "options": {}
-      },
-      {
-        "name": "org.osbuild.locale",
+      ],
+      "assembler": {
+        "name": "org.osbuild.qemu",
         "options": {
-          "language": "en_US"
-        }
-      },
-      {
-        "name": "org.osbuild.fstab",
-        "options": {
-          "filesystems": [
+          "format": "qcow2",
+          "filename": "disk.qcow2",
+          "size": 2147483648,
+          "ptuuid": "0x14fc63d2",
+          "pttype": "mbr",
+          "partitions": [
             {
-              "uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
-              "vfs_type": "ext4",
-              "path": "/",
-              "options": "defaults",
-              "freq": 1,
-              "passno": 1
+              "start": 2048,
+              "bootable": true,
+              "filesystem": {
+                "type": "ext4",
+                "uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
+                "mountpoint": "/"
+              }
             }
           ]
         }
-      },
-      {
-        "name": "org.osbuild.grub2",
-        "options": {
-          "root_fs_uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
-          "kernel_opts": "ro biosdevname=0 net.ifnames=0",
-          "legacy": true
-        }
-      },
-      {
-        "name": "org.osbuild.selinux",
-        "options": {
-          "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
-        }
-      }
-    ],
-    "assembler": {
-      "name": "org.osbuild.qemu",
-      "options": {
-        "format": "qcow2",
-        "filename": "disk.qcow2",
-        "size": 2147483648,
-        "ptuuid": "0x14fc63d2",
-        "pttype": "mbr",
-        "partitions": [
-          {
-            "start": 2048,
-            "bootable": true,
-            "filesystem": {
-              "type": "ext4",
-              "uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
-              "mountpoint": "/"
-            }
-          }
-        ]
       }
     }
   },

--- a/test/cases/qcow2_empty_blueprint.json
+++ b/test/cases/qcow2_empty_blueprint.json
@@ -2,12 +2,14 @@
   "compose": {
     "distro": "fedora-30",
     "arch": "x86_64",
-    "checksums": {
-      "fedora": "sha256:9f596e18f585bee30ac41c11fb11a83ed6b11d5b341c1cb56ca4015d7717cb97"
-    },
     "output-format": "qcow2",
     "filename": "disk.qcow2",
     "blueprint": {}
+  },
+  "rpmmd": {
+    "checksums": {
+      "fedora": "sha256:9f596e18f585bee30ac41c11fb11a83ed6b11d5b341c1cb56ca4015d7717cb97"
+    }
   },
   "pipeline": {
     "build": {

--- a/test/cases/qcow2_local_boot.json
+++ b/test/cases/qcow2_local_boot.json
@@ -2,7 +2,7 @@
   "boot": {
     "type": "qemu"
   },
-  "compose": {
+  "compose-request": {
     "distro": "fedora-30",
     "arch": "x86_64",
     "output-format": "qcow2",

--- a/test/cases/qcow2_local_boot.json
+++ b/test/cases/qcow2_local_boot.json
@@ -37,6 +37,11 @@
       }
     }
   },
+  "rpmmd": {
+    "checksums": {
+      "fedora": "sha256:9f596e18f585bee30ac41c11fb11a83ed6b11d5b341c1cb56ca4015d7717cb97"
+    }
+  },
   "pipeline": {
     "build": {
       "pipeline": {

--- a/test/cases/qcow2_local_boot.json
+++ b/test/cases/qcow2_local_boot.json
@@ -42,153 +42,156 @@
       "fedora": "sha256:9f596e18f585bee30ac41c11fb11a83ed6b11d5b341c1cb56ca4015d7717cb97"
     }
   },
-  "pipeline": {
-    "build": {
-      "pipeline": {
-        "stages": [
-          {
-            "name": "org.osbuild.dnf",
-            "options": {
-              "repos": [
-                {
-                  "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-30&arch=x86_64",
-                  "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBFturGcBEACv0xBo91V2n0uEC2vh69ywCiSyvUgN/AQH8EZpCVtM7NyjKgKm\nbbY4G3R0M3ir1xXmvUDvK0493/qOiFrjkplvzXFTGpPTi0ypqGgxc5d0ohRA1M75\nL+0AIlXoOgHQ358/c4uO8X0JAA1NYxCkAW1KSJgFJ3RjukrfqSHWthS1d4o8fhHy\nKJKEnirE5hHqB50dafXrBfgZdaOs3C6ppRIePFe2o4vUEapMTCHFw0woQR8Ah4/R\nn7Z9G9Ln+0Cinmy0nbIDiZJ+pgLAXCOWBfDUzcOjDGKvcpoZharA07c0q1/5ojzO\n4F0Fh4g/BUmtrASwHfcIbjHyCSr1j/3Iz883iy07gJY5Yhiuaqmp0o0f9fgHkG53\n2xCU1owmACqaIBNQMukvXRDtB2GJMuKa/asTZDP6R5re+iXs7+s9ohcRRAKGyAyc\nYKIQKcaA+6M8T7/G+TPHZX6HJWqJJiYB+EC2ERblpvq9TPlLguEWcmvjbVc31nyq\nSDoO3ncFWKFmVsbQPTbP+pKUmlLfJwtb5XqxNR5GEXSwVv4I7IqBmJz1MmRafnBZ\ng0FJUtH668GnldO20XbnSVBr820F5SISMXVwCXDXEvGwwiB8Lt8PvqzXnGIFDAu3\nDlQI5sxSqpPVWSyw08ppKT2Tpmy8adiBotLfaCFl2VTHwOae48X2dMPBvQARAQAB\ntDFGZWRvcmEgKDMwKSA8ZmVkb3JhLTMwLXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQI4BBMBAgAiBQJbbqxnAhsPBgsJCAcDAgYVCAIJCgsEFgIDAQIeAQIXgAAK\nCRDvPBEfz8ZZudTnD/9170LL3nyTVUCFmBjT9wZ4gYnpwtKVPa/pKnxbbS+Bmmac\ng9TrT9pZbqOHrNJLiZ3Zx1Hp+8uxr3Lo6kbYwImLhkOEDrf4aP17HfQ6VYFbQZI8\nf79OFxWJ7si9+3gfzeh9UYFEqOQfzIjLWFyfnas0OnV/P+RMQ1Zr+vPRqO7AR2va\nN9wg+Xl7157dhXPCGYnGMNSoxCbpRs0JNlzvJMuAea5nTTznRaJZtK/xKsqLn51D\nK07k9MHVFXakOH8QtMCUglbwfTfIpO5YRq5imxlWbqsYWVQy1WGJFyW6hWC0+RcJ\nOx5zGtOfi4/dN+xJ+ibnbyvy/il7Qm+vyFhCYqIPyS5m2UVJUuao3eApE38k78/o\n8aQOTnFQZ+U1Sw+6woFTxjqRQBXlQm2+7Bt3bqGATg4sXXWPbmwdL87Ic+mxn/ml\nSMfQux/5k6iAu1kQhwkO2YJn9eII6HIPkW+2m5N1JsUyJQe4cbtZE5Yh3TRA0dm7\n+zoBRfCXkOW4krchbgww/ptVmzMMP7GINJdROrJnsGl5FVeid9qHzV7aZycWSma7\nCxBYB1J8HCbty5NjtD6XMYRrMLxXugvX6Q4NPPH+2NKjzX4SIDejS6JjgrP3KA3O\npMuo7ZHMfveBngv8yP+ZD/1sS6l+dfExvdaJdOdgFCnp4p3gPbw5+Lv70HrMjA==\n=BfZ/\n-----END PGP PUBLIC KEY BLOCK-----\n",
-                  "checksum": "sha256:9f596e18f585bee30ac41c11fb11a83ed6b11d5b341c1cb56ca4015d7717cb97"
-                }
-              ],
-              "packages": [
-                "dnf",
-                "dosfstools",
-                "e2fsprogs",
-                "grub2-pc",
-                "policycoreutils",
-                "qemu-img",
-                "systemd",
-                "tar"
-              ],
-              "releasever": "30",
-              "basearch": "x86_64",
-              "module_platform_id": "platform:f30"
+  "manifest": {
+    "sources": {},
+    "pipeline": {
+      "build": {
+        "pipeline": {
+          "stages": [
+            {
+              "name": "org.osbuild.dnf",
+              "options": {
+                "repos": [
+                  {
+                    "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-30&arch=x86_64",
+                    "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBFturGcBEACv0xBo91V2n0uEC2vh69ywCiSyvUgN/AQH8EZpCVtM7NyjKgKm\nbbY4G3R0M3ir1xXmvUDvK0493/qOiFrjkplvzXFTGpPTi0ypqGgxc5d0ohRA1M75\nL+0AIlXoOgHQ358/c4uO8X0JAA1NYxCkAW1KSJgFJ3RjukrfqSHWthS1d4o8fhHy\nKJKEnirE5hHqB50dafXrBfgZdaOs3C6ppRIePFe2o4vUEapMTCHFw0woQR8Ah4/R\nn7Z9G9Ln+0Cinmy0nbIDiZJ+pgLAXCOWBfDUzcOjDGKvcpoZharA07c0q1/5ojzO\n4F0Fh4g/BUmtrASwHfcIbjHyCSr1j/3Iz883iy07gJY5Yhiuaqmp0o0f9fgHkG53\n2xCU1owmACqaIBNQMukvXRDtB2GJMuKa/asTZDP6R5re+iXs7+s9ohcRRAKGyAyc\nYKIQKcaA+6M8T7/G+TPHZX6HJWqJJiYB+EC2ERblpvq9TPlLguEWcmvjbVc31nyq\nSDoO3ncFWKFmVsbQPTbP+pKUmlLfJwtb5XqxNR5GEXSwVv4I7IqBmJz1MmRafnBZ\ng0FJUtH668GnldO20XbnSVBr820F5SISMXVwCXDXEvGwwiB8Lt8PvqzXnGIFDAu3\nDlQI5sxSqpPVWSyw08ppKT2Tpmy8adiBotLfaCFl2VTHwOae48X2dMPBvQARAQAB\ntDFGZWRvcmEgKDMwKSA8ZmVkb3JhLTMwLXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQI4BBMBAgAiBQJbbqxnAhsPBgsJCAcDAgYVCAIJCgsEFgIDAQIeAQIXgAAK\nCRDvPBEfz8ZZudTnD/9170LL3nyTVUCFmBjT9wZ4gYnpwtKVPa/pKnxbbS+Bmmac\ng9TrT9pZbqOHrNJLiZ3Zx1Hp+8uxr3Lo6kbYwImLhkOEDrf4aP17HfQ6VYFbQZI8\nf79OFxWJ7si9+3gfzeh9UYFEqOQfzIjLWFyfnas0OnV/P+RMQ1Zr+vPRqO7AR2va\nN9wg+Xl7157dhXPCGYnGMNSoxCbpRs0JNlzvJMuAea5nTTznRaJZtK/xKsqLn51D\nK07k9MHVFXakOH8QtMCUglbwfTfIpO5YRq5imxlWbqsYWVQy1WGJFyW6hWC0+RcJ\nOx5zGtOfi4/dN+xJ+ibnbyvy/il7Qm+vyFhCYqIPyS5m2UVJUuao3eApE38k78/o\n8aQOTnFQZ+U1Sw+6woFTxjqRQBXlQm2+7Bt3bqGATg4sXXWPbmwdL87Ic+mxn/ml\nSMfQux/5k6iAu1kQhwkO2YJn9eII6HIPkW+2m5N1JsUyJQe4cbtZE5Yh3TRA0dm7\n+zoBRfCXkOW4krchbgww/ptVmzMMP7GINJdROrJnsGl5FVeid9qHzV7aZycWSma7\nCxBYB1J8HCbty5NjtD6XMYRrMLxXugvX6Q4NPPH+2NKjzX4SIDejS6JjgrP3KA3O\npMuo7ZHMfveBngv8yP+ZD/1sS6l+dfExvdaJdOdgFCnp4p3gPbw5+Lv70HrMjA==\n=BfZ/\n-----END PGP PUBLIC KEY BLOCK-----\n",
+                    "checksum": "sha256:9f596e18f585bee30ac41c11fb11a83ed6b11d5b341c1cb56ca4015d7717cb97"
+                  }
+                ],
+                "packages": [
+                  "dnf",
+                  "dosfstools",
+                  "e2fsprogs",
+                  "grub2-pc",
+                  "policycoreutils",
+                  "qemu-img",
+                  "systemd",
+                  "tar"
+                ],
+                "releasever": "30",
+                "basearch": "x86_64",
+                "module_platform_id": "platform:f30"
+              }
+            }
+          ]
+        },
+        "runner": "org.osbuild.fedora30"
+      },
+      "stages": [
+        {
+          "name": "org.osbuild.dnf",
+          "options": {
+            "repos": [
+              {
+                "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-30&arch=x86_64",
+                "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBFturGcBEACv0xBo91V2n0uEC2vh69ywCiSyvUgN/AQH8EZpCVtM7NyjKgKm\nbbY4G3R0M3ir1xXmvUDvK0493/qOiFrjkplvzXFTGpPTi0ypqGgxc5d0ohRA1M75\nL+0AIlXoOgHQ358/c4uO8X0JAA1NYxCkAW1KSJgFJ3RjukrfqSHWthS1d4o8fhHy\nKJKEnirE5hHqB50dafXrBfgZdaOs3C6ppRIePFe2o4vUEapMTCHFw0woQR8Ah4/R\nn7Z9G9Ln+0Cinmy0nbIDiZJ+pgLAXCOWBfDUzcOjDGKvcpoZharA07c0q1/5ojzO\n4F0Fh4g/BUmtrASwHfcIbjHyCSr1j/3Iz883iy07gJY5Yhiuaqmp0o0f9fgHkG53\n2xCU1owmACqaIBNQMukvXRDtB2GJMuKa/asTZDP6R5re+iXs7+s9ohcRRAKGyAyc\nYKIQKcaA+6M8T7/G+TPHZX6HJWqJJiYB+EC2ERblpvq9TPlLguEWcmvjbVc31nyq\nSDoO3ncFWKFmVsbQPTbP+pKUmlLfJwtb5XqxNR5GEXSwVv4I7IqBmJz1MmRafnBZ\ng0FJUtH668GnldO20XbnSVBr820F5SISMXVwCXDXEvGwwiB8Lt8PvqzXnGIFDAu3\nDlQI5sxSqpPVWSyw08ppKT2Tpmy8adiBotLfaCFl2VTHwOae48X2dMPBvQARAQAB\ntDFGZWRvcmEgKDMwKSA8ZmVkb3JhLTMwLXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQI4BBMBAgAiBQJbbqxnAhsPBgsJCAcDAgYVCAIJCgsEFgIDAQIeAQIXgAAK\nCRDvPBEfz8ZZudTnD/9170LL3nyTVUCFmBjT9wZ4gYnpwtKVPa/pKnxbbS+Bmmac\ng9TrT9pZbqOHrNJLiZ3Zx1Hp+8uxr3Lo6kbYwImLhkOEDrf4aP17HfQ6VYFbQZI8\nf79OFxWJ7si9+3gfzeh9UYFEqOQfzIjLWFyfnas0OnV/P+RMQ1Zr+vPRqO7AR2va\nN9wg+Xl7157dhXPCGYnGMNSoxCbpRs0JNlzvJMuAea5nTTznRaJZtK/xKsqLn51D\nK07k9MHVFXakOH8QtMCUglbwfTfIpO5YRq5imxlWbqsYWVQy1WGJFyW6hWC0+RcJ\nOx5zGtOfi4/dN+xJ+ibnbyvy/il7Qm+vyFhCYqIPyS5m2UVJUuao3eApE38k78/o\n8aQOTnFQZ+U1Sw+6woFTxjqRQBXlQm2+7Bt3bqGATg4sXXWPbmwdL87Ic+mxn/ml\nSMfQux/5k6iAu1kQhwkO2YJn9eII6HIPkW+2m5N1JsUyJQe4cbtZE5Yh3TRA0dm7\n+zoBRfCXkOW4krchbgww/ptVmzMMP7GINJdROrJnsGl5FVeid9qHzV7aZycWSma7\nCxBYB1J8HCbty5NjtD6XMYRrMLxXugvX6Q4NPPH+2NKjzX4SIDejS6JjgrP3KA3O\npMuo7ZHMfveBngv8yP+ZD/1sS6l+dfExvdaJdOdgFCnp4p3gPbw5+Lv70HrMjA==\n=BfZ/\n-----END PGP PUBLIC KEY BLOCK-----\n",
+                "checksum": "sha256:9f596e18f585bee30ac41c11fb11a83ed6b11d5b341c1cb56ca4015d7717cb97"
+              }
+            ],
+            "packages": [
+              "@Fedora Cloud Server",
+              "chrony",
+              "grub2-pc",
+              "kernel-core",
+              "langpacks-en",
+              "polkit",
+              "selinux-policy-targeted",
+              "systemd-udev"
+            ],
+            "exclude_packages": [
+              "dracut-config-rescue",
+              "etables",
+              "firewalld",
+              "gobject-introspection",
+              "plymouth"
+            ],
+            "releasever": "30",
+            "basearch": "x86_64",
+            "module_platform_id": "platform:f30"
+          }
+        },
+        {
+          "name": "org.osbuild.locale",
+          "options": {
+            "language": "en_US"
+          }
+        },
+        {
+          "name": "org.osbuild.fstab",
+          "options": {
+            "filesystems": [
+              {
+                "uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
+                "vfs_type": "ext4",
+                "path": "/",
+                "options": "defaults",
+                "freq": 1,
+                "passno": 1
+              }
+            ]
+          }
+        },
+        {
+          "name": "org.osbuild.grub2",
+          "options": {
+            "root_fs_uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
+            "kernel_opts": "ro biosdevname=0 net.ifnames=0",
+            "legacy": true
+          }
+        },
+        {
+          "name": "org.osbuild.systemd",
+          "options": {
+            "enabled_services": [
+              "sshd"
+            ]
+          }
+        },
+        {
+          "name": "org.osbuild.users",
+          "options": {
+            "users": {
+              "redhat": {
+                "groups": [
+                  "wheel"
+                ],
+                "password": "$6$IR7O7z56ouB/OInP$.hscD6dQqPQGwMuQ.idumixSHI/JEyaUfiCAHVSpGO/iNLEvvVZVOQL23zBzQbc2.yJ25xAZD75H0tXqKJpEE/",
+                "key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC61wMCjOSHwbVb4VfVyl5sn497qW4PsdQ7Ty7aD6wDNZ/QjjULkDV/yW5WjDlDQ7UqFH0Sr7vywjqDizUAqK7zM5FsUKsUXWHWwg/ehKg8j9xKcMv11AkFoUoujtfAujnKODkk58XSA9whPr7qcw3vPrmog680pnMSzf9LC7J6kXfs6lkoKfBh9VnlxusCrw2yg0qI1fHAZBLPx7mW6+me71QZsS6sVz8v8KXyrXsKTdnF50FjzHcK9HXDBtSJS5wA3fkcRYymJe0o6WMWNdgSRVpoSiWaHHmFgdMUJaYoCfhXzyl7LtNb3Q+Sveg+tJK7JaRXBLMUllOlJ6ll5Hod root@localhost"
+              }
             }
           }
-        ]
-      },
-      "runner": "org.osbuild.fedora30"
-    },
-    "stages": [
-      {
-        "name": "org.osbuild.dnf",
-        "options": {
-          "repos": [
-            {
-              "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-30&arch=x86_64",
-              "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBFturGcBEACv0xBo91V2n0uEC2vh69ywCiSyvUgN/AQH8EZpCVtM7NyjKgKm\nbbY4G3R0M3ir1xXmvUDvK0493/qOiFrjkplvzXFTGpPTi0ypqGgxc5d0ohRA1M75\nL+0AIlXoOgHQ358/c4uO8X0JAA1NYxCkAW1KSJgFJ3RjukrfqSHWthS1d4o8fhHy\nKJKEnirE5hHqB50dafXrBfgZdaOs3C6ppRIePFe2o4vUEapMTCHFw0woQR8Ah4/R\nn7Z9G9Ln+0Cinmy0nbIDiZJ+pgLAXCOWBfDUzcOjDGKvcpoZharA07c0q1/5ojzO\n4F0Fh4g/BUmtrASwHfcIbjHyCSr1j/3Iz883iy07gJY5Yhiuaqmp0o0f9fgHkG53\n2xCU1owmACqaIBNQMukvXRDtB2GJMuKa/asTZDP6R5re+iXs7+s9ohcRRAKGyAyc\nYKIQKcaA+6M8T7/G+TPHZX6HJWqJJiYB+EC2ERblpvq9TPlLguEWcmvjbVc31nyq\nSDoO3ncFWKFmVsbQPTbP+pKUmlLfJwtb5XqxNR5GEXSwVv4I7IqBmJz1MmRafnBZ\ng0FJUtH668GnldO20XbnSVBr820F5SISMXVwCXDXEvGwwiB8Lt8PvqzXnGIFDAu3\nDlQI5sxSqpPVWSyw08ppKT2Tpmy8adiBotLfaCFl2VTHwOae48X2dMPBvQARAQAB\ntDFGZWRvcmEgKDMwKSA8ZmVkb3JhLTMwLXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQI4BBMBAgAiBQJbbqxnAhsPBgsJCAcDAgYVCAIJCgsEFgIDAQIeAQIXgAAK\nCRDvPBEfz8ZZudTnD/9170LL3nyTVUCFmBjT9wZ4gYnpwtKVPa/pKnxbbS+Bmmac\ng9TrT9pZbqOHrNJLiZ3Zx1Hp+8uxr3Lo6kbYwImLhkOEDrf4aP17HfQ6VYFbQZI8\nf79OFxWJ7si9+3gfzeh9UYFEqOQfzIjLWFyfnas0OnV/P+RMQ1Zr+vPRqO7AR2va\nN9wg+Xl7157dhXPCGYnGMNSoxCbpRs0JNlzvJMuAea5nTTznRaJZtK/xKsqLn51D\nK07k9MHVFXakOH8QtMCUglbwfTfIpO5YRq5imxlWbqsYWVQy1WGJFyW6hWC0+RcJ\nOx5zGtOfi4/dN+xJ+ibnbyvy/il7Qm+vyFhCYqIPyS5m2UVJUuao3eApE38k78/o\n8aQOTnFQZ+U1Sw+6woFTxjqRQBXlQm2+7Bt3bqGATg4sXXWPbmwdL87Ic+mxn/ml\nSMfQux/5k6iAu1kQhwkO2YJn9eII6HIPkW+2m5N1JsUyJQe4cbtZE5Yh3TRA0dm7\n+zoBRfCXkOW4krchbgww/ptVmzMMP7GINJdROrJnsGl5FVeid9qHzV7aZycWSma7\nCxBYB1J8HCbty5NjtD6XMYRrMLxXugvX6Q4NPPH+2NKjzX4SIDejS6JjgrP3KA3O\npMuo7ZHMfveBngv8yP+ZD/1sS6l+dfExvdaJdOdgFCnp4p3gPbw5+Lv70HrMjA==\n=BfZ/\n-----END PGP PUBLIC KEY BLOCK-----\n",
-              "checksum": "sha256:9f596e18f585bee30ac41c11fb11a83ed6b11d5b341c1cb56ca4015d7717cb97"
-            }
-          ],
-          "packages": [
-            "@Fedora Cloud Server",
-            "chrony",
-            "grub2-pc",
-            "kernel-core",
-            "langpacks-en",
-            "polkit",
-            "selinux-policy-targeted",
-            "systemd-udev"
-          ],
-          "exclude_packages": [
-            "dracut-config-rescue",
-            "etables",
-            "firewalld",
-            "gobject-introspection",
-            "plymouth"
-          ],
-          "releasever": "30",
-          "basearch": "x86_64",
-          "module_platform_id": "platform:f30"
+        },
+        {
+          "name": "org.osbuild.selinux",
+          "options": {
+            "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
+          }
+        },
+        {
+          "name": "org.osbuild.fix-bls",
+          "options": {}
         }
-      },
-      {
-        "name": "org.osbuild.locale",
+      ],
+      "assembler": {
+        "name": "org.osbuild.qemu",
         "options": {
-          "language": "en_US"
-        }
-      },
-      {
-        "name": "org.osbuild.fstab",
-        "options": {
-          "filesystems": [
+          "format": "qcow2",
+          "filename": "disk.qcow2",
+          "size": 2147483648,
+          "ptuuid": "0x14fc63d2",
+          "pttype": "mbr",
+          "partitions": [
             {
-              "uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
-              "vfs_type": "ext4",
-              "path": "/",
-              "options": "defaults",
-              "freq": 1,
-              "passno": 1
+              "start": 2048,
+              "bootable": true,
+              "filesystem": {
+                "type": "ext4",
+                "uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
+                "mountpoint": "/"
+              }
             }
           ]
         }
-      },
-      {
-        "name": "org.osbuild.grub2",
-        "options": {
-          "root_fs_uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
-          "kernel_opts": "ro biosdevname=0 net.ifnames=0",
-          "legacy": true
-        }
-      },
-      {
-        "name": "org.osbuild.systemd",
-        "options": {
-          "enabled_services": [
-            "sshd"
-          ]
-        }
-      },
-      {
-        "name": "org.osbuild.users",
-        "options": {
-          "users": {
-            "redhat": {
-              "groups": [
-                "wheel"
-              ],
-              "password": "$6$IR7O7z56ouB/OInP$.hscD6dQqPQGwMuQ.idumixSHI/JEyaUfiCAHVSpGO/iNLEvvVZVOQL23zBzQbc2.yJ25xAZD75H0tXqKJpEE/",
-              "key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC61wMCjOSHwbVb4VfVyl5sn497qW4PsdQ7Ty7aD6wDNZ/QjjULkDV/yW5WjDlDQ7UqFH0Sr7vywjqDizUAqK7zM5FsUKsUXWHWwg/ehKg8j9xKcMv11AkFoUoujtfAujnKODkk58XSA9whPr7qcw3vPrmog680pnMSzf9LC7J6kXfs6lkoKfBh9VnlxusCrw2yg0qI1fHAZBLPx7mW6+me71QZsS6sVz8v8KXyrXsKTdnF50FjzHcK9HXDBtSJS5wA3fkcRYymJe0o6WMWNdgSRVpoSiWaHHmFgdMUJaYoCfhXzyl7LtNb3Q+Sveg+tJK7JaRXBLMUllOlJ6ll5Hod root@localhost"
-            }
-          }
-        }
-      },
-      {
-        "name": "org.osbuild.selinux",
-        "options": {
-          "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
-        }
-      },
-      {
-        "name": "org.osbuild.fix-bls",
-        "options": {}
-      }
-    ],
-    "assembler": {
-      "name": "org.osbuild.qemu",
-      "options": {
-        "format": "qcow2",
-        "filename": "disk.qcow2",
-        "size": 2147483648,
-        "ptuuid": "0x14fc63d2",
-        "pttype": "mbr",
-        "partitions": [
-          {
-            "start": 2048,
-            "bootable": true,
-            "filesystem": {
-              "type": "ext4",
-              "uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
-              "mountpoint": "/"
-            }
-          }
-        ]
       }
     }
   }

--- a/test/cases/rhel82_ami.json
+++ b/test/cases/rhel82_ami.json
@@ -2,7 +2,7 @@
   "boot": {
     "type": "qemu-extract"
   },
-  "compose": {
+  "compose-request": {
     "distro": "rhel-8.2",
     "arch": "x86_64",
     "filename": "image.raw.xz",

--- a/test/cases/rhel82_ami.json
+++ b/test/cases/rhel82_ami.json
@@ -15,178 +15,181 @@
       "appstream": "sha256:662e1dc0e465dd5e8efec9f42ef24ac9fd8418294254c3c98ea0342d6e903aed"
     }
   },
-  "pipeline": {
-    "build": {
-      "pipeline": {
-        "stages": [
-          {
-            "name": "org.osbuild.dnf",
-            "options": {
-              "repos": [
-                {
-                  "baseurl": "http://download.devel.redhat.com/rhel-8/nightly/RHEL-8/latest-RHEL-8.2.0/compose/BaseOS/x86_64/os",
-                  "checksum": "sha256:3ce6f4ffa7d05b81fec2ba5a1c4917b351231c3433f2f5eed86ed5f8f97168a1"
-                },
-                {
-                  "baseurl": "http://download.devel.redhat.com/rhel-8/nightly/RHEL-8/latest-RHEL-8.2.0/compose/AppStream/x86_64/os",
-                  "checksum": "sha256:662e1dc0e465dd5e8efec9f42ef24ac9fd8418294254c3c98ea0342d6e903aed"
-                }
-              ],
-              "packages": [
-                "dnf",
-                "dosfstools",
-                "dracut-config-generic",
-                "e2fsprogs",
-                "glibc",
-                "grub2-pc",
-                "policycoreutils",
-                "python36",
-                "qemu-img",
-                "systemd",
-                "tar",
-                "xfsprogs"
-              ],
-              "releasever": "8",
-              "basearch": "x86_64",
-              "module_platform_id": "platform:el8"
+  "manifest": {
+    "sources": {},
+    "pipeline": {
+      "build": {
+        "pipeline": {
+          "stages": [
+            {
+              "name": "org.osbuild.dnf",
+              "options": {
+                "repos": [
+                  {
+                    "baseurl": "http://download.devel.redhat.com/rhel-8/nightly/RHEL-8/latest-RHEL-8.2.0/compose/BaseOS/x86_64/os",
+                    "checksum": "sha256:3ce6f4ffa7d05b81fec2ba5a1c4917b351231c3433f2f5eed86ed5f8f97168a1"
+                  },
+                  {
+                    "baseurl": "http://download.devel.redhat.com/rhel-8/nightly/RHEL-8/latest-RHEL-8.2.0/compose/AppStream/x86_64/os",
+                    "checksum": "sha256:662e1dc0e465dd5e8efec9f42ef24ac9fd8418294254c3c98ea0342d6e903aed"
+                  }
+                ],
+                "packages": [
+                  "dnf",
+                  "dosfstools",
+                  "dracut-config-generic",
+                  "e2fsprogs",
+                  "glibc",
+                  "grub2-pc",
+                  "policycoreutils",
+                  "python36",
+                  "qemu-img",
+                  "systemd",
+                  "tar",
+                  "xfsprogs"
+                ],
+                "releasever": "8",
+                "basearch": "x86_64",
+                "module_platform_id": "platform:el8"
+              }
             }
+          ]
+        },
+        "runner": "org.osbuild.rhel82"
+      },
+      "stages": [
+        {
+          "name": "org.osbuild.dnf",
+          "options": {
+            "repos": [
+              {
+                "baseurl": "http://download.devel.redhat.com/rhel-8/nightly/RHEL-8/latest-RHEL-8.2.0/compose/BaseOS/x86_64/os",
+                "checksum": "sha256:3ce6f4ffa7d05b81fec2ba5a1c4917b351231c3433f2f5eed86ed5f8f97168a1"
+              },
+              {
+                "baseurl": "http://download.devel.redhat.com/rhel-8/nightly/RHEL-8/latest-RHEL-8.2.0/compose/AppStream/x86_64/os",
+                "checksum": "sha256:662e1dc0e465dd5e8efec9f42ef24ac9fd8418294254c3c98ea0342d6e903aed"
+              }
+            ],
+            "packages": [
+              "@core",
+              "NetworkManager",
+              "checkpolicy",
+              "chrony",
+              "cloud-init",
+              "cloud-init",
+              "cloud-utils-growpart",
+              "dhcp-client",
+              "dracut-config-generic",
+              "gdisk",
+              "grub2-pc",
+              "insights-client",
+              "kernel",
+              "langpacks-en",
+              "net-tools",
+              "redhat-release",
+              "redhat-release-eula",
+              "rng-tools",
+              "rsync",
+              "selinux-policy-targeted",
+              "tar",
+              "yum-utils"
+            ],
+            "exclude_packages": [
+              "aic94xx-firmware",
+              "alsa-firmware",
+              "alsa-lib",
+              "alsa-tools-firmware",
+              "biosdevname",
+              "dracut-config-rescue",
+              "firewalld",
+              "iprutils",
+              "ivtv-firmware",
+              "iwl100-firmware",
+              "iwl1000-firmware",
+              "iwl105-firmware",
+              "iwl135-firmware",
+              "iwl2000-firmware",
+              "iwl2030-firmware",
+              "iwl3160-firmware",
+              "iwl3945-firmware",
+              "iwl4965-firmware",
+              "iwl5000-firmware",
+              "iwl5150-firmware",
+              "iwl6000-firmware",
+              "iwl6000g2a-firmware",
+              "iwl6000g2b-firmware",
+              "iwl6050-firmware",
+              "iwl7260-firmware",
+              "libertas-sd8686-firmware",
+              "libertas-sd8787-firmware",
+              "libertas-usb8388-firmware",
+              "plymouth",
+              "timedatex"
+            ],
+            "releasever": "8",
+            "basearch": "x86_64",
+            "module_platform_id": "platform:el8"
           }
-        ]
-      },
-      "runner": "org.osbuild.rhel82"
-    },
-    "stages": [
-      {
-        "name": "org.osbuild.dnf",
-        "options": {
-          "repos": [
-            {
-              "baseurl": "http://download.devel.redhat.com/rhel-8/nightly/RHEL-8/latest-RHEL-8.2.0/compose/BaseOS/x86_64/os",
-              "checksum": "sha256:3ce6f4ffa7d05b81fec2ba5a1c4917b351231c3433f2f5eed86ed5f8f97168a1"
-            },
-            {
-              "baseurl": "http://download.devel.redhat.com/rhel-8/nightly/RHEL-8/latest-RHEL-8.2.0/compose/AppStream/x86_64/os",
-              "checksum": "sha256:662e1dc0e465dd5e8efec9f42ef24ac9fd8418294254c3c98ea0342d6e903aed"
-            }
-          ],
-          "packages": [
-            "@core",
-            "NetworkManager",
-            "checkpolicy",
-            "chrony",
-            "cloud-init",
-            "cloud-init",
-            "cloud-utils-growpart",
-            "dhcp-client",
-            "dracut-config-generic",
-            "gdisk",
-            "grub2-pc",
-            "insights-client",
-            "kernel",
-            "langpacks-en",
-            "net-tools",
-            "redhat-release",
-            "redhat-release-eula",
-            "rng-tools",
-            "rsync",
-            "selinux-policy-targeted",
-            "tar",
-            "yum-utils"
-          ],
-          "exclude_packages": [
-            "aic94xx-firmware",
-            "alsa-firmware",
-            "alsa-lib",
-            "alsa-tools-firmware",
-            "biosdevname",
-            "dracut-config-rescue",
-            "firewalld",
-            "iprutils",
-            "ivtv-firmware",
-            "iwl100-firmware",
-            "iwl1000-firmware",
-            "iwl105-firmware",
-            "iwl135-firmware",
-            "iwl2000-firmware",
-            "iwl2030-firmware",
-            "iwl3160-firmware",
-            "iwl3945-firmware",
-            "iwl4965-firmware",
-            "iwl5000-firmware",
-            "iwl5150-firmware",
-            "iwl6000-firmware",
-            "iwl6000g2a-firmware",
-            "iwl6000g2b-firmware",
-            "iwl6050-firmware",
-            "iwl7260-firmware",
-            "libertas-sd8686-firmware",
-            "libertas-sd8787-firmware",
-            "libertas-usb8388-firmware",
-            "plymouth",
-            "timedatex"
-          ],
-          "releasever": "8",
-          "basearch": "x86_64",
-          "module_platform_id": "platform:el8"
+        },
+        {
+          "name": "org.osbuild.fix-bls",
+          "options": {}
+        },
+        {
+          "name": "org.osbuild.fstab",
+          "options": {
+            "filesystems": [
+              {
+                "uuid": "0bd700f8-090f-4556-b797-b340297ea1bd",
+                "vfs_type": "xfs",
+                "path": "/",
+                "options": "defaults"
+              }
+            ]
+          }
+        },
+        {
+          "name": "org.osbuild.grub2",
+          "options": {
+            "root_fs_uuid": "0bd700f8-090f-4556-b797-b340297ea1bd",
+            "kernel_opts": "ro console=ttyS0,115200n8 console=tty0 net.ifnames=0 rd.blacklist=nouveau nvme_core.io_timeout=4294967295 crashkernel=auto",
+            "legacy": true
+          }
+        },
+        {
+          "name": "org.osbuild.locale",
+          "options": {
+            "language": "en_US"
+          }
+        },
+        {
+          "name": "org.osbuild.selinux",
+          "options": {
+            "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
+          }
         }
-      },
-      {
-        "name": "org.osbuild.fix-bls",
-        "options": {}
-      },
-      {
-        "name": "org.osbuild.fstab",
+      ],
+      "assembler": {
+        "name": "org.osbuild.qemu",
         "options": {
-          "filesystems": [
+          "format": "raw.xz",
+          "filename": "image.raw.xz",
+          "size": 6442450944,
+          "ptuuid": "0x14fc63d2",
+          "pttype": "mbr",
+          "partitions": [
             {
-              "uuid": "0bd700f8-090f-4556-b797-b340297ea1bd",
-              "vfs_type": "xfs",
-              "path": "/",
-              "options": "defaults"
+              "start": 2048,
+              "bootable": true,
+              "filesystem": {
+                "type": "xfs",
+                "uuid": "0bd700f8-090f-4556-b797-b340297ea1bd",
+                "mountpoint": "/"
+              }
             }
           ]
         }
-      },
-      {
-        "name": "org.osbuild.grub2",
-        "options": {
-          "root_fs_uuid": "0bd700f8-090f-4556-b797-b340297ea1bd",
-          "kernel_opts": "ro console=ttyS0,115200n8 console=tty0 net.ifnames=0 rd.blacklist=nouveau nvme_core.io_timeout=4294967295 crashkernel=auto",
-          "legacy": true
-        }
-      },
-      {
-        "name": "org.osbuild.locale",
-        "options": {
-          "language": "en_US"
-        }
-      },
-      {
-        "name": "org.osbuild.selinux",
-        "options": {
-          "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
-        }
-      }
-    ],
-    "assembler": {
-      "name": "org.osbuild.qemu",
-      "options": {
-        "format": "raw.xz",
-        "filename": "image.raw.xz",
-        "size": 6442450944,
-        "ptuuid": "0x14fc63d2",
-        "pttype": "mbr",
-        "partitions": [
-          {
-            "start": 2048,
-            "bootable": true,
-            "filesystem": {
-              "type": "xfs",
-              "uuid": "0bd700f8-090f-4556-b797-b340297ea1bd",
-              "mountpoint": "/"
-            }
-          }
-        ]
       }
     }
   },

--- a/test/cases/rhel82_ami.json
+++ b/test/cases/rhel82_ami.json
@@ -5,13 +5,15 @@
   "compose": {
     "distro": "rhel-8.2",
     "arch": "x86_64",
-    "checksums": {
-      "baseos": "sha256:3ce6f4ffa7d05b81fec2ba5a1c4917b351231c3433f2f5eed86ed5f8f97168a1",
-      "appstream": "sha256:662e1dc0e465dd5e8efec9f42ef24ac9fd8418294254c3c98ea0342d6e903aed"
-    },
     "filename": "image.raw.xz",
     "output-format": "ami",
     "blueprint": {}
+  },
+  "rpmmd": {
+    "checksums": {
+      "baseos": "sha256:3ce6f4ffa7d05b81fec2ba5a1c4917b351231c3433f2f5eed86ed5f8f97168a1",
+      "appstream": "sha256:662e1dc0e465dd5e8efec9f42ef24ac9fd8418294254c3c98ea0342d6e903aed"
+    }
   },
   "pipeline": {
     "build": {

--- a/test/cases/rhel82_ext4_filesystem.json
+++ b/test/cases/rhel82_ext4_filesystem.json
@@ -21,120 +21,123 @@
       "appstream": "sha256:662e1dc0e465dd5e8efec9f42ef24ac9fd8418294254c3c98ea0342d6e903aed"
     }
   },
-  "pipeline": {
-    "build": {
-      "pipeline": {
-        "stages": [
-          {
-            "name": "org.osbuild.dnf",
-            "options": {
-              "repos": [
-                {
-                  "baseurl": "http://download.devel.redhat.com/rhel-8/nightly/RHEL-8/latest-RHEL-8.2.0/compose/BaseOS/x86_64/os",
-                  "checksum": "sha256:3ce6f4ffa7d05b81fec2ba5a1c4917b351231c3433f2f5eed86ed5f8f97168a1"
-                },
-                {
-                  "baseurl": "http://download.devel.redhat.com/rhel-8/nightly/RHEL-8/latest-RHEL-8.2.0/compose/AppStream/x86_64/os",
-                  "checksum": "sha256:662e1dc0e465dd5e8efec9f42ef24ac9fd8418294254c3c98ea0342d6e903aed"
-                }
-              ],
-              "packages": [
-                "dnf",
-                "dosfstools",
-                "dracut-config-generic",
-                "e2fsprogs",
-                "glibc",
-                "grub2-pc",
-                "policycoreutils",
-                "python36",
-                "qemu-img",
-                "systemd",
-                "tar",
-                "xfsprogs"
-              ],
-              "releasever": "8",
-              "basearch": "x86_64",
-              "module_platform_id": "platform:el8"
+  "manifest": {
+    "sources": {},
+    "pipeline": {
+      "build": {
+        "pipeline": {
+          "stages": [
+            {
+              "name": "org.osbuild.dnf",
+              "options": {
+                "repos": [
+                  {
+                    "baseurl": "http://download.devel.redhat.com/rhel-8/nightly/RHEL-8/latest-RHEL-8.2.0/compose/BaseOS/x86_64/os",
+                    "checksum": "sha256:3ce6f4ffa7d05b81fec2ba5a1c4917b351231c3433f2f5eed86ed5f8f97168a1"
+                  },
+                  {
+                    "baseurl": "http://download.devel.redhat.com/rhel-8/nightly/RHEL-8/latest-RHEL-8.2.0/compose/AppStream/x86_64/os",
+                    "checksum": "sha256:662e1dc0e465dd5e8efec9f42ef24ac9fd8418294254c3c98ea0342d6e903aed"
+                  }
+                ],
+                "packages": [
+                  "dnf",
+                  "dosfstools",
+                  "dracut-config-generic",
+                  "e2fsprogs",
+                  "glibc",
+                  "grub2-pc",
+                  "policycoreutils",
+                  "python36",
+                  "qemu-img",
+                  "systemd",
+                  "tar",
+                  "xfsprogs"
+                ],
+                "releasever": "8",
+                "basearch": "x86_64",
+                "module_platform_id": "platform:el8"
+              }
+            }
+          ]
+        },
+        "runner": "org.osbuild.rhel82"
+      },
+      "stages": [
+        {
+          "name": "org.osbuild.dnf",
+          "options": {
+            "repos": [
+              {
+                "baseurl": "http://download.devel.redhat.com/rhel-8/nightly/RHEL-8/latest-RHEL-8.2.0/compose/BaseOS/x86_64/os",
+                "checksum": "sha256:3ce6f4ffa7d05b81fec2ba5a1c4917b351231c3433f2f5eed86ed5f8f97168a1"
+              },
+              {
+                "baseurl": "http://download.devel.redhat.com/rhel-8/nightly/RHEL-8/latest-RHEL-8.2.0/compose/AppStream/x86_64/os",
+                "checksum": "sha256:662e1dc0e465dd5e8efec9f42ef24ac9fd8418294254c3c98ea0342d6e903aed"
+              }
+            ],
+            "packages": [
+              "chrony",
+              "dracut-config-generic",
+              "firewalld",
+              "kernel",
+              "langpacks-en",
+              "policycoreutils",
+              "selinux-policy-targeted"
+            ],
+            "exclude_packages": [
+              "dracut-config-rescue",
+              "timedatex"
+            ],
+            "releasever": "8",
+            "basearch": "x86_64",
+            "module_platform_id": "platform:el8"
+          }
+        },
+        {
+          "name": "org.osbuild.fix-bls",
+          "options": {}
+        },
+        {
+          "name": "org.osbuild.grub2",
+          "options": {
+            "root_fs_uuid": "0bd700f8-090f-4556-b797-b340297ea1bd",
+            "kernel_opts": "ro net.ifnames=0",
+            "legacy": true
+          }
+        },
+        {
+          "name": "org.osbuild.locale",
+          "options": {
+            "language": "en_US"
+          }
+        },
+        {
+          "name": "org.osbuild.users",
+          "options": {
+            "users": {
+              "redhat": {
+                "key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC61wMCjOSHwbVb4VfVyl5sn497qW4PsdQ7Ty7aD6wDNZ/QjjULkDV/yW5WjDlDQ7UqFH0Sr7vywjqDizUAqK7zM5FsUKsUXWHWwg/ehKg8j9xKcMv11AkFoUoujtfAujnKODkk58XSA9whPr7qcw3vPrmog680pnMSzf9LC7J6kXfs6lkoKfBh9VnlxusCrw2yg0qI1fHAZBLPx7mW6+me71QZsS6sVz8v8KXyrXsKTdnF50FjzHcK9HXDBtSJS5wA3fkcRYymJe0o6WMWNdgSRVpoSiWaHHmFgdMUJaYoCfhXzyl7LtNb3Q+Sveg+tJK7JaRXBLMUllOlJ6ll5Hod"
+              }
             }
           }
-        ]
-      },
-      "runner": "org.osbuild.rhel82"
-    },
-    "stages": [
-      {
-        "name": "org.osbuild.dnf",
-        "options": {
-          "repos": [
-            {
-              "baseurl": "http://download.devel.redhat.com/rhel-8/nightly/RHEL-8/latest-RHEL-8.2.0/compose/BaseOS/x86_64/os",
-              "checksum": "sha256:3ce6f4ffa7d05b81fec2ba5a1c4917b351231c3433f2f5eed86ed5f8f97168a1"
-            },
-            {
-              "baseurl": "http://download.devel.redhat.com/rhel-8/nightly/RHEL-8/latest-RHEL-8.2.0/compose/AppStream/x86_64/os",
-              "checksum": "sha256:662e1dc0e465dd5e8efec9f42ef24ac9fd8418294254c3c98ea0342d6e903aed"
-            }
-          ],
-          "packages": [
-            "chrony",
-            "dracut-config-generic",
-            "firewalld",
-            "kernel",
-            "langpacks-en",
-            "policycoreutils",
-            "selinux-policy-targeted"
-          ],
-          "exclude_packages": [
-            "dracut-config-rescue",
-            "timedatex"
-          ],
-          "releasever": "8",
-          "basearch": "x86_64",
-          "module_platform_id": "platform:el8"
+        },
+        {
+          "name": "org.osbuild.selinux",
+          "options": {
+            "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
+          }
         }
-      },
-      {
-        "name": "org.osbuild.fix-bls",
-        "options": {}
-      },
-      {
-        "name": "org.osbuild.grub2",
+      ],
+      "assembler": {
+        "name": "org.osbuild.rawfs",
         "options": {
+          "filename": "filesystem.img",
           "root_fs_uuid": "0bd700f8-090f-4556-b797-b340297ea1bd",
-          "kernel_opts": "ro net.ifnames=0",
-          "legacy": true
+          "size": 2147483648,
+          "fs_type": "xfs"
         }
-      },
-      {
-        "name": "org.osbuild.locale",
-        "options": {
-          "language": "en_US"
-        }
-      },
-      {
-        "name": "org.osbuild.users",
-        "options": {
-          "users": {
-            "redhat": {
-              "key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC61wMCjOSHwbVb4VfVyl5sn497qW4PsdQ7Ty7aD6wDNZ/QjjULkDV/yW5WjDlDQ7UqFH0Sr7vywjqDizUAqK7zM5FsUKsUXWHWwg/ehKg8j9xKcMv11AkFoUoujtfAujnKODkk58XSA9whPr7qcw3vPrmog680pnMSzf9LC7J6kXfs6lkoKfBh9VnlxusCrw2yg0qI1fHAZBLPx7mW6+me71QZsS6sVz8v8KXyrXsKTdnF50FjzHcK9HXDBtSJS5wA3fkcRYymJe0o6WMWNdgSRVpoSiWaHHmFgdMUJaYoCfhXzyl7LtNb3Q+Sveg+tJK7JaRXBLMUllOlJ6ll5Hod"
-            }
-          }
-        }
-      },
-      {
-        "name": "org.osbuild.selinux",
-        "options": {
-          "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
-        }
-      }
-    ],
-    "assembler": {
-      "name": "org.osbuild.rawfs",
-      "options": {
-        "filename": "filesystem.img",
-        "root_fs_uuid": "0bd700f8-090f-4556-b797-b340297ea1bd",
-        "size": 2147483648,
-        "fs_type": "xfs"
       }
     }
   }

--- a/test/cases/rhel82_ext4_filesystem.json
+++ b/test/cases/rhel82_ext4_filesystem.json
@@ -2,10 +2,6 @@
   "compose": {
     "distro": "rhel-8.2",
     "arch": "x86_64",
-    "checksums": {
-      "baseos": "sha256:3ce6f4ffa7d05b81fec2ba5a1c4917b351231c3433f2f5eed86ed5f8f97168a1",
-      "appstream": "sha256:662e1dc0e465dd5e8efec9f42ef24ac9fd8418294254c3c98ea0342d6e903aed"
-    },
     "filename": "filesystem.img",
     "output-format": "ext4-filesystem",
     "blueprint": {
@@ -17,6 +13,12 @@
           }
         ]
       }
+    }
+  },
+  "rpmmd": {
+    "checksums": {
+      "baseos": "sha256:3ce6f4ffa7d05b81fec2ba5a1c4917b351231c3433f2f5eed86ed5f8f97168a1",
+      "appstream": "sha256:662e1dc0e465dd5e8efec9f42ef24ac9fd8418294254c3c98ea0342d6e903aed"
     }
   },
   "pipeline": {

--- a/test/cases/rhel82_ext4_filesystem.json
+++ b/test/cases/rhel82_ext4_filesystem.json
@@ -1,5 +1,5 @@
 {
-  "compose": {
+  "compose-request": {
     "distro": "rhel-8.2",
     "arch": "x86_64",
     "filename": "filesystem.img",

--- a/test/cases/rhel82_groups.json
+++ b/test/cases/rhel82_groups.json
@@ -26,119 +26,122 @@
       "appstream": "sha256:662e1dc0e465dd5e8efec9f42ef24ac9fd8418294254c3c98ea0342d6e903aed"
     }
   },
-  "pipeline": {
-    "build": {
-      "pipeline": {
-        "stages": [
-          {
-            "name": "org.osbuild.dnf",
-            "options": {
-              "repos": [
-                {
-                  "baseurl": "http://download.devel.redhat.com/rhel-8/nightly/RHEL-8/latest-RHEL-8.2.0/compose/BaseOS/x86_64/os",
-                  "checksum": "sha256:3ce6f4ffa7d05b81fec2ba5a1c4917b351231c3433f2f5eed86ed5f8f97168a1"
-                },
-                {
-                  "baseurl": "http://download.devel.redhat.com/rhel-8/nightly/RHEL-8/latest-RHEL-8.2.0/compose/AppStream/x86_64/os",
-                  "checksum": "sha256:662e1dc0e465dd5e8efec9f42ef24ac9fd8418294254c3c98ea0342d6e903aed"
-                }
-              ],
-              "packages": [
-                "dnf",
-                "dosfstools",
-                "dracut-config-generic",
-                "e2fsprogs",
-                "glibc",
-                "grub2-pc",
-                "policycoreutils",
-                "python36",
-                "qemu-img",
-                "systemd",
-                "tar",
-                "xfsprogs"
-              ],
-              "releasever": "8",
-              "basearch": "x86_64",
-              "module_platform_id": "platform:el8"
+  "manifest": {
+    "sources": {},
+    "pipeline": {
+      "build": {
+        "pipeline": {
+          "stages": [
+            {
+              "name": "org.osbuild.dnf",
+              "options": {
+                "repos": [
+                  {
+                    "baseurl": "http://download.devel.redhat.com/rhel-8/nightly/RHEL-8/latest-RHEL-8.2.0/compose/BaseOS/x86_64/os",
+                    "checksum": "sha256:3ce6f4ffa7d05b81fec2ba5a1c4917b351231c3433f2f5eed86ed5f8f97168a1"
+                  },
+                  {
+                    "baseurl": "http://download.devel.redhat.com/rhel-8/nightly/RHEL-8/latest-RHEL-8.2.0/compose/AppStream/x86_64/os",
+                    "checksum": "sha256:662e1dc0e465dd5e8efec9f42ef24ac9fd8418294254c3c98ea0342d6e903aed"
+                  }
+                ],
+                "packages": [
+                  "dnf",
+                  "dosfstools",
+                  "dracut-config-generic",
+                  "e2fsprogs",
+                  "glibc",
+                  "grub2-pc",
+                  "policycoreutils",
+                  "python36",
+                  "qemu-img",
+                  "systemd",
+                  "tar",
+                  "xfsprogs"
+                ],
+                "releasever": "8",
+                "basearch": "x86_64",
+                "module_platform_id": "platform:el8"
+              }
+            }
+          ]
+        },
+        "runner": "org.osbuild.rhel82"
+      },
+      "stages": [
+        {
+          "name": "org.osbuild.dnf",
+          "options": {
+            "repos": [
+              {
+                "baseurl": "http://download.devel.redhat.com/rhel-8/nightly/RHEL-8/latest-RHEL-8.2.0/compose/BaseOS/x86_64/os",
+                "checksum": "sha256:3ce6f4ffa7d05b81fec2ba5a1c4917b351231c3433f2f5eed86ed5f8f97168a1"
+              },
+              {
+                "baseurl": "http://download.devel.redhat.com/rhel-8/nightly/RHEL-8/latest-RHEL-8.2.0/compose/AppStream/x86_64/os",
+                "checksum": "sha256:662e1dc0e465dd5e8efec9f42ef24ac9fd8418294254c3c98ea0342d6e903aed"
+              }
+            ],
+            "packages": [
+              "@anaconda-tools",
+              "chrony",
+              "dracut-config-generic",
+              "firewalld",
+              "kernel",
+              "langpacks-en",
+              "policycoreutils",
+              "selinux-policy-targeted"
+            ],
+            "exclude_packages": [
+              "dracut-config-rescue",
+              "timedatex"
+            ],
+            "releasever": "8",
+            "basearch": "x86_64",
+            "module_platform_id": "platform:el8"
+          }
+        },
+        {
+          "name": "org.osbuild.fix-bls",
+          "options": {}
+        },
+        {
+          "name": "org.osbuild.grub2",
+          "options": {
+            "root_fs_uuid": "0bd700f8-090f-4556-b797-b340297ea1bd",
+            "kernel_opts": "ro net.ifnames=0",
+            "legacy": true
+          }
+        },
+        {
+          "name": "org.osbuild.locale",
+          "options": {
+            "language": "en_US"
+          }
+        },
+        {
+          "name": "org.osbuild.users",
+          "options": {
+            "users": {
+              "redhat": {
+                "key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC61wMCjOSHwbVb4VfVyl5sn497qW4PsdQ7Ty7aD6wDNZ/QjjULkDV/yW5WjDlDQ7UqFH0Sr7vywjqDizUAqK7zM5FsUKsUXWHWwg/ehKg8j9xKcMv11AkFoUoujtfAujnKODkk58XSA9whPr7qcw3vPrmog680pnMSzf9LC7J6kXfs6lkoKfBh9VnlxusCrw2yg0qI1fHAZBLPx7mW6+me71QZsS6sVz8v8KXyrXsKTdnF50FjzHcK9HXDBtSJS5wA3fkcRYymJe0o6WMWNdgSRVpoSiWaHHmFgdMUJaYoCfhXzyl7LtNb3Q+Sveg+tJK7JaRXBLMUllOlJ6ll5Hod"
+              }
             }
           }
-        ]
-      },
-      "runner": "org.osbuild.rhel82"
-    },
-    "stages": [
-      {
-        "name": "org.osbuild.dnf",
-        "options": {
-          "repos": [
-            {
-              "baseurl": "http://download.devel.redhat.com/rhel-8/nightly/RHEL-8/latest-RHEL-8.2.0/compose/BaseOS/x86_64/os",
-              "checksum": "sha256:3ce6f4ffa7d05b81fec2ba5a1c4917b351231c3433f2f5eed86ed5f8f97168a1"
-            },
-            {
-              "baseurl": "http://download.devel.redhat.com/rhel-8/nightly/RHEL-8/latest-RHEL-8.2.0/compose/AppStream/x86_64/os",
-              "checksum": "sha256:662e1dc0e465dd5e8efec9f42ef24ac9fd8418294254c3c98ea0342d6e903aed"
-            }
-          ],
-          "packages": [
-            "@anaconda-tools",
-            "chrony",
-            "dracut-config-generic",
-            "firewalld",
-            "kernel",
-            "langpacks-en",
-            "policycoreutils",
-            "selinux-policy-targeted"
-          ],
-          "exclude_packages": [
-            "dracut-config-rescue",
-            "timedatex"
-          ],
-          "releasever": "8",
-          "basearch": "x86_64",
-          "module_platform_id": "platform:el8"
-        }
-      },
-      {
-        "name": "org.osbuild.fix-bls",
-        "options": {}
-      },
-      {
-        "name": "org.osbuild.grub2",
-        "options": {
-          "root_fs_uuid": "0bd700f8-090f-4556-b797-b340297ea1bd",
-          "kernel_opts": "ro net.ifnames=0",
-          "legacy": true
-        }
-      },
-      {
-        "name": "org.osbuild.locale",
-        "options": {
-          "language": "en_US"
-        }
-      },
-      {
-        "name": "org.osbuild.users",
-        "options": {
-          "users": {
-            "redhat": {
-              "key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC61wMCjOSHwbVb4VfVyl5sn497qW4PsdQ7Ty7aD6wDNZ/QjjULkDV/yW5WjDlDQ7UqFH0Sr7vywjqDizUAqK7zM5FsUKsUXWHWwg/ehKg8j9xKcMv11AkFoUoujtfAujnKODkk58XSA9whPr7qcw3vPrmog680pnMSzf9LC7J6kXfs6lkoKfBh9VnlxusCrw2yg0qI1fHAZBLPx7mW6+me71QZsS6sVz8v8KXyrXsKTdnF50FjzHcK9HXDBtSJS5wA3fkcRYymJe0o6WMWNdgSRVpoSiWaHHmFgdMUJaYoCfhXzyl7LtNb3Q+Sveg+tJK7JaRXBLMUllOlJ6ll5Hod"
-            }
+        },
+        {
+          "name": "org.osbuild.selinux",
+          "options": {
+            "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
           }
         }
-      },
-      {
-        "name": "org.osbuild.selinux",
+      ],
+      "assembler": {
+        "name": "org.osbuild.tar",
         "options": {
-          "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
+          "filename": "root.tar.xz",
+          "compression": "xz"
         }
-      }
-    ],
-    "assembler": {
-      "name": "org.osbuild.tar",
-      "options": {
-        "filename": "root.tar.xz",
-        "compression": "xz"
       }
     }
   }

--- a/test/cases/rhel82_groups.json
+++ b/test/cases/rhel82_groups.json
@@ -1,5 +1,5 @@
 {
-  "compose": {
+  "compose-request": {
     "output-format": "tar",
     "distro": "rhel-8.2",
     "arch": "x86_64",

--- a/test/cases/rhel82_groups.json
+++ b/test/cases/rhel82_groups.json
@@ -3,10 +3,6 @@
     "output-format": "tar",
     "distro": "rhel-8.2",
     "arch": "x86_64",
-    "checksums": {
-      "baseos": "sha256:3ce6f4ffa7d05b81fec2ba5a1c4917b351231c3433f2f5eed86ed5f8f97168a1",
-      "appstream": "sha256:662e1dc0e465dd5e8efec9f42ef24ac9fd8418294254c3c98ea0342d6e903aed"
-    },
     "filename": "root.tar.xz",
     "blueprint": {
       "groups": [
@@ -22,6 +18,12 @@
           }
         ]
       }
+    }
+  },
+  "rpmmd": {
+    "checksums": {
+      "baseos": "sha256:3ce6f4ffa7d05b81fec2ba5a1c4917b351231c3433f2f5eed86ed5f8f97168a1",
+      "appstream": "sha256:662e1dc0e465dd5e8efec9f42ef24ac9fd8418294254c3c98ea0342d6e903aed"
     }
   },
   "pipeline": {

--- a/test/cases/rhel82_openstack.json
+++ b/test/cases/rhel82_openstack.json
@@ -5,13 +5,15 @@
   "compose": {
     "distro": "rhel-8.2",
     "arch": "x86_64",
-    "checksums": {
-      "baseos": "sha256:3ce6f4ffa7d05b81fec2ba5a1c4917b351231c3433f2f5eed86ed5f8f97168a1",
-      "appstream": "sha256:662e1dc0e465dd5e8efec9f42ef24ac9fd8418294254c3c98ea0342d6e903aed"
-    },
     "filename": "disk.qcow2",
     "output-format": "openstack",
     "blueprint": {}
+  },
+  "rpmmd": {
+    "checksums": {
+      "baseos": "sha256:3ce6f4ffa7d05b81fec2ba5a1c4917b351231c3433f2f5eed86ed5f8f97168a1",
+      "appstream": "sha256:662e1dc0e465dd5e8efec9f42ef24ac9fd8418294254c3c98ea0342d6e903aed"
+    }
   },
   "pipeline": {
     "build": {

--- a/test/cases/rhel82_openstack.json
+++ b/test/cases/rhel82_openstack.json
@@ -2,7 +2,7 @@
   "boot": {
     "type": "qemu"
   },
-  "compose": {
+  "compose-request": {
     "distro": "rhel-8.2",
     "arch": "x86_64",
     "filename": "disk.qcow2",

--- a/test/cases/rhel82_openstack.json
+++ b/test/cases/rhel82_openstack.json
@@ -15,136 +15,139 @@
       "appstream": "sha256:662e1dc0e465dd5e8efec9f42ef24ac9fd8418294254c3c98ea0342d6e903aed"
     }
   },
-  "pipeline": {
-    "build": {
-      "pipeline": {
-        "stages": [
-          {
-            "name": "org.osbuild.dnf",
-            "options": {
-              "repos": [
-                {
-                  "baseurl": "http://download.devel.redhat.com/rhel-8/nightly/RHEL-8/latest-RHEL-8.2.0/compose/BaseOS/x86_64/os",
-                  "checksum": "sha256:3ce6f4ffa7d05b81fec2ba5a1c4917b351231c3433f2f5eed86ed5f8f97168a1"
-                },
-                {
-                  "baseurl": "http://download.devel.redhat.com/rhel-8/nightly/RHEL-8/latest-RHEL-8.2.0/compose/AppStream/x86_64/os",
-                  "checksum": "sha256:662e1dc0e465dd5e8efec9f42ef24ac9fd8418294254c3c98ea0342d6e903aed"
-                }
-              ],
-              "packages": [
-                "dnf",
-                "dosfstools",
-                "dracut-config-generic",
-                "e2fsprogs",
-                "glibc",
-                "grub2-pc",
-                "policycoreutils",
-                "python36",
-                "qemu-img",
-                "systemd",
-                "tar",
-                "xfsprogs"
-              ],
-              "releasever": "8",
-              "basearch": "x86_64",
-              "module_platform_id": "platform:el8"
+  "manifest": {
+    "sources": {},
+    "pipeline": {
+      "build": {
+        "pipeline": {
+          "stages": [
+            {
+              "name": "org.osbuild.dnf",
+              "options": {
+                "repos": [
+                  {
+                    "baseurl": "http://download.devel.redhat.com/rhel-8/nightly/RHEL-8/latest-RHEL-8.2.0/compose/BaseOS/x86_64/os",
+                    "checksum": "sha256:3ce6f4ffa7d05b81fec2ba5a1c4917b351231c3433f2f5eed86ed5f8f97168a1"
+                  },
+                  {
+                    "baseurl": "http://download.devel.redhat.com/rhel-8/nightly/RHEL-8/latest-RHEL-8.2.0/compose/AppStream/x86_64/os",
+                    "checksum": "sha256:662e1dc0e465dd5e8efec9f42ef24ac9fd8418294254c3c98ea0342d6e903aed"
+                  }
+                ],
+                "packages": [
+                  "dnf",
+                  "dosfstools",
+                  "dracut-config-generic",
+                  "e2fsprogs",
+                  "glibc",
+                  "grub2-pc",
+                  "policycoreutils",
+                  "python36",
+                  "qemu-img",
+                  "systemd",
+                  "tar",
+                  "xfsprogs"
+                ],
+                "releasever": "8",
+                "basearch": "x86_64",
+                "module_platform_id": "platform:el8"
+              }
             }
+          ]
+        },
+        "runner": "org.osbuild.rhel82"
+      },
+      "stages": [
+        {
+          "name": "org.osbuild.dnf",
+          "options": {
+            "repos": [
+              {
+                "baseurl": "http://download.devel.redhat.com/rhel-8/nightly/RHEL-8/latest-RHEL-8.2.0/compose/BaseOS/x86_64/os",
+                "checksum": "sha256:3ce6f4ffa7d05b81fec2ba5a1c4917b351231c3433f2f5eed86ed5f8f97168a1"
+              },
+              {
+                "baseurl": "http://download.devel.redhat.com/rhel-8/nightly/RHEL-8/latest-RHEL-8.2.0/compose/AppStream/x86_64/os",
+                "checksum": "sha256:662e1dc0e465dd5e8efec9f42ef24ac9fd8418294254c3c98ea0342d6e903aed"
+              }
+            ],
+            "packages": [
+              "@Core",
+              "cloud-init",
+              "dracut-config-generic",
+              "grub2-pc",
+              "kernel",
+              "langpacks-en",
+              "qemu-guest-agent",
+              "selinux-policy-targeted",
+              "spice-vdagent"
+            ],
+            "exclude_packages": [
+              "dracut-config-rescue"
+            ],
+            "releasever": "8",
+            "basearch": "x86_64",
+            "module_platform_id": "platform:el8"
           }
-        ]
-      },
-      "runner": "org.osbuild.rhel82"
-    },
-    "stages": [
-      {
-        "name": "org.osbuild.dnf",
-        "options": {
-          "repos": [
-            {
-              "baseurl": "http://download.devel.redhat.com/rhel-8/nightly/RHEL-8/latest-RHEL-8.2.0/compose/BaseOS/x86_64/os",
-              "checksum": "sha256:3ce6f4ffa7d05b81fec2ba5a1c4917b351231c3433f2f5eed86ed5f8f97168a1"
-            },
-            {
-              "baseurl": "http://download.devel.redhat.com/rhel-8/nightly/RHEL-8/latest-RHEL-8.2.0/compose/AppStream/x86_64/os",
-              "checksum": "sha256:662e1dc0e465dd5e8efec9f42ef24ac9fd8418294254c3c98ea0342d6e903aed"
-            }
-          ],
-          "packages": [
-            "@Core",
-            "cloud-init",
-            "dracut-config-generic",
-            "grub2-pc",
-            "kernel",
-            "langpacks-en",
-            "qemu-guest-agent",
-            "selinux-policy-targeted",
-            "spice-vdagent"
-          ],
-          "exclude_packages": [
-            "dracut-config-rescue"
-          ],
-          "releasever": "8",
-          "basearch": "x86_64",
-          "module_platform_id": "platform:el8"
+        },
+        {
+          "name": "org.osbuild.fix-bls",
+          "options": {}
+        },
+        {
+          "name": "org.osbuild.fstab",
+          "options": {
+            "filesystems": [
+              {
+                "uuid": "0bd700f8-090f-4556-b797-b340297ea1bd",
+                "vfs_type": "xfs",
+                "path": "/",
+                "options": "defaults"
+              }
+            ]
+          }
+        },
+        {
+          "name": "org.osbuild.grub2",
+          "options": {
+            "root_fs_uuid": "0bd700f8-090f-4556-b797-b340297ea1bd",
+            "kernel_opts": "ro net.ifnames=0",
+            "legacy": true
+          }
+        },
+        {
+          "name": "org.osbuild.locale",
+          "options": {
+            "language": "en_US"
+          }
+        },
+        {
+          "name": "org.osbuild.selinux",
+          "options": {
+            "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
+          }
         }
-      },
-      {
-        "name": "org.osbuild.fix-bls",
-        "options": {}
-      },
-      {
-        "name": "org.osbuild.fstab",
+      ],
+      "assembler": {
+        "name": "org.osbuild.qemu",
         "options": {
-          "filesystems": [
+          "format": "qcow2",
+          "filename": "disk.qcow2",
+          "size": 2147483648,
+          "ptuuid": "0x14fc63d2",
+          "pttype": "mbr",
+          "partitions": [
             {
-              "uuid": "0bd700f8-090f-4556-b797-b340297ea1bd",
-              "vfs_type": "xfs",
-              "path": "/",
-              "options": "defaults"
+              "start": 2048,
+              "bootable": true,
+              "filesystem": {
+                "type": "xfs",
+                "uuid": "0bd700f8-090f-4556-b797-b340297ea1bd",
+                "mountpoint": "/"
+              }
             }
           ]
         }
-      },
-      {
-        "name": "org.osbuild.grub2",
-        "options": {
-          "root_fs_uuid": "0bd700f8-090f-4556-b797-b340297ea1bd",
-          "kernel_opts": "ro net.ifnames=0",
-          "legacy": true
-        }
-      },
-      {
-        "name": "org.osbuild.locale",
-        "options": {
-          "language": "en_US"
-        }
-      },
-      {
-        "name": "org.osbuild.selinux",
-        "options": {
-          "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
-        }
-      }
-    ],
-    "assembler": {
-      "name": "org.osbuild.qemu",
-      "options": {
-        "format": "qcow2",
-        "filename": "disk.qcow2",
-        "size": 2147483648,
-        "ptuuid": "0x14fc63d2",
-        "pttype": "mbr",
-        "partitions": [
-          {
-            "start": 2048,
-            "bootable": true,
-            "filesystem": {
-              "type": "xfs",
-              "uuid": "0bd700f8-090f-4556-b797-b340297ea1bd",
-              "mountpoint": "/"
-            }
-          }
-        ]
       }
     }
   },

--- a/test/cases/rhel82_partitioned_disk.json
+++ b/test/cases/rhel82_partitioned_disk.json
@@ -21,147 +21,149 @@
       "appstream": "sha256:662e1dc0e465dd5e8efec9f42ef24ac9fd8418294254c3c98ea0342d6e903aed"
     }
   },
-  "pipeline": {
-    "build": {
-      "pipeline": {
-        "stages": [
-          {
-            "name": "org.osbuild.dnf",
-            "options": {
-              "repos": [
-                {
-                  "baseurl": "http://download.devel.redhat.com/rhel-8/nightly/RHEL-8/latest-RHEL-8.2.0/compose/BaseOS/x86_64/os",
-                  "checksum": "sha256:3ce6f4ffa7d05b81fec2ba5a1c4917b351231c3433f2f5eed86ed5f8f97168a1"
-                },
-                {
-                  "baseurl": "http://download.devel.redhat.com/rhel-8/nightly/RHEL-8/latest-RHEL-8.2.0/compose/AppStream/x86_64/os",
-                  "checksum": "sha256:662e1dc0e465dd5e8efec9f42ef24ac9fd8418294254c3c98ea0342d6e903aed"
-                }
-              ],
-              "packages": [
-                "dnf",
-                "dosfstools",
-                "dracut-config-generic",
-                "e2fsprogs",
-                "glibc",
-                "grub2-pc",
-                "policycoreutils",
-                "python36",
-                "qemu-img",
-                "systemd",
-                "tar",
-                "xfsprogs"
-              ],
-              "releasever": "8",
-              "basearch": "x86_64",
-              "module_platform_id": "platform:el8"
+  "manifest": {
+    "sources": {},
+    "pipeline": {
+      "build": {
+        "pipeline": {
+          "stages": [
+            {
+              "name": "org.osbuild.dnf",
+              "options": {
+                "repos": [
+                  {
+                    "baseurl": "http://download.devel.redhat.com/rhel-8/nightly/RHEL-8/latest-RHEL-8.2.0/compose/BaseOS/x86_64/os",
+                    "checksum": "sha256:3ce6f4ffa7d05b81fec2ba5a1c4917b351231c3433f2f5eed86ed5f8f97168a1"
+                  },
+                  {
+                    "baseurl": "http://download.devel.redhat.com/rhel-8/nightly/RHEL-8/latest-RHEL-8.2.0/compose/AppStream/x86_64/os",
+                    "checksum": "sha256:662e1dc0e465dd5e8efec9f42ef24ac9fd8418294254c3c98ea0342d6e903aed"
+                  }
+                ],
+                "packages": [
+                  "dnf",
+                  "dosfstools",
+                  "dracut-config-generic",
+                  "e2fsprogs",
+                  "glibc",
+                  "grub2-pc",
+                  "policycoreutils",
+                  "python36",
+                  "qemu-img",
+                  "systemd",
+                  "tar",
+                  "xfsprogs"
+                ],
+                "releasever": "8",
+                "basearch": "x86_64",
+                "module_platform_id": "platform:el8"
+              }
+            }
+          ]
+        },
+        "runner": "org.osbuild.rhel82"
+      },
+      "stages": [
+        {
+          "name": "org.osbuild.dnf",
+          "options": {
+            "repos": [
+              {
+                "baseurl": "http://download.devel.redhat.com/rhel-8/nightly/RHEL-8/latest-RHEL-8.2.0/compose/BaseOS/x86_64/os",
+                "checksum": "sha256:3ce6f4ffa7d05b81fec2ba5a1c4917b351231c3433f2f5eed86ed5f8f97168a1"
+              },
+              {
+                "baseurl": "http://download.devel.redhat.com/rhel-8/nightly/RHEL-8/latest-RHEL-8.2.0/compose/AppStream/x86_64/os",
+                "checksum": "sha256:662e1dc0e465dd5e8efec9f42ef24ac9fd8418294254c3c98ea0342d6e903aed"
+              }
+            ],
+            "packages": [
+              "@core",
+              "chrony",
+              "dracut-config-generic",
+              "firewalld",
+              "grub2-pc",
+              "kernel",
+              "langpacks-en",
+              "selinux-policy-targeted"
+            ],
+            "exclude_packages": [
+              "dracut-config-rescue",
+              "timedatex"
+            ],
+            "releasever": "8",
+            "basearch": "x86_64",
+            "module_platform_id": "platform:el8"
+          }
+        },
+        {
+          "name": "org.osbuild.fix-bls",
+          "options": {}
+        },
+        {
+          "name": "org.osbuild.fstab",
+          "options": {
+            "filesystems": [
+              {
+                "uuid": "0bd700f8-090f-4556-b797-b340297ea1bd",
+                "vfs_type": "xfs",
+                "path": "/",
+                "options": "defaults"
+              }
+            ]
+          }
+        },
+        {
+          "name": "org.osbuild.grub2",
+          "options": {
+            "root_fs_uuid": "0bd700f8-090f-4556-b797-b340297ea1bd",
+            "kernel_opts": "ro net.ifnames=0",
+            "legacy": true
+          }
+        },
+        {
+          "name": "org.osbuild.locale",
+          "options": {
+            "language": "en_US"
+          }
+        },
+        {
+          "name": "org.osbuild.users",
+          "options": {
+            "users": {
+              "redhat": {
+                "key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC61wMCjOSHwbVb4VfVyl5sn497qW4PsdQ7Ty7aD6wDNZ/QjjULkDV/yW5WjDlDQ7UqFH0Sr7vywjqDizUAqK7zM5FsUKsUXWHWwg/ehKg8j9xKcMv11AkFoUoujtfAujnKODkk58XSA9whPr7qcw3vPrmog680pnMSzf9LC7J6kXfs6lkoKfBh9VnlxusCrw2yg0qI1fHAZBLPx7mW6+me71QZsS6sVz8v8KXyrXsKTdnF50FjzHcK9HXDBtSJS5wA3fkcRYymJe0o6WMWNdgSRVpoSiWaHHmFgdMUJaYoCfhXzyl7LtNb3Q+Sveg+tJK7JaRXBLMUllOlJ6ll5Hod"
+              }
             }
           }
-        ]
-      },
-      "runner": "org.osbuild.rhel82"
-    },
-    "stages": [
-      {
-        "name": "org.osbuild.dnf",
-        "options": {
-          "repos": [
-            {
-              "baseurl": "http://download.devel.redhat.com/rhel-8/nightly/RHEL-8/latest-RHEL-8.2.0/compose/BaseOS/x86_64/os",
-              "checksum": "sha256:3ce6f4ffa7d05b81fec2ba5a1c4917b351231c3433f2f5eed86ed5f8f97168a1"
-            },
-            {
-              "baseurl": "http://download.devel.redhat.com/rhel-8/nightly/RHEL-8/latest-RHEL-8.2.0/compose/AppStream/x86_64/os",
-              "checksum": "sha256:662e1dc0e465dd5e8efec9f42ef24ac9fd8418294254c3c98ea0342d6e903aed"
-            }
-          ],
-          "packages": [
-            "@core",
-            "chrony",
-            "dracut-config-generic",
-            "firewalld",
-            "grub2-pc",
-            "kernel",
-            "langpacks-en",
-            "selinux-policy-targeted"
-          ],
-          "exclude_packages": [
-            "dracut-config-rescue",
-            "timedatex"
-          ],
-          "releasever": "8",
-          "basearch": "x86_64",
-          "module_platform_id": "platform:el8"
+        },
+        {
+          "name": "org.osbuild.selinux",
+          "options": {
+            "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
+          }
         }
-      },
-      {
-        "name": "org.osbuild.fix-bls",
-        "options": {}
-      },
-      {
-        "name": "org.osbuild.fstab",
+      ],
+      "assembler": {
+        "name": "org.osbuild.qemu",
         "options": {
-          "filesystems": [
+          "format": "raw",
+          "filename": "disk.img",
+          "ptuuid": "0x14fc63d2",
+          "size": 2147483648,
+          "pttype": "mbr",
+          "partitions": [
             {
-              "uuid": "0bd700f8-090f-4556-b797-b340297ea1bd",
-              "vfs_type": "xfs",
-              "path": "/",
-              "options": "defaults"
+              "start": 2048,
+              "bootable": true,
+              "filesystem": {
+                "type": "xfs",
+                "uuid": "0bd700f8-090f-4556-b797-b340297ea1bd",
+                "mountpoint": "/"
+              }
             }
           ]
         }
-      },
-      {
-        "name": "org.osbuild.grub2",
-        "options": {
-          "root_fs_uuid": "0bd700f8-090f-4556-b797-b340297ea1bd",
-          "kernel_opts": "ro net.ifnames=0",
-          "legacy": true
-        }
-      },
-      {
-        "name": "org.osbuild.locale",
-        "options": {
-          "language": "en_US"
-        }
-      },
-      {
-        "name": "org.osbuild.users",
-        "options": {
-          "users": {
-            "redhat": {
-              "key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC61wMCjOSHwbVb4VfVyl5sn497qW4PsdQ7Ty7aD6wDNZ/QjjULkDV/yW5WjDlDQ7UqFH0Sr7vywjqDizUAqK7zM5FsUKsUXWHWwg/ehKg8j9xKcMv11AkFoUoujtfAujnKODkk58XSA9whPr7qcw3vPrmog680pnMSzf9LC7J6kXfs6lkoKfBh9VnlxusCrw2yg0qI1fHAZBLPx7mW6+me71QZsS6sVz8v8KXyrXsKTdnF50FjzHcK9HXDBtSJS5wA3fkcRYymJe0o6WMWNdgSRVpoSiWaHHmFgdMUJaYoCfhXzyl7LtNb3Q+Sveg+tJK7JaRXBLMUllOlJ6ll5Hod"
-            }
-          }
-        }
-      },
-      {
-        "name": "org.osbuild.selinux",
-        "options": {
-          "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
-        }
-      }
-    ],
-    "assembler": {
-      "name": "org.osbuild.qemu",
-      "options": {
-        "format": "raw",
-        "filename": "disk.img",
-        "ptuuid": "0x14fc63d2",
-        "size": 2147483648,
-        "ptuuid": "0x14fc63d2",
-        "pttype": "mbr",
-        "partitions": [
-          {
-            "start": 2048,
-            "bootable": true,
-            "filesystem": {
-              "type": "xfs",
-              "uuid": "0bd700f8-090f-4556-b797-b340297ea1bd",
-              "mountpoint": "/"
-            }
-          }
-        ]
       }
     }
   }

--- a/test/cases/rhel82_partitioned_disk.json
+++ b/test/cases/rhel82_partitioned_disk.json
@@ -2,10 +2,6 @@
   "compose": {
     "distro": "rhel-8.2",
     "arch": "x86_64",
-    "checksums": {
-      "baseos": "sha256:3ce6f4ffa7d05b81fec2ba5a1c4917b351231c3433f2f5eed86ed5f8f97168a1",
-      "appstream": "sha256:662e1dc0e465dd5e8efec9f42ef24ac9fd8418294254c3c98ea0342d6e903aed"
-    },
     "filename": "disk.img",
     "output-format": "partitioned-disk",
     "blueprint": {
@@ -17,6 +13,12 @@
           }
         ]
       }
+    }
+  },
+  "rpmmd": {
+    "checksums": {
+      "baseos": "sha256:3ce6f4ffa7d05b81fec2ba5a1c4917b351231c3433f2f5eed86ed5f8f97168a1",
+      "appstream": "sha256:662e1dc0e465dd5e8efec9f42ef24ac9fd8418294254c3c98ea0342d6e903aed"
     }
   },
   "pipeline": {

--- a/test/cases/rhel82_partitioned_disk.json
+++ b/test/cases/rhel82_partitioned_disk.json
@@ -1,5 +1,5 @@
 {
-  "compose": {
+  "compose-request": {
     "distro": "rhel-8.2",
     "arch": "x86_64",
     "filename": "disk.img",

--- a/test/cases/rhel82_qcow2.json
+++ b/test/cases/rhel82_qcow2.json
@@ -15,192 +15,195 @@
       "appstream": "sha256:662e1dc0e465dd5e8efec9f42ef24ac9fd8418294254c3c98ea0342d6e903aed"
     }
   },
-  "pipeline": {
-    "build": {
-      "pipeline": {
-        "stages": [
-          {
-            "name": "org.osbuild.dnf",
-            "options": {
-              "repos": [
-                {
-                  "baseurl": "http://download.devel.redhat.com/rhel-8/nightly/RHEL-8/latest-RHEL-8.2.0/compose/BaseOS/x86_64/os",
-                  "checksum": "sha256:3ce6f4ffa7d05b81fec2ba5a1c4917b351231c3433f2f5eed86ed5f8f97168a1"
-                },
-                {
-                  "baseurl": "http://download.devel.redhat.com/rhel-8/nightly/RHEL-8/latest-RHEL-8.2.0/compose/AppStream/x86_64/os",
-                  "checksum": "sha256:662e1dc0e465dd5e8efec9f42ef24ac9fd8418294254c3c98ea0342d6e903aed"
-                }
-              ],
-              "packages": [
-                "dnf",
-                "dosfstools",
-                "dracut-config-generic",
-                "e2fsprogs",
-                "glibc",
-                "grub2-pc",
-                "policycoreutils",
-                "python36",
-                "qemu-img",
-                "systemd",
-                "tar",
-                "xfsprogs"
-              ],
-              "releasever": "8",
-              "basearch": "x86_64",
-              "module_platform_id": "platform:el8"
+  "manifest": {
+    "sources": {},
+    "pipeline": {
+      "build": {
+        "pipeline": {
+          "stages": [
+            {
+              "name": "org.osbuild.dnf",
+              "options": {
+                "repos": [
+                  {
+                    "baseurl": "http://download.devel.redhat.com/rhel-8/nightly/RHEL-8/latest-RHEL-8.2.0/compose/BaseOS/x86_64/os",
+                    "checksum": "sha256:3ce6f4ffa7d05b81fec2ba5a1c4917b351231c3433f2f5eed86ed5f8f97168a1"
+                  },
+                  {
+                    "baseurl": "http://download.devel.redhat.com/rhel-8/nightly/RHEL-8/latest-RHEL-8.2.0/compose/AppStream/x86_64/os",
+                    "checksum": "sha256:662e1dc0e465dd5e8efec9f42ef24ac9fd8418294254c3c98ea0342d6e903aed"
+                  }
+                ],
+                "packages": [
+                  "dnf",
+                  "dosfstools",
+                  "dracut-config-generic",
+                  "e2fsprogs",
+                  "glibc",
+                  "grub2-pc",
+                  "policycoreutils",
+                  "python36",
+                  "qemu-img",
+                  "systemd",
+                  "tar",
+                  "xfsprogs"
+                ],
+                "releasever": "8",
+                "basearch": "x86_64",
+                "module_platform_id": "platform:el8"
+              }
             }
+          ]
+        },
+        "runner": "org.osbuild.rhel82"
+      },
+      "stages": [
+        {
+          "name": "org.osbuild.dnf",
+          "options": {
+            "repos": [
+              {
+                "baseurl": "http://download.devel.redhat.com/rhel-8/nightly/RHEL-8/latest-RHEL-8.2.0/compose/BaseOS/x86_64/os",
+                "checksum": "sha256:3ce6f4ffa7d05b81fec2ba5a1c4917b351231c3433f2f5eed86ed5f8f97168a1"
+              },
+              {
+                "baseurl": "http://download.devel.redhat.com/rhel-8/nightly/RHEL-8/latest-RHEL-8.2.0/compose/AppStream/x86_64/os",
+                "checksum": "sha256:662e1dc0e465dd5e8efec9f42ef24ac9fd8418294254c3c98ea0342d6e903aed"
+              }
+            ],
+            "packages": [
+              "@core",
+              "NetworkManager",
+              "chrony",
+              "cloud-init",
+              "cloud-utils-growpart",
+              "cockpit-system",
+              "cockpit-ws",
+              "dhcp-client",
+              "dnf",
+              "dnf-plugin-spacewalk",
+              "dnf-utils",
+              "dracut-config-generic",
+              "dracut-norescue",
+              "grub2-pc",
+              "insights-client",
+              "kernel",
+              "nfs-utils",
+              "python3-jsonschema",
+              "qemu-guest-agent",
+              "redhat-release",
+              "redhat-release-eula",
+              "rhn-client-tools",
+              "rhn-setup",
+              "rhnlib",
+              "rhnsd",
+              "rng-tools",
+              "rsync",
+              "subscription-manager-cockpit",
+              "tar",
+              "tcpdump",
+              "yum"
+            ],
+            "exclude_packages": [
+              "aic94xx-firmware",
+              "alsa-firmware",
+              "alsa-lib",
+              "alsa-tools-firmware",
+              "biosdevname",
+              "dracut-config-rescue",
+              "fedora-release",
+              "fedora-repos",
+              "firewalld",
+              "iprutils",
+              "ivtv-firmware",
+              "iwl100-firmware",
+              "iwl1000-firmware",
+              "iwl105-firmware",
+              "iwl135-firmware",
+              "iwl2000-firmware",
+              "iwl2030-firmware",
+              "iwl3160-firmware",
+              "iwl3945-firmware",
+              "iwl4965-firmware",
+              "iwl5000-firmware",
+              "iwl5150-firmware",
+              "iwl6000-firmware",
+              "iwl6000g2a-firmware",
+              "iwl6000g2b-firmware",
+              "iwl6050-firmware",
+              "iwl7260-firmware",
+              "langpacks-*",
+              "langpacks-en",
+              "langpacks-en",
+              "libertas-sd8686-firmware",
+              "libertas-sd8787-firmware",
+              "libertas-usb8388-firmware",
+              "plymouth",
+              "timedatex"
+            ],
+            "releasever": "8",
+            "basearch": "x86_64",
+            "module_platform_id": "platform:el8"
           }
-        ]
-      },
-      "runner": "org.osbuild.rhel82"
-    },
-    "stages": [
-      {
-        "name": "org.osbuild.dnf",
-        "options": {
-          "repos": [
-            {
-              "baseurl": "http://download.devel.redhat.com/rhel-8/nightly/RHEL-8/latest-RHEL-8.2.0/compose/BaseOS/x86_64/os",
-              "checksum": "sha256:3ce6f4ffa7d05b81fec2ba5a1c4917b351231c3433f2f5eed86ed5f8f97168a1"
-            },
-            {
-              "baseurl": "http://download.devel.redhat.com/rhel-8/nightly/RHEL-8/latest-RHEL-8.2.0/compose/AppStream/x86_64/os",
-              "checksum": "sha256:662e1dc0e465dd5e8efec9f42ef24ac9fd8418294254c3c98ea0342d6e903aed"
-            }
-          ],
-          "packages": [
-            "@core",
-            "NetworkManager",
-            "chrony",
-            "cloud-init",
-            "cloud-utils-growpart",
-            "cockpit-system",
-            "cockpit-ws",
-            "dhcp-client",
-            "dnf",
-            "dnf-plugin-spacewalk",
-            "dnf-utils",
-            "dracut-config-generic",
-            "dracut-norescue",
-            "grub2-pc",
-            "insights-client",
-            "kernel",
-            "nfs-utils",
-            "python3-jsonschema",
-            "qemu-guest-agent",
-            "redhat-release",
-            "redhat-release-eula",
-            "rhn-client-tools",
-            "rhn-setup",
-            "rhnlib",
-            "rhnsd",
-            "rng-tools",
-            "rsync",
-            "subscription-manager-cockpit",
-            "tar",
-            "tcpdump",
-            "yum"
-          ],
-          "exclude_packages": [
-            "aic94xx-firmware",
-            "alsa-firmware",
-            "alsa-lib",
-            "alsa-tools-firmware",
-            "biosdevname",
-            "dracut-config-rescue",
-            "fedora-release",
-            "fedora-repos",
-            "firewalld",
-            "iprutils",
-            "ivtv-firmware",
-            "iwl100-firmware",
-            "iwl1000-firmware",
-            "iwl105-firmware",
-            "iwl135-firmware",
-            "iwl2000-firmware",
-            "iwl2030-firmware",
-            "iwl3160-firmware",
-            "iwl3945-firmware",
-            "iwl4965-firmware",
-            "iwl5000-firmware",
-            "iwl5150-firmware",
-            "iwl6000-firmware",
-            "iwl6000g2a-firmware",
-            "iwl6000g2b-firmware",
-            "iwl6050-firmware",
-            "iwl7260-firmware",
-            "langpacks-*",
-            "langpacks-en",
-            "langpacks-en",
-            "libertas-sd8686-firmware",
-            "libertas-sd8787-firmware",
-            "libertas-usb8388-firmware",
-            "plymouth",
-            "timedatex"
-          ],
-          "releasever": "8",
-          "basearch": "x86_64",
-          "module_platform_id": "platform:el8"
+        },
+        {
+          "name": "org.osbuild.fix-bls",
+          "options": {}
+        },
+        {
+          "name": "org.osbuild.fstab",
+          "options": {
+            "filesystems": [
+              {
+                "uuid": "0bd700f8-090f-4556-b797-b340297ea1bd",
+                "vfs_type": "xfs",
+                "path": "/",
+                "options": "defaults"
+              }
+            ]
+          }
+        },
+        {
+          "name": "org.osbuild.grub2",
+          "options": {
+            "root_fs_uuid": "0bd700f8-090f-4556-b797-b340297ea1bd",
+            "kernel_opts": "console=ttyS0 console=ttyS0,115200n8 no_timer_check crashkernel=auto net.ifnames=0",
+            "legacy": true
+          }
+        },
+        {
+          "name": "org.osbuild.locale",
+          "options": {
+            "language": "en_US"
+          }
+        },
+        {
+          "name": "org.osbuild.selinux",
+          "options": {
+            "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
+          }
         }
-      },
-      {
-        "name": "org.osbuild.fix-bls",
-        "options": {}
-      },
-      {
-        "name": "org.osbuild.fstab",
+      ],
+      "assembler": {
+        "name": "org.osbuild.qemu",
         "options": {
-          "filesystems": [
+          "format": "qcow2",
+          "filename": "disk.qcow2",
+          "size": 2147483648,
+          "ptuuid": "0x14fc63d2",
+          "pttype": "mbr",
+          "partitions": [
             {
-              "uuid": "0bd700f8-090f-4556-b797-b340297ea1bd",
-              "vfs_type": "xfs",
-              "path": "/",
-              "options": "defaults"
+              "start": 2048,
+              "bootable": true,
+              "filesystem": {
+                "type": "xfs",
+                "uuid": "0bd700f8-090f-4556-b797-b340297ea1bd",
+                "mountpoint": "/"
+              }
             }
           ]
         }
-      },
-      {
-        "name": "org.osbuild.grub2",
-        "options": {
-          "root_fs_uuid": "0bd700f8-090f-4556-b797-b340297ea1bd",
-          "kernel_opts": "console=ttyS0 console=ttyS0,115200n8 no_timer_check crashkernel=auto net.ifnames=0",
-          "legacy": true
-        }
-      },
-      {
-        "name": "org.osbuild.locale",
-        "options": {
-          "language": "en_US"
-        }
-      },
-      {
-        "name": "org.osbuild.selinux",
-        "options": {
-          "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
-        }
-      }
-    ],
-    "assembler": {
-      "name": "org.osbuild.qemu",
-      "options": {
-        "format": "qcow2",
-        "filename": "disk.qcow2",
-        "size": 2147483648,
-        "ptuuid": "0x14fc63d2",
-        "pttype": "mbr",
-        "partitions": [
-          {
-            "start": 2048,
-            "bootable": true,
-            "filesystem": {
-              "type": "xfs",
-              "uuid": "0bd700f8-090f-4556-b797-b340297ea1bd",
-              "mountpoint": "/"
-            }
-          }
-        ]
       }
     }
   },

--- a/test/cases/rhel82_qcow2.json
+++ b/test/cases/rhel82_qcow2.json
@@ -2,7 +2,7 @@
   "boot": {
     "type": "qemu"
   },
-  "compose": {
+  "compose-request": {
     "distro": "rhel-8.2",
     "arch": "x86_64",
     "filename": "disk.qcow2",

--- a/test/cases/rhel82_qcow2.json
+++ b/test/cases/rhel82_qcow2.json
@@ -5,13 +5,15 @@
   "compose": {
     "distro": "rhel-8.2",
     "arch": "x86_64",
-    "checksums": {
-      "baseos": "sha256:3ce6f4ffa7d05b81fec2ba5a1c4917b351231c3433f2f5eed86ed5f8f97168a1",
-      "appstream": "sha256:662e1dc0e465dd5e8efec9f42ef24ac9fd8418294254c3c98ea0342d6e903aed"
-    },
     "filename": "disk.qcow2",
     "output-format": "qcow2",
     "blueprint": {}
+  },
+  "rpmmd": {
+    "checksums": {
+      "baseos": "sha256:3ce6f4ffa7d05b81fec2ba5a1c4917b351231c3433f2f5eed86ed5f8f97168a1",
+      "appstream": "sha256:662e1dc0e465dd5e8efec9f42ef24ac9fd8418294254c3c98ea0342d6e903aed"
+    }
   },
   "pipeline": {
     "build": {

--- a/test/cases/rhel82_tar.json
+++ b/test/cases/rhel82_tar.json
@@ -1,5 +1,5 @@
 {
-  "compose": {
+  "compose-request": {
     "output-format": "tar",
     "distro": "rhel-8.2",
     "arch": "x86_64",

--- a/test/cases/rhel82_tar.json
+++ b/test/cases/rhel82_tar.json
@@ -21,118 +21,121 @@
       "appstream": "sha256:662e1dc0e465dd5e8efec9f42ef24ac9fd8418294254c3c98ea0342d6e903aed"
     }
   },
-  "pipeline": {
-    "build": {
-      "pipeline": {
-        "stages": [
-          {
-            "name": "org.osbuild.dnf",
-            "options": {
-              "repos": [
-                {
-                  "baseurl": "http://download.devel.redhat.com/rhel-8/nightly/RHEL-8/latest-RHEL-8.2.0/compose/BaseOS/x86_64/os",
-                  "checksum": "sha256:3ce6f4ffa7d05b81fec2ba5a1c4917b351231c3433f2f5eed86ed5f8f97168a1"
-                },
-                {
-                  "baseurl": "http://download.devel.redhat.com/rhel-8/nightly/RHEL-8/latest-RHEL-8.2.0/compose/AppStream/x86_64/os",
-                  "checksum": "sha256:662e1dc0e465dd5e8efec9f42ef24ac9fd8418294254c3c98ea0342d6e903aed"
-                }
-              ],
-              "packages": [
-                "dnf",
-                "dosfstools",
-                "dracut-config-generic",
-                "e2fsprogs",
-                "glibc",
-                "grub2-pc",
-                "policycoreutils",
-                "python36",
-                "qemu-img",
-                "systemd",
-                "tar",
-                "xfsprogs"
-              ],
-              "releasever": "8",
-              "basearch": "x86_64",
-              "module_platform_id": "platform:el8"
+  "manifest": {
+    "sources": {},
+    "pipeline": {
+      "build": {
+        "pipeline": {
+          "stages": [
+            {
+              "name": "org.osbuild.dnf",
+              "options": {
+                "repos": [
+                  {
+                    "baseurl": "http://download.devel.redhat.com/rhel-8/nightly/RHEL-8/latest-RHEL-8.2.0/compose/BaseOS/x86_64/os",
+                    "checksum": "sha256:3ce6f4ffa7d05b81fec2ba5a1c4917b351231c3433f2f5eed86ed5f8f97168a1"
+                  },
+                  {
+                    "baseurl": "http://download.devel.redhat.com/rhel-8/nightly/RHEL-8/latest-RHEL-8.2.0/compose/AppStream/x86_64/os",
+                    "checksum": "sha256:662e1dc0e465dd5e8efec9f42ef24ac9fd8418294254c3c98ea0342d6e903aed"
+                  }
+                ],
+                "packages": [
+                  "dnf",
+                  "dosfstools",
+                  "dracut-config-generic",
+                  "e2fsprogs",
+                  "glibc",
+                  "grub2-pc",
+                  "policycoreutils",
+                  "python36",
+                  "qemu-img",
+                  "systemd",
+                  "tar",
+                  "xfsprogs"
+                ],
+                "releasever": "8",
+                "basearch": "x86_64",
+                "module_platform_id": "platform:el8"
+              }
+            }
+          ]
+        },
+        "runner": "org.osbuild.rhel82"
+      },
+      "stages": [
+        {
+          "name": "org.osbuild.dnf",
+          "options": {
+            "repos": [
+              {
+                "baseurl": "http://download.devel.redhat.com/rhel-8/nightly/RHEL-8/latest-RHEL-8.2.0/compose/BaseOS/x86_64/os",
+                "checksum": "sha256:3ce6f4ffa7d05b81fec2ba5a1c4917b351231c3433f2f5eed86ed5f8f97168a1"
+              },
+              {
+                "baseurl": "http://download.devel.redhat.com/rhel-8/nightly/RHEL-8/latest-RHEL-8.2.0/compose/AppStream/x86_64/os",
+                "checksum": "sha256:662e1dc0e465dd5e8efec9f42ef24ac9fd8418294254c3c98ea0342d6e903aed"
+              }
+            ],
+            "packages": [
+              "chrony",
+              "dracut-config-generic",
+              "firewalld",
+              "kernel",
+              "langpacks-en",
+              "policycoreutils",
+              "selinux-policy-targeted"
+            ],
+            "exclude_packages": [
+              "dracut-config-rescue",
+              "timedatex"
+            ],
+            "releasever": "8",
+            "basearch": "x86_64",
+            "module_platform_id": "platform:el8"
+          }
+        },
+        {
+          "name": "org.osbuild.fix-bls",
+          "options": {}
+        },
+        {
+          "name": "org.osbuild.grub2",
+          "options": {
+            "root_fs_uuid": "0bd700f8-090f-4556-b797-b340297ea1bd",
+            "kernel_opts": "ro net.ifnames=0",
+            "legacy": true
+          }
+        },
+        {
+          "name": "org.osbuild.locale",
+          "options": {
+            "language": "en_US"
+          }
+        },
+        {
+          "name": "org.osbuild.users",
+          "options": {
+            "users": {
+              "redhat": {
+                "key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC61wMCjOSHwbVb4VfVyl5sn497qW4PsdQ7Ty7aD6wDNZ/QjjULkDV/yW5WjDlDQ7UqFH0Sr7vywjqDizUAqK7zM5FsUKsUXWHWwg/ehKg8j9xKcMv11AkFoUoujtfAujnKODkk58XSA9whPr7qcw3vPrmog680pnMSzf9LC7J6kXfs6lkoKfBh9VnlxusCrw2yg0qI1fHAZBLPx7mW6+me71QZsS6sVz8v8KXyrXsKTdnF50FjzHcK9HXDBtSJS5wA3fkcRYymJe0o6WMWNdgSRVpoSiWaHHmFgdMUJaYoCfhXzyl7LtNb3Q+Sveg+tJK7JaRXBLMUllOlJ6ll5Hod"
+              }
             }
           }
-        ]
-      },
-      "runner": "org.osbuild.rhel82"
-    },
-    "stages": [
-      {
-        "name": "org.osbuild.dnf",
-        "options": {
-          "repos": [
-            {
-              "baseurl": "http://download.devel.redhat.com/rhel-8/nightly/RHEL-8/latest-RHEL-8.2.0/compose/BaseOS/x86_64/os",
-              "checksum": "sha256:3ce6f4ffa7d05b81fec2ba5a1c4917b351231c3433f2f5eed86ed5f8f97168a1"
-            },
-            {
-              "baseurl": "http://download.devel.redhat.com/rhel-8/nightly/RHEL-8/latest-RHEL-8.2.0/compose/AppStream/x86_64/os",
-              "checksum": "sha256:662e1dc0e465dd5e8efec9f42ef24ac9fd8418294254c3c98ea0342d6e903aed"
-            }
-          ],
-          "packages": [
-            "chrony",
-            "dracut-config-generic",
-            "firewalld",
-            "kernel",
-            "langpacks-en",
-            "policycoreutils",
-            "selinux-policy-targeted"
-          ],
-          "exclude_packages": [
-            "dracut-config-rescue",
-            "timedatex"
-          ],
-          "releasever": "8",
-          "basearch": "x86_64",
-          "module_platform_id": "platform:el8"
-        }
-      },
-      {
-        "name": "org.osbuild.fix-bls",
-        "options": {}
-      },
-      {
-        "name": "org.osbuild.grub2",
-        "options": {
-          "root_fs_uuid": "0bd700f8-090f-4556-b797-b340297ea1bd",
-          "kernel_opts": "ro net.ifnames=0",
-          "legacy": true
-        }
-      },
-      {
-        "name": "org.osbuild.locale",
-        "options": {
-          "language": "en_US"
-        }
-      },
-      {
-        "name": "org.osbuild.users",
-        "options": {
-          "users": {
-            "redhat": {
-              "key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC61wMCjOSHwbVb4VfVyl5sn497qW4PsdQ7Ty7aD6wDNZ/QjjULkDV/yW5WjDlDQ7UqFH0Sr7vywjqDizUAqK7zM5FsUKsUXWHWwg/ehKg8j9xKcMv11AkFoUoujtfAujnKODkk58XSA9whPr7qcw3vPrmog680pnMSzf9LC7J6kXfs6lkoKfBh9VnlxusCrw2yg0qI1fHAZBLPx7mW6+me71QZsS6sVz8v8KXyrXsKTdnF50FjzHcK9HXDBtSJS5wA3fkcRYymJe0o6WMWNdgSRVpoSiWaHHmFgdMUJaYoCfhXzyl7LtNb3Q+Sveg+tJK7JaRXBLMUllOlJ6ll5Hod"
-            }
+        },
+        {
+          "name": "org.osbuild.selinux",
+          "options": {
+            "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
           }
         }
-      },
-      {
-        "name": "org.osbuild.selinux",
+      ],
+      "assembler": {
+        "name": "org.osbuild.tar",
         "options": {
-          "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
+          "filename": "root.tar.xz",
+          "compression": "xz"
         }
-      }
-    ],
-    "assembler": {
-      "name": "org.osbuild.tar",
-      "options": {
-        "filename": "root.tar.xz",
-        "compression": "xz"
       }
     }
   }

--- a/test/cases/rhel82_tar.json
+++ b/test/cases/rhel82_tar.json
@@ -3,10 +3,6 @@
     "output-format": "tar",
     "distro": "rhel-8.2",
     "arch": "x86_64",
-    "checksums": {
-      "baseos": "sha256:3ce6f4ffa7d05b81fec2ba5a1c4917b351231c3433f2f5eed86ed5f8f97168a1",
-      "appstream": "sha256:662e1dc0e465dd5e8efec9f42ef24ac9fd8418294254c3c98ea0342d6e903aed"
-    },
     "filename": "root.tar.xz",
     "blueprint": {
       "customizations": {
@@ -17,6 +13,12 @@
           }
         ]
       }
+    }
+  },
+  "rpmmd": {
+    "checksums": {
+      "baseos": "sha256:3ce6f4ffa7d05b81fec2ba5a1c4917b351231c3433f2f5eed86ed5f8f97168a1",
+      "appstream": "sha256:662e1dc0e465dd5e8efec9f42ef24ac9fd8418294254c3c98ea0342d6e903aed"
     }
   },
   "pipeline": {

--- a/test/cases/rhel82_vhd.json
+++ b/test/cases/rhel82_vhd.json
@@ -5,13 +5,15 @@
   "compose": {
     "distro": "rhel-8.2",
     "arch": "x86_64",
-    "checksums": {
-      "baseos": "sha256:3ce6f4ffa7d05b81fec2ba5a1c4917b351231c3433f2f5eed86ed5f8f97168a1",
-      "appstream": "sha256:662e1dc0e465dd5e8efec9f42ef24ac9fd8418294254c3c98ea0342d6e903aed"
-    },
     "filename": "disk.vhd",
     "output-format": "vhd",
     "blueprint": {}
+  },
+  "rpmmd": {
+    "checksums": {
+      "baseos": "sha256:3ce6f4ffa7d05b81fec2ba5a1c4917b351231c3433f2f5eed86ed5f8f97168a1",
+      "appstream": "sha256:662e1dc0e465dd5e8efec9f42ef24ac9fd8418294254c3c98ea0342d6e903aed"
+    }
   },
   "pipeline": {
     "build": {

--- a/test/cases/rhel82_vhd.json
+++ b/test/cases/rhel82_vhd.json
@@ -15,151 +15,154 @@
       "appstream": "sha256:662e1dc0e465dd5e8efec9f42ef24ac9fd8418294254c3c98ea0342d6e903aed"
     }
   },
-  "pipeline": {
-    "build": {
-      "pipeline": {
-        "stages": [
-          {
-            "name": "org.osbuild.dnf",
-            "options": {
-              "repos": [
-                {
-                  "baseurl": "http://download.devel.redhat.com/rhel-8/nightly/RHEL-8/latest-RHEL-8.2.0/compose/BaseOS/x86_64/os",
-                  "checksum": "sha256:3ce6f4ffa7d05b81fec2ba5a1c4917b351231c3433f2f5eed86ed5f8f97168a1"
-                },
-                {
-                  "baseurl": "http://download.devel.redhat.com/rhel-8/nightly/RHEL-8/latest-RHEL-8.2.0/compose/AppStream/x86_64/os",
-                  "checksum": "sha256:662e1dc0e465dd5e8efec9f42ef24ac9fd8418294254c3c98ea0342d6e903aed"
-                }
-              ],
-              "packages": [
-                "dnf",
-                "dosfstools",
-                "dracut-config-generic",
-                "e2fsprogs",
-                "glibc",
-                "grub2-pc",
-                "policycoreutils",
-                "python36",
-                "qemu-img",
-                "systemd",
-                "tar",
-                "xfsprogs"
-              ],
-              "releasever": "8",
-              "basearch": "x86_64",
-              "module_platform_id": "platform:el8"
+  "manifest": {
+    "sources": {},
+    "pipeline": {
+      "build": {
+        "pipeline": {
+          "stages": [
+            {
+              "name": "org.osbuild.dnf",
+              "options": {
+                "repos": [
+                  {
+                    "baseurl": "http://download.devel.redhat.com/rhel-8/nightly/RHEL-8/latest-RHEL-8.2.0/compose/BaseOS/x86_64/os",
+                    "checksum": "sha256:3ce6f4ffa7d05b81fec2ba5a1c4917b351231c3433f2f5eed86ed5f8f97168a1"
+                  },
+                  {
+                    "baseurl": "http://download.devel.redhat.com/rhel-8/nightly/RHEL-8/latest-RHEL-8.2.0/compose/AppStream/x86_64/os",
+                    "checksum": "sha256:662e1dc0e465dd5e8efec9f42ef24ac9fd8418294254c3c98ea0342d6e903aed"
+                  }
+                ],
+                "packages": [
+                  "dnf",
+                  "dosfstools",
+                  "dracut-config-generic",
+                  "e2fsprogs",
+                  "glibc",
+                  "grub2-pc",
+                  "policycoreutils",
+                  "python36",
+                  "qemu-img",
+                  "systemd",
+                  "tar",
+                  "xfsprogs"
+                ],
+                "releasever": "8",
+                "basearch": "x86_64",
+                "module_platform_id": "platform:el8"
+              }
             }
+          ]
+        },
+        "runner": "org.osbuild.rhel82"
+      },
+      "stages": [
+        {
+          "name": "org.osbuild.dnf",
+          "options": {
+            "repos": [
+              {
+                "baseurl": "http://download.devel.redhat.com/rhel-8/nightly/RHEL-8/latest-RHEL-8.2.0/compose/BaseOS/x86_64/os",
+                "checksum": "sha256:3ce6f4ffa7d05b81fec2ba5a1c4917b351231c3433f2f5eed86ed5f8f97168a1"
+              },
+              {
+                "baseurl": "http://download.devel.redhat.com/rhel-8/nightly/RHEL-8/latest-RHEL-8.2.0/compose/AppStream/x86_64/os",
+                "checksum": "sha256:662e1dc0e465dd5e8efec9f42ef24ac9fd8418294254c3c98ea0342d6e903aed"
+              }
+            ],
+            "packages": [
+              "@Core",
+              "WALinuxAgent",
+              "chrony",
+              "cloud-init",
+              "cloud-utils-growpart",
+              "dracut-config-generic",
+              "gdisk",
+              "grub2-pc",
+              "kernel",
+              "langpacks-en",
+              "net-tools",
+              "python3",
+              "selinux-policy-targeted"
+            ],
+            "exclude_packages": [
+              "dracut-config-rescue",
+              "timedatex"
+            ],
+            "releasever": "8",
+            "basearch": "x86_64",
+            "module_platform_id": "platform:el8"
           }
-        ]
-      },
-      "runner": "org.osbuild.rhel82"
-    },
-    "stages": [
-      {
-        "name": "org.osbuild.dnf",
-        "options": {
-          "repos": [
-            {
-              "baseurl": "http://download.devel.redhat.com/rhel-8/nightly/RHEL-8/latest-RHEL-8.2.0/compose/BaseOS/x86_64/os",
-              "checksum": "sha256:3ce6f4ffa7d05b81fec2ba5a1c4917b351231c3433f2f5eed86ed5f8f97168a1"
-            },
-            {
-              "baseurl": "http://download.devel.redhat.com/rhel-8/nightly/RHEL-8/latest-RHEL-8.2.0/compose/AppStream/x86_64/os",
-              "checksum": "sha256:662e1dc0e465dd5e8efec9f42ef24ac9fd8418294254c3c98ea0342d6e903aed"
-            }
-          ],
-          "packages": [
-            "@Core",
-            "WALinuxAgent",
-            "chrony",
-            "cloud-init",
-            "cloud-utils-growpart",
-            "dracut-config-generic",
-            "gdisk",
-            "grub2-pc",
-            "kernel",
-            "langpacks-en",
-            "net-tools",
-            "python3",
-            "selinux-policy-targeted"
-          ],
-          "exclude_packages": [
-            "dracut-config-rescue",
-            "timedatex"
-          ],
-          "releasever": "8",
-          "basearch": "x86_64",
-          "module_platform_id": "platform:el8"
+        },
+        {
+          "name": "org.osbuild.fix-bls",
+          "options": {}
+        },
+        {
+          "name": "org.osbuild.fstab",
+          "options": {
+            "filesystems": [
+              {
+                "uuid": "0bd700f8-090f-4556-b797-b340297ea1bd",
+                "vfs_type": "xfs",
+                "path": "/",
+                "options": "defaults"
+              }
+            ]
+          }
+        },
+        {
+          "name": "org.osbuild.grub2",
+          "options": {
+            "root_fs_uuid": "0bd700f8-090f-4556-b797-b340297ea1bd",
+            "kernel_opts": "ro biosdevname=0 rootdelay=300 console=ttyS0 earlyprintk=ttyS0 net.ifnames=0",
+            "legacy": true
+          }
+        },
+        {
+          "name": "org.osbuild.locale",
+          "options": {
+            "language": "en_US"
+          }
+        },
+        {
+          "name": "org.osbuild.systemd",
+          "options": {
+            "enabled_services": [
+              "sshd",
+              "waagent"
+            ],
+            "default_target": "multi-user.target"
+          }
+        },
+        {
+          "name": "org.osbuild.selinux",
+          "options": {
+            "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
+          }
         }
-      },
-      {
-        "name": "org.osbuild.fix-bls",
-        "options": {}
-      },
-      {
-        "name": "org.osbuild.fstab",
+      ],
+      "assembler": {
+        "name": "org.osbuild.qemu",
         "options": {
-          "filesystems": [
+          "format": "vpc",
+          "filename": "disk.vhd",
+          "size": 2147483648,
+          "ptuuid": "0x14fc63d2",
+          "pttype": "mbr",
+          "partitions": [
             {
-              "uuid": "0bd700f8-090f-4556-b797-b340297ea1bd",
-              "vfs_type": "xfs",
-              "path": "/",
-              "options": "defaults"
+              "start": 2048,
+              "bootable": true,
+              "filesystem": {
+                "type": "xfs",
+                "uuid": "0bd700f8-090f-4556-b797-b340297ea1bd",
+                "mountpoint": "/"
+              }
             }
           ]
         }
-      },
-      {
-        "name": "org.osbuild.grub2",
-        "options": {
-          "root_fs_uuid": "0bd700f8-090f-4556-b797-b340297ea1bd",
-          "kernel_opts": "ro biosdevname=0 rootdelay=300 console=ttyS0 earlyprintk=ttyS0 net.ifnames=0",
-          "legacy": true
-        }
-      },
-      {
-        "name": "org.osbuild.locale",
-        "options": {
-          "language": "en_US"
-        }
-      },
-      {
-        "name": "org.osbuild.systemd",
-        "options": {
-          "enabled_services": [
-            "sshd",
-            "waagent"
-          ],
-          "default_target": "multi-user.target"
-        }
-      },
-      {
-        "name": "org.osbuild.selinux",
-        "options": {
-          "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
-        }
-      }
-    ],
-    "assembler": {
-      "name": "org.osbuild.qemu",
-      "options": {
-        "format": "vpc",
-        "filename": "disk.vhd",
-        "size": 2147483648,
-        "ptuuid": "0x14fc63d2",
-        "pttype": "mbr",
-        "partitions": [
-          {
-            "start": 2048,
-            "bootable": true,
-            "filesystem": {
-              "type": "xfs",
-              "uuid": "0bd700f8-090f-4556-b797-b340297ea1bd",
-              "mountpoint": "/"
-            }
-          }
-        ]
       }
     }
   },

--- a/test/cases/rhel82_vhd.json
+++ b/test/cases/rhel82_vhd.json
@@ -2,7 +2,7 @@
   "boot": {
     "type": "qemu"
   },
-  "compose": {
+  "compose-request": {
     "distro": "rhel-8.2",
     "arch": "x86_64",
     "filename": "disk.vhd",

--- a/test/cases/rhel82_vmdk.json
+++ b/test/cases/rhel82_vmdk.json
@@ -5,10 +5,6 @@
   "compose": {
     "distro": "rhel-8.2",
     "arch": "x86_64",
-    "checksums": {
-      "baseos": "sha256:3ce6f4ffa7d05b81fec2ba5a1c4917b351231c3433f2f5eed86ed5f8f97168a1",
-      "appstream": "sha256:662e1dc0e465dd5e8efec9f42ef24ac9fd8418294254c3c98ea0342d6e903aed"
-    },
     "filename": "disk.vmdk",
     "output-format": "vmdk",
     "blueprint": {
@@ -20,6 +16,12 @@
           }
         ]
       }
+    }
+  },
+  "rpmmd": {
+    "checksums": {
+      "baseos": "sha256:3ce6f4ffa7d05b81fec2ba5a1c4917b351231c3433f2f5eed86ed5f8f97168a1",
+      "appstream": "sha256:662e1dc0e465dd5e8efec9f42ef24ac9fd8418294254c3c98ea0342d6e903aed"
     }
   },
   "pipeline": {

--- a/test/cases/rhel82_vmdk.json
+++ b/test/cases/rhel82_vmdk.json
@@ -2,7 +2,7 @@
   "boot": {
     "type": "qemu"
   },
-  "compose": {
+  "compose-request": {
     "distro": "rhel-8.2",
     "arch": "x86_64",
     "filename": "disk.vmdk",

--- a/test/cases/rhel82_vmdk.json
+++ b/test/cases/rhel82_vmdk.json
@@ -24,147 +24,150 @@
       "appstream": "sha256:662e1dc0e465dd5e8efec9f42ef24ac9fd8418294254c3c98ea0342d6e903aed"
     }
   },
-  "pipeline": {
-    "build": {
-      "pipeline": {
-        "stages": [
-          {
-            "name": "org.osbuild.dnf",
-            "options": {
-              "repos": [
-                {
-                  "baseurl": "http://download.devel.redhat.com/rhel-8/nightly/RHEL-8/latest-RHEL-8.2.0/compose/BaseOS/x86_64/os",
-                  "checksum": "sha256:3ce6f4ffa7d05b81fec2ba5a1c4917b351231c3433f2f5eed86ed5f8f97168a1"
-                },
-                {
-                  "baseurl": "http://download.devel.redhat.com/rhel-8/nightly/RHEL-8/latest-RHEL-8.2.0/compose/AppStream/x86_64/os",
-                  "checksum": "sha256:662e1dc0e465dd5e8efec9f42ef24ac9fd8418294254c3c98ea0342d6e903aed"
-                }
-              ],
-              "packages": [
-                "dnf",
-                "dosfstools",
-                "dracut-config-generic",
-                "e2fsprogs",
-                "glibc",
-                "grub2-pc",
-                "policycoreutils",
-                "python36",
-                "qemu-img",
-                "systemd",
-                "tar",
-                "xfsprogs"
-              ],
-              "releasever": "8",
-              "basearch": "x86_64",
-              "module_platform_id": "platform:el8"
+  "manifest": {
+    "sources": {},
+    "pipeline": {
+      "build": {
+        "pipeline": {
+          "stages": [
+            {
+              "name": "org.osbuild.dnf",
+              "options": {
+                "repos": [
+                  {
+                    "baseurl": "http://download.devel.redhat.com/rhel-8/nightly/RHEL-8/latest-RHEL-8.2.0/compose/BaseOS/x86_64/os",
+                    "checksum": "sha256:3ce6f4ffa7d05b81fec2ba5a1c4917b351231c3433f2f5eed86ed5f8f97168a1"
+                  },
+                  {
+                    "baseurl": "http://download.devel.redhat.com/rhel-8/nightly/RHEL-8/latest-RHEL-8.2.0/compose/AppStream/x86_64/os",
+                    "checksum": "sha256:662e1dc0e465dd5e8efec9f42ef24ac9fd8418294254c3c98ea0342d6e903aed"
+                  }
+                ],
+                "packages": [
+                  "dnf",
+                  "dosfstools",
+                  "dracut-config-generic",
+                  "e2fsprogs",
+                  "glibc",
+                  "grub2-pc",
+                  "policycoreutils",
+                  "python36",
+                  "qemu-img",
+                  "systemd",
+                  "tar",
+                  "xfsprogs"
+                ],
+                "releasever": "8",
+                "basearch": "x86_64",
+                "module_platform_id": "platform:el8"
+              }
+            }
+          ]
+        },
+        "runner": "org.osbuild.rhel82"
+      },
+      "stages": [
+        {
+          "name": "org.osbuild.dnf",
+          "options": {
+            "repos": [
+              {
+                "baseurl": "http://download.devel.redhat.com/rhel-8/nightly/RHEL-8/latest-RHEL-8.2.0/compose/BaseOS/x86_64/os",
+                "checksum": "sha256:3ce6f4ffa7d05b81fec2ba5a1c4917b351231c3433f2f5eed86ed5f8f97168a1"
+              },
+              {
+                "baseurl": "http://download.devel.redhat.com/rhel-8/nightly/RHEL-8/latest-RHEL-8.2.0/compose/AppStream/x86_64/os",
+                "checksum": "sha256:662e1dc0e465dd5e8efec9f42ef24ac9fd8418294254c3c98ea0342d6e903aed"
+              }
+            ],
+            "packages": [
+              "@core",
+              "chrony",
+              "dracut-config-generic",
+              "firewalld",
+              "grub2-pc",
+              "kernel",
+              "langpacks-en",
+              "open-vm-tools",
+              "selinux-policy-targeted"
+            ],
+            "exclude_packages": [
+              "dracut-config-rescue",
+              "timedatex"
+            ],
+            "releasever": "8",
+            "basearch": "x86_64",
+            "module_platform_id": "platform:el8"
+          }
+        },
+        {
+          "name": "org.osbuild.fix-bls",
+          "options": {}
+        },
+        {
+          "name": "org.osbuild.fstab",
+          "options": {
+            "filesystems": [
+              {
+                "uuid": "0bd700f8-090f-4556-b797-b340297ea1bd",
+                "vfs_type": "xfs",
+                "path": "/",
+                "options": "defaults"
+              }
+            ]
+          }
+        },
+        {
+          "name": "org.osbuild.grub2",
+          "options": {
+            "root_fs_uuid": "0bd700f8-090f-4556-b797-b340297ea1bd",
+            "kernel_opts": "ro net.ifnames=0",
+            "legacy": true
+          }
+        },
+        {
+          "name": "org.osbuild.locale",
+          "options": {
+            "language": "en_US"
+          }
+        },
+        {
+          "name": "org.osbuild.users",
+          "options": {
+            "users": {
+              "redhat": {
+                "key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC61wMCjOSHwbVb4VfVyl5sn497qW4PsdQ7Ty7aD6wDNZ/QjjULkDV/yW5WjDlDQ7UqFH0Sr7vywjqDizUAqK7zM5FsUKsUXWHWwg/ehKg8j9xKcMv11AkFoUoujtfAujnKODkk58XSA9whPr7qcw3vPrmog680pnMSzf9LC7J6kXfs6lkoKfBh9VnlxusCrw2yg0qI1fHAZBLPx7mW6+me71QZsS6sVz8v8KXyrXsKTdnF50FjzHcK9HXDBtSJS5wA3fkcRYymJe0o6WMWNdgSRVpoSiWaHHmFgdMUJaYoCfhXzyl7LtNb3Q+Sveg+tJK7JaRXBLMUllOlJ6ll5Hod"
+              }
             }
           }
-        ]
-      },
-      "runner": "org.osbuild.rhel82"
-    },
-    "stages": [
-      {
-        "name": "org.osbuild.dnf",
-        "options": {
-          "repos": [
-            {
-              "baseurl": "http://download.devel.redhat.com/rhel-8/nightly/RHEL-8/latest-RHEL-8.2.0/compose/BaseOS/x86_64/os",
-              "checksum": "sha256:3ce6f4ffa7d05b81fec2ba5a1c4917b351231c3433f2f5eed86ed5f8f97168a1"
-            },
-            {
-              "baseurl": "http://download.devel.redhat.com/rhel-8/nightly/RHEL-8/latest-RHEL-8.2.0/compose/AppStream/x86_64/os",
-              "checksum": "sha256:662e1dc0e465dd5e8efec9f42ef24ac9fd8418294254c3c98ea0342d6e903aed"
-            }
-          ],
-          "packages": [
-            "@core",
-            "chrony",
-            "dracut-config-generic",
-            "firewalld",
-            "grub2-pc",
-            "kernel",
-            "langpacks-en",
-            "open-vm-tools",
-            "selinux-policy-targeted"
-          ],
-          "exclude_packages": [
-            "dracut-config-rescue",
-            "timedatex"
-          ],
-          "releasever": "8",
-          "basearch": "x86_64",
-          "module_platform_id": "platform:el8"
+        },
+        {
+          "name": "org.osbuild.selinux",
+          "options": {
+            "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
+          }
         }
-      },
-      {
-        "name": "org.osbuild.fix-bls",
-        "options": {}
-      },
-      {
-        "name": "org.osbuild.fstab",
+      ],
+      "assembler": {
+        "name": "org.osbuild.qemu",
         "options": {
-          "filesystems": [
+          "format": "vmdk",
+          "filename": "disk.vmdk",
+          "size": 2147483648,
+          "ptuuid": "0x14fc63d2",
+          "pttype": "mbr",
+          "partitions": [
             {
-              "uuid": "0bd700f8-090f-4556-b797-b340297ea1bd",
-              "vfs_type": "xfs",
-              "path": "/",
-              "options": "defaults"
+              "start": 2048,
+              "bootable": true,
+              "filesystem": {
+                "type": "xfs",
+                "uuid": "0bd700f8-090f-4556-b797-b340297ea1bd",
+                "mountpoint": "/"
+              }
             }
           ]
         }
-      },
-      {
-        "name": "org.osbuild.grub2",
-        "options": {
-          "root_fs_uuid": "0bd700f8-090f-4556-b797-b340297ea1bd",
-          "kernel_opts": "ro net.ifnames=0",
-          "legacy": true
-        }
-      },
-      {
-        "name": "org.osbuild.locale",
-        "options": {
-          "language": "en_US"
-        }
-      },
-      {
-        "name": "org.osbuild.users",
-        "options": {
-          "users": {
-            "redhat": {
-              "key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC61wMCjOSHwbVb4VfVyl5sn497qW4PsdQ7Ty7aD6wDNZ/QjjULkDV/yW5WjDlDQ7UqFH0Sr7vywjqDizUAqK7zM5FsUKsUXWHWwg/ehKg8j9xKcMv11AkFoUoujtfAujnKODkk58XSA9whPr7qcw3vPrmog680pnMSzf9LC7J6kXfs6lkoKfBh9VnlxusCrw2yg0qI1fHAZBLPx7mW6+me71QZsS6sVz8v8KXyrXsKTdnF50FjzHcK9HXDBtSJS5wA3fkcRYymJe0o6WMWNdgSRVpoSiWaHHmFgdMUJaYoCfhXzyl7LtNb3Q+Sveg+tJK7JaRXBLMUllOlJ6ll5Hod"
-            }
-          }
-        }
-      },
-      {
-        "name": "org.osbuild.selinux",
-        "options": {
-          "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
-        }
-      }
-    ],
-    "assembler": {
-      "name": "org.osbuild.qemu",
-      "options": {
-        "format": "vmdk",
-        "filename": "disk.vmdk",
-        "size": 2147483648,
-        "ptuuid": "0x14fc63d2",
-        "pttype": "mbr",
-        "partitions": [
-          {
-            "start": 2048,
-            "bootable": true,
-            "filesystem": {
-              "type": "xfs",
-              "uuid": "0bd700f8-090f-4556-b797-b340297ea1bd",
-              "mountpoint": "/"
-            }
-          }
-        ]
       }
     }
   },

--- a/test/cases/tar_local_boot.json
+++ b/test/cases/tar_local_boot.json
@@ -2,7 +2,7 @@
   "boot": {
     "type": "nspawn-extract"
   },
-  "compose": {
+  "compose-request": {
     "output-format": "tar",
     "distro": "fedora-30",
     "arch": "x86_64",

--- a/test/cases/tar_local_boot.json
+++ b/test/cases/tar_local_boot.json
@@ -37,6 +37,11 @@
       }
     }
   },
+  "rpmmd": {
+    "checksums": {
+      "fedora": "sha256:9f596e18f585bee30ac41c11fb11a83ed6b11d5b341c1cb56ca4015d7717cb97"
+    }
+  },
   "pipeline": {
     "build": {
       "pipeline": {

--- a/test/cases/tar_local_boot.json
+++ b/test/cases/tar_local_boot.json
@@ -42,121 +42,124 @@
       "fedora": "sha256:9f596e18f585bee30ac41c11fb11a83ed6b11d5b341c1cb56ca4015d7717cb97"
     }
   },
-  "pipeline": {
-    "build": {
-      "pipeline": {
-        "stages": [
-          {
-            "name": "org.osbuild.dnf",
-            "options": {
-              "repos": [
-                {
-                  "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-30&arch=x86_64",
-                  "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBFturGcBEACv0xBo91V2n0uEC2vh69ywCiSyvUgN/AQH8EZpCVtM7NyjKgKm\nbbY4G3R0M3ir1xXmvUDvK0493/qOiFrjkplvzXFTGpPTi0ypqGgxc5d0ohRA1M75\nL+0AIlXoOgHQ358/c4uO8X0JAA1NYxCkAW1KSJgFJ3RjukrfqSHWthS1d4o8fhHy\nKJKEnirE5hHqB50dafXrBfgZdaOs3C6ppRIePFe2o4vUEapMTCHFw0woQR8Ah4/R\nn7Z9G9Ln+0Cinmy0nbIDiZJ+pgLAXCOWBfDUzcOjDGKvcpoZharA07c0q1/5ojzO\n4F0Fh4g/BUmtrASwHfcIbjHyCSr1j/3Iz883iy07gJY5Yhiuaqmp0o0f9fgHkG53\n2xCU1owmACqaIBNQMukvXRDtB2GJMuKa/asTZDP6R5re+iXs7+s9ohcRRAKGyAyc\nYKIQKcaA+6M8T7/G+TPHZX6HJWqJJiYB+EC2ERblpvq9TPlLguEWcmvjbVc31nyq\nSDoO3ncFWKFmVsbQPTbP+pKUmlLfJwtb5XqxNR5GEXSwVv4I7IqBmJz1MmRafnBZ\ng0FJUtH668GnldO20XbnSVBr820F5SISMXVwCXDXEvGwwiB8Lt8PvqzXnGIFDAu3\nDlQI5sxSqpPVWSyw08ppKT2Tpmy8adiBotLfaCFl2VTHwOae48X2dMPBvQARAQAB\ntDFGZWRvcmEgKDMwKSA8ZmVkb3JhLTMwLXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQI4BBMBAgAiBQJbbqxnAhsPBgsJCAcDAgYVCAIJCgsEFgIDAQIeAQIXgAAK\nCRDvPBEfz8ZZudTnD/9170LL3nyTVUCFmBjT9wZ4gYnpwtKVPa/pKnxbbS+Bmmac\ng9TrT9pZbqOHrNJLiZ3Zx1Hp+8uxr3Lo6kbYwImLhkOEDrf4aP17HfQ6VYFbQZI8\nf79OFxWJ7si9+3gfzeh9UYFEqOQfzIjLWFyfnas0OnV/P+RMQ1Zr+vPRqO7AR2va\nN9wg+Xl7157dhXPCGYnGMNSoxCbpRs0JNlzvJMuAea5nTTznRaJZtK/xKsqLn51D\nK07k9MHVFXakOH8QtMCUglbwfTfIpO5YRq5imxlWbqsYWVQy1WGJFyW6hWC0+RcJ\nOx5zGtOfi4/dN+xJ+ibnbyvy/il7Qm+vyFhCYqIPyS5m2UVJUuao3eApE38k78/o\n8aQOTnFQZ+U1Sw+6woFTxjqRQBXlQm2+7Bt3bqGATg4sXXWPbmwdL87Ic+mxn/ml\nSMfQux/5k6iAu1kQhwkO2YJn9eII6HIPkW+2m5N1JsUyJQe4cbtZE5Yh3TRA0dm7\n+zoBRfCXkOW4krchbgww/ptVmzMMP7GINJdROrJnsGl5FVeid9qHzV7aZycWSma7\nCxBYB1J8HCbty5NjtD6XMYRrMLxXugvX6Q4NPPH+2NKjzX4SIDejS6JjgrP3KA3O\npMuo7ZHMfveBngv8yP+ZD/1sS6l+dfExvdaJdOdgFCnp4p3gPbw5+Lv70HrMjA==\n=BfZ/\n-----END PGP PUBLIC KEY BLOCK-----\n",
-                  "checksum": "sha256:9f596e18f585bee30ac41c11fb11a83ed6b11d5b341c1cb56ca4015d7717cb97"
-                }
-              ],
-              "packages": [
-                "dnf",
-                "dosfstools",
-                "e2fsprogs",
-                "grub2-pc",
-                "policycoreutils",
-                "qemu-img",
-                "systemd",
-                "tar"
-              ],
-              "releasever": "30",
-              "basearch": "x86_64",
-              "module_platform_id": "platform:f30"
-            }
-          }
-        ]
-      },
-      "runner": "org.osbuild.fedora30"
-    },
-    "stages": [
-      {
-        "name": "org.osbuild.dnf",
-        "options": {
-          "repos": [
+  "manifest": {
+    "sources": {},
+    "pipeline": {
+      "build": {
+        "pipeline": {
+          "stages": [
             {
-              "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-30&arch=x86_64",
-              "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBFturGcBEACv0xBo91V2n0uEC2vh69ywCiSyvUgN/AQH8EZpCVtM7NyjKgKm\nbbY4G3R0M3ir1xXmvUDvK0493/qOiFrjkplvzXFTGpPTi0ypqGgxc5d0ohRA1M75\nL+0AIlXoOgHQ358/c4uO8X0JAA1NYxCkAW1KSJgFJ3RjukrfqSHWthS1d4o8fhHy\nKJKEnirE5hHqB50dafXrBfgZdaOs3C6ppRIePFe2o4vUEapMTCHFw0woQR8Ah4/R\nn7Z9G9Ln+0Cinmy0nbIDiZJ+pgLAXCOWBfDUzcOjDGKvcpoZharA07c0q1/5ojzO\n4F0Fh4g/BUmtrASwHfcIbjHyCSr1j/3Iz883iy07gJY5Yhiuaqmp0o0f9fgHkG53\n2xCU1owmACqaIBNQMukvXRDtB2GJMuKa/asTZDP6R5re+iXs7+s9ohcRRAKGyAyc\nYKIQKcaA+6M8T7/G+TPHZX6HJWqJJiYB+EC2ERblpvq9TPlLguEWcmvjbVc31nyq\nSDoO3ncFWKFmVsbQPTbP+pKUmlLfJwtb5XqxNR5GEXSwVv4I7IqBmJz1MmRafnBZ\ng0FJUtH668GnldO20XbnSVBr820F5SISMXVwCXDXEvGwwiB8Lt8PvqzXnGIFDAu3\nDlQI5sxSqpPVWSyw08ppKT2Tpmy8adiBotLfaCFl2VTHwOae48X2dMPBvQARAQAB\ntDFGZWRvcmEgKDMwKSA8ZmVkb3JhLTMwLXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQI4BBMBAgAiBQJbbqxnAhsPBgsJCAcDAgYVCAIJCgsEFgIDAQIeAQIXgAAK\nCRDvPBEfz8ZZudTnD/9170LL3nyTVUCFmBjT9wZ4gYnpwtKVPa/pKnxbbS+Bmmac\ng9TrT9pZbqOHrNJLiZ3Zx1Hp+8uxr3Lo6kbYwImLhkOEDrf4aP17HfQ6VYFbQZI8\nf79OFxWJ7si9+3gfzeh9UYFEqOQfzIjLWFyfnas0OnV/P+RMQ1Zr+vPRqO7AR2va\nN9wg+Xl7157dhXPCGYnGMNSoxCbpRs0JNlzvJMuAea5nTTznRaJZtK/xKsqLn51D\nK07k9MHVFXakOH8QtMCUglbwfTfIpO5YRq5imxlWbqsYWVQy1WGJFyW6hWC0+RcJ\nOx5zGtOfi4/dN+xJ+ibnbyvy/il7Qm+vyFhCYqIPyS5m2UVJUuao3eApE38k78/o\n8aQOTnFQZ+U1Sw+6woFTxjqRQBXlQm2+7Bt3bqGATg4sXXWPbmwdL87Ic+mxn/ml\nSMfQux/5k6iAu1kQhwkO2YJn9eII6HIPkW+2m5N1JsUyJQe4cbtZE5Yh3TRA0dm7\n+zoBRfCXkOW4krchbgww/ptVmzMMP7GINJdROrJnsGl5FVeid9qHzV7aZycWSma7\nCxBYB1J8HCbty5NjtD6XMYRrMLxXugvX6Q4NPPH+2NKjzX4SIDejS6JjgrP3KA3O\npMuo7ZHMfveBngv8yP+ZD/1sS6l+dfExvdaJdOdgFCnp4p3gPbw5+Lv70HrMjA==\n=BfZ/\n-----END PGP PUBLIC KEY BLOCK-----\n",
-              "checksum": "sha256:9f596e18f585bee30ac41c11fb11a83ed6b11d5b341c1cb56ca4015d7717cb97"
+              "name": "org.osbuild.dnf",
+              "options": {
+                "repos": [
+                  {
+                    "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-30&arch=x86_64",
+                    "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBFturGcBEACv0xBo91V2n0uEC2vh69ywCiSyvUgN/AQH8EZpCVtM7NyjKgKm\nbbY4G3R0M3ir1xXmvUDvK0493/qOiFrjkplvzXFTGpPTi0ypqGgxc5d0ohRA1M75\nL+0AIlXoOgHQ358/c4uO8X0JAA1NYxCkAW1KSJgFJ3RjukrfqSHWthS1d4o8fhHy\nKJKEnirE5hHqB50dafXrBfgZdaOs3C6ppRIePFe2o4vUEapMTCHFw0woQR8Ah4/R\nn7Z9G9Ln+0Cinmy0nbIDiZJ+pgLAXCOWBfDUzcOjDGKvcpoZharA07c0q1/5ojzO\n4F0Fh4g/BUmtrASwHfcIbjHyCSr1j/3Iz883iy07gJY5Yhiuaqmp0o0f9fgHkG53\n2xCU1owmACqaIBNQMukvXRDtB2GJMuKa/asTZDP6R5re+iXs7+s9ohcRRAKGyAyc\nYKIQKcaA+6M8T7/G+TPHZX6HJWqJJiYB+EC2ERblpvq9TPlLguEWcmvjbVc31nyq\nSDoO3ncFWKFmVsbQPTbP+pKUmlLfJwtb5XqxNR5GEXSwVv4I7IqBmJz1MmRafnBZ\ng0FJUtH668GnldO20XbnSVBr820F5SISMXVwCXDXEvGwwiB8Lt8PvqzXnGIFDAu3\nDlQI5sxSqpPVWSyw08ppKT2Tpmy8adiBotLfaCFl2VTHwOae48X2dMPBvQARAQAB\ntDFGZWRvcmEgKDMwKSA8ZmVkb3JhLTMwLXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQI4BBMBAgAiBQJbbqxnAhsPBgsJCAcDAgYVCAIJCgsEFgIDAQIeAQIXgAAK\nCRDvPBEfz8ZZudTnD/9170LL3nyTVUCFmBjT9wZ4gYnpwtKVPa/pKnxbbS+Bmmac\ng9TrT9pZbqOHrNJLiZ3Zx1Hp+8uxr3Lo6kbYwImLhkOEDrf4aP17HfQ6VYFbQZI8\nf79OFxWJ7si9+3gfzeh9UYFEqOQfzIjLWFyfnas0OnV/P+RMQ1Zr+vPRqO7AR2va\nN9wg+Xl7157dhXPCGYnGMNSoxCbpRs0JNlzvJMuAea5nTTznRaJZtK/xKsqLn51D\nK07k9MHVFXakOH8QtMCUglbwfTfIpO5YRq5imxlWbqsYWVQy1WGJFyW6hWC0+RcJ\nOx5zGtOfi4/dN+xJ+ibnbyvy/il7Qm+vyFhCYqIPyS5m2UVJUuao3eApE38k78/o\n8aQOTnFQZ+U1Sw+6woFTxjqRQBXlQm2+7Bt3bqGATg4sXXWPbmwdL87Ic+mxn/ml\nSMfQux/5k6iAu1kQhwkO2YJn9eII6HIPkW+2m5N1JsUyJQe4cbtZE5Yh3TRA0dm7\n+zoBRfCXkOW4krchbgww/ptVmzMMP7GINJdROrJnsGl5FVeid9qHzV7aZycWSma7\nCxBYB1J8HCbty5NjtD6XMYRrMLxXugvX6Q4NPPH+2NKjzX4SIDejS6JjgrP3KA3O\npMuo7ZHMfveBngv8yP+ZD/1sS6l+dfExvdaJdOdgFCnp4p3gPbw5+Lv70HrMjA==\n=BfZ/\n-----END PGP PUBLIC KEY BLOCK-----\n",
+                    "checksum": "sha256:9f596e18f585bee30ac41c11fb11a83ed6b11d5b341c1cb56ca4015d7717cb97"
+                  }
+                ],
+                "packages": [
+                  "dnf",
+                  "dosfstools",
+                  "e2fsprogs",
+                  "grub2-pc",
+                  "policycoreutils",
+                  "qemu-img",
+                  "systemd",
+                  "tar"
+                ],
+                "releasever": "30",
+                "basearch": "x86_64",
+                "module_platform_id": "platform:f30"
+              }
             }
-          ],
-          "packages": [
-            "chrony",
-            "firewalld",
-            "kernel",
-            "langpacks-en",
-            "openssh-server",
-            "policycoreutils",
-            "selinux-policy-targeted"
-          ],
-          "exclude_packages": [
-            "dracut-config-rescue"
-          ],
-          "releasever": "30",
-          "basearch": "x86_64",
-          "module_platform_id": "platform:f30"
-        }
-      },
-      {
-        "name": "org.osbuild.locale",
-        "options": {
-          "language": "en_US"
-        }
-      },
-      {
-        "name": "org.osbuild.grub2",
-        "options": {
-          "root_fs_uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
-          "kernel_opts": "ro biosdevname=0 net.ifnames=0",
-          "legacy": true
-        }
-      },
-      {
-        "name": "org.osbuild.systemd",
-        "options": {
-          "enabled_services": [
-            "sshd"
-          ],
-          "disabled_services": [
-            "auditd"
           ]
-        }
+        },
+        "runner": "org.osbuild.fedora30"
       },
-      {
-        "name": "org.osbuild.users",
-        "options": {
-          "users": {
-            "redhat": {
-              "groups": [
-                "wheel"
-              ],
-              "password": "$6$IR7O7z56ouB/OInP$.hscD6dQqPQGwMuQ.idumixSHI/JEyaUfiCAHVSpGO/iNLEvvVZVOQL23zBzQbc2.yJ25xAZD75H0tXqKJpEE/",
-              "key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC61wMCjOSHwbVb4VfVyl5sn497qW4PsdQ7Ty7aD6wDNZ/QjjULkDV/yW5WjDlDQ7UqFH0Sr7vywjqDizUAqK7zM5FsUKsUXWHWwg/ehKg8j9xKcMv11AkFoUoujtfAujnKODkk58XSA9whPr7qcw3vPrmog680pnMSzf9LC7J6kXfs6lkoKfBh9VnlxusCrw2yg0qI1fHAZBLPx7mW6+me71QZsS6sVz8v8KXyrXsKTdnF50FjzHcK9HXDBtSJS5wA3fkcRYymJe0o6WMWNdgSRVpoSiWaHHmFgdMUJaYoCfhXzyl7LtNb3Q+Sveg+tJK7JaRXBLMUllOlJ6ll5Hod root@localhost"
+      "stages": [
+        {
+          "name": "org.osbuild.dnf",
+          "options": {
+            "repos": [
+              {
+                "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-30&arch=x86_64",
+                "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBFturGcBEACv0xBo91V2n0uEC2vh69ywCiSyvUgN/AQH8EZpCVtM7NyjKgKm\nbbY4G3R0M3ir1xXmvUDvK0493/qOiFrjkplvzXFTGpPTi0ypqGgxc5d0ohRA1M75\nL+0AIlXoOgHQ358/c4uO8X0JAA1NYxCkAW1KSJgFJ3RjukrfqSHWthS1d4o8fhHy\nKJKEnirE5hHqB50dafXrBfgZdaOs3C6ppRIePFe2o4vUEapMTCHFw0woQR8Ah4/R\nn7Z9G9Ln+0Cinmy0nbIDiZJ+pgLAXCOWBfDUzcOjDGKvcpoZharA07c0q1/5ojzO\n4F0Fh4g/BUmtrASwHfcIbjHyCSr1j/3Iz883iy07gJY5Yhiuaqmp0o0f9fgHkG53\n2xCU1owmACqaIBNQMukvXRDtB2GJMuKa/asTZDP6R5re+iXs7+s9ohcRRAKGyAyc\nYKIQKcaA+6M8T7/G+TPHZX6HJWqJJiYB+EC2ERblpvq9TPlLguEWcmvjbVc31nyq\nSDoO3ncFWKFmVsbQPTbP+pKUmlLfJwtb5XqxNR5GEXSwVv4I7IqBmJz1MmRafnBZ\ng0FJUtH668GnldO20XbnSVBr820F5SISMXVwCXDXEvGwwiB8Lt8PvqzXnGIFDAu3\nDlQI5sxSqpPVWSyw08ppKT2Tpmy8adiBotLfaCFl2VTHwOae48X2dMPBvQARAQAB\ntDFGZWRvcmEgKDMwKSA8ZmVkb3JhLTMwLXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQI4BBMBAgAiBQJbbqxnAhsPBgsJCAcDAgYVCAIJCgsEFgIDAQIeAQIXgAAK\nCRDvPBEfz8ZZudTnD/9170LL3nyTVUCFmBjT9wZ4gYnpwtKVPa/pKnxbbS+Bmmac\ng9TrT9pZbqOHrNJLiZ3Zx1Hp+8uxr3Lo6kbYwImLhkOEDrf4aP17HfQ6VYFbQZI8\nf79OFxWJ7si9+3gfzeh9UYFEqOQfzIjLWFyfnas0OnV/P+RMQ1Zr+vPRqO7AR2va\nN9wg+Xl7157dhXPCGYnGMNSoxCbpRs0JNlzvJMuAea5nTTznRaJZtK/xKsqLn51D\nK07k9MHVFXakOH8QtMCUglbwfTfIpO5YRq5imxlWbqsYWVQy1WGJFyW6hWC0+RcJ\nOx5zGtOfi4/dN+xJ+ibnbyvy/il7Qm+vyFhCYqIPyS5m2UVJUuao3eApE38k78/o\n8aQOTnFQZ+U1Sw+6woFTxjqRQBXlQm2+7Bt3bqGATg4sXXWPbmwdL87Ic+mxn/ml\nSMfQux/5k6iAu1kQhwkO2YJn9eII6HIPkW+2m5N1JsUyJQe4cbtZE5Yh3TRA0dm7\n+zoBRfCXkOW4krchbgww/ptVmzMMP7GINJdROrJnsGl5FVeid9qHzV7aZycWSma7\nCxBYB1J8HCbty5NjtD6XMYRrMLxXugvX6Q4NPPH+2NKjzX4SIDejS6JjgrP3KA3O\npMuo7ZHMfveBngv8yP+ZD/1sS6l+dfExvdaJdOdgFCnp4p3gPbw5+Lv70HrMjA==\n=BfZ/\n-----END PGP PUBLIC KEY BLOCK-----\n",
+                "checksum": "sha256:9f596e18f585bee30ac41c11fb11a83ed6b11d5b341c1cb56ca4015d7717cb97"
+              }
+            ],
+            "packages": [
+              "chrony",
+              "firewalld",
+              "kernel",
+              "langpacks-en",
+              "openssh-server",
+              "policycoreutils",
+              "selinux-policy-targeted"
+            ],
+            "exclude_packages": [
+              "dracut-config-rescue"
+            ],
+            "releasever": "30",
+            "basearch": "x86_64",
+            "module_platform_id": "platform:f30"
+          }
+        },
+        {
+          "name": "org.osbuild.locale",
+          "options": {
+            "language": "en_US"
+          }
+        },
+        {
+          "name": "org.osbuild.grub2",
+          "options": {
+            "root_fs_uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
+            "kernel_opts": "ro biosdevname=0 net.ifnames=0",
+            "legacy": true
+          }
+        },
+        {
+          "name": "org.osbuild.systemd",
+          "options": {
+            "enabled_services": [
+              "sshd"
+            ],
+            "disabled_services": [
+              "auditd"
+            ]
+          }
+        },
+        {
+          "name": "org.osbuild.users",
+          "options": {
+            "users": {
+              "redhat": {
+                "groups": [
+                  "wheel"
+                ],
+                "password": "$6$IR7O7z56ouB/OInP$.hscD6dQqPQGwMuQ.idumixSHI/JEyaUfiCAHVSpGO/iNLEvvVZVOQL23zBzQbc2.yJ25xAZD75H0tXqKJpEE/",
+                "key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC61wMCjOSHwbVb4VfVyl5sn497qW4PsdQ7Ty7aD6wDNZ/QjjULkDV/yW5WjDlDQ7UqFH0Sr7vywjqDizUAqK7zM5FsUKsUXWHWwg/ehKg8j9xKcMv11AkFoUoujtfAujnKODkk58XSA9whPr7qcw3vPrmog680pnMSzf9LC7J6kXfs6lkoKfBh9VnlxusCrw2yg0qI1fHAZBLPx7mW6+me71QZsS6sVz8v8KXyrXsKTdnF50FjzHcK9HXDBtSJS5wA3fkcRYymJe0o6WMWNdgSRVpoSiWaHHmFgdMUJaYoCfhXzyl7LtNb3Q+Sveg+tJK7JaRXBLMUllOlJ6ll5Hod root@localhost"
+              }
             }
           }
+        },
+        {
+          "name": "org.osbuild.selinux",
+          "options": {
+            "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
+          }
+        },
+        {
+          "name": "org.osbuild.fix-bls",
+          "options": {}
         }
-      },
-      {
-        "name": "org.osbuild.selinux",
+      ],
+      "assembler": {
+        "name": "org.osbuild.tar",
         "options": {
-          "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
+          "filename": "root.tar.xz"
         }
-      },
-      {
-        "name": "org.osbuild.fix-bls",
-        "options": {}
-      }
-    ],
-    "assembler": {
-      "name": "org.osbuild.tar",
-      "options": {
-        "filename": "root.tar.xz"
       }
     }
   }

--- a/test/cases/vhd_empty_blueprint.json
+++ b/test/cases/vhd_empty_blueprint.json
@@ -1,5 +1,5 @@
 {
-  "compose": {
+  "compose-request": {
     "distro": "fedora-30",
     "arch": "x86_64",
     "output-format": "vhd",

--- a/test/cases/vhd_empty_blueprint.json
+++ b/test/cases/vhd_empty_blueprint.json
@@ -2,12 +2,14 @@
   "compose": {
     "distro": "fedora-30",
     "arch": "x86_64",
-    "checksums": {
-      "fedora": "sha256:9f596e18f585bee30ac41c11fb11a83ed6b11d5b341c1cb56ca4015d7717cb97"
-    },
     "output-format": "vhd",
     "filename": "disk.vhd",
     "blueprint": {}
+  },
+  "rpmmd": {
+    "checksums": {
+      "fedora": "sha256:9f596e18f585bee30ac41c11fb11a83ed6b11d5b341c1cb56ca4015d7717cb97"
+    }
   },
   "pipeline": {
     "build": {

--- a/test/cases/vhd_empty_blueprint.json
+++ b/test/cases/vhd_empty_blueprint.json
@@ -11,145 +11,148 @@
       "fedora": "sha256:9f596e18f585bee30ac41c11fb11a83ed6b11d5b341c1cb56ca4015d7717cb97"
     }
   },
-  "pipeline": {
-    "build": {
-      "pipeline": {
-        "stages": [
-          {
-            "name": "org.osbuild.dnf",
-            "options": {
-              "repos": [
-                {
-                  "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-30&arch=x86_64",
-                  "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBFturGcBEACv0xBo91V2n0uEC2vh69ywCiSyvUgN/AQH8EZpCVtM7NyjKgKm\nbbY4G3R0M3ir1xXmvUDvK0493/qOiFrjkplvzXFTGpPTi0ypqGgxc5d0ohRA1M75\nL+0AIlXoOgHQ358/c4uO8X0JAA1NYxCkAW1KSJgFJ3RjukrfqSHWthS1d4o8fhHy\nKJKEnirE5hHqB50dafXrBfgZdaOs3C6ppRIePFe2o4vUEapMTCHFw0woQR8Ah4/R\nn7Z9G9Ln+0Cinmy0nbIDiZJ+pgLAXCOWBfDUzcOjDGKvcpoZharA07c0q1/5ojzO\n4F0Fh4g/BUmtrASwHfcIbjHyCSr1j/3Iz883iy07gJY5Yhiuaqmp0o0f9fgHkG53\n2xCU1owmACqaIBNQMukvXRDtB2GJMuKa/asTZDP6R5re+iXs7+s9ohcRRAKGyAyc\nYKIQKcaA+6M8T7/G+TPHZX6HJWqJJiYB+EC2ERblpvq9TPlLguEWcmvjbVc31nyq\nSDoO3ncFWKFmVsbQPTbP+pKUmlLfJwtb5XqxNR5GEXSwVv4I7IqBmJz1MmRafnBZ\ng0FJUtH668GnldO20XbnSVBr820F5SISMXVwCXDXEvGwwiB8Lt8PvqzXnGIFDAu3\nDlQI5sxSqpPVWSyw08ppKT2Tpmy8adiBotLfaCFl2VTHwOae48X2dMPBvQARAQAB\ntDFGZWRvcmEgKDMwKSA8ZmVkb3JhLTMwLXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQI4BBMBAgAiBQJbbqxnAhsPBgsJCAcDAgYVCAIJCgsEFgIDAQIeAQIXgAAK\nCRDvPBEfz8ZZudTnD/9170LL3nyTVUCFmBjT9wZ4gYnpwtKVPa/pKnxbbS+Bmmac\ng9TrT9pZbqOHrNJLiZ3Zx1Hp+8uxr3Lo6kbYwImLhkOEDrf4aP17HfQ6VYFbQZI8\nf79OFxWJ7si9+3gfzeh9UYFEqOQfzIjLWFyfnas0OnV/P+RMQ1Zr+vPRqO7AR2va\nN9wg+Xl7157dhXPCGYnGMNSoxCbpRs0JNlzvJMuAea5nTTznRaJZtK/xKsqLn51D\nK07k9MHVFXakOH8QtMCUglbwfTfIpO5YRq5imxlWbqsYWVQy1WGJFyW6hWC0+RcJ\nOx5zGtOfi4/dN+xJ+ibnbyvy/il7Qm+vyFhCYqIPyS5m2UVJUuao3eApE38k78/o\n8aQOTnFQZ+U1Sw+6woFTxjqRQBXlQm2+7Bt3bqGATg4sXXWPbmwdL87Ic+mxn/ml\nSMfQux/5k6iAu1kQhwkO2YJn9eII6HIPkW+2m5N1JsUyJQe4cbtZE5Yh3TRA0dm7\n+zoBRfCXkOW4krchbgww/ptVmzMMP7GINJdROrJnsGl5FVeid9qHzV7aZycWSma7\nCxBYB1J8HCbty5NjtD6XMYRrMLxXugvX6Q4NPPH+2NKjzX4SIDejS6JjgrP3KA3O\npMuo7ZHMfveBngv8yP+ZD/1sS6l+dfExvdaJdOdgFCnp4p3gPbw5+Lv70HrMjA==\n=BfZ/\n-----END PGP PUBLIC KEY BLOCK-----\n",
-                  "checksum": "sha256:9f596e18f585bee30ac41c11fb11a83ed6b11d5b341c1cb56ca4015d7717cb97"
-                }
-              ],
-              "packages": [
-                "dnf",
-                "dosfstools",
-                "e2fsprogs",
-                "grub2-pc",
-                "policycoreutils",
-                "qemu-img",
-                "systemd",
-                "tar"
-              ],
-              "releasever": "30",
-              "basearch": "x86_64",
-              "module_platform_id": "platform:f30"
+  "manifest": {
+    "sources": {},
+    "pipeline": {
+      "build": {
+        "pipeline": {
+          "stages": [
+            {
+              "name": "org.osbuild.dnf",
+              "options": {
+                "repos": [
+                  {
+                    "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-30&arch=x86_64",
+                    "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBFturGcBEACv0xBo91V2n0uEC2vh69ywCiSyvUgN/AQH8EZpCVtM7NyjKgKm\nbbY4G3R0M3ir1xXmvUDvK0493/qOiFrjkplvzXFTGpPTi0ypqGgxc5d0ohRA1M75\nL+0AIlXoOgHQ358/c4uO8X0JAA1NYxCkAW1KSJgFJ3RjukrfqSHWthS1d4o8fhHy\nKJKEnirE5hHqB50dafXrBfgZdaOs3C6ppRIePFe2o4vUEapMTCHFw0woQR8Ah4/R\nn7Z9G9Ln+0Cinmy0nbIDiZJ+pgLAXCOWBfDUzcOjDGKvcpoZharA07c0q1/5ojzO\n4F0Fh4g/BUmtrASwHfcIbjHyCSr1j/3Iz883iy07gJY5Yhiuaqmp0o0f9fgHkG53\n2xCU1owmACqaIBNQMukvXRDtB2GJMuKa/asTZDP6R5re+iXs7+s9ohcRRAKGyAyc\nYKIQKcaA+6M8T7/G+TPHZX6HJWqJJiYB+EC2ERblpvq9TPlLguEWcmvjbVc31nyq\nSDoO3ncFWKFmVsbQPTbP+pKUmlLfJwtb5XqxNR5GEXSwVv4I7IqBmJz1MmRafnBZ\ng0FJUtH668GnldO20XbnSVBr820F5SISMXVwCXDXEvGwwiB8Lt8PvqzXnGIFDAu3\nDlQI5sxSqpPVWSyw08ppKT2Tpmy8adiBotLfaCFl2VTHwOae48X2dMPBvQARAQAB\ntDFGZWRvcmEgKDMwKSA8ZmVkb3JhLTMwLXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQI4BBMBAgAiBQJbbqxnAhsPBgsJCAcDAgYVCAIJCgsEFgIDAQIeAQIXgAAK\nCRDvPBEfz8ZZudTnD/9170LL3nyTVUCFmBjT9wZ4gYnpwtKVPa/pKnxbbS+Bmmac\ng9TrT9pZbqOHrNJLiZ3Zx1Hp+8uxr3Lo6kbYwImLhkOEDrf4aP17HfQ6VYFbQZI8\nf79OFxWJ7si9+3gfzeh9UYFEqOQfzIjLWFyfnas0OnV/P+RMQ1Zr+vPRqO7AR2va\nN9wg+Xl7157dhXPCGYnGMNSoxCbpRs0JNlzvJMuAea5nTTznRaJZtK/xKsqLn51D\nK07k9MHVFXakOH8QtMCUglbwfTfIpO5YRq5imxlWbqsYWVQy1WGJFyW6hWC0+RcJ\nOx5zGtOfi4/dN+xJ+ibnbyvy/il7Qm+vyFhCYqIPyS5m2UVJUuao3eApE38k78/o\n8aQOTnFQZ+U1Sw+6woFTxjqRQBXlQm2+7Bt3bqGATg4sXXWPbmwdL87Ic+mxn/ml\nSMfQux/5k6iAu1kQhwkO2YJn9eII6HIPkW+2m5N1JsUyJQe4cbtZE5Yh3TRA0dm7\n+zoBRfCXkOW4krchbgww/ptVmzMMP7GINJdROrJnsGl5FVeid9qHzV7aZycWSma7\nCxBYB1J8HCbty5NjtD6XMYRrMLxXugvX6Q4NPPH+2NKjzX4SIDejS6JjgrP3KA3O\npMuo7ZHMfveBngv8yP+ZD/1sS6l+dfExvdaJdOdgFCnp4p3gPbw5+Lv70HrMjA==\n=BfZ/\n-----END PGP PUBLIC KEY BLOCK-----\n",
+                    "checksum": "sha256:9f596e18f585bee30ac41c11fb11a83ed6b11d5b341c1cb56ca4015d7717cb97"
+                  }
+                ],
+                "packages": [
+                  "dnf",
+                  "dosfstools",
+                  "e2fsprogs",
+                  "grub2-pc",
+                  "policycoreutils",
+                  "qemu-img",
+                  "systemd",
+                  "tar"
+                ],
+                "releasever": "30",
+                "basearch": "x86_64",
+                "module_platform_id": "platform:f30"
+              }
             }
+          ]
+        },
+        "runner": "org.osbuild.fedora30"
+      },
+      "stages": [
+        {
+          "name": "org.osbuild.dnf",
+          "options": {
+            "repos": [
+              {
+                "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-30&arch=x86_64",
+                "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBFturGcBEACv0xBo91V2n0uEC2vh69ywCiSyvUgN/AQH8EZpCVtM7NyjKgKm\nbbY4G3R0M3ir1xXmvUDvK0493/qOiFrjkplvzXFTGpPTi0ypqGgxc5d0ohRA1M75\nL+0AIlXoOgHQ358/c4uO8X0JAA1NYxCkAW1KSJgFJ3RjukrfqSHWthS1d4o8fhHy\nKJKEnirE5hHqB50dafXrBfgZdaOs3C6ppRIePFe2o4vUEapMTCHFw0woQR8Ah4/R\nn7Z9G9Ln+0Cinmy0nbIDiZJ+pgLAXCOWBfDUzcOjDGKvcpoZharA07c0q1/5ojzO\n4F0Fh4g/BUmtrASwHfcIbjHyCSr1j/3Iz883iy07gJY5Yhiuaqmp0o0f9fgHkG53\n2xCU1owmACqaIBNQMukvXRDtB2GJMuKa/asTZDP6R5re+iXs7+s9ohcRRAKGyAyc\nYKIQKcaA+6M8T7/G+TPHZX6HJWqJJiYB+EC2ERblpvq9TPlLguEWcmvjbVc31nyq\nSDoO3ncFWKFmVsbQPTbP+pKUmlLfJwtb5XqxNR5GEXSwVv4I7IqBmJz1MmRafnBZ\ng0FJUtH668GnldO20XbnSVBr820F5SISMXVwCXDXEvGwwiB8Lt8PvqzXnGIFDAu3\nDlQI5sxSqpPVWSyw08ppKT2Tpmy8adiBotLfaCFl2VTHwOae48X2dMPBvQARAQAB\ntDFGZWRvcmEgKDMwKSA8ZmVkb3JhLTMwLXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQI4BBMBAgAiBQJbbqxnAhsPBgsJCAcDAgYVCAIJCgsEFgIDAQIeAQIXgAAK\nCRDvPBEfz8ZZudTnD/9170LL3nyTVUCFmBjT9wZ4gYnpwtKVPa/pKnxbbS+Bmmac\ng9TrT9pZbqOHrNJLiZ3Zx1Hp+8uxr3Lo6kbYwImLhkOEDrf4aP17HfQ6VYFbQZI8\nf79OFxWJ7si9+3gfzeh9UYFEqOQfzIjLWFyfnas0OnV/P+RMQ1Zr+vPRqO7AR2va\nN9wg+Xl7157dhXPCGYnGMNSoxCbpRs0JNlzvJMuAea5nTTznRaJZtK/xKsqLn51D\nK07k9MHVFXakOH8QtMCUglbwfTfIpO5YRq5imxlWbqsYWVQy1WGJFyW6hWC0+RcJ\nOx5zGtOfi4/dN+xJ+ibnbyvy/il7Qm+vyFhCYqIPyS5m2UVJUuao3eApE38k78/o\n8aQOTnFQZ+U1Sw+6woFTxjqRQBXlQm2+7Bt3bqGATg4sXXWPbmwdL87Ic+mxn/ml\nSMfQux/5k6iAu1kQhwkO2YJn9eII6HIPkW+2m5N1JsUyJQe4cbtZE5Yh3TRA0dm7\n+zoBRfCXkOW4krchbgww/ptVmzMMP7GINJdROrJnsGl5FVeid9qHzV7aZycWSma7\nCxBYB1J8HCbty5NjtD6XMYRrMLxXugvX6Q4NPPH+2NKjzX4SIDejS6JjgrP3KA3O\npMuo7ZHMfveBngv8yP+ZD/1sS6l+dfExvdaJdOdgFCnp4p3gPbw5+Lv70HrMjA==\n=BfZ/\n-----END PGP PUBLIC KEY BLOCK-----\n",
+                "checksum": "sha256:9f596e18f585bee30ac41c11fb11a83ed6b11d5b341c1cb56ca4015d7717cb97"
+              }
+            ],
+            "packages": [
+              "@Core",
+              "WALinuxAgent",
+              "chrony",
+              "dracut-config-generic",
+              "glibc-all-langpacks",
+              "grub2-pc",
+              "initscripts",
+              "kernel",
+              "langpacks-en",
+              "libxcrypt-compat",
+              "net-tools",
+              "ntfsprogs",
+              "selinux-policy-targeted"
+            ],
+            "exclude_packages": [
+              "dracut-config-rescue"
+            ],
+            "releasever": "30",
+            "basearch": "x86_64",
+            "module_platform_id": "platform:f30"
           }
-        ]
-      },
-      "runner": "org.osbuild.fedora30"
-    },
-    "stages": [
-      {
-        "name": "org.osbuild.dnf",
-        "options": {
-          "repos": [
-            {
-              "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-30&arch=x86_64",
-              "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBFturGcBEACv0xBo91V2n0uEC2vh69ywCiSyvUgN/AQH8EZpCVtM7NyjKgKm\nbbY4G3R0M3ir1xXmvUDvK0493/qOiFrjkplvzXFTGpPTi0ypqGgxc5d0ohRA1M75\nL+0AIlXoOgHQ358/c4uO8X0JAA1NYxCkAW1KSJgFJ3RjukrfqSHWthS1d4o8fhHy\nKJKEnirE5hHqB50dafXrBfgZdaOs3C6ppRIePFe2o4vUEapMTCHFw0woQR8Ah4/R\nn7Z9G9Ln+0Cinmy0nbIDiZJ+pgLAXCOWBfDUzcOjDGKvcpoZharA07c0q1/5ojzO\n4F0Fh4g/BUmtrASwHfcIbjHyCSr1j/3Iz883iy07gJY5Yhiuaqmp0o0f9fgHkG53\n2xCU1owmACqaIBNQMukvXRDtB2GJMuKa/asTZDP6R5re+iXs7+s9ohcRRAKGyAyc\nYKIQKcaA+6M8T7/G+TPHZX6HJWqJJiYB+EC2ERblpvq9TPlLguEWcmvjbVc31nyq\nSDoO3ncFWKFmVsbQPTbP+pKUmlLfJwtb5XqxNR5GEXSwVv4I7IqBmJz1MmRafnBZ\ng0FJUtH668GnldO20XbnSVBr820F5SISMXVwCXDXEvGwwiB8Lt8PvqzXnGIFDAu3\nDlQI5sxSqpPVWSyw08ppKT2Tpmy8adiBotLfaCFl2VTHwOae48X2dMPBvQARAQAB\ntDFGZWRvcmEgKDMwKSA8ZmVkb3JhLTMwLXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQI4BBMBAgAiBQJbbqxnAhsPBgsJCAcDAgYVCAIJCgsEFgIDAQIeAQIXgAAK\nCRDvPBEfz8ZZudTnD/9170LL3nyTVUCFmBjT9wZ4gYnpwtKVPa/pKnxbbS+Bmmac\ng9TrT9pZbqOHrNJLiZ3Zx1Hp+8uxr3Lo6kbYwImLhkOEDrf4aP17HfQ6VYFbQZI8\nf79OFxWJ7si9+3gfzeh9UYFEqOQfzIjLWFyfnas0OnV/P+RMQ1Zr+vPRqO7AR2va\nN9wg+Xl7157dhXPCGYnGMNSoxCbpRs0JNlzvJMuAea5nTTznRaJZtK/xKsqLn51D\nK07k9MHVFXakOH8QtMCUglbwfTfIpO5YRq5imxlWbqsYWVQy1WGJFyW6hWC0+RcJ\nOx5zGtOfi4/dN+xJ+ibnbyvy/il7Qm+vyFhCYqIPyS5m2UVJUuao3eApE38k78/o\n8aQOTnFQZ+U1Sw+6woFTxjqRQBXlQm2+7Bt3bqGATg4sXXWPbmwdL87Ic+mxn/ml\nSMfQux/5k6iAu1kQhwkO2YJn9eII6HIPkW+2m5N1JsUyJQe4cbtZE5Yh3TRA0dm7\n+zoBRfCXkOW4krchbgww/ptVmzMMP7GINJdROrJnsGl5FVeid9qHzV7aZycWSma7\nCxBYB1J8HCbty5NjtD6XMYRrMLxXugvX6Q4NPPH+2NKjzX4SIDejS6JjgrP3KA3O\npMuo7ZHMfveBngv8yP+ZD/1sS6l+dfExvdaJdOdgFCnp4p3gPbw5+Lv70HrMjA==\n=BfZ/\n-----END PGP PUBLIC KEY BLOCK-----\n",
-              "checksum": "sha256:9f596e18f585bee30ac41c11fb11a83ed6b11d5b341c1cb56ca4015d7717cb97"
-            }
-          ],
-          "packages": [
-            "@Core",
-            "WALinuxAgent",
-            "chrony",
-            "dracut-config-generic",
-            "glibc-all-langpacks",
-            "grub2-pc",
-            "initscripts",
-            "kernel",
-            "langpacks-en",
-            "libxcrypt-compat",
-            "net-tools",
-            "ntfsprogs",
-            "selinux-policy-targeted"
-          ],
-          "exclude_packages": [
-            "dracut-config-rescue"
-          ],
-          "releasever": "30",
-          "basearch": "x86_64",
-          "module_platform_id": "platform:f30"
+        },
+        {
+          "name": "org.osbuild.fix-bls",
+          "options": {}
+        },
+        {
+          "name": "org.osbuild.locale",
+          "options": {
+            "language": "en_US"
+          }
+        },
+        {
+          "name": "org.osbuild.fstab",
+          "options": {
+            "filesystems": [
+              {
+                "uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
+                "vfs_type": "ext4",
+                "path": "/",
+                "options": "defaults",
+                "freq": 1,
+                "passno": 1
+              }
+            ]
+          }
+        },
+        {
+          "name": "org.osbuild.grub2",
+          "options": {
+            "root_fs_uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
+            "kernel_opts": "ro biosdevname=0 rootdelay=300 console=ttyS0 earlyprintk=ttyS0 net.ifnames=0",
+            "legacy": true
+          }
+        },
+        {
+          "name": "org.osbuild.systemd",
+          "options": {
+            "enabled_services": [
+              "sshd",
+              "waagent"
+            ],
+            "disabled_services": [
+              "proc-sys-fs-binfmt_misc.mount",
+              "loadmodules.service"
+            ]
+          }
+        },
+        {
+          "name": "org.osbuild.selinux",
+          "options": {
+            "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
+          }
         }
-      },
-      {
-        "name": "org.osbuild.fix-bls",
-        "options": {}
-      },
-      {
-        "name": "org.osbuild.locale",
+      ],
+      "assembler": {
+        "name": "org.osbuild.qemu",
         "options": {
-          "language": "en_US"
-        }
-      },
-      {
-        "name": "org.osbuild.fstab",
-        "options": {
-          "filesystems": [
+          "format": "vpc",
+          "filename": "disk.vhd",
+          "size": 2147483648,
+          "ptuuid": "0x14fc63d2",
+          "pttype": "mbr",
+          "partitions": [
             {
-              "uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
-              "vfs_type": "ext4",
-              "path": "/",
-              "options": "defaults",
-              "freq": 1,
-              "passno": 1
+              "start": 2048,
+              "bootable": true,
+              "filesystem": {
+                "type": "ext4",
+                "uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
+                "mountpoint": "/"
+              }
             }
           ]
         }
-      },
-      {
-        "name": "org.osbuild.grub2",
-        "options": {
-          "root_fs_uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
-          "kernel_opts": "ro biosdevname=0 rootdelay=300 console=ttyS0 earlyprintk=ttyS0 net.ifnames=0",
-          "legacy": true
-        }
-      },
-      {
-        "name": "org.osbuild.systemd",
-        "options": {
-          "enabled_services": [
-            "sshd",
-            "waagent"
-          ],
-          "disabled_services": [
-            "proc-sys-fs-binfmt_misc.mount",
-            "loadmodules.service"
-          ]
-        }
-      },
-      {
-        "name": "org.osbuild.selinux",
-        "options": {
-          "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
-        }
-      }
-    ],
-    "assembler": {
-      "name": "org.osbuild.qemu",
-      "options": {
-        "format": "vpc",
-        "filename": "disk.vhd",
-        "size": 2147483648,
-        "ptuuid": "0x14fc63d2",
-        "pttype": "mbr",
-        "partitions": [
-          {
-            "start": 2048,
-            "bootable": true,
-            "filesystem": {
-              "type": "ext4",
-              "uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
-              "mountpoint": "/"
-            }
-          }
-        ]
       }
     }
   },

--- a/test/cases/vhd_local_boot.json
+++ b/test/cases/vhd_local_boot.json
@@ -42,151 +42,154 @@
       "fedora": "sha256:9f596e18f585bee30ac41c11fb11a83ed6b11d5b341c1cb56ca4015d7717cb97"
     }
   },
-  "pipeline": {
-    "build": {
-      "pipeline": {
-        "stages": [
-          {
-            "name": "org.osbuild.dnf",
-            "options": {
-              "repos": [
-                {
-                  "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-30&arch=x86_64",
-                  "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBFturGcBEACv0xBo91V2n0uEC2vh69ywCiSyvUgN/AQH8EZpCVtM7NyjKgKm\nbbY4G3R0M3ir1xXmvUDvK0493/qOiFrjkplvzXFTGpPTi0ypqGgxc5d0ohRA1M75\nL+0AIlXoOgHQ358/c4uO8X0JAA1NYxCkAW1KSJgFJ3RjukrfqSHWthS1d4o8fhHy\nKJKEnirE5hHqB50dafXrBfgZdaOs3C6ppRIePFe2o4vUEapMTCHFw0woQR8Ah4/R\nn7Z9G9Ln+0Cinmy0nbIDiZJ+pgLAXCOWBfDUzcOjDGKvcpoZharA07c0q1/5ojzO\n4F0Fh4g/BUmtrASwHfcIbjHyCSr1j/3Iz883iy07gJY5Yhiuaqmp0o0f9fgHkG53\n2xCU1owmACqaIBNQMukvXRDtB2GJMuKa/asTZDP6R5re+iXs7+s9ohcRRAKGyAyc\nYKIQKcaA+6M8T7/G+TPHZX6HJWqJJiYB+EC2ERblpvq9TPlLguEWcmvjbVc31nyq\nSDoO3ncFWKFmVsbQPTbP+pKUmlLfJwtb5XqxNR5GEXSwVv4I7IqBmJz1MmRafnBZ\ng0FJUtH668GnldO20XbnSVBr820F5SISMXVwCXDXEvGwwiB8Lt8PvqzXnGIFDAu3\nDlQI5sxSqpPVWSyw08ppKT2Tpmy8adiBotLfaCFl2VTHwOae48X2dMPBvQARAQAB\ntDFGZWRvcmEgKDMwKSA8ZmVkb3JhLTMwLXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQI4BBMBAgAiBQJbbqxnAhsPBgsJCAcDAgYVCAIJCgsEFgIDAQIeAQIXgAAK\nCRDvPBEfz8ZZudTnD/9170LL3nyTVUCFmBjT9wZ4gYnpwtKVPa/pKnxbbS+Bmmac\ng9TrT9pZbqOHrNJLiZ3Zx1Hp+8uxr3Lo6kbYwImLhkOEDrf4aP17HfQ6VYFbQZI8\nf79OFxWJ7si9+3gfzeh9UYFEqOQfzIjLWFyfnas0OnV/P+RMQ1Zr+vPRqO7AR2va\nN9wg+Xl7157dhXPCGYnGMNSoxCbpRs0JNlzvJMuAea5nTTznRaJZtK/xKsqLn51D\nK07k9MHVFXakOH8QtMCUglbwfTfIpO5YRq5imxlWbqsYWVQy1WGJFyW6hWC0+RcJ\nOx5zGtOfi4/dN+xJ+ibnbyvy/il7Qm+vyFhCYqIPyS5m2UVJUuao3eApE38k78/o\n8aQOTnFQZ+U1Sw+6woFTxjqRQBXlQm2+7Bt3bqGATg4sXXWPbmwdL87Ic+mxn/ml\nSMfQux/5k6iAu1kQhwkO2YJn9eII6HIPkW+2m5N1JsUyJQe4cbtZE5Yh3TRA0dm7\n+zoBRfCXkOW4krchbgww/ptVmzMMP7GINJdROrJnsGl5FVeid9qHzV7aZycWSma7\nCxBYB1J8HCbty5NjtD6XMYRrMLxXugvX6Q4NPPH+2NKjzX4SIDejS6JjgrP3KA3O\npMuo7ZHMfveBngv8yP+ZD/1sS6l+dfExvdaJdOdgFCnp4p3gPbw5+Lv70HrMjA==\n=BfZ/\n-----END PGP PUBLIC KEY BLOCK-----\n",
-                  "checksum": "sha256:9f596e18f585bee30ac41c11fb11a83ed6b11d5b341c1cb56ca4015d7717cb97"
-                }
-              ],
-              "packages": [
-                "dnf",
-                "dosfstools",
-                "e2fsprogs",
-                "grub2-pc",
-                "policycoreutils",
-                "qemu-img",
-                "systemd",
-                "tar"
-              ],
-              "releasever": "30",
-              "basearch": "x86_64",
-              "module_platform_id": "platform:f30"
+  "manifest": {
+    "sources": {},
+    "pipeline": {
+      "build": {
+        "pipeline": {
+          "stages": [
+            {
+              "name": "org.osbuild.dnf",
+              "options": {
+                "repos": [
+                  {
+                    "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-30&arch=x86_64",
+                    "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBFturGcBEACv0xBo91V2n0uEC2vh69ywCiSyvUgN/AQH8EZpCVtM7NyjKgKm\nbbY4G3R0M3ir1xXmvUDvK0493/qOiFrjkplvzXFTGpPTi0ypqGgxc5d0ohRA1M75\nL+0AIlXoOgHQ358/c4uO8X0JAA1NYxCkAW1KSJgFJ3RjukrfqSHWthS1d4o8fhHy\nKJKEnirE5hHqB50dafXrBfgZdaOs3C6ppRIePFe2o4vUEapMTCHFw0woQR8Ah4/R\nn7Z9G9Ln+0Cinmy0nbIDiZJ+pgLAXCOWBfDUzcOjDGKvcpoZharA07c0q1/5ojzO\n4F0Fh4g/BUmtrASwHfcIbjHyCSr1j/3Iz883iy07gJY5Yhiuaqmp0o0f9fgHkG53\n2xCU1owmACqaIBNQMukvXRDtB2GJMuKa/asTZDP6R5re+iXs7+s9ohcRRAKGyAyc\nYKIQKcaA+6M8T7/G+TPHZX6HJWqJJiYB+EC2ERblpvq9TPlLguEWcmvjbVc31nyq\nSDoO3ncFWKFmVsbQPTbP+pKUmlLfJwtb5XqxNR5GEXSwVv4I7IqBmJz1MmRafnBZ\ng0FJUtH668GnldO20XbnSVBr820F5SISMXVwCXDXEvGwwiB8Lt8PvqzXnGIFDAu3\nDlQI5sxSqpPVWSyw08ppKT2Tpmy8adiBotLfaCFl2VTHwOae48X2dMPBvQARAQAB\ntDFGZWRvcmEgKDMwKSA8ZmVkb3JhLTMwLXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQI4BBMBAgAiBQJbbqxnAhsPBgsJCAcDAgYVCAIJCgsEFgIDAQIeAQIXgAAK\nCRDvPBEfz8ZZudTnD/9170LL3nyTVUCFmBjT9wZ4gYnpwtKVPa/pKnxbbS+Bmmac\ng9TrT9pZbqOHrNJLiZ3Zx1Hp+8uxr3Lo6kbYwImLhkOEDrf4aP17HfQ6VYFbQZI8\nf79OFxWJ7si9+3gfzeh9UYFEqOQfzIjLWFyfnas0OnV/P+RMQ1Zr+vPRqO7AR2va\nN9wg+Xl7157dhXPCGYnGMNSoxCbpRs0JNlzvJMuAea5nTTznRaJZtK/xKsqLn51D\nK07k9MHVFXakOH8QtMCUglbwfTfIpO5YRq5imxlWbqsYWVQy1WGJFyW6hWC0+RcJ\nOx5zGtOfi4/dN+xJ+ibnbyvy/il7Qm+vyFhCYqIPyS5m2UVJUuao3eApE38k78/o\n8aQOTnFQZ+U1Sw+6woFTxjqRQBXlQm2+7Bt3bqGATg4sXXWPbmwdL87Ic+mxn/ml\nSMfQux/5k6iAu1kQhwkO2YJn9eII6HIPkW+2m5N1JsUyJQe4cbtZE5Yh3TRA0dm7\n+zoBRfCXkOW4krchbgww/ptVmzMMP7GINJdROrJnsGl5FVeid9qHzV7aZycWSma7\nCxBYB1J8HCbty5NjtD6XMYRrMLxXugvX6Q4NPPH+2NKjzX4SIDejS6JjgrP3KA3O\npMuo7ZHMfveBngv8yP+ZD/1sS6l+dfExvdaJdOdgFCnp4p3gPbw5+Lv70HrMjA==\n=BfZ/\n-----END PGP PUBLIC KEY BLOCK-----\n",
+                    "checksum": "sha256:9f596e18f585bee30ac41c11fb11a83ed6b11d5b341c1cb56ca4015d7717cb97"
+                  }
+                ],
+                "packages": [
+                  "dnf",
+                  "dosfstools",
+                  "e2fsprogs",
+                  "grub2-pc",
+                  "policycoreutils",
+                  "qemu-img",
+                  "systemd",
+                  "tar"
+                ],
+                "releasever": "30",
+                "basearch": "x86_64",
+                "module_platform_id": "platform:f30"
+              }
+            }
+          ]
+        },
+        "runner": "org.osbuild.fedora30"
+      },
+      "stages": [
+        {
+          "name": "org.osbuild.dnf",
+          "options": {
+            "repos": [
+              {
+                "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-30&arch=x86_64",
+                "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBFturGcBEACv0xBo91V2n0uEC2vh69ywCiSyvUgN/AQH8EZpCVtM7NyjKgKm\nbbY4G3R0M3ir1xXmvUDvK0493/qOiFrjkplvzXFTGpPTi0ypqGgxc5d0ohRA1M75\nL+0AIlXoOgHQ358/c4uO8X0JAA1NYxCkAW1KSJgFJ3RjukrfqSHWthS1d4o8fhHy\nKJKEnirE5hHqB50dafXrBfgZdaOs3C6ppRIePFe2o4vUEapMTCHFw0woQR8Ah4/R\nn7Z9G9Ln+0Cinmy0nbIDiZJ+pgLAXCOWBfDUzcOjDGKvcpoZharA07c0q1/5ojzO\n4F0Fh4g/BUmtrASwHfcIbjHyCSr1j/3Iz883iy07gJY5Yhiuaqmp0o0f9fgHkG53\n2xCU1owmACqaIBNQMukvXRDtB2GJMuKa/asTZDP6R5re+iXs7+s9ohcRRAKGyAyc\nYKIQKcaA+6M8T7/G+TPHZX6HJWqJJiYB+EC2ERblpvq9TPlLguEWcmvjbVc31nyq\nSDoO3ncFWKFmVsbQPTbP+pKUmlLfJwtb5XqxNR5GEXSwVv4I7IqBmJz1MmRafnBZ\ng0FJUtH668GnldO20XbnSVBr820F5SISMXVwCXDXEvGwwiB8Lt8PvqzXnGIFDAu3\nDlQI5sxSqpPVWSyw08ppKT2Tpmy8adiBotLfaCFl2VTHwOae48X2dMPBvQARAQAB\ntDFGZWRvcmEgKDMwKSA8ZmVkb3JhLTMwLXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQI4BBMBAgAiBQJbbqxnAhsPBgsJCAcDAgYVCAIJCgsEFgIDAQIeAQIXgAAK\nCRDvPBEfz8ZZudTnD/9170LL3nyTVUCFmBjT9wZ4gYnpwtKVPa/pKnxbbS+Bmmac\ng9TrT9pZbqOHrNJLiZ3Zx1Hp+8uxr3Lo6kbYwImLhkOEDrf4aP17HfQ6VYFbQZI8\nf79OFxWJ7si9+3gfzeh9UYFEqOQfzIjLWFyfnas0OnV/P+RMQ1Zr+vPRqO7AR2va\nN9wg+Xl7157dhXPCGYnGMNSoxCbpRs0JNlzvJMuAea5nTTznRaJZtK/xKsqLn51D\nK07k9MHVFXakOH8QtMCUglbwfTfIpO5YRq5imxlWbqsYWVQy1WGJFyW6hWC0+RcJ\nOx5zGtOfi4/dN+xJ+ibnbyvy/il7Qm+vyFhCYqIPyS5m2UVJUuao3eApE38k78/o\n8aQOTnFQZ+U1Sw+6woFTxjqRQBXlQm2+7Bt3bqGATg4sXXWPbmwdL87Ic+mxn/ml\nSMfQux/5k6iAu1kQhwkO2YJn9eII6HIPkW+2m5N1JsUyJQe4cbtZE5Yh3TRA0dm7\n+zoBRfCXkOW4krchbgww/ptVmzMMP7GINJdROrJnsGl5FVeid9qHzV7aZycWSma7\nCxBYB1J8HCbty5NjtD6XMYRrMLxXugvX6Q4NPPH+2NKjzX4SIDejS6JjgrP3KA3O\npMuo7ZHMfveBngv8yP+ZD/1sS6l+dfExvdaJdOdgFCnp4p3gPbw5+Lv70HrMjA==\n=BfZ/\n-----END PGP PUBLIC KEY BLOCK-----\n",
+                "checksum": "sha256:9f596e18f585bee30ac41c11fb11a83ed6b11d5b341c1cb56ca4015d7717cb97"
+              }
+            ],
+            "packages": [
+              "@Core",
+              "WALinuxAgent",
+              "chrony",
+              "grub2-pc",
+              "kernel",
+              "langpacks-en",
+              "libxcrypt-compat",
+              "net-tools",
+              "ntfsprogs",
+              "selinux-policy-targeted"
+            ],
+            "exclude_packages": [
+              "dracut-config-rescue"
+            ],
+            "releasever": "30",
+            "basearch": "x86_64",
+            "module_platform_id": "platform:f30"
+          }
+        },
+        {
+          "name": "org.osbuild.locale",
+          "options": {
+            "language": "en_US"
+          }
+        },
+        {
+          "name": "org.osbuild.fstab",
+          "options": {
+            "filesystems": [
+              {
+                "uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
+                "vfs_type": "ext4",
+                "path": "/",
+                "options": "defaults",
+                "freq": 1,
+                "passno": 1
+              }
+            ]
+          }
+        },
+        {
+          "name": "org.osbuild.grub2",
+          "options": {
+            "root_fs_uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
+            "kernel_opts": "ro biosdevname=0 net.ifnames=0",
+            "legacy": true
+          }
+        },
+        {
+          "name": "org.osbuild.systemd",
+          "options": {
+            "enabled_services": [
+              "sshd"
+            ]
+          }
+        },
+        {
+          "name": "org.osbuild.users",
+          "options": {
+            "users": {
+              "redhat": {
+                "groups": [
+                  "wheel"
+                ],
+                "password": "$6$IR7O7z56ouB/OInP$.hscD6dQqPQGwMuQ.idumixSHI/JEyaUfiCAHVSpGO/iNLEvvVZVOQL23zBzQbc2.yJ25xAZD75H0tXqKJpEE/",
+                "key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC61wMCjOSHwbVb4VfVyl5sn497qW4PsdQ7Ty7aD6wDNZ/QjjULkDV/yW5WjDlDQ7UqFH0Sr7vywjqDizUAqK7zM5FsUKsUXWHWwg/ehKg8j9xKcMv11AkFoUoujtfAujnKODkk58XSA9whPr7qcw3vPrmog680pnMSzf9LC7J6kXfs6lkoKfBh9VnlxusCrw2yg0qI1fHAZBLPx7mW6+me71QZsS6sVz8v8KXyrXsKTdnF50FjzHcK9HXDBtSJS5wA3fkcRYymJe0o6WMWNdgSRVpoSiWaHHmFgdMUJaYoCfhXzyl7LtNb3Q+Sveg+tJK7JaRXBLMUllOlJ6ll5Hod root@localhost"
+              }
             }
           }
-        ]
-      },
-      "runner": "org.osbuild.fedora30"
-    },
-    "stages": [
-      {
-        "name": "org.osbuild.dnf",
-        "options": {
-          "repos": [
-            {
-              "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-30&arch=x86_64",
-              "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBFturGcBEACv0xBo91V2n0uEC2vh69ywCiSyvUgN/AQH8EZpCVtM7NyjKgKm\nbbY4G3R0M3ir1xXmvUDvK0493/qOiFrjkplvzXFTGpPTi0ypqGgxc5d0ohRA1M75\nL+0AIlXoOgHQ358/c4uO8X0JAA1NYxCkAW1KSJgFJ3RjukrfqSHWthS1d4o8fhHy\nKJKEnirE5hHqB50dafXrBfgZdaOs3C6ppRIePFe2o4vUEapMTCHFw0woQR8Ah4/R\nn7Z9G9Ln+0Cinmy0nbIDiZJ+pgLAXCOWBfDUzcOjDGKvcpoZharA07c0q1/5ojzO\n4F0Fh4g/BUmtrASwHfcIbjHyCSr1j/3Iz883iy07gJY5Yhiuaqmp0o0f9fgHkG53\n2xCU1owmACqaIBNQMukvXRDtB2GJMuKa/asTZDP6R5re+iXs7+s9ohcRRAKGyAyc\nYKIQKcaA+6M8T7/G+TPHZX6HJWqJJiYB+EC2ERblpvq9TPlLguEWcmvjbVc31nyq\nSDoO3ncFWKFmVsbQPTbP+pKUmlLfJwtb5XqxNR5GEXSwVv4I7IqBmJz1MmRafnBZ\ng0FJUtH668GnldO20XbnSVBr820F5SISMXVwCXDXEvGwwiB8Lt8PvqzXnGIFDAu3\nDlQI5sxSqpPVWSyw08ppKT2Tpmy8adiBotLfaCFl2VTHwOae48X2dMPBvQARAQAB\ntDFGZWRvcmEgKDMwKSA8ZmVkb3JhLTMwLXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQI4BBMBAgAiBQJbbqxnAhsPBgsJCAcDAgYVCAIJCgsEFgIDAQIeAQIXgAAK\nCRDvPBEfz8ZZudTnD/9170LL3nyTVUCFmBjT9wZ4gYnpwtKVPa/pKnxbbS+Bmmac\ng9TrT9pZbqOHrNJLiZ3Zx1Hp+8uxr3Lo6kbYwImLhkOEDrf4aP17HfQ6VYFbQZI8\nf79OFxWJ7si9+3gfzeh9UYFEqOQfzIjLWFyfnas0OnV/P+RMQ1Zr+vPRqO7AR2va\nN9wg+Xl7157dhXPCGYnGMNSoxCbpRs0JNlzvJMuAea5nTTznRaJZtK/xKsqLn51D\nK07k9MHVFXakOH8QtMCUglbwfTfIpO5YRq5imxlWbqsYWVQy1WGJFyW6hWC0+RcJ\nOx5zGtOfi4/dN+xJ+ibnbyvy/il7Qm+vyFhCYqIPyS5m2UVJUuao3eApE38k78/o\n8aQOTnFQZ+U1Sw+6woFTxjqRQBXlQm2+7Bt3bqGATg4sXXWPbmwdL87Ic+mxn/ml\nSMfQux/5k6iAu1kQhwkO2YJn9eII6HIPkW+2m5N1JsUyJQe4cbtZE5Yh3TRA0dm7\n+zoBRfCXkOW4krchbgww/ptVmzMMP7GINJdROrJnsGl5FVeid9qHzV7aZycWSma7\nCxBYB1J8HCbty5NjtD6XMYRrMLxXugvX6Q4NPPH+2NKjzX4SIDejS6JjgrP3KA3O\npMuo7ZHMfveBngv8yP+ZD/1sS6l+dfExvdaJdOdgFCnp4p3gPbw5+Lv70HrMjA==\n=BfZ/\n-----END PGP PUBLIC KEY BLOCK-----\n",
-              "checksum": "sha256:9f596e18f585bee30ac41c11fb11a83ed6b11d5b341c1cb56ca4015d7717cb97"
-            }
-          ],
-          "packages": [
-            "@Core",
-            "WALinuxAgent",
-            "chrony",
-            "grub2-pc",
-            "kernel",
-            "langpacks-en",
-            "libxcrypt-compat",
-            "net-tools",
-            "ntfsprogs",
-            "selinux-policy-targeted"
-          ],
-          "exclude_packages": [
-            "dracut-config-rescue"
-          ],
-          "releasever": "30",
-          "basearch": "x86_64",
-          "module_platform_id": "platform:f30"
+        },
+        {
+          "name": "org.osbuild.fix-bls",
+          "options": {}
+        },
+        {
+          "name": "org.osbuild.selinux",
+          "options": {
+            "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
+          }
         }
-      },
-      {
-        "name": "org.osbuild.locale",
+      ],
+      "assembler": {
+        "name": "org.osbuild.qemu",
         "options": {
-          "language": "en_US"
-        }
-      },
-      {
-        "name": "org.osbuild.fstab",
-        "options": {
-          "filesystems": [
+          "format": "qcow2",
+          "filename": "disk.vhd",
+          "size": 2147483648,
+          "ptuuid": "0x14fc63d2",
+          "pttype": "mbr",
+          "partitions": [
             {
-              "uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
-              "vfs_type": "ext4",
-              "path": "/",
-              "options": "defaults",
-              "freq": 1,
-              "passno": 1
+              "start": 2048,
+              "bootable": true,
+              "filesystem": {
+                "type": "ext4",
+                "uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
+                "mountpoint": "/"
+              }
             }
           ]
         }
-      },
-      {
-        "name": "org.osbuild.grub2",
-        "options": {
-          "root_fs_uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
-          "kernel_opts": "ro biosdevname=0 net.ifnames=0",
-          "legacy": true
-        }
-      },
-      {
-        "name": "org.osbuild.systemd",
-        "options": {
-          "enabled_services": [
-            "sshd"
-          ]
-        }
-      },
-      {
-        "name": "org.osbuild.users",
-        "options": {
-          "users": {
-            "redhat": {
-              "groups": [
-                "wheel"
-              ],
-              "password": "$6$IR7O7z56ouB/OInP$.hscD6dQqPQGwMuQ.idumixSHI/JEyaUfiCAHVSpGO/iNLEvvVZVOQL23zBzQbc2.yJ25xAZD75H0tXqKJpEE/",
-              "key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC61wMCjOSHwbVb4VfVyl5sn497qW4PsdQ7Ty7aD6wDNZ/QjjULkDV/yW5WjDlDQ7UqFH0Sr7vywjqDizUAqK7zM5FsUKsUXWHWwg/ehKg8j9xKcMv11AkFoUoujtfAujnKODkk58XSA9whPr7qcw3vPrmog680pnMSzf9LC7J6kXfs6lkoKfBh9VnlxusCrw2yg0qI1fHAZBLPx7mW6+me71QZsS6sVz8v8KXyrXsKTdnF50FjzHcK9HXDBtSJS5wA3fkcRYymJe0o6WMWNdgSRVpoSiWaHHmFgdMUJaYoCfhXzyl7LtNb3Q+Sveg+tJK7JaRXBLMUllOlJ6ll5Hod root@localhost"
-            }
-          }
-        }
-      },
-      {
-        "name": "org.osbuild.fix-bls",
-        "options": {}
-      },
-      {
-        "name": "org.osbuild.selinux",
-        "options": {
-          "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
-        }
-      }
-    ],
-    "assembler": {
-      "name": "org.osbuild.qemu",
-      "options": {
-        "format": "qcow2",
-        "filename": "disk.vhd",
-        "size": 2147483648,
-        "ptuuid": "0x14fc63d2",
-        "pttype": "mbr",
-        "partitions": [
-          {
-            "start": 2048,
-            "bootable": true,
-            "filesystem": {
-              "type": "ext4",
-              "uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
-              "mountpoint": "/"
-            }
-          }
-        ]
       }
     }
   }

--- a/test/cases/vhd_local_boot.json
+++ b/test/cases/vhd_local_boot.json
@@ -37,6 +37,11 @@
       }
     }
   },
+  "rpmmd": {
+    "checksums": {
+      "fedora": "sha256:9f596e18f585bee30ac41c11fb11a83ed6b11d5b341c1cb56ca4015d7717cb97"
+    }
+  },
   "pipeline": {
     "build": {
       "pipeline": {

--- a/test/cases/vhd_local_boot.json
+++ b/test/cases/vhd_local_boot.json
@@ -2,7 +2,7 @@
   "boot": {
     "type": "qemu"
   },
-  "compose": {
+  "compose-request": {
     "distro": "fedora-30",
     "arch": "x86_64",
     "output-format": "vhd",

--- a/test/cases/vmdk_empty_blueprint.json
+++ b/test/cases/vmdk_empty_blueprint.json
@@ -2,12 +2,14 @@
   "compose": {
     "distro": "fedora-30",
     "arch": "x86_64",
-    "checksums": {
-      "fedora": "sha256:9f596e18f585bee30ac41c11fb11a83ed6b11d5b341c1cb56ca4015d7717cb97"
-    },
     "output-format": "vmdk",
     "filename": "disk.vmdk",
     "blueprint": {}
+  },
+  "rpmmd": {
+    "checksums": {
+      "fedora": "sha256:9f596e18f585bee30ac41c11fb11a83ed6b11d5b341c1cb56ca4015d7717cb97"
+    }
   },
   "pipeline": {
     "build": {

--- a/test/cases/vmdk_empty_blueprint.json
+++ b/test/cases/vmdk_empty_blueprint.json
@@ -11,127 +11,130 @@
       "fedora": "sha256:9f596e18f585bee30ac41c11fb11a83ed6b11d5b341c1cb56ca4015d7717cb97"
     }
   },
-  "pipeline": {
-    "build": {
-      "pipeline": {
-        "stages": [
-          {
-            "name": "org.osbuild.dnf",
-            "options": {
-              "repos": [
-                {
-                  "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-30&arch=x86_64",
-                  "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBFturGcBEACv0xBo91V2n0uEC2vh69ywCiSyvUgN/AQH8EZpCVtM7NyjKgKm\nbbY4G3R0M3ir1xXmvUDvK0493/qOiFrjkplvzXFTGpPTi0ypqGgxc5d0ohRA1M75\nL+0AIlXoOgHQ358/c4uO8X0JAA1NYxCkAW1KSJgFJ3RjukrfqSHWthS1d4o8fhHy\nKJKEnirE5hHqB50dafXrBfgZdaOs3C6ppRIePFe2o4vUEapMTCHFw0woQR8Ah4/R\nn7Z9G9Ln+0Cinmy0nbIDiZJ+pgLAXCOWBfDUzcOjDGKvcpoZharA07c0q1/5ojzO\n4F0Fh4g/BUmtrASwHfcIbjHyCSr1j/3Iz883iy07gJY5Yhiuaqmp0o0f9fgHkG53\n2xCU1owmACqaIBNQMukvXRDtB2GJMuKa/asTZDP6R5re+iXs7+s9ohcRRAKGyAyc\nYKIQKcaA+6M8T7/G+TPHZX6HJWqJJiYB+EC2ERblpvq9TPlLguEWcmvjbVc31nyq\nSDoO3ncFWKFmVsbQPTbP+pKUmlLfJwtb5XqxNR5GEXSwVv4I7IqBmJz1MmRafnBZ\ng0FJUtH668GnldO20XbnSVBr820F5SISMXVwCXDXEvGwwiB8Lt8PvqzXnGIFDAu3\nDlQI5sxSqpPVWSyw08ppKT2Tpmy8adiBotLfaCFl2VTHwOae48X2dMPBvQARAQAB\ntDFGZWRvcmEgKDMwKSA8ZmVkb3JhLTMwLXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQI4BBMBAgAiBQJbbqxnAhsPBgsJCAcDAgYVCAIJCgsEFgIDAQIeAQIXgAAK\nCRDvPBEfz8ZZudTnD/9170LL3nyTVUCFmBjT9wZ4gYnpwtKVPa/pKnxbbS+Bmmac\ng9TrT9pZbqOHrNJLiZ3Zx1Hp+8uxr3Lo6kbYwImLhkOEDrf4aP17HfQ6VYFbQZI8\nf79OFxWJ7si9+3gfzeh9UYFEqOQfzIjLWFyfnas0OnV/P+RMQ1Zr+vPRqO7AR2va\nN9wg+Xl7157dhXPCGYnGMNSoxCbpRs0JNlzvJMuAea5nTTznRaJZtK/xKsqLn51D\nK07k9MHVFXakOH8QtMCUglbwfTfIpO5YRq5imxlWbqsYWVQy1WGJFyW6hWC0+RcJ\nOx5zGtOfi4/dN+xJ+ibnbyvy/il7Qm+vyFhCYqIPyS5m2UVJUuao3eApE38k78/o\n8aQOTnFQZ+U1Sw+6woFTxjqRQBXlQm2+7Bt3bqGATg4sXXWPbmwdL87Ic+mxn/ml\nSMfQux/5k6iAu1kQhwkO2YJn9eII6HIPkW+2m5N1JsUyJQe4cbtZE5Yh3TRA0dm7\n+zoBRfCXkOW4krchbgww/ptVmzMMP7GINJdROrJnsGl5FVeid9qHzV7aZycWSma7\nCxBYB1J8HCbty5NjtD6XMYRrMLxXugvX6Q4NPPH+2NKjzX4SIDejS6JjgrP3KA3O\npMuo7ZHMfveBngv8yP+ZD/1sS6l+dfExvdaJdOdgFCnp4p3gPbw5+Lv70HrMjA==\n=BfZ/\n-----END PGP PUBLIC KEY BLOCK-----\n",
-                  "checksum": "sha256:9f596e18f585bee30ac41c11fb11a83ed6b11d5b341c1cb56ca4015d7717cb97"
-                }
-              ],
-              "packages": [
-                "dnf",
-                "dosfstools",
-                "e2fsprogs",
-                "grub2-pc",
-                "policycoreutils",
-                "qemu-img",
-                "systemd",
-                "tar"
-              ],
-              "releasever": "30",
-              "basearch": "x86_64",
-              "module_platform_id": "platform:f30"
+  "manifest": {
+    "sources": {},
+    "pipeline": {
+      "build": {
+        "pipeline": {
+          "stages": [
+            {
+              "name": "org.osbuild.dnf",
+              "options": {
+                "repos": [
+                  {
+                    "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-30&arch=x86_64",
+                    "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBFturGcBEACv0xBo91V2n0uEC2vh69ywCiSyvUgN/AQH8EZpCVtM7NyjKgKm\nbbY4G3R0M3ir1xXmvUDvK0493/qOiFrjkplvzXFTGpPTi0ypqGgxc5d0ohRA1M75\nL+0AIlXoOgHQ358/c4uO8X0JAA1NYxCkAW1KSJgFJ3RjukrfqSHWthS1d4o8fhHy\nKJKEnirE5hHqB50dafXrBfgZdaOs3C6ppRIePFe2o4vUEapMTCHFw0woQR8Ah4/R\nn7Z9G9Ln+0Cinmy0nbIDiZJ+pgLAXCOWBfDUzcOjDGKvcpoZharA07c0q1/5ojzO\n4F0Fh4g/BUmtrASwHfcIbjHyCSr1j/3Iz883iy07gJY5Yhiuaqmp0o0f9fgHkG53\n2xCU1owmACqaIBNQMukvXRDtB2GJMuKa/asTZDP6R5re+iXs7+s9ohcRRAKGyAyc\nYKIQKcaA+6M8T7/G+TPHZX6HJWqJJiYB+EC2ERblpvq9TPlLguEWcmvjbVc31nyq\nSDoO3ncFWKFmVsbQPTbP+pKUmlLfJwtb5XqxNR5GEXSwVv4I7IqBmJz1MmRafnBZ\ng0FJUtH668GnldO20XbnSVBr820F5SISMXVwCXDXEvGwwiB8Lt8PvqzXnGIFDAu3\nDlQI5sxSqpPVWSyw08ppKT2Tpmy8adiBotLfaCFl2VTHwOae48X2dMPBvQARAQAB\ntDFGZWRvcmEgKDMwKSA8ZmVkb3JhLTMwLXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQI4BBMBAgAiBQJbbqxnAhsPBgsJCAcDAgYVCAIJCgsEFgIDAQIeAQIXgAAK\nCRDvPBEfz8ZZudTnD/9170LL3nyTVUCFmBjT9wZ4gYnpwtKVPa/pKnxbbS+Bmmac\ng9TrT9pZbqOHrNJLiZ3Zx1Hp+8uxr3Lo6kbYwImLhkOEDrf4aP17HfQ6VYFbQZI8\nf79OFxWJ7si9+3gfzeh9UYFEqOQfzIjLWFyfnas0OnV/P+RMQ1Zr+vPRqO7AR2va\nN9wg+Xl7157dhXPCGYnGMNSoxCbpRs0JNlzvJMuAea5nTTznRaJZtK/xKsqLn51D\nK07k9MHVFXakOH8QtMCUglbwfTfIpO5YRq5imxlWbqsYWVQy1WGJFyW6hWC0+RcJ\nOx5zGtOfi4/dN+xJ+ibnbyvy/il7Qm+vyFhCYqIPyS5m2UVJUuao3eApE38k78/o\n8aQOTnFQZ+U1Sw+6woFTxjqRQBXlQm2+7Bt3bqGATg4sXXWPbmwdL87Ic+mxn/ml\nSMfQux/5k6iAu1kQhwkO2YJn9eII6HIPkW+2m5N1JsUyJQe4cbtZE5Yh3TRA0dm7\n+zoBRfCXkOW4krchbgww/ptVmzMMP7GINJdROrJnsGl5FVeid9qHzV7aZycWSma7\nCxBYB1J8HCbty5NjtD6XMYRrMLxXugvX6Q4NPPH+2NKjzX4SIDejS6JjgrP3KA3O\npMuo7ZHMfveBngv8yP+ZD/1sS6l+dfExvdaJdOdgFCnp4p3gPbw5+Lv70HrMjA==\n=BfZ/\n-----END PGP PUBLIC KEY BLOCK-----\n",
+                    "checksum": "sha256:9f596e18f585bee30ac41c11fb11a83ed6b11d5b341c1cb56ca4015d7717cb97"
+                  }
+                ],
+                "packages": [
+                  "dnf",
+                  "dosfstools",
+                  "e2fsprogs",
+                  "grub2-pc",
+                  "policycoreutils",
+                  "qemu-img",
+                  "systemd",
+                  "tar"
+                ],
+                "releasever": "30",
+                "basearch": "x86_64",
+                "module_platform_id": "platform:f30"
+              }
             }
+          ]
+        },
+        "runner": "org.osbuild.fedora30"
+      },
+      "stages": [
+        {
+          "name": "org.osbuild.dnf",
+          "options": {
+            "repos": [
+              {
+                "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-30&arch=x86_64",
+                "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBFturGcBEACv0xBo91V2n0uEC2vh69ywCiSyvUgN/AQH8EZpCVtM7NyjKgKm\nbbY4G3R0M3ir1xXmvUDvK0493/qOiFrjkplvzXFTGpPTi0ypqGgxc5d0ohRA1M75\nL+0AIlXoOgHQ358/c4uO8X0JAA1NYxCkAW1KSJgFJ3RjukrfqSHWthS1d4o8fhHy\nKJKEnirE5hHqB50dafXrBfgZdaOs3C6ppRIePFe2o4vUEapMTCHFw0woQR8Ah4/R\nn7Z9G9Ln+0Cinmy0nbIDiZJ+pgLAXCOWBfDUzcOjDGKvcpoZharA07c0q1/5ojzO\n4F0Fh4g/BUmtrASwHfcIbjHyCSr1j/3Iz883iy07gJY5Yhiuaqmp0o0f9fgHkG53\n2xCU1owmACqaIBNQMukvXRDtB2GJMuKa/asTZDP6R5re+iXs7+s9ohcRRAKGyAyc\nYKIQKcaA+6M8T7/G+TPHZX6HJWqJJiYB+EC2ERblpvq9TPlLguEWcmvjbVc31nyq\nSDoO3ncFWKFmVsbQPTbP+pKUmlLfJwtb5XqxNR5GEXSwVv4I7IqBmJz1MmRafnBZ\ng0FJUtH668GnldO20XbnSVBr820F5SISMXVwCXDXEvGwwiB8Lt8PvqzXnGIFDAu3\nDlQI5sxSqpPVWSyw08ppKT2Tpmy8adiBotLfaCFl2VTHwOae48X2dMPBvQARAQAB\ntDFGZWRvcmEgKDMwKSA8ZmVkb3JhLTMwLXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQI4BBMBAgAiBQJbbqxnAhsPBgsJCAcDAgYVCAIJCgsEFgIDAQIeAQIXgAAK\nCRDvPBEfz8ZZudTnD/9170LL3nyTVUCFmBjT9wZ4gYnpwtKVPa/pKnxbbS+Bmmac\ng9TrT9pZbqOHrNJLiZ3Zx1Hp+8uxr3Lo6kbYwImLhkOEDrf4aP17HfQ6VYFbQZI8\nf79OFxWJ7si9+3gfzeh9UYFEqOQfzIjLWFyfnas0OnV/P+RMQ1Zr+vPRqO7AR2va\nN9wg+Xl7157dhXPCGYnGMNSoxCbpRs0JNlzvJMuAea5nTTznRaJZtK/xKsqLn51D\nK07k9MHVFXakOH8QtMCUglbwfTfIpO5YRq5imxlWbqsYWVQy1WGJFyW6hWC0+RcJ\nOx5zGtOfi4/dN+xJ+ibnbyvy/il7Qm+vyFhCYqIPyS5m2UVJUuao3eApE38k78/o\n8aQOTnFQZ+U1Sw+6woFTxjqRQBXlQm2+7Bt3bqGATg4sXXWPbmwdL87Ic+mxn/ml\nSMfQux/5k6iAu1kQhwkO2YJn9eII6HIPkW+2m5N1JsUyJQe4cbtZE5Yh3TRA0dm7\n+zoBRfCXkOW4krchbgww/ptVmzMMP7GINJdROrJnsGl5FVeid9qHzV7aZycWSma7\nCxBYB1J8HCbty5NjtD6XMYRrMLxXugvX6Q4NPPH+2NKjzX4SIDejS6JjgrP3KA3O\npMuo7ZHMfveBngv8yP+ZD/1sS6l+dfExvdaJdOdgFCnp4p3gPbw5+Lv70HrMjA==\n=BfZ/\n-----END PGP PUBLIC KEY BLOCK-----\n",
+                "checksum": "sha256:9f596e18f585bee30ac41c11fb11a83ed6b11d5b341c1cb56ca4015d7717cb97"
+              }
+            ],
+            "packages": [
+              "@core",
+              "chrony",
+              "firewalld",
+              "grub2-pc",
+              "kernel",
+              "langpacks-en",
+              "open-vm-tools",
+              "selinux-policy-targeted"
+            ],
+            "exclude_packages": [
+              "dracut-config-rescue"
+            ],
+            "releasever": "30",
+            "basearch": "x86_64",
+            "module_platform_id": "platform:f30"
           }
-        ]
-      },
-      "runner": "org.osbuild.fedora30"
-    },
-    "stages": [
-      {
-        "name": "org.osbuild.dnf",
-        "options": {
-          "repos": [
-            {
-              "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-30&arch=x86_64",
-              "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBFturGcBEACv0xBo91V2n0uEC2vh69ywCiSyvUgN/AQH8EZpCVtM7NyjKgKm\nbbY4G3R0M3ir1xXmvUDvK0493/qOiFrjkplvzXFTGpPTi0ypqGgxc5d0ohRA1M75\nL+0AIlXoOgHQ358/c4uO8X0JAA1NYxCkAW1KSJgFJ3RjukrfqSHWthS1d4o8fhHy\nKJKEnirE5hHqB50dafXrBfgZdaOs3C6ppRIePFe2o4vUEapMTCHFw0woQR8Ah4/R\nn7Z9G9Ln+0Cinmy0nbIDiZJ+pgLAXCOWBfDUzcOjDGKvcpoZharA07c0q1/5ojzO\n4F0Fh4g/BUmtrASwHfcIbjHyCSr1j/3Iz883iy07gJY5Yhiuaqmp0o0f9fgHkG53\n2xCU1owmACqaIBNQMukvXRDtB2GJMuKa/asTZDP6R5re+iXs7+s9ohcRRAKGyAyc\nYKIQKcaA+6M8T7/G+TPHZX6HJWqJJiYB+EC2ERblpvq9TPlLguEWcmvjbVc31nyq\nSDoO3ncFWKFmVsbQPTbP+pKUmlLfJwtb5XqxNR5GEXSwVv4I7IqBmJz1MmRafnBZ\ng0FJUtH668GnldO20XbnSVBr820F5SISMXVwCXDXEvGwwiB8Lt8PvqzXnGIFDAu3\nDlQI5sxSqpPVWSyw08ppKT2Tpmy8adiBotLfaCFl2VTHwOae48X2dMPBvQARAQAB\ntDFGZWRvcmEgKDMwKSA8ZmVkb3JhLTMwLXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQI4BBMBAgAiBQJbbqxnAhsPBgsJCAcDAgYVCAIJCgsEFgIDAQIeAQIXgAAK\nCRDvPBEfz8ZZudTnD/9170LL3nyTVUCFmBjT9wZ4gYnpwtKVPa/pKnxbbS+Bmmac\ng9TrT9pZbqOHrNJLiZ3Zx1Hp+8uxr3Lo6kbYwImLhkOEDrf4aP17HfQ6VYFbQZI8\nf79OFxWJ7si9+3gfzeh9UYFEqOQfzIjLWFyfnas0OnV/P+RMQ1Zr+vPRqO7AR2va\nN9wg+Xl7157dhXPCGYnGMNSoxCbpRs0JNlzvJMuAea5nTTznRaJZtK/xKsqLn51D\nK07k9MHVFXakOH8QtMCUglbwfTfIpO5YRq5imxlWbqsYWVQy1WGJFyW6hWC0+RcJ\nOx5zGtOfi4/dN+xJ+ibnbyvy/il7Qm+vyFhCYqIPyS5m2UVJUuao3eApE38k78/o\n8aQOTnFQZ+U1Sw+6woFTxjqRQBXlQm2+7Bt3bqGATg4sXXWPbmwdL87Ic+mxn/ml\nSMfQux/5k6iAu1kQhwkO2YJn9eII6HIPkW+2m5N1JsUyJQe4cbtZE5Yh3TRA0dm7\n+zoBRfCXkOW4krchbgww/ptVmzMMP7GINJdROrJnsGl5FVeid9qHzV7aZycWSma7\nCxBYB1J8HCbty5NjtD6XMYRrMLxXugvX6Q4NPPH+2NKjzX4SIDejS6JjgrP3KA3O\npMuo7ZHMfveBngv8yP+ZD/1sS6l+dfExvdaJdOdgFCnp4p3gPbw5+Lv70HrMjA==\n=BfZ/\n-----END PGP PUBLIC KEY BLOCK-----\n",
-              "checksum": "sha256:9f596e18f585bee30ac41c11fb11a83ed6b11d5b341c1cb56ca4015d7717cb97"
-            }
-          ],
-          "packages": [
-            "@core",
-            "chrony",
-            "firewalld",
-            "grub2-pc",
-            "kernel",
-            "langpacks-en",
-            "open-vm-tools",
-            "selinux-policy-targeted"
-          ],
-          "exclude_packages": [
-            "dracut-config-rescue"
-          ],
-          "releasever": "30",
-          "basearch": "x86_64",
-          "module_platform_id": "platform:f30"
+        },
+        {
+          "name": "org.osbuild.fix-bls",
+          "options": {}
+        },
+        {
+          "name": "org.osbuild.locale",
+          "options": {
+            "language": "en_US"
+          }
+        },
+        {
+          "name": "org.osbuild.fstab",
+          "options": {
+            "filesystems": [
+              {
+                "uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
+                "vfs_type": "ext4",
+                "path": "/",
+                "options": "defaults",
+                "freq": 1,
+                "passno": 1
+              }
+            ]
+          }
+        },
+        {
+          "name": "org.osbuild.grub2",
+          "options": {
+            "root_fs_uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
+            "kernel_opts": "ro biosdevname=0 net.ifnames=0",
+            "legacy": true
+          }
+        },
+        {
+          "name": "org.osbuild.selinux",
+          "options": {
+            "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
+          }
         }
-      },
-      {
-        "name": "org.osbuild.fix-bls",
-        "options": {}
-      },
-      {
-        "name": "org.osbuild.locale",
+      ],
+      "assembler": {
+        "name": "org.osbuild.qemu",
         "options": {
-          "language": "en_US"
-        }
-      },
-      {
-        "name": "org.osbuild.fstab",
-        "options": {
-          "filesystems": [
+          "format": "vmdk",
+          "filename": "disk.vmdk",
+          "size": 2147483648,
+          "ptuuid": "0x14fc63d2",
+          "pttype": "mbr",
+          "partitions": [
             {
-              "uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
-              "vfs_type": "ext4",
-              "path": "/",
-              "options": "defaults",
-              "freq": 1,
-              "passno": 1
+              "start": 2048,
+              "bootable": true,
+              "filesystem": {
+                "type": "ext4",
+                "uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
+                "mountpoint": "/"
+              }
             }
           ]
         }
-      },
-      {
-        "name": "org.osbuild.grub2",
-        "options": {
-          "root_fs_uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
-          "kernel_opts": "ro biosdevname=0 net.ifnames=0",
-          "legacy": true
-        }
-      },
-      {
-        "name": "org.osbuild.selinux",
-        "options": {
-          "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
-        }
-      }
-    ],
-    "assembler": {
-      "name": "org.osbuild.qemu",
-      "options": {
-        "format": "vmdk",
-        "filename": "disk.vmdk",
-        "size": 2147483648,
-        "ptuuid": "0x14fc63d2",
-        "pttype": "mbr",
-        "partitions": [
-          {
-            "start": 2048,
-            "bootable": true,
-            "filesystem": {
-              "type": "ext4",
-              "uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
-              "mountpoint": "/"
-            }
-          }
-        ]
       }
     }
   },

--- a/test/cases/vmdk_empty_blueprint.json
+++ b/test/cases/vmdk_empty_blueprint.json
@@ -1,5 +1,5 @@
 {
-  "compose": {
+  "compose-request": {
     "distro": "fedora-30",
     "arch": "x86_64",
     "output-format": "vmdk",

--- a/test/cases/vmdk_local_boot.json
+++ b/test/cases/vmdk_local_boot.json
@@ -37,6 +37,11 @@
       }
     }
   },
+  "rpmmd": {
+    "checksums": {
+      "fedora": "sha256:9f596e18f585bee30ac41c11fb11a83ed6b11d5b341c1cb56ca4015d7717cb97"
+    }
+  },
   "pipeline": {
     "build": {
       "pipeline": {

--- a/test/cases/vmdk_local_boot.json
+++ b/test/cases/vmdk_local_boot.json
@@ -42,149 +42,152 @@
       "fedora": "sha256:9f596e18f585bee30ac41c11fb11a83ed6b11d5b341c1cb56ca4015d7717cb97"
     }
   },
-  "pipeline": {
-    "build": {
-      "pipeline": {
-        "stages": [
-          {
-            "name": "org.osbuild.dnf",
-            "options": {
-              "repos": [
-                {
-                  "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-30&arch=x86_64",
-                  "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBFturGcBEACv0xBo91V2n0uEC2vh69ywCiSyvUgN/AQH8EZpCVtM7NyjKgKm\nbbY4G3R0M3ir1xXmvUDvK0493/qOiFrjkplvzXFTGpPTi0ypqGgxc5d0ohRA1M75\nL+0AIlXoOgHQ358/c4uO8X0JAA1NYxCkAW1KSJgFJ3RjukrfqSHWthS1d4o8fhHy\nKJKEnirE5hHqB50dafXrBfgZdaOs3C6ppRIePFe2o4vUEapMTCHFw0woQR8Ah4/R\nn7Z9G9Ln+0Cinmy0nbIDiZJ+pgLAXCOWBfDUzcOjDGKvcpoZharA07c0q1/5ojzO\n4F0Fh4g/BUmtrASwHfcIbjHyCSr1j/3Iz883iy07gJY5Yhiuaqmp0o0f9fgHkG53\n2xCU1owmACqaIBNQMukvXRDtB2GJMuKa/asTZDP6R5re+iXs7+s9ohcRRAKGyAyc\nYKIQKcaA+6M8T7/G+TPHZX6HJWqJJiYB+EC2ERblpvq9TPlLguEWcmvjbVc31nyq\nSDoO3ncFWKFmVsbQPTbP+pKUmlLfJwtb5XqxNR5GEXSwVv4I7IqBmJz1MmRafnBZ\ng0FJUtH668GnldO20XbnSVBr820F5SISMXVwCXDXEvGwwiB8Lt8PvqzXnGIFDAu3\nDlQI5sxSqpPVWSyw08ppKT2Tpmy8adiBotLfaCFl2VTHwOae48X2dMPBvQARAQAB\ntDFGZWRvcmEgKDMwKSA8ZmVkb3JhLTMwLXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQI4BBMBAgAiBQJbbqxnAhsPBgsJCAcDAgYVCAIJCgsEFgIDAQIeAQIXgAAK\nCRDvPBEfz8ZZudTnD/9170LL3nyTVUCFmBjT9wZ4gYnpwtKVPa/pKnxbbS+Bmmac\ng9TrT9pZbqOHrNJLiZ3Zx1Hp+8uxr3Lo6kbYwImLhkOEDrf4aP17HfQ6VYFbQZI8\nf79OFxWJ7si9+3gfzeh9UYFEqOQfzIjLWFyfnas0OnV/P+RMQ1Zr+vPRqO7AR2va\nN9wg+Xl7157dhXPCGYnGMNSoxCbpRs0JNlzvJMuAea5nTTznRaJZtK/xKsqLn51D\nK07k9MHVFXakOH8QtMCUglbwfTfIpO5YRq5imxlWbqsYWVQy1WGJFyW6hWC0+RcJ\nOx5zGtOfi4/dN+xJ+ibnbyvy/il7Qm+vyFhCYqIPyS5m2UVJUuao3eApE38k78/o\n8aQOTnFQZ+U1Sw+6woFTxjqRQBXlQm2+7Bt3bqGATg4sXXWPbmwdL87Ic+mxn/ml\nSMfQux/5k6iAu1kQhwkO2YJn9eII6HIPkW+2m5N1JsUyJQe4cbtZE5Yh3TRA0dm7\n+zoBRfCXkOW4krchbgww/ptVmzMMP7GINJdROrJnsGl5FVeid9qHzV7aZycWSma7\nCxBYB1J8HCbty5NjtD6XMYRrMLxXugvX6Q4NPPH+2NKjzX4SIDejS6JjgrP3KA3O\npMuo7ZHMfveBngv8yP+ZD/1sS6l+dfExvdaJdOdgFCnp4p3gPbw5+Lv70HrMjA==\n=BfZ/\n-----END PGP PUBLIC KEY BLOCK-----\n",
-                  "checksum": "sha256:9f596e18f585bee30ac41c11fb11a83ed6b11d5b341c1cb56ca4015d7717cb97"
-                }
-              ],
-              "packages": [
-                "dnf",
-                "dosfstools",
-                "e2fsprogs",
-                "grub2-pc",
-                "policycoreutils",
-                "qemu-img",
-                "systemd",
-                "tar"
-              ],
-              "releasever": "30",
-              "basearch": "x86_64",
-              "module_platform_id": "platform:f30"
+  "manifest": {
+    "sources": {},
+    "pipeline": {
+      "build": {
+        "pipeline": {
+          "stages": [
+            {
+              "name": "org.osbuild.dnf",
+              "options": {
+                "repos": [
+                  {
+                    "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-30&arch=x86_64",
+                    "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBFturGcBEACv0xBo91V2n0uEC2vh69ywCiSyvUgN/AQH8EZpCVtM7NyjKgKm\nbbY4G3R0M3ir1xXmvUDvK0493/qOiFrjkplvzXFTGpPTi0ypqGgxc5d0ohRA1M75\nL+0AIlXoOgHQ358/c4uO8X0JAA1NYxCkAW1KSJgFJ3RjukrfqSHWthS1d4o8fhHy\nKJKEnirE5hHqB50dafXrBfgZdaOs3C6ppRIePFe2o4vUEapMTCHFw0woQR8Ah4/R\nn7Z9G9Ln+0Cinmy0nbIDiZJ+pgLAXCOWBfDUzcOjDGKvcpoZharA07c0q1/5ojzO\n4F0Fh4g/BUmtrASwHfcIbjHyCSr1j/3Iz883iy07gJY5Yhiuaqmp0o0f9fgHkG53\n2xCU1owmACqaIBNQMukvXRDtB2GJMuKa/asTZDP6R5re+iXs7+s9ohcRRAKGyAyc\nYKIQKcaA+6M8T7/G+TPHZX6HJWqJJiYB+EC2ERblpvq9TPlLguEWcmvjbVc31nyq\nSDoO3ncFWKFmVsbQPTbP+pKUmlLfJwtb5XqxNR5GEXSwVv4I7IqBmJz1MmRafnBZ\ng0FJUtH668GnldO20XbnSVBr820F5SISMXVwCXDXEvGwwiB8Lt8PvqzXnGIFDAu3\nDlQI5sxSqpPVWSyw08ppKT2Tpmy8adiBotLfaCFl2VTHwOae48X2dMPBvQARAQAB\ntDFGZWRvcmEgKDMwKSA8ZmVkb3JhLTMwLXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQI4BBMBAgAiBQJbbqxnAhsPBgsJCAcDAgYVCAIJCgsEFgIDAQIeAQIXgAAK\nCRDvPBEfz8ZZudTnD/9170LL3nyTVUCFmBjT9wZ4gYnpwtKVPa/pKnxbbS+Bmmac\ng9TrT9pZbqOHrNJLiZ3Zx1Hp+8uxr3Lo6kbYwImLhkOEDrf4aP17HfQ6VYFbQZI8\nf79OFxWJ7si9+3gfzeh9UYFEqOQfzIjLWFyfnas0OnV/P+RMQ1Zr+vPRqO7AR2va\nN9wg+Xl7157dhXPCGYnGMNSoxCbpRs0JNlzvJMuAea5nTTznRaJZtK/xKsqLn51D\nK07k9MHVFXakOH8QtMCUglbwfTfIpO5YRq5imxlWbqsYWVQy1WGJFyW6hWC0+RcJ\nOx5zGtOfi4/dN+xJ+ibnbyvy/il7Qm+vyFhCYqIPyS5m2UVJUuao3eApE38k78/o\n8aQOTnFQZ+U1Sw+6woFTxjqRQBXlQm2+7Bt3bqGATg4sXXWPbmwdL87Ic+mxn/ml\nSMfQux/5k6iAu1kQhwkO2YJn9eII6HIPkW+2m5N1JsUyJQe4cbtZE5Yh3TRA0dm7\n+zoBRfCXkOW4krchbgww/ptVmzMMP7GINJdROrJnsGl5FVeid9qHzV7aZycWSma7\nCxBYB1J8HCbty5NjtD6XMYRrMLxXugvX6Q4NPPH+2NKjzX4SIDejS6JjgrP3KA3O\npMuo7ZHMfveBngv8yP+ZD/1sS6l+dfExvdaJdOdgFCnp4p3gPbw5+Lv70HrMjA==\n=BfZ/\n-----END PGP PUBLIC KEY BLOCK-----\n",
+                    "checksum": "sha256:9f596e18f585bee30ac41c11fb11a83ed6b11d5b341c1cb56ca4015d7717cb97"
+                  }
+                ],
+                "packages": [
+                  "dnf",
+                  "dosfstools",
+                  "e2fsprogs",
+                  "grub2-pc",
+                  "policycoreutils",
+                  "qemu-img",
+                  "systemd",
+                  "tar"
+                ],
+                "releasever": "30",
+                "basearch": "x86_64",
+                "module_platform_id": "platform:f30"
+              }
+            }
+          ]
+        },
+        "runner": "org.osbuild.fedora30"
+      },
+      "stages": [
+        {
+          "name": "org.osbuild.dnf",
+          "options": {
+            "repos": [
+              {
+                "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-30&arch=x86_64",
+                "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBFturGcBEACv0xBo91V2n0uEC2vh69ywCiSyvUgN/AQH8EZpCVtM7NyjKgKm\nbbY4G3R0M3ir1xXmvUDvK0493/qOiFrjkplvzXFTGpPTi0ypqGgxc5d0ohRA1M75\nL+0AIlXoOgHQ358/c4uO8X0JAA1NYxCkAW1KSJgFJ3RjukrfqSHWthS1d4o8fhHy\nKJKEnirE5hHqB50dafXrBfgZdaOs3C6ppRIePFe2o4vUEapMTCHFw0woQR8Ah4/R\nn7Z9G9Ln+0Cinmy0nbIDiZJ+pgLAXCOWBfDUzcOjDGKvcpoZharA07c0q1/5ojzO\n4F0Fh4g/BUmtrASwHfcIbjHyCSr1j/3Iz883iy07gJY5Yhiuaqmp0o0f9fgHkG53\n2xCU1owmACqaIBNQMukvXRDtB2GJMuKa/asTZDP6R5re+iXs7+s9ohcRRAKGyAyc\nYKIQKcaA+6M8T7/G+TPHZX6HJWqJJiYB+EC2ERblpvq9TPlLguEWcmvjbVc31nyq\nSDoO3ncFWKFmVsbQPTbP+pKUmlLfJwtb5XqxNR5GEXSwVv4I7IqBmJz1MmRafnBZ\ng0FJUtH668GnldO20XbnSVBr820F5SISMXVwCXDXEvGwwiB8Lt8PvqzXnGIFDAu3\nDlQI5sxSqpPVWSyw08ppKT2Tpmy8adiBotLfaCFl2VTHwOae48X2dMPBvQARAQAB\ntDFGZWRvcmEgKDMwKSA8ZmVkb3JhLTMwLXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQI4BBMBAgAiBQJbbqxnAhsPBgsJCAcDAgYVCAIJCgsEFgIDAQIeAQIXgAAK\nCRDvPBEfz8ZZudTnD/9170LL3nyTVUCFmBjT9wZ4gYnpwtKVPa/pKnxbbS+Bmmac\ng9TrT9pZbqOHrNJLiZ3Zx1Hp+8uxr3Lo6kbYwImLhkOEDrf4aP17HfQ6VYFbQZI8\nf79OFxWJ7si9+3gfzeh9UYFEqOQfzIjLWFyfnas0OnV/P+RMQ1Zr+vPRqO7AR2va\nN9wg+Xl7157dhXPCGYnGMNSoxCbpRs0JNlzvJMuAea5nTTznRaJZtK/xKsqLn51D\nK07k9MHVFXakOH8QtMCUglbwfTfIpO5YRq5imxlWbqsYWVQy1WGJFyW6hWC0+RcJ\nOx5zGtOfi4/dN+xJ+ibnbyvy/il7Qm+vyFhCYqIPyS5m2UVJUuao3eApE38k78/o\n8aQOTnFQZ+U1Sw+6woFTxjqRQBXlQm2+7Bt3bqGATg4sXXWPbmwdL87Ic+mxn/ml\nSMfQux/5k6iAu1kQhwkO2YJn9eII6HIPkW+2m5N1JsUyJQe4cbtZE5Yh3TRA0dm7\n+zoBRfCXkOW4krchbgww/ptVmzMMP7GINJdROrJnsGl5FVeid9qHzV7aZycWSma7\nCxBYB1J8HCbty5NjtD6XMYRrMLxXugvX6Q4NPPH+2NKjzX4SIDejS6JjgrP3KA3O\npMuo7ZHMfveBngv8yP+ZD/1sS6l+dfExvdaJdOdgFCnp4p3gPbw5+Lv70HrMjA==\n=BfZ/\n-----END PGP PUBLIC KEY BLOCK-----\n",
+                "checksum": "sha256:9f596e18f585bee30ac41c11fb11a83ed6b11d5b341c1cb56ca4015d7717cb97"
+              }
+            ],
+            "packages": [
+              "@core",
+              "chrony",
+              "firewalld",
+              "grub2-pc",
+              "kernel",
+              "langpacks-en",
+              "open-vm-tools",
+              "selinux-policy-targeted"
+            ],
+            "exclude_packages": [
+              "dracut-config-rescue"
+            ],
+            "releasever": "30",
+            "basearch": "x86_64",
+            "module_platform_id": "platform:f30"
+          }
+        },
+        {
+          "name": "org.osbuild.locale",
+          "options": {
+            "language": "en_US"
+          }
+        },
+        {
+          "name": "org.osbuild.fstab",
+          "options": {
+            "filesystems": [
+              {
+                "uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
+                "vfs_type": "ext4",
+                "path": "/",
+                "options": "defaults",
+                "freq": 1,
+                "passno": 1
+              }
+            ]
+          }
+        },
+        {
+          "name": "org.osbuild.grub2",
+          "options": {
+            "root_fs_uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
+            "kernel_opts": "ro biosdevname=0 net.ifnames=0",
+            "legacy": true
+          }
+        },
+        {
+          "name": "org.osbuild.systemd",
+          "options": {
+            "enabled_services": [
+              "sshd"
+            ]
+          }
+        },
+        {
+          "name": "org.osbuild.users",
+          "options": {
+            "users": {
+              "redhat": {
+                "groups": [
+                  "wheel"
+                ],
+                "password": "$6$IR7O7z56ouB/OInP$.hscD6dQqPQGwMuQ.idumixSHI/JEyaUfiCAHVSpGO/iNLEvvVZVOQL23zBzQbc2.yJ25xAZD75H0tXqKJpEE/",
+                "key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC61wMCjOSHwbVb4VfVyl5sn497qW4PsdQ7Ty7aD6wDNZ/QjjULkDV/yW5WjDlDQ7UqFH0Sr7vywjqDizUAqK7zM5FsUKsUXWHWwg/ehKg8j9xKcMv11AkFoUoujtfAujnKODkk58XSA9whPr7qcw3vPrmog680pnMSzf9LC7J6kXfs6lkoKfBh9VnlxusCrw2yg0qI1fHAZBLPx7mW6+me71QZsS6sVz8v8KXyrXsKTdnF50FjzHcK9HXDBtSJS5wA3fkcRYymJe0o6WMWNdgSRVpoSiWaHHmFgdMUJaYoCfhXzyl7LtNb3Q+Sveg+tJK7JaRXBLMUllOlJ6ll5Hod root@localhost"
+              }
             }
           }
-        ]
-      },
-      "runner": "org.osbuild.fedora30"
-    },
-    "stages": [
-      {
-        "name": "org.osbuild.dnf",
-        "options": {
-          "repos": [
-            {
-              "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-30&arch=x86_64",
-              "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBFturGcBEACv0xBo91V2n0uEC2vh69ywCiSyvUgN/AQH8EZpCVtM7NyjKgKm\nbbY4G3R0M3ir1xXmvUDvK0493/qOiFrjkplvzXFTGpPTi0ypqGgxc5d0ohRA1M75\nL+0AIlXoOgHQ358/c4uO8X0JAA1NYxCkAW1KSJgFJ3RjukrfqSHWthS1d4o8fhHy\nKJKEnirE5hHqB50dafXrBfgZdaOs3C6ppRIePFe2o4vUEapMTCHFw0woQR8Ah4/R\nn7Z9G9Ln+0Cinmy0nbIDiZJ+pgLAXCOWBfDUzcOjDGKvcpoZharA07c0q1/5ojzO\n4F0Fh4g/BUmtrASwHfcIbjHyCSr1j/3Iz883iy07gJY5Yhiuaqmp0o0f9fgHkG53\n2xCU1owmACqaIBNQMukvXRDtB2GJMuKa/asTZDP6R5re+iXs7+s9ohcRRAKGyAyc\nYKIQKcaA+6M8T7/G+TPHZX6HJWqJJiYB+EC2ERblpvq9TPlLguEWcmvjbVc31nyq\nSDoO3ncFWKFmVsbQPTbP+pKUmlLfJwtb5XqxNR5GEXSwVv4I7IqBmJz1MmRafnBZ\ng0FJUtH668GnldO20XbnSVBr820F5SISMXVwCXDXEvGwwiB8Lt8PvqzXnGIFDAu3\nDlQI5sxSqpPVWSyw08ppKT2Tpmy8adiBotLfaCFl2VTHwOae48X2dMPBvQARAQAB\ntDFGZWRvcmEgKDMwKSA8ZmVkb3JhLTMwLXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQI4BBMBAgAiBQJbbqxnAhsPBgsJCAcDAgYVCAIJCgsEFgIDAQIeAQIXgAAK\nCRDvPBEfz8ZZudTnD/9170LL3nyTVUCFmBjT9wZ4gYnpwtKVPa/pKnxbbS+Bmmac\ng9TrT9pZbqOHrNJLiZ3Zx1Hp+8uxr3Lo6kbYwImLhkOEDrf4aP17HfQ6VYFbQZI8\nf79OFxWJ7si9+3gfzeh9UYFEqOQfzIjLWFyfnas0OnV/P+RMQ1Zr+vPRqO7AR2va\nN9wg+Xl7157dhXPCGYnGMNSoxCbpRs0JNlzvJMuAea5nTTznRaJZtK/xKsqLn51D\nK07k9MHVFXakOH8QtMCUglbwfTfIpO5YRq5imxlWbqsYWVQy1WGJFyW6hWC0+RcJ\nOx5zGtOfi4/dN+xJ+ibnbyvy/il7Qm+vyFhCYqIPyS5m2UVJUuao3eApE38k78/o\n8aQOTnFQZ+U1Sw+6woFTxjqRQBXlQm2+7Bt3bqGATg4sXXWPbmwdL87Ic+mxn/ml\nSMfQux/5k6iAu1kQhwkO2YJn9eII6HIPkW+2m5N1JsUyJQe4cbtZE5Yh3TRA0dm7\n+zoBRfCXkOW4krchbgww/ptVmzMMP7GINJdROrJnsGl5FVeid9qHzV7aZycWSma7\nCxBYB1J8HCbty5NjtD6XMYRrMLxXugvX6Q4NPPH+2NKjzX4SIDejS6JjgrP3KA3O\npMuo7ZHMfveBngv8yP+ZD/1sS6l+dfExvdaJdOdgFCnp4p3gPbw5+Lv70HrMjA==\n=BfZ/\n-----END PGP PUBLIC KEY BLOCK-----\n",
-              "checksum": "sha256:9f596e18f585bee30ac41c11fb11a83ed6b11d5b341c1cb56ca4015d7717cb97"
-            }
-          ],
-          "packages": [
-            "@core",
-            "chrony",
-            "firewalld",
-            "grub2-pc",
-            "kernel",
-            "langpacks-en",
-            "open-vm-tools",
-            "selinux-policy-targeted"
-          ],
-          "exclude_packages": [
-            "dracut-config-rescue"
-          ],
-          "releasever": "30",
-          "basearch": "x86_64",
-          "module_platform_id": "platform:f30"
+        },
+        {
+          "name": "org.osbuild.selinux",
+          "options": {
+            "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
+          }
+        },
+        {
+          "name": "org.osbuild.fix-bls",
+          "options": {}
         }
-      },
-      {
-        "name": "org.osbuild.locale",
+      ],
+      "assembler": {
+        "name": "org.osbuild.qemu",
         "options": {
-          "language": "en_US"
-        }
-      },
-      {
-        "name": "org.osbuild.fstab",
-        "options": {
-          "filesystems": [
+          "format": "vmdk",
+          "filename": "disk.vmdk",
+          "size": 2147483648,
+          "ptuuid": "0x14fc63d2",
+          "pttype": "mbr",
+          "partitions": [
             {
-              "uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
-              "vfs_type": "ext4",
-              "path": "/",
-              "options": "defaults",
-              "freq": 1,
-              "passno": 1
+              "start": 2048,
+              "bootable": true,
+              "filesystem": {
+                "type": "ext4",
+                "uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
+                "mountpoint": "/"
+              }
             }
           ]
         }
-      },
-      {
-        "name": "org.osbuild.grub2",
-        "options": {
-          "root_fs_uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
-          "kernel_opts": "ro biosdevname=0 net.ifnames=0",
-          "legacy": true
-        }
-      },
-      {
-        "name": "org.osbuild.systemd",
-        "options": {
-          "enabled_services": [
-            "sshd"
-          ]
-        }
-      },
-      {
-        "name": "org.osbuild.users",
-        "options": {
-          "users": {
-            "redhat": {
-              "groups": [
-                "wheel"
-              ],
-              "password": "$6$IR7O7z56ouB/OInP$.hscD6dQqPQGwMuQ.idumixSHI/JEyaUfiCAHVSpGO/iNLEvvVZVOQL23zBzQbc2.yJ25xAZD75H0tXqKJpEE/",
-              "key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC61wMCjOSHwbVb4VfVyl5sn497qW4PsdQ7Ty7aD6wDNZ/QjjULkDV/yW5WjDlDQ7UqFH0Sr7vywjqDizUAqK7zM5FsUKsUXWHWwg/ehKg8j9xKcMv11AkFoUoujtfAujnKODkk58XSA9whPr7qcw3vPrmog680pnMSzf9LC7J6kXfs6lkoKfBh9VnlxusCrw2yg0qI1fHAZBLPx7mW6+me71QZsS6sVz8v8KXyrXsKTdnF50FjzHcK9HXDBtSJS5wA3fkcRYymJe0o6WMWNdgSRVpoSiWaHHmFgdMUJaYoCfhXzyl7LtNb3Q+Sveg+tJK7JaRXBLMUllOlJ6ll5Hod root@localhost"
-            }
-          }
-        }
-      },
-      {
-        "name": "org.osbuild.selinux",
-        "options": {
-          "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
-        }
-      },
-      {
-        "name": "org.osbuild.fix-bls",
-        "options": {}
-      }
-    ],
-    "assembler": {
-      "name": "org.osbuild.qemu",
-      "options": {
-        "format": "vmdk",
-        "filename": "disk.vmdk",
-        "size": 2147483648,
-        "ptuuid": "0x14fc63d2",
-        "pttype": "mbr",
-        "partitions": [
-          {
-            "start": 2048,
-            "bootable": true,
-            "filesystem": {
-              "type": "ext4",
-              "uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
-              "mountpoint": "/"
-            }
-          }
-        ]
       }
     }
   }

--- a/test/cases/vmdk_local_boot.json
+++ b/test/cases/vmdk_local_boot.json
@@ -2,7 +2,7 @@
   "boot": {
     "type": "qemu"
   },
-  "compose": {
+  "compose-request": {
     "distro": "fedora-30",
     "arch": "x86_64",
     "output-format": "vmdk",

--- a/test/run
+++ b/test/run
@@ -194,7 +194,7 @@ def run_test(case, private_key, store):
 
     print(f"osbuild successfully built pipeline {output_id}")
 
-    filename = os.path.join(store, "refs", output_id, case["compose"]["filename"])
+    filename = os.path.join(store, "refs", output_id, case["compose-request"]["filename"])
 
     fn, ex = os.path.splitext(filename)
     if ex == ".xz":
@@ -248,11 +248,11 @@ def main():
                 case = json.load(f)
 
             if arg.distros:
-                if case["compose"]["distro"] not in arg.distros:
+                if case["compose-request"]["distro"] not in arg.distros:
                     continue
 
             if arg.arches:
-                if case["compose"]["arch"] not in arg.arches:
+                if case["compose-request"]["arch"] not in arg.arches:
                     continue
 
             print(f"RUNNING: {filename}")


### PR DESCRIPTION
Make a clearer split between the user-defined input, and the generated data to compare with. Also move from testing Pipelines to Manifests.

This is all in preparation for auto-generating test-cases and for adding support for rpm-based pipelines.