### PR TITLE
rcm: merge the two PushCompose functions

### DIFF
--- a/cmd/osbuild-composer/main.go
+++ b/cmd/osbuild-composer/main.go
@@ -116,7 +116,7 @@ func main() {
 			log.Fatal("The RCM API socket unit is misconfigured. It should contain only one socket.")
 		}
 		rcmListener := rcmApiListeners[0]
-		rcmAPI := rcm.New(logger, store, rpm)
+		rcmAPI := rcm.New(logger, store, rpm, distros)
 		go func() {
 			err := rcmAPI.Serve(rcmListener)
 			// If the RCM API fails, take down the whole process, not just a single gorutine

--- a/cmd/osbuild-composer/main.go
+++ b/cmd/osbuild-composer/main.go
@@ -99,7 +99,7 @@ func main() {
 		logger = log.New(os.Stdout, "", 0)
 	}
 
-	store := store.New(&stateDir, distribution, *distros)
+	store := store.New(&stateDir, *distros)
 
 	jobAPI := jobqueue.New(logger, store)
 	weldrAPI := weldr.New(rpm, common.CurrentArch(), distribution, logger, store)

--- a/internal/jobqueue/api_test.go
+++ b/internal/jobqueue/api_test.go
@@ -34,12 +34,11 @@ func TestBasic(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		distroStruct := test_distro.New()
 		registry, err := distro_mock.NewDefaultRegistry()
 		if err != nil {
 			t.Fatal(err)
 		}
-		api := jobqueue.New(nil, store.New(nil, distroStruct, *registry))
+		api := jobqueue.New(nil, store.New(nil, *registry))
 
 		test.TestNonJsonRoute(t, api, false, c.Method, c.Path, c.Body, c.ExpectedStatus, c.ExpectedResponse)
 	}
@@ -52,10 +51,10 @@ func TestCreate(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	store := store.New(nil, distroStruct, *registry)
+	store := store.New(nil, *registry)
 	api := jobqueue.New(nil, store)
 
-	err = store.PushCompose(id, &blueprint.Blueprint{}, nil, nil, "x86_64", "qcow2", 0, nil)
+	err = store.PushCompose(distroStruct, id, &blueprint.Blueprint{}, nil, nil, "x86_64", "qcow2", 0, nil)
 	if err != nil {
 		t.Fatalf("error pushing compose: %v", err)
 	}
@@ -71,11 +70,11 @@ func testUpdateTransition(t *testing.T, from, to string, expectedStatus int, exp
 	if err != nil {
 		t.Fatal(err)
 	}
-	store := store.New(nil, distroStruct, *registry)
+	store := store.New(nil, *registry)
 	api := jobqueue.New(nil, store)
 
 	if from != "VOID" {
-		err := store.PushCompose(id, &blueprint.Blueprint{}, nil, nil, "x86_64", "qcow2", 0, nil)
+		err := store.PushCompose(distroStruct, id, &blueprint.Blueprint{}, nil, nil, "x86_64", "qcow2", 0, nil)
 		if err != nil {
 			t.Fatalf("error pushing compose: %v", err)
 		}

--- a/internal/mocks/rpmmd/fixtures.go
+++ b/internal/mocks/rpmmd/fixtures.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/osbuild/osbuild-composer/internal/blueprint"
-	test_distro "github.com/osbuild/osbuild-composer/internal/distro/fedoratest"
 	"github.com/osbuild/osbuild-composer/internal/rpmmd"
 	"github.com/osbuild/osbuild-composer/internal/store"
 	"github.com/osbuild/osbuild-composer/internal/target"
@@ -93,9 +92,8 @@ func createBaseStoreFixture() *store.Store {
 		},
 	}
 
-	d := test_distro.New()
 	r, _ := distro_mock.NewDefaultRegistry()
-	s := store.New(nil, d, *r)
+	s := store.New(nil, *r)
 
 	s.Blueprints[bName] = b
 	s.Composes = map[uuid.UUID]compose.Compose{
@@ -190,9 +188,8 @@ func createStoreWithoutComposesFixture() *store.Store {
 		Customizations: nil,
 	}
 
-	d := test_distro.New()
 	r, _ := distro_mock.NewDefaultRegistry()
-	s := store.New(nil, d, *r)
+	s := store.New(nil, *r)
 
 	s.Blueprints[bName] = b
 

--- a/internal/rcm/api_test.go
+++ b/internal/rcm/api_test.go
@@ -9,7 +9,6 @@ import (
 	"regexp"
 	"testing"
 
-	"github.com/osbuild/osbuild-composer/internal/distro/fedoratest"
 	distro_mock "github.com/osbuild/osbuild-composer/internal/mocks/distro"
 	rpmmd_mock "github.com/osbuild/osbuild-composer/internal/mocks/rpmmd"
 	"github.com/osbuild/osbuild-composer/internal/rcm"
@@ -53,8 +52,7 @@ func TestBasicRcmAPI(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	distroStruct := fedoratest.New()
-	api := rcm.New(nil, store.New(nil, distroStruct, *registry), rpmmd_mock.NewRPMMDMock(rpmmd_mock.BaseFixture()), registry)
+	api := rcm.New(nil, store.New(nil, *registry), rpmmd_mock.NewRPMMDMock(rpmmd_mock.BaseFixture()), registry)
 
 	for _, c := range cases {
 		resp := internalRequest(api, c.Method, c.Path, c.Body, c.ContentType)
@@ -76,12 +74,11 @@ func TestBasicRcmAPI(t *testing.T) {
 
 func TestSubmitCompose(t *testing.T) {
 	// Test the most basic use case: Submit a new job and get its status.
-	distroStruct := fedoratest.New()
 	registry, err := distro_mock.NewDefaultRegistry()
 	if err != nil {
 		t.Fatal(err)
 	}
-	api := rcm.New(nil, store.New(nil, distroStruct, *registry), rpmmd_mock.NewRPMMDMock(rpmmd_mock.BaseFixture()), registry)
+	api := rcm.New(nil, store.New(nil, *registry), rpmmd_mock.NewRPMMDMock(rpmmd_mock.BaseFixture()), registry)
 
 	var submit_reply struct {
 		UUID uuid.UUID `json:"compose_id"`

--- a/internal/rcm/api_test.go
+++ b/internal/rcm/api_test.go
@@ -54,7 +54,7 @@ func TestBasicRcmAPI(t *testing.T) {
 		t.Fatal(err)
 	}
 	distroStruct := fedoratest.New()
-	api := rcm.New(nil, store.New(nil, distroStruct, *registry), rpmmd_mock.NewRPMMDMock(rpmmd_mock.BaseFixture()))
+	api := rcm.New(nil, store.New(nil, distroStruct, *registry), rpmmd_mock.NewRPMMDMock(rpmmd_mock.BaseFixture()), registry)
 
 	for _, c := range cases {
 		resp := internalRequest(api, c.Method, c.Path, c.Body, c.ContentType)
@@ -81,7 +81,7 @@ func TestSubmitCompose(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	api := rcm.New(nil, store.New(nil, distroStruct, *registry), rpmmd_mock.NewRPMMDMock(rpmmd_mock.BaseFixture()))
+	api := rcm.New(nil, store.New(nil, distroStruct, *registry), rpmmd_mock.NewRPMMDMock(rpmmd_mock.BaseFixture()), registry)
 
 	var submit_reply struct {
 		UUID uuid.UUID `json:"compose_id"`

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -76,7 +76,8 @@ type ComposeRequest struct {
 	Distro          distro.Distro
 	Arch            common.Architecture
 	Repositories    []rpmmd.RepoConfig
-	Checksums       map[string]string
+	Packages        []rpmmd.PackageSpec
+	BuildPackages   []rpmmd.PackageSpec
 	RequestedImages []common.ImageRequest
 }
 
@@ -679,7 +680,7 @@ func (s *Store) PushComposeRequest(request ComposeRequest) error {
 		if !exists {
 			panic("fatal error, image type should exist but it does not")
 		}
-		manifestStruct, err := request.Distro.Manifest(request.Blueprint.Customizations, request.Repositories, nil, nil, arch, imgTypeCompatStr, 0)
+		manifestStruct, err := request.Distro.Manifest(request.Blueprint.Customizations, request.Repositories, request.Packages, request.BuildPackages, arch, imgTypeCompatStr, 0)
 		if err != nil {
 			return err
 		}

--- a/internal/weldr/api.go
+++ b/internal/weldr/api.go
@@ -843,7 +843,7 @@ func (api *API) blueprintsDepsolveHandler(writer http.ResponseWriter, request *h
 			continue
 		}
 
-		dependencies, _, err := api.depsolveBlueprint(blueprint, "", api.arch, false)
+		dependencies, _, err := api.depsolveBlueprint(blueprint, "", api.arch)
 
 		if err != nil {
 			errors := responseError{
@@ -939,7 +939,7 @@ func (api *API) blueprintsFreezeHandler(writer http.ResponseWriter, request *htt
 			break
 		}
 
-		dependencies, _, err := api.depsolveBlueprint(&blueprint, "", api.arch, false)
+		dependencies, _, err := api.depsolveBlueprint(&blueprint, "", api.arch)
 		if err != nil {
 			rerr := responseError{
 				ID:  "BlueprintsError",
@@ -1418,7 +1418,7 @@ func (api *API) composeHandler(writer http.ResponseWriter, request *http.Request
 	}
 
 	if bp != nil {
-		packages, buildPackages, err := api.depsolveBlueprint(bp, cr.ComposeType, api.arch, true)
+		packages, buildPackages, err := api.depsolveBlueprint(bp, cr.ComposeType, api.arch)
 		if err != nil {
 			errors := responseError{
 				ID:  "DepsolveError",
@@ -1977,7 +1977,7 @@ func getPkgNameGlob(pkg blueprint.Package) string {
 	return pkg.Name
 }
 
-func (api *API) depsolveBlueprint(bp *blueprint.Blueprint, outputType, arch string, clean bool) ([]rpmmd.PackageSpec, []rpmmd.PackageSpec, error) {
+func (api *API) depsolveBlueprint(bp *blueprint.Blueprint, outputType, arch string) ([]rpmmd.PackageSpec, []rpmmd.PackageSpec, error) {
 	repos := api.distro.Repositories(api.arch)
 	for _, source := range api.store.GetAllSources() {
 		repos = append(repos, source.RepoConfig())

--- a/internal/weldr/api.go
+++ b/internal/weldr/api.go
@@ -1364,7 +1364,6 @@ func (api *API) composeHandler(writer http.ResponseWriter, request *http.Request
 		BuildID uuid.UUID `json:"build_id"`
 		Status  bool      `json:"status"`
 	}
-	const MegaByte = 1024 * 1024
 
 	contentType := request.Header["Content-Type"]
 	if len(contentType) != 1 || contentType[0] != "application/json" {
@@ -1409,14 +1408,6 @@ func (api *API) composeHandler(writer http.ResponseWriter, request *http.Request
 	}
 
 	bp := api.store.GetBlueprintCommitted(cr.BlueprintName)
-
-	size := cr.Size
-
-	// Microsoft Azure requires vhd images to be rounded up to the nearest MB
-	if cr.ComposeType == "vhd" && size%MegaByte != 0 {
-		size = (size/MegaByte + 1) * MegaByte
-	}
-
 	if bp != nil {
 		packages, buildPackages, err := api.depsolveBlueprint(bp, cr.ComposeType, api.arch)
 		if err != nil {
@@ -1428,7 +1419,7 @@ func (api *API) composeHandler(writer http.ResponseWriter, request *http.Request
 			return
 		}
 
-		err = api.store.PushCompose(api.distro, reply.BuildID, bp, packages, buildPackages, api.arch, cr.ComposeType, size, uploadTarget)
+		err = api.store.PushCompose(api.distro, reply.BuildID, bp, packages, buildPackages, api.arch, cr.ComposeType, cr.Size, uploadTarget)
 
 		// TODO: we should probably do some kind of blueprint validation in future
 		// for now, let's just 500 and bail out

--- a/internal/weldr/api.go
+++ b/internal/weldr/api.go
@@ -1428,7 +1428,7 @@ func (api *API) composeHandler(writer http.ResponseWriter, request *http.Request
 			return
 		}
 
-		err = api.store.PushCompose(reply.BuildID, bp, packages, buildPackages, api.arch, cr.ComposeType, size, uploadTarget)
+		err = api.store.PushCompose(api.distro, reply.BuildID, bp, packages, buildPackages, api.arch, cr.ComposeType, size, uploadTarget)
 
 		// TODO: we should probably do some kind of blueprint validation in future
 		// for now, let's just 500 and bail out


### PR DESCRIPTION
See individual commits. Lots of cleanup-type commits leading up to be able to merge these two functions.

@msehnout I wonder about the benefit of the common types. There's lots of code to convert between them and strings, all of which can return an error.