### PR TITLE
Convert osbuild-dnf-json-tests to using asserts + test docs

### DIFF
--- a/cmd/osbuild-dnf-json-tests/main_test.go
+++ b/cmd/osbuild-dnf-json-tests/main_test.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"os/exec"
 	"testing"
+	"github.com/stretchr/testify/assert"
 	"path"
 )
 
@@ -39,13 +40,9 @@ func TestFetchChecksum(t *testing.T) {
 	dir, err := setUpTemporaryRepository()
 	defer func(dir string) {
 		err := tearDownTemporaryRepository(dir)
-		if err != nil {
-			t.Errorf("Warning: failed to clean up temporary repository.")
-		}
+		assert.Nil(t, err, "Failed to clean up temporary repository.")
 	}(dir)
-	if err != nil {
-		t.Fatalf("Failed to set up temporary repository: %v", err)
-	}
+	assert.Nilf(t, err, "Failed to set up temporary repository: %v", err)
 
 	repoCfg := rpmmd.RepoConfig{
 		Id:        "repo",
@@ -55,10 +52,6 @@ func TestFetchChecksum(t *testing.T) {
 	}
 	rpmMetadata := rpmmd.NewRPMMD(path.Join(dir, "rpmmd"))
 	_, c, err := rpmMetadata.FetchMetadata([]rpmmd.RepoConfig{repoCfg}, "platform:f31")
-	if err != nil {
-		t.Fatalf("Failed to fetch checksum: %v", err)
-	}
-	if c["repo"] == "" {
-		t.Errorf("The checksum is empty")
-	}
+	assert.Nilf(t, err, "Failed to fetch checksum: %v", err)
+	assert.NotEqual(t, "", c["repo"], "The checksum is empty")
 }

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/google/uuid v1.1.1
 	github.com/julienschmidt/httprouter v1.2.0
 	github.com/pkg/errors v0.9.1 // indirect
-	github.com/stretchr/testify v1.4.0 // indirect
+	github.com/stretchr/testify v1.4.0
 	golang.org/x/net v0.0.0-20200202094626-16171245cfb2 // indirect
 	golang.org/x/sys v0.0.0-20200212091648-12a6c2dcc1e4 // indirect
 )

--- a/test/README.md
+++ b/test/README.md
@@ -1,5 +1,41 @@
 # osbuild-composer testing information
 
+Test binaries, regardless of their scope/type (e.g. unit, API, integration)
+must follow the syntax of the Go
+[testing package](https://golang.org/pkg/testing/), that is implement only
+`TestXxx` functions with their setup/teardown when necessary in a `yyy_test.go`
+file.
+
+Test scenario discovery, execution and reporting will be handled by `go test`.
+
+Some test files will be executed directly by `go test` during rpm build time
+and/or in CI. These are usually unit tests. Scenarios which require more complex
+setup, e.g. a running osbuild-composer are not intented to be executed directly
+by `go test` at build time. Instead they are intended to be executed as
+stand-alone test binaries on a clean system which has been configured in
+advance (because this is easier/more feasible). These stand-alone test binaries
+are also compiled via `go test -c -o` during rpm build or via `make build`.
+See *Integration testing* for more information.
+
+
+## Notes on asserts and comparing expected values
+
+When comparing for expected values in test functions you should use the
+[testify/assert](https://godoc.org/github.com/stretchr/testify/assert) or
+[testify/require](https://godoc.org/github.com/stretchr/testify/require)
+packages. Both of them provide an impressive array of assertions with the
+possibility to use formatted strings as error messages. For example:
+
+```
+assert.Nilf(t, err, "Failed to set up temporary repository: %v", err)
+```
+
+If you want to fail immediately, not doing any more of the asserts use the
+require package instead of the assert package, otherwise you'll end up with
+panics and nil pointer memory problems.
+
+Stand-alone test binaries also have the `-test.failfast` option.
+
 
 ## Integration testing
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -50,6 +50,8 @@ github.com/aws/aws-sdk-go/service/sts/stsiface
 github.com/coreos/go-semver/semver
 # github.com/coreos/go-systemd v0.0.0-20190719114852-fd7a80b32e1f
 github.com/coreos/go-systemd/activation
+# github.com/davecgh/go-spew v1.1.0
+github.com/davecgh/go-spew/spew
 # github.com/gobwas/glob v0.2.3
 github.com/gobwas/glob
 github.com/gobwas/glob/compiler
@@ -74,6 +76,10 @@ github.com/jmespath/go-jmespath
 github.com/julienschmidt/httprouter
 # github.com/mattn/go-ieproxy v0.0.0-20190610004146-91bb50d98149
 github.com/mattn/go-ieproxy
+# github.com/pmezard/go-difflib v1.0.0
+github.com/pmezard/go-difflib/difflib
+# github.com/stretchr/testify v1.4.0
+github.com/stretchr/testify/assert
 # golang.org/x/net v0.0.0-20200202094626-16171245cfb2
 golang.org/x/net/http/httpproxy
 golang.org/x/net/idna
@@ -85,3 +91,5 @@ golang.org/x/text/secure/bidirule
 golang.org/x/text/transform
 golang.org/x/text/unicode/bidi
 golang.org/x/text/unicode/norm
+# gopkg.in/yaml.v2 v2.2.2
+gopkg.in/yaml.v2


### PR DESCRIPTION
@msehnout the asserts part should be straight forward but can you pay attention to the test docs? Is this what you meant in your commment here https://github.com/osbuild/osbuild-composer/issues/309#issuecomment-598589328