### PR TITLE
osbuild-composer: don't use hardcoded state directory

### DIFF
--- a/cmd/osbuild-composer/main.go
+++ b/cmd/osbuild-composer/main.go
@@ -54,7 +54,10 @@ func main() {
 	flag.BoolVar(&verbose, "v", false, "Print access log")
 	flag.Parse()
 
-	stateDir := "/var/lib/osbuild-composer"
+	stateDir, ok := os.LookupEnv("STATE_DIRECTORY")
+	if !ok {
+		log.Fatal("STATE_DIRECTORY is not set. Is the service file missing StateDirectory=?")
+	}
 
 	listeners, err := activation.ListenersWithNames()
 	if err != nil {

--- a/distribution/osbuild-composer.service
+++ b/distribution/osbuild-composer.service
@@ -15,6 +15,7 @@ Restart=on-failure
 
 # systemd >= 240 sets this, but osbuild-composer runs on earlier versions
 Environment="CACHE_DIRECTORY=/var/cache/osbuild-composer"
+Environment="STATE_DIRECTORY=/var/lib/osbuild-composer"
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Use $STATE_DIRECTORY environment variable which is set by systemd
because we use: StateDirectory=osbuild-composer in the service unit.

_Note: I haven't yet had time to run integration tests on this => draft._