### PR TITLE
proposal: osbuild composer alternative suitable for interactive debugging

### DIFF
--- a/cmd/osbuild-composer/configuration.go
+++ b/cmd/osbuild-composer/configuration.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"github.com/osbuild/osbuild-composer/internal/distro"
+	"github.com/osbuild/osbuild-composer/internal/rpmmd"
+	"io/ioutil"
+	"log"
+	"os"
+	"path"
+)
+
+type connectionConfig struct {
+	CACertFile     string
+	ServerKeyFile  string
+	ServerCertFile string
+}
+
+func createTLSConfig(c *connectionConfig) (*tls.Config, error) {
+	caCertPEM, err := ioutil.ReadFile(c.CACertFile)
+	if err != nil {
+		return nil, err
+	}
+
+	roots := x509.NewCertPool()
+	ok := roots.AppendCertsFromPEM(caCertPEM)
+	if !ok {
+		panic("failed to parse root certificate")
+	}
+
+	cert, err := tls.LoadX509KeyPair(c.ServerCertFile, c.ServerKeyFile)
+	if err != nil {
+		return nil, err
+	}
+	return &tls.Config{
+		Certificates: []tls.Certificate{cert},
+		ClientAuth:   tls.RequireAndVerifyClientCert,
+		ClientCAs:    roots,
+	}, nil
+}
+
+func createDistroConfiguration(registryPaths []string) (rpmmd.RPMMD, distro.Distro, *distro.Registry) {
+	cacheDirectory, ok := os.LookupEnv("CACHE_DIRECTORY")
+	if !ok {
+		log.Fatal("CACHE_DIRECTORY is not set. Is the service file missing CacheDirectory=?")
+	}
+
+	rpm := rpmmd.NewRPMMD(path.Join(cacheDirectory, "rpmmd"))
+
+	distros, err := distro.NewDefaultRegistry(registryPaths)
+	if err != nil {
+		log.Fatalf("Error loading distros: %v", err)
+	}
+
+	distribution, err := distros.FromHost()
+	if err != nil {
+		log.Fatalf("Could not determine distro from host: " + err.Error())
+	}
+
+	return rpm, distribution, distros
+}

--- a/cmd/osbuild-composer/debug_main.go
+++ b/cmd/osbuild-composer/debug_main.go
@@ -1,0 +1,86 @@
+// +build debug
+
+package main
+
+import (
+	"github.com/osbuild/osbuild-composer/internal/common"
+	"github.com/osbuild/osbuild-composer/internal/jobqueue"
+	"github.com/osbuild/osbuild-composer/internal/rcm"
+	"github.com/osbuild/osbuild-composer/internal/store"
+	"github.com/osbuild/osbuild-composer/internal/weldr"
+	"io/ioutil"
+	"log"
+	"net"
+	"os"
+	"path/filepath"
+)
+
+func setUpUDSListener(path string) net.Listener {
+	if err := os.RemoveAll(path); err != nil {
+		log.Panic(err)
+	}
+	l, err := net.Listen("unix", path)
+	if err != nil {
+		log.Panic("listen error:", err)
+	}
+	return l
+}
+
+func setUpTCPListener(socket string) net.Listener {
+	l, err := net.Listen("tcp", socket)
+	if err != nil {
+		log.Panic("listen error:", err)
+	}
+	return l
+}
+
+func main() {
+	// Set up temp directory
+	dir, err := ioutil.TempDir("", "osbuild-composer-debug-")
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	// Set environment variable which are set by systemd in production
+	stateDir := filepath.Join(dir, "state")
+	_ = os.Mkdir(stateDir, 0700)
+
+	cacheDir := filepath.Join(dir, "cache")
+	_ = os.Mkdir(cacheDir, 0700)
+
+	_ = os.Setenv("STATE_DIRECTORY", stateDir)
+	_ = os.Setenv("CACHE_DIRECTORY", stateDir)
+
+	// Create all necessary distro configurations
+	rpm, distribution, distros := createDistroConfiguration([]string{"."})
+	store := store.New(&stateDir, distribution, *distros)
+
+	// Run all the APIs
+	logger := log.New(os.Stdout, "", 0)
+
+	// UDS only Job API
+	jobListener := setUpUDSListener(filepath.Join(dir, "job.socket"))
+	defer jobListener.Close()
+	jobAPI := jobqueue.New(logger, store)
+	go func() {
+		err := jobAPI.Serve(jobListener)
+		common.PanicOnError(err)
+	}()
+
+	// RCM API running on localhost
+	rcmListener := setUpTCPListener("127.0.0.1:8080")
+	defer rcmListener.Close()
+	rcmAPI := rcm.New(logger, store, rpm)
+	go func() {
+		err := rcmAPI.Serve(rcmListener)
+		// If the RCM API fails, take down the whole process, not just a single gorutine
+		log.Fatal("RCM API failed: ", err)
+	}()
+
+	weldrListener := setUpUDSListener(filepath.Join(dir, "weldr.socket"))
+	defer weldrListener.Close()
+	weldrAPI := weldr.New(rpm, common.CurrentArch(), distribution, logger, store)
+	err = weldrAPI.Serve(weldrListener)
+	common.PanicOnError(err)
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -114,9 +114,9 @@ func New(stateDir *string, distroArg distro.Distro, distroRegistryArg distro.Reg
 	var s Store
 
 	if stateDir != nil {
-		err := os.Mkdir(*stateDir+"/"+"outputs", 0700)
+		err := os.Mkdir(filepath.Join(*stateDir, "outputs"), 0700)
 		if err != nil && !os.IsExist(err) {
-			log.Fatalf("cannot create output directory")
+			log.Fatal("cannot create output directory: ", err)
 		}
 
 		stateFile := *stateDir + "/state.json"


### PR DESCRIPTION
As I've already mentioned in the document about becoming a more welcoming open-source project, I'd love to have the possibility to run osbuild-composer in debugger. If it was possible with zero configuration, it'd be the best.

This PR contains an alternative to `cmd/osbuild-composer` which is independent of systemd and thus I can just click the bug button in IDE and I can easily debug the code in our web APIs. See `cmd/osbuild-composer/debug_main.go` for the implementation.

It uses conditional compilation so it does not affect the production binary in any way. Most of the code in the file is just creating sockets and setting environment variables which are set by systemd. Neither of these is a subject to frequent change, so it shouldn't go out of sync often.

_Note: I've requested review from everybody who I think might be interested. Sorry if I missed you!_