### PR TITLE
tests/image: rewrite to go testing framework

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,5 +25,5 @@ script:
   - eval "$(gimme 1.13.x)"
   # ubuntu's rpm package sets dbpath to ~/.rpmdb, which makes rpm fail...
   - sudo sh -c 'mkdir /etc/rpm; echo "%_dbpath /var/lib/rpm" > /etc/rpm/macros'
-  - go build -tags travis ./cmd/osbuild-image-tests
-  - sudo ./osbuild-image-tests --distro $TRAVIS_JOB_NAME
+  - go test -c -tags travis,integration -o osbuild-image-tests ./cmd/osbuild-image-tests
+  - sudo ./osbuild-image-tests -test.v --distro $TRAVIS_JOB_NAME

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,13 +10,13 @@ addons:
       - systemd-container
 matrix:
   include:
-    - name: fedora-30
+    - name: f30
       arch: amd64
-    - name: fedora-30
+    - name: f30
       arch: arm64
-    - name: fedora-31
+    - name: f31
       arch: amd64
-    - name: fedora-31
+    - name: f31
       arch: arm64
 
 language: generic
@@ -26,4 +26,4 @@ script:
   # ubuntu's rpm package sets dbpath to ~/.rpmdb, which makes rpm fail...
   - sudo sh -c 'mkdir /etc/rpm; echo "%_dbpath /var/lib/rpm" > /etc/rpm/macros'
   - go test -c -tags travis,integration -o osbuild-image-tests ./cmd/osbuild-image-tests
-  - sudo ./osbuild-image-tests -test.v --distro $TRAVIS_JOB_NAME
+  - sudo ./osbuild-image-tests -test.v test/cases/$TRAVIS_JOB_NAME*

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ build:
 	go test -c -tags=integration -o osbuild-weldr-tests ./internal/weldrcheck/
 	go test -c -tags=integration -o osbuild-dnf-json-tests ./cmd/osbuild-dnf-json-tests/main_test.go
 	go test -c -tags=integration -o osbuild-rcm-tests ./cmd/osbuild-rcm-tests/main_test.go
+	go test -c -tags=integration -o osbuild-image-tests ./cmd/osbuild-image-tests/main_test.go
 
 .PHONY: install
 install:

