### PR TITLE
store/jobqueue: remove `distro` field from jobs

### DIFF
--- a/internal/jobqueue/api.go
+++ b/internal/jobqueue/api.go
@@ -105,7 +105,6 @@ func (api *API) addJobHandler(writer http.ResponseWriter, request *http.Request,
 	_ = json.NewEncoder(writer).Encode(Job{
 		ID:           nextJob.ComposeID,
 		ImageBuildID: nextJob.ImageBuildID,
-		Distro:       nextJob.Distro,
 		Manifest:     nextJob.Manifest,
 		Targets:      nextJob.Targets,
 		OutputType:   nextJob.ImageType,

--- a/internal/jobqueue/api_test.go
+++ b/internal/jobqueue/api_test.go
@@ -60,7 +60,7 @@ func TestCreate(t *testing.T) {
 	}
 
 	test.TestRoute(t, api, false, "POST", "/job-queue/v1/jobs", `{}`, http.StatusCreated,
-		`{"id":"ffffffff-ffff-ffff-ffff-ffffffffffff","image_build_id":0,"distro":"fedora-30","manifest":{"sources":{},"pipeline":{}},"targets":[],"output_type":"qcow2"}`, "created", "uuid")
+		`{"id":"ffffffff-ffff-ffff-ffff-ffffffffffff","image_build_id":0,"manifest":{"sources":{},"pipeline":{}},"targets":[],"output_type":"qcow2"}`, "created", "uuid")
 }
 
 func testUpdateTransition(t *testing.T, from, to string, expectedStatus int, expectedResponse string) {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -53,7 +53,6 @@ type Store struct {
 type Job struct {
 	ComposeID    uuid.UUID
 	ImageBuildID int
-	Distro       string
 	Manifest     *osbuild.Manifest
 	Targets      []*target.Target
 	ImageType    string
@@ -166,10 +165,6 @@ func New(stateDir *string, distroRegistryArg distro.Registry) *Store {
 					// s.Composes[composeID] = compose
 				case common.IBWaiting:
 					// Push waiting composes back into the pending jobs queue
-					distroStr, exists := imgBuild.Distro.ToString()
-					if !exists {
-						panic("fatal error, distro tag should exist but does not")
-					}
 					imageTypeCompat, exists := imgBuild.ImageType.ToCompatString()
 					if !exists {
 						panic("fatal error, image type tag should exist but does not")
@@ -177,7 +172,6 @@ func New(stateDir *string, distroRegistryArg distro.Registry) *Store {
 					s.pendingJobs <- Job{
 						ComposeID:    composeID,
 						ImageBuildID: imgBuild.Id,
-						Distro:       distroStr,
 						Manifest:     imgBuild.Manifest,
 						Targets:      imgBuild.Targets,
 						ImageType:    imageTypeCompat,
@@ -641,7 +635,6 @@ func (s *Store) PushCompose(distro distro.Distro, composeID uuid.UUID, bp *bluep
 	s.pendingJobs <- Job{
 		ComposeID:    composeID,
 		ImageBuildID: 0,
-		Distro:       distro.Name(),
 		Manifest:     manifestStruct,
 		Targets:      targets,
 		ImageType:    composeType,


### PR DESCRIPTION
A job's purpose is to build an osbuild manifest and upload the results
somewhere. It should not know about which distro was used to generate
the pipeline.

Workers depended on the distro package in two ways:

1. To set an osbuild `--build-env`. This is not necessary anymore in new
   versions of osbuild. More importantly, it was wrong: it passed the
   runner from the distro that is being built, instead of one that
   matches the host.

   This patch simply removes that logic.

2. To fetch the output filename with `Distro.FilenameFromType()`. While
   that is useful, I don't think it warrants the dependency.

   This patch uses the fact that all current pipelines output exactly
   one file and uploads that. This should probably be extended in the
   future to upload all output files, or to name them explicitly in the
   upload target.

The worker should now compile to a smaller binary and do less
unnecessary work on startup (like reading repository files).