### PR TITLE
spec: add systemd scriptlets for the rcm subpackage

### DIFF
--- a/golang-github-osbuild-composer.spec
+++ b/golang-github-osbuild-composer.spec
@@ -151,6 +151,15 @@ RCM-specific version of osbuild-composer not intended for public usage.
 %files rcm
 %{_unitdir}/osbuild-rcm.socket
 
+%post rcm
+%systemd_post osbuild-rcm.socket
+
+%preun rcm
+%systemd_preun osbuild-rcm.socket
+
+%postun rcm
+%systemd_postun_with_restart osbuild-rcm.socket
+
 %package tests
 Summary:	Integration tests
 Requires: 	osbuild-composer


### PR DESCRIPTION
Fedora packaging guidelines require that we use scriptlets when shipping
unit files:
https://docs.fedoraproject.org/en-US/packaging-guidelines/Scriptlets/#_systemd
the rcm subpackage needs to use these as well as the main package.