--- a/cmd/osbuild-image-tests/context-managers.go
+++ b/cmd/osbuild-image-tests/context-managers.go
@@ -90,7 +90,7 @@ func withBootedQemuImage(image string, ns netNS, f func() error) error {
 
 		qemuCmd := ns.NamespacedCommand(
 			"qemu-system-x86_64",
-			"-m", "2048",
+			"-m", "1024",
 			"-snapshot",
 			"-accel", "accel=kvm:hvf:tcg",
 			"-cdrom", cloudInitFile.Name(),

--- a/cmd/osbuild-image-tests/context-managers.go
+++ b/cmd/osbuild-image-tests/context-managers.go
@@ -21,7 +21,7 @@ func withNetworkNamespace(f func(ns netNS) error) error {
 	defer func() {
 		err := ns.Delete()
 		if err != nil {
-			log.Printf("cannot delete network namespace: %v", err)
+			log.Printf("cannot delete network namespace: %#v", err)
 		}
 	}()
 
@@ -33,13 +33,13 @@ func withNetworkNamespace(f func(ns netNS) error) error {
 func withTempFile(dir, pattern string, f func(file *os.File) error) error {
 	tempFile, err := ioutil.TempFile(dir, pattern)
 	if err != nil {
-		return fmt.Errorf("cannot create the temporary file: %v", err)
+		return fmt.Errorf("cannot create the temporary file: %#v", err)
 	}
 
 	defer func() {
 		err := os.Remove(tempFile.Name())
 		if err != nil {
-			log.Printf("cannot remove the temporary file: %v", err)
+			log.Printf("cannot remove the temporary file: %#v", err)
 		}
 	}()
 
@@ -64,7 +64,7 @@ func writeCloudInitISO(writer io.Writer, userData, metaData string) error {
 
 	err := isoCmd.Run()
 	if err != nil {
-		return fmt.Errorf("cannot create cloud-init iso: %v", err)
+		return fmt.Errorf("cannot create cloud-init iso: %#v", err)
 	}
 
 	return nil
@@ -85,7 +85,7 @@ func withBootedQemuImage(image string, ns netNS, f func() error) error {
 
 		err = cloudInitFile.Close()
 		if err != nil {
-			return fmt.Errorf("cannot close temporary cloudinit file: %v", err)
+			return fmt.Errorf("cannot close temporary cloudinit file: %#v", err)
 		}
 
 		qemuCmd := ns.NamespacedCommand(
@@ -101,13 +101,13 @@ func withBootedQemuImage(image string, ns netNS, f func() error) error {
 
 		err = qemuCmd.Start()
 		if err != nil {
-			return fmt.Errorf("cannot start the qemu process: %v", err)
+			return fmt.Errorf("cannot start the qemu process: %#v", err)
 		}
 
 		defer func() {
 			err := killProcessCleanly(qemuCmd.Process, time.Second)
 			if err != nil {
-				log.Printf("cannot kill the qemu process: %v", err)
+				log.Printf("cannot kill the qemu process: %#v", err)
 			}
 		}()
 
@@ -128,13 +128,13 @@ func withBootedNspawnImage(image, name string, ns netNS, f func() error) error {
 
 	err := cmd.Start()
 	if err != nil {
-		return fmt.Errorf("cannot start the systemd-nspawn process: %v", err)
+		return fmt.Errorf("cannot start the systemd-nspawn process: %#v", err)
 	}
 
 	defer func() {
 		err := killProcessCleanly(cmd.Process, time.Second)
 		if err != nil {
-			log.Printf("cannot kill the systemd-nspawn process: %v", err)
+			log.Printf("cannot kill the systemd-nspawn process: %#v", err)
 		}
 	}()
 
@@ -154,13 +154,13 @@ func withBootedNspawnDirectory(dir, name string, ns netNS, f func() error) error
 
 	err := cmd.Start()
 	if err != nil {
-		return fmt.Errorf("cannot start the systemd-nspawn process: %v", err)
+		return fmt.Errorf("cannot start the systemd-nspawn process: %#v", err)
 	}
 
 	defer func() {
 		err := killProcessCleanly(cmd.Process, time.Second)
 		if err != nil {
-			log.Printf("cannot kill the systemd-nspawn process: %v", err)
+			log.Printf("cannot kill the systemd-nspawn process: %#v", err)
 		}
 	}()
 
@@ -173,13 +173,13 @@ func withBootedNspawnDirectory(dir, name string, ns netNS, f func() error) error
 func withExtractedTarArchive(archive string, f func(dir string) error) error {
 	dir, err := ioutil.TempDir("", "tar-archive")
 	if err != nil {
-		return fmt.Errorf("cannot create a temporary dir: %v", err)
+		return fmt.Errorf("cannot create a temporary dir: %#v", err)
 	}
 
 	defer func() {
 		err := os.RemoveAll(dir)
 		if err != nil {
-			log.Printf("cannot remove the temporary dir: %v", err)
+			log.Printf("cannot remove the temporary dir: %#v", err)
 		}
 	}()
 
@@ -193,7 +193,7 @@ func withExtractedTarArchive(archive string, f func(dir string) error) error {
 
 	err = cmd.Run()
 	if err != nil {
-		return fmt.Errorf("cannot untar the archive: %v", err)
+		return fmt.Errorf("cannot untar the archive: %#v", err)
 	}
 
 	return f(dir)

--- a/cmd/osbuild-image-tests/helpers.go
+++ b/cmd/osbuild-image-tests/helpers.go
@@ -20,7 +20,7 @@ func durationMin(a, b time.Duration) time.Duration {
 func killProcessCleanly(process *os.Process, timeout time.Duration) error {
 	err := process.Signal(syscall.SIGTERM)
 	if err != nil {
-		log.Printf("cannot send SIGTERM to process, sending SIGKILL instead: %v", err)
+		log.Printf("cannot send SIGTERM to process, sending SIGKILL instead: %#v", err)
 		return process.Kill()
 	}
 

--- a/cmd/osbuild-image-tests/main_test.go
+++ b/cmd/osbuild-image-tests/main_test.go
@@ -319,11 +319,6 @@ func runTests(t *testing.T, cases []string, d string) {
 				hostDistroName, err := distro.GetHostDistroName()
 				require.Nil(t, err)
 
-				// TODO: forge distro name for now
-				if strings.HasPrefix(hostDistroName, "fedora") {
-					hostDistroName = "fedora-30"
-				}
-
 				if testcase.ComposeRequest.Distro != hostDistroName {
 					t.Skipf("the required distro is %s, the host distro is %s", testcase.ComposeRequest.Distro, hostDistroName)
 				}

--- a/cmd/osbuild-image-tests/main_test.go
+++ b/cmd/osbuild-image-tests/main_test.go
@@ -52,7 +52,7 @@ func runOsbuild(manifest []byte, store string) (string, error) {
 		if _, ok := err.(*exec.ExitError); ok {
 			return "", fmt.Errorf("running osbuild failed: %s", outBuffer.String())
 		}
-		return "", fmt.Errorf("running osbuild failed from an unexpected reason: %v", err)
+		return "", fmt.Errorf("running osbuild failed from an unexpected reason: %#v", err)
 	}
 
 	var result struct {
@@ -61,7 +61,7 @@ func runOsbuild(manifest []byte, store string) (string, error) {
 
 	err = json.NewDecoder(&outBuffer).Decode(&result)
 	if err != nil {
-		return "", fmt.Errorf("cannot decode osbuild output: %v", err)
+		return "", fmt.Errorf("cannot decode osbuild output: %#v", err)
 	}
 
 	return result.OutputID, nil
@@ -73,7 +73,7 @@ func extractXZ(archivePath string) error {
 	cmd.Stderr = os.Stderr
 	cmd.Stdout = os.Stderr
 	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("cannot extract xz archive: %v", err)
+		return fmt.Errorf("cannot extract xz archive: %#v", err)
 	}
 
 	return nil
@@ -94,7 +94,7 @@ func splitExtension(path string) (string, string) {
 func testImageInfo(t *testing.T, imagePath string, rawImageInfoExpected []byte) {
 	var imageInfoExpected interface{}
 	err := json.Unmarshal(rawImageInfoExpected, &imageInfoExpected)
-	require.Nilf(t, err, "cannot decode expected image info: %v", err)
+	require.Nilf(t, err, "cannot decode expected image info: %#v", err)
 
 	cmd := exec.Command(imageInfoPath, imagePath)
 	cmd.Stderr = os.Stderr
@@ -102,14 +102,14 @@ func testImageInfo(t *testing.T, imagePath string, rawImageInfoExpected []byte) 
 	cmd.Stdout = writer
 
 	err = cmd.Start()
-	require.Nilf(t, err, "image-info cannot start: %v", err)
+	require.Nilf(t, err, "image-info cannot start: %#v", err)
 
 	var imageInfoGot interface{}
 	err = json.NewDecoder(reader).Decode(&imageInfoGot)
-	require.Nilf(t, err, "decoding image-info output failed: %v", err)
+	require.Nilf(t, err, "decoding image-info output failed: %#v", err)
 
 	err = cmd.Wait()
-	require.Nilf(t, err, "running image-info failed: %v", err)
+	require.Nilf(t, err, "running image-info failed: %#v", err)
 
 	assert.Equal(t, imageInfoExpected, imageInfoGot)
 }
@@ -148,7 +148,7 @@ func trySSHOnce(ns netNS) error {
 				return &timeoutError{}
 			}
 		} else {
-			return fmt.Errorf("ssh command failed from unknown reason: %v", err)
+			return fmt.Errorf("ssh command failed from unknown reason: %#v", err)
 		}
 	}
 
@@ -244,12 +244,12 @@ func testImage(t *testing.T, testcase testcaseStruct, imagePath, outputID string
 // tests the result
 func runTestcase(t *testing.T, testcase testcaseStruct) {
 	store, err := ioutil.TempDir("/var/tmp", "osbuild-image-tests-")
-	require.Nilf(t, err, "cannot create temporary store: %v", err)
+	require.Nilf(t, err, "cannot create temporary store: %#v", err)
 
 	defer func() {
 		err := os.RemoveAll(store)
 		if err != nil {
-			log.Printf("cannot remove temporary store: %v\n", err)
+			log.Printf("cannot remove temporary store: %#v\n", err)
 		}
 	}()
 
@@ -276,7 +276,7 @@ func runTestcase(t *testing.T, testcase testcaseStruct) {
 func getAllCases() ([]string, error) {
 	cases, err := ioutil.ReadDir(testCasesDirectoryPath)
 	if err != nil {
-		return nil, fmt.Errorf("cannot list test cases: %v", err)
+		return nil, fmt.Errorf("cannot list test cases: %#v", err)
 	}
 
 	casesPaths := []string{}
@@ -297,11 +297,11 @@ func runTests(t *testing.T, cases []string) {
 	for _, path := range cases {
 		t.Run(path, func(t *testing.T) {
 			f, err := os.Open(path)
-			require.Nilf(t, err, "%s: cannot open test case: %v", path, err)
+			require.Nilf(t, err, "%s: cannot open test case: %#v", path, err)
 
 			var testcase testcaseStruct
 			err = json.NewDecoder(f).Decode(&testcase)
-			require.Nilf(t, err, "%s: cannot decode test case: %v", path, err)
+			require.Nilf(t, err, "%s: cannot decode test case: %#v", path, err)
 
 			currentArch := common.CurrentArch()
 			if testcase.ComposeRequest.Arch != currentArch {

--- a/cmd/osbuild-image-tests/main_test.go
+++ b/cmd/osbuild-image-tests/main_test.go
@@ -22,10 +22,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/osbuild/osbuild-composer/internal/common"
-	"github.com/osbuild/osbuild-composer/internal/distro"
 )
-
-var distroArg = flag.String("distro", "", "which distro tests to run")
 
 type testcaseStruct struct {
 	ComposeRequest struct {
@@ -296,7 +293,7 @@ func getAllCases() ([]string, error) {
 }
 
 // runTests opens, parses and runs all the specified testcases
-func runTests(t *testing.T, cases []string, d string) {
+func runTests(t *testing.T, cases []string) {
 	for _, path := range cases {
 		t.Run(path, func(t *testing.T) {
 			f, err := os.Open(path)
@@ -309,19 +306,6 @@ func runTests(t *testing.T, cases []string, d string) {
 			currentArch := common.CurrentArch()
 			if testcase.ComposeRequest.Arch != currentArch {
 				t.Skipf("the required arch is %s, the current arch is %s", testcase.ComposeRequest.Arch, currentArch)
-			}
-
-			if d != "" {
-				if testcase.ComposeRequest.Distro != d {
-					t.Skipf("the required distro is %s, the passed distro is %s", testcase.ComposeRequest.Distro, d)
-				}
-			} else {
-				hostDistroName, err := distro.GetHostDistroName()
-				require.Nil(t, err)
-
-				if testcase.ComposeRequest.Distro != hostDistroName {
-					t.Skipf("the required distro is %s, the host distro is %s", testcase.ComposeRequest.Distro, hostDistroName)
-				}
 			}
 
 			runTestcase(t, testcase)
@@ -339,5 +323,5 @@ func TestImages(t *testing.T) {
 		require.Nil(t, err)
 	}
 
-	runTests(t, cases, *distroArg)
+	runTests(t, cases)
 }

--- a/cmd/osbuild-image-tests/netns.go
+++ b/cmd/osbuild-image-tests/netns.go
@@ -36,16 +36,16 @@ func newNetworkNamespace() (netNS, error) {
 		if os.IsNotExist(err) {
 			err := os.Mkdir(netnsDir, 0755)
 			if err != nil {
-				return "", fmt.Errorf("cannot create %s: %v", netnsDir, err)
+				return "", fmt.Errorf("cannot create %s: %#v", netnsDir, err)
 			}
 		} else {
-			return "", fmt.Errorf("cannot stat %s: %v", netnsDir, err)
+			return "", fmt.Errorf("cannot stat %s: %#v", netnsDir, err)
 		}
 	}
 
 	f, err := ioutil.TempFile(netnsDir, "osbuild-composer-namespace")
 	if err != nil {
-		return "", fmt.Errorf("cannot create a tempfile: %v", err)
+		return "", fmt.Errorf("cannot create a tempfile: %#v", err)
 	}
 
 	// We want to remove the temporary file if the namespace initialization fails.
@@ -57,14 +57,14 @@ func newNetworkNamespace() (netNS, error) {
 		if !initOK {
 			err := os.Remove(f.Name())
 			if err != nil {
-				log.Printf("cannot remove the temporary namespace: %v", err)
+				log.Printf("cannot remove the temporary namespace: %#v", err)
 			}
 		}
 	}()
 
 	oldNS, err := os.Open("/proc/self/ns/net")
 	if err != nil {
-		return "", fmt.Errorf("cannot open the current namespace: %v", err)
+		return "", fmt.Errorf("cannot open the current namespace: %#v", err)
 	}
 
 	err = syscall.Unshare(syscall.CLONE_NEWNET)
@@ -77,7 +77,7 @@ func newNetworkNamespace() (netNS, error) {
 			// We cannot return to the original namespace.
 			// As we don't know nothing about affected threads, let's just
 			// quit immediately.
-			log.Fatalf("returning to the original namespace failed, quitting: %v", err)
+			log.Fatalf("returning to the original namespace failed, quitting: %#v", err)
 		}
 	}()
 
@@ -86,7 +86,7 @@ func newNetworkNamespace() (netNS, error) {
 	cmd.Stdout = os.Stderr
 	err = cmd.Run()
 	if err != nil {
-		return "", fmt.Errorf("cannot set up a loopback device in the new namespace: %v", err)
+		return "", fmt.Errorf("cannot set up a loopback device in the new namespace: %#v", err)
 	}
 
 	cmd = exec.Command("mount", "-o", "bind", "/proc/self/ns/net", f.Name())
@@ -94,7 +94,7 @@ func newNetworkNamespace() (netNS, error) {
 	cmd.Stdout = os.Stderr
 	err = cmd.Run()
 	if err != nil {
-		return "", fmt.Errorf("cannot bind mount the new namespace: %v", err)
+		return "", fmt.Errorf("cannot bind mount the new namespace: %#v", err)
 	}
 
 	ns := netNS(path.Base(f.Name()))
@@ -134,12 +134,12 @@ func (n netNS) Delete() error {
 	cmd.Stdout = os.Stdout
 	err := cmd.Run()
 	if err != nil {
-		return fmt.Errorf("cannot unmount the network namespace: %v", err)
+		return fmt.Errorf("cannot unmount the network namespace: %#v", err)
 	}
 
 	err = os.Remove(n.Path())
 	if err != nil {
-		return fmt.Errorf("cannot delete the network namespace file: %v", err)
+		return fmt.Errorf("cannot delete the network namespace file: %#v", err)
 	}
 
 	return nil

--- a/golang-github-osbuild-composer.spec
+++ b/golang-github-osbuild-composer.spec
@@ -66,7 +66,6 @@ export GOFLAGS=-mod=vendor
 %endif
 %gobuild -o _bin/osbuild-composer %{goipath}/cmd/osbuild-composer
 %gobuild -o _bin/osbuild-worker %{goipath}/cmd/osbuild-worker
-%gobuild -o _bin/osbuild-image-tests %{goipath}/cmd/osbuild-image-tests
 
 # Build test binaries with `go test -c`, so that they can take advantage of
 # golang's testing package. The golang rpm macros don't support building them
@@ -78,6 +77,7 @@ go test -c -tags=integration -ldflags="${TEST_LDFLAGS}" -o _bin/osbuild-tests %{
 go test -c -tags=integration -ldflags="${TEST_LDFLAGS}" -o _bin/osbuild-dnf-json-tests %{goipath}/cmd/osbuild-dnf-json-tests
 go test -c -tags=integration -ldflags="${TEST_LDFLAGS}" -o _bin/osbuild-weldr-tests %{goipath}/internal/weldrcheck/
 go test -c -tags=integration -ldflags="${TEST_LDFLAGS}" -o _bin/osbuild-rcm-tests %{goipath}/cmd/osbuild-rcm-tests
+go test -c -tags=integration -ldflags="${TEST_LDFLAGS}" -o _bin/osbuild-image-tests %{goipath}/cmd/osbuild-image-tests
 
 %install
 install -m 0755 -vd                                         %{buildroot}%{_libexecdir}/osbuild-composer


### PR DESCRIPTION
I decided not to use the testing framework in functions which are not directly tight to testing (booting images, running osbuild). I think it's reasonable to use classic error handling there and propagate the errors to places directly tight to testing and then use the testing library. This enables us to reuse the code in different part of projects if needed.

Other changes:
- I removed the hack which assumed that every fedora is Fedora 30. We currently do have tests for other Fedora versions, therefore it's not needed anymore.
- The testing VM has now only 1GB of memory, now it should be able to run in [teg/testvm](https://github.com/teg/test-vm/).

This PR is depending on #336, before it gets merged, the CI will be failing.