### PR TITLE
ci/lint: add integration tag

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -4,6 +4,10 @@ linters-settings:
       - shadow # default value recommended by golangci
       - composites
 
+run:
+  build-tags:
+    - integration
+
 issues:
   # Maximum issues count per one linter. Set to 0 to disable. Default is 50.
   max-issues-per-linter: 0


### PR DESCRIPTION
In the current PRs (#325 and #335) we have an issue with the linter failing on a dead code in integration tests. The linter isn't failing on main_test.go file because it somehow ignores the integration tag. However, it fails on other files which main_test.go depends on and which have the integration tag.

This commit tells golangci-lint to always use the integration tag while doing the inspection.

I think there shouldn't be any false negatives resulting from this change. However, I may be wrong, feel free to correct me.

Another solution is to turn off the `deadcode` linter in the affected files, however I think that this PR solves this issue more elegantly.

Note: This commit doesn't have any effect on our current codebase.