### PR TITLE
tests: use go's test framework in osbuild-dnf-json-tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ __pycache__
 
 /osbuild-composer
 /osbuild-worker
+/osbuild-weldr-tests
 /osbuild-pipeline
 /osbuild-upload-azure
 /osbuild-upload-aws

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ build:
 	go build -o osbuild-upload-aws ./cmd/osbuild-upload-aws/
 	go build -o osbuild-tests ./cmd/osbuild-tests/
 	go build -o osbuild-weldr-tests ./cmd/osbuild-weldr-tests/
-	go build -o osbuild-dnf-json-tests ./cmd/osbuild-dnf-json-tests/
+	go test -c -tags=integration -o osbuild-dnf-json-tests ./cmd/osbuild-dnf-json-tests/main_test.go
 	go build -o osbuild-rcm-tests ./cmd/osbuild-rcm-tests/
 
 .PHONY: install

--- a/cmd/osbuild-dnf-json-tests/main_test.go
+++ b/cmd/osbuild-dnf-json-tests/main_test.go
@@ -1,30 +1,18 @@
 // This package contains tests related to dnf-json and rpmmd package.
+
+// +build integration
+
 package main
 
 import (
 	"fmt"
 	"github.com/osbuild/osbuild-composer/internal/rpmmd"
 	"io/ioutil"
-	"log"
 	"os"
 	"os/exec"
+	"testing"
 	"path"
 )
-
-func main() {
-	// Tests that the package wrapping dnf-json works as expected
-	dir, err := setUpTemporaryRepository()
-	defer func(dir string) {
-		err := tearDownTemporaryRepository(dir)
-		if err != nil {
-			log.Print("Warning: failed to clean up temporary repository.")
-		}
-	}(dir)
-	if err != nil {
-		log.Panic("Failed to set up temporary repository:", err)
-	}
-	TestFetchChecksum(false, dir)
-}
 
 func setUpTemporaryRepository() (string, error) {
 	dir, err := ioutil.TempDir("/tmp", "osbuild-composer-test-")
@@ -47,25 +35,30 @@ func tearDownTemporaryRepository(dir string) error {
 	return os.RemoveAll(dir)
 }
 
-func TestFetchChecksum(quiet bool, dir string) {
+func TestFetchChecksum(t *testing.T) {
+	dir, err := setUpTemporaryRepository()
+	defer func(dir string) {
+		err := tearDownTemporaryRepository(dir)
+		if err != nil {
+			t.Errorf("Warning: failed to clean up temporary repository.")
+		}
+	}(dir)
+	if err != nil {
+		t.Fatalf("Failed to set up temporary repository: %v", err)
+	}
+
 	repoCfg := rpmmd.RepoConfig{
 		Id:        "repo",
 		Name:      "repo",
 		BaseURL:   fmt.Sprintf("file://%s", dir),
 		IgnoreSSL: true,
 	}
-	if !quiet {
-		log.Println("Running TestFetchChecksum on:", dir)
-	}
 	rpmMetadata := rpmmd.NewRPMMD(path.Join(dir, "rpmmd"))
 	_, c, err := rpmMetadata.FetchMetadata([]rpmmd.RepoConfig{repoCfg}, "platform:f31")
 	if err != nil {
-		log.Panic("Failed to fetch checksum:", err)
+		t.Fatalf("Failed to fetch checksum: %v", err)
 	}
 	if c["repo"] == "" {
-		log.Panic("The checksum is empty")
-	}
-	if !quiet {
-		log.Println("TestFetchChecksum: SUCCESS")
+		t.Errorf("The checksum is empty")
 	}
 }

--- a/golang-github-osbuild-composer.spec
+++ b/golang-github-osbuild-composer.spec
@@ -68,8 +68,15 @@ export GOFLAGS=-mod=vendor
 %gobuild -o _bin/osbuild-worker %{goipath}/cmd/osbuild-worker
 %gobuild -o _bin/osbuild-tests %{goipath}/cmd/osbuild-tests
 %gobuild -o _bin/osbuild-weldr-tests %{goipath}/cmd/osbuild-weldr-tests
-%gobuild -o _bin/osbuild-dnf-json-tests %{goipath}/cmd/osbuild-dnf-json-tests
 %gobuild -o _bin/osbuild-image-tests %{goipath}/cmd/osbuild-image-tests
+
+# Build test binaries with `go test -c`, so that they can take advantage of
+# golang's testing package. The golang rpm macros don't support building them
+# directly. Thus, do it manually, taking care to also include a build id.
+
+TEST_LDFLAGS="${LDFLAGS:-} -B 0x$(od -N 20 -An -tx1 -w100 /dev/urandom | tr -d ' ')"
+
+go test -c -tags=integration -ldflags="${TEST_LDFLAGS}" -o _bin/osbuild-dnf-json-tests %{goipath}/cmd/osbuild-dnf-json-tests
 
 %install
 install -m 0755 -vd                                         %{buildroot}%{_libexecdir}/osbuild-composer


### PR DESCRIPTION
This is based on @atodorov's https://github.com/osbuild/osbuild-composer/pull/282. It contains the same commits, but changes the spec file to not use the `gotest` macro for building the binary. It also squashes the last two commits, because the intermediate state doesn't work.