### PR TITLE
distro: don't expose repositories in distro objects

### DIFF
--- a/cmd/osbuild-pipeline/main.go
+++ b/cmd/osbuild-pipeline/main.go
@@ -74,7 +74,7 @@ func main() {
 		}
 	}
 
-	distros, err := distro.NewDefaultRegistry([]string{"."})
+	distros, err := distro.NewDefaultRegistry()
 	if err != nil {
 		panic(err)
 	}
@@ -86,6 +86,11 @@ func main() {
 			_, _ = fmt.Fprintln(os.Stderr, " *", distro)
 		}
 		return
+	}
+
+	repos, err := rpmmd.LoadRepositories([]string{"."}, distroArg)
+	if err != nil {
+		panic(err)
 	}
 
 	packages := make([]string, len(blueprint.Packages))
@@ -112,7 +117,7 @@ func main() {
 	}
 
 	rpmmd := rpmmd.NewRPMMD(path.Join(home, ".cache/osbuild-composer/rpmmd"))
-	packageSpecs, checksums, err := rpmmd.Depsolve(packages, exclude_pkgs, d.Repositories(archArg), d.ModulePlatformID())
+	packageSpecs, checksums, err := rpmmd.Depsolve(packages, exclude_pkgs, repos[archArg], d.ModulePlatformID())
 	if err != nil {
 		panic("Could not depsolve: " + err.Error())
 	}
@@ -121,7 +126,7 @@ func main() {
 	if err != nil {
 		panic("Could not get build packages: " + err.Error())
 	}
-	buildPackageSpecs, _, err := rpmmd.Depsolve(buildPkgs, nil, d.Repositories(archArg), d.ModulePlatformID())
+	buildPackageSpecs, _, err := rpmmd.Depsolve(buildPkgs, nil, repos[archArg], d.ModulePlatformID())
 	if err != nil {
 		panic("Could not depsolve build packages: " + err.Error())
 	}
@@ -139,7 +144,7 @@ func main() {
 		}
 	} else {
 		size := d.GetSizeForOutputType(imageType, 0)
-		manifest, err := d.Manifest(blueprint.Customizations, nil, packageSpecs, buildPackageSpecs, archArg, imageType, size)
+		manifest, err := d.Manifest(blueprint.Customizations, repos[archArg], packageSpecs, buildPackageSpecs, archArg, imageType, size)
 		if err != nil {
 			panic(err.Error())
 		}

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -15,6 +15,7 @@ import (
 
 	test_distro "github.com/osbuild/osbuild-composer/internal/distro/fedoratest"
 	rpmmd_mock "github.com/osbuild/osbuild-composer/internal/mocks/rpmmd"
+	"github.com/osbuild/osbuild-composer/internal/rpmmd"
 	"github.com/osbuild/osbuild-composer/internal/weldr"
 
 	"github.com/google/go-cmp/cmp"
@@ -209,8 +210,9 @@ func TestMain(m *testing.M) {
 	fixture := rpmmd_mock.BaseFixture()
 	rpm := rpmmd_mock.NewRPMMDMock(fixture)
 	distro := test_distro.New()
+	repos := []rpmmd.RepoConfig{{Id: "test-id", BaseURL: "http://example.com/test/os/test_arch"}}
 	logger := log.New(os.Stdout, "", 0)
-	api := weldr.New(rpm, "test_arch", distro, logger, fixture.Store)
+	api := weldr.New(rpm, "test_arch", distro, repos, logger, fixture.Store)
 	server := http.Server{Handler: api}
 	defer server.Close()
 

--- a/internal/distro/distro.go
+++ b/internal/distro/distro.go
@@ -34,10 +34,6 @@ type Distro interface {
 	// for modularity support.
 	ModulePlatformID() string
 
-	// Returns a list of repositories from which this distribution gets its
-	// content.
-	Repositories(arch string) []rpmmd.RepoConfig
-
 	// Returns a sorted list of the output formats this distro supports.
 	ListOutputFormats() []string
 
@@ -58,7 +54,7 @@ type Distro interface {
 	// Returns an osbuild manifest, containing the sources and pipeline necessary
 	// to generates an image in the given output format with all packages and
 	// customizations specified in the given blueprint.
-	Manifest(b *blueprint.Customizations, additionalRepos []rpmmd.RepoConfig, packageSpecs, buildPackageSpecs []rpmmd.PackageSpec, outputArchitecture, imageFormat string, size uint64) (*osbuild.Manifest, error)
+	Manifest(b *blueprint.Customizations, repos []rpmmd.RepoConfig, packageSpecs, buildPackageSpecs []rpmmd.PackageSpec, outputArchitecture, imageFormat string, size uint64) (*osbuild.Manifest, error)
 
 	// Returns a osbuild runner that can be used on this distro.
 	Runner() string
@@ -83,24 +79,24 @@ func NewRegistry(distros ...Distro) (*Registry, error) {
 }
 
 // Create a new Registry containing all known distros.
-func NewDefaultRegistry(confPaths []string) (*Registry, error) {
-	f30, err := fedora30.New(confPaths)
+func NewDefaultRegistry() (*Registry, error) {
+	f30, err := fedora30.New()
 	if err != nil {
 		return nil, fmt.Errorf("error loading fedora30: %v", err)
 	}
-	f31, err := fedora31.New(confPaths)
+	f31, err := fedora31.New()
 	if err != nil {
 		return nil, fmt.Errorf("error loading fedora31: %v", err)
 	}
-	f32, err := fedora32.New(confPaths)
+	f32, err := fedora32.New()
 	if err != nil {
 		return nil, fmt.Errorf("error loading fedora32: %v", err)
 	}
-	el81, err := rhel81.New(confPaths)
+	el81, err := rhel81.New()
 	if err != nil {
 		return nil, fmt.Errorf("error loading rhel81: %v", err)
 	}
-	el82, err := rhel82.New(confPaths)
+	el82, err := rhel82.New()
 	if err != nil {
 		return nil, fmt.Errorf("error loading rhel82: %v", err)
 	}

--- a/internal/distro/distro_test.go
+++ b/internal/distro/distro_test.go
@@ -47,8 +47,12 @@ func TestDistro_Manifest(t *testing.T) {
 			t.Logf("Skipping '%s'.", fileInfo.Name())
 			continue
 		}
+		repoMap, err := rpmmd.LoadRepositories([]string{"../.."}, tt.ComposeRequest.Distro)
+		if err != nil {
+			t.Fatalf("rpmmd.LoadRepositories: %v", err)
+		}
 		t.Run(tt.ComposeRequest.OutputFormat, func(t *testing.T) {
-			distros, err := distro.NewDefaultRegistry([]string{"../.."})
+			distros, err := distro.NewDefaultRegistry()
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -59,7 +63,7 @@ func TestDistro_Manifest(t *testing.T) {
 			}
 			size := d.GetSizeForOutputType(tt.ComposeRequest.OutputFormat, 0)
 			got, err := d.Manifest(tt.ComposeRequest.Blueprint.Customizations,
-				nil,
+				repoMap[tt.ComposeRequest.Arch],
 				tt.RpmMD.Packages,
 				tt.RpmMD.BuildPackages,
 				tt.ComposeRequest.Arch,
@@ -88,7 +92,7 @@ func TestDistro_RegistryList(t *testing.T) {
 		"rhel-8.2",
 	}
 
-	distros, err := distro.NewDefaultRegistry([]string{"../.."})
+	distros, err := distro.NewDefaultRegistry()
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/distro/fedora30/distro_test.go
+++ b/internal/distro/fedora30/distro_test.go
@@ -19,7 +19,7 @@ func TestListOutputFormats(t *testing.T) {
 		"vmdk",
 	}
 
-	f30, err := fedora30.New([]string{"../../../"})
+	f30, err := fedora30.New()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -96,7 +96,7 @@ func TestFilenameFromType(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			f30, err := fedora30.New([]string{"../../../"})
+			f30, err := fedora30.New()
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/internal/distro/fedora31/distro.go
+++ b/internal/distro/fedora31/distro.go
@@ -2,8 +2,6 @@ package fedora31
 
 import (
 	"errors"
-	"fmt"
-	"log"
 	"sort"
 	"strconv"
 
@@ -28,7 +26,6 @@ type arch struct {
 	BootloaderPackages []string
 	BuildPackages      []string
 	UEFI               bool
-	Repositories       []rpmmd.RepoConfig
 }
 
 type output struct {
@@ -47,11 +44,10 @@ type output struct {
 const Distro = common.Fedora31
 const ModulePlatformID = "platform:f31"
 
-func New(confPaths []string) (*Fedora31, error) {
+func New() (*Fedora31, error) {
 	const GigaByte = 1024 * 1024 * 1024
 
 	r := Fedora31{
-		arches:  map[string]arch{},
 		outputs: map[string]output{},
 		buildPackages: []string{
 			"dnf",
@@ -62,45 +58,28 @@ func New(confPaths []string) (*Fedora31, error) {
 			"systemd",
 			"tar",
 		},
-	}
-
-	repoMap, err := rpmmd.LoadRepositories(confPaths, r.Name())
-	if err != nil {
-		return nil, fmt.Errorf("Could not load repository data for %s: %s", r.Name(), err.Error())
-	}
-
-	repos, exists := repoMap["x86_64"]
-	if !exists {
-		log.Printf("Could not load architecture-specific repository data for x86_64 (%s)", r.Name())
-	} else {
-		r.arches["x86_64"] = arch{
-			Name: "x86_64",
-			BootloaderPackages: []string{
-				"grub2-pc",
+		arches: map[string]arch{
+			"x86_64": arch{
+				Name: "x86_64",
+				BootloaderPackages: []string{
+					"grub2-pc",
+				},
+				BuildPackages: []string{
+					"grub2-pc",
+				},
 			},
-			BuildPackages: []string{
-				"grub2-pc",
+			"aarch64": arch{
+				Name: "aarch64",
+				BootloaderPackages: []string{
+					"dracut-config-generic",
+					"efibootmgr",
+					"grub2-efi-aa64",
+					"grub2-tools",
+					"shim-aa64",
+				},
+				UEFI: true,
 			},
-			Repositories: repos,
-		}
-	}
-
-	repos, exists = repoMap["aarch64"]
-	if !exists {
-		log.Printf("Could not load architecture-specific repository data for aarch64 (%s)", r.Name())
-	} else {
-		r.arches["aarch64"] = arch{
-			Name: "aarch64",
-			BootloaderPackages: []string{
-				"dracut-config-generic",
-				"efibootmgr",
-				"grub2-efi-aa64",
-				"grub2-tools",
-				"shim-aa64",
-			},
-			UEFI:         true,
-			Repositories: repos,
-		}
+		},
 	}
 
 	r.outputs["ami"] = output{
@@ -326,10 +305,6 @@ func (r *Fedora31) ModulePlatformID() string {
 	return ModulePlatformID
 }
 
-func (r *Fedora31) Repositories(arch string) []rpmmd.RepoConfig {
-	return r.arches[arch].Repositories
-}
-
 func (r *Fedora31) ListOutputFormats() []string {
 	formats := make([]string, 0, len(r.outputs))
 	for name := range r.outputs {
@@ -386,7 +361,7 @@ func (r *Fedora31) BuildPackages(outputArchitecture string) ([]string, error) {
 	return append(r.buildPackages, arch.BuildPackages...), nil
 }
 
-func (r *Fedora31) pipeline(c *blueprint.Customizations, additionalRepos []rpmmd.RepoConfig, packageSpecs, buildPackageSpecs []rpmmd.PackageSpec, outputArchitecture, outputFormat string, size uint64) (*osbuild.Pipeline, error) {
+func (r *Fedora31) pipeline(c *blueprint.Customizations, repos []rpmmd.RepoConfig, packageSpecs, buildPackageSpecs []rpmmd.PackageSpec, outputArchitecture, outputFormat string, size uint64) (*osbuild.Pipeline, error) {
 	output, exists := r.outputs[outputFormat]
 	if !exists {
 		return nil, errors.New("invalid output format: " + outputFormat)
@@ -398,9 +373,9 @@ func (r *Fedora31) pipeline(c *blueprint.Customizations, additionalRepos []rpmmd
 	}
 
 	p := &osbuild.Pipeline{}
-	p.SetBuild(r.buildPipeline(arch, buildPackageSpecs), "org.osbuild.fedora31")
+	p.SetBuild(r.buildPipeline(repos, arch, buildPackageSpecs), "org.osbuild.fedora31")
 
-	p.AddStage(osbuild.NewRPMStage(r.rpmStageOptions(arch, additionalRepos, packageSpecs)))
+	p.AddStage(osbuild.NewRPMStage(r.rpmStageOptions(arch, repos, packageSpecs)))
 	p.AddStage(osbuild.NewFixBLSStage())
 
 	// TODO support setting all languages and install corresponding langpack-* package
@@ -475,8 +450,8 @@ func (r *Fedora31) sources(packages []rpmmd.PackageSpec) *osbuild.Sources {
 	}
 }
 
-func (r *Fedora31) Manifest(c *blueprint.Customizations, additionalRepos []rpmmd.RepoConfig, packageSpecs, buildPackageSpecs []rpmmd.PackageSpec, outputArchitecture, outputFormat string, size uint64) (*osbuild.Manifest, error) {
-	pipeline, err := r.pipeline(c, additionalRepos, packageSpecs, buildPackageSpecs, outputArchitecture, outputFormat, size)
+func (r *Fedora31) Manifest(c *blueprint.Customizations, repos []rpmmd.RepoConfig, packageSpecs, buildPackageSpecs []rpmmd.PackageSpec, outputArchitecture, outputFormat string, size uint64) (*osbuild.Manifest, error) {
+	pipeline, err := r.pipeline(c, repos, packageSpecs, buildPackageSpecs, outputArchitecture, outputFormat, size)
 	if err != nil {
 		return nil, err
 	}
@@ -491,15 +466,14 @@ func (r *Fedora31) Runner() string {
 	return "org.osbuild.fedora31"
 }
 
-func (r *Fedora31) buildPipeline(arch arch, buildPackageSpecs []rpmmd.PackageSpec) *osbuild.Pipeline {
+func (r *Fedora31) buildPipeline(repos []rpmmd.RepoConfig, arch arch, buildPackageSpecs []rpmmd.PackageSpec) *osbuild.Pipeline {
 	p := &osbuild.Pipeline{}
-	p.AddStage(osbuild.NewRPMStage(r.rpmStageOptions(arch, nil, buildPackageSpecs)))
+	p.AddStage(osbuild.NewRPMStage(r.rpmStageOptions(arch, repos, buildPackageSpecs)))
 	return p
 }
 
-func (r *Fedora31) rpmStageOptions(arch arch, additionalRepos []rpmmd.RepoConfig, specs []rpmmd.PackageSpec) *osbuild.RPMStageOptions {
+func (r *Fedora31) rpmStageOptions(arch arch, repos []rpmmd.RepoConfig, specs []rpmmd.PackageSpec) *osbuild.RPMStageOptions {
 	var gpgKeys []string
-	repos := append(arch.Repositories, additionalRepos...)
 	for _, repo := range repos {
 		if repo.GPGKey == "" {
 			continue

--- a/internal/distro/fedora31/distro_test.go
+++ b/internal/distro/fedora31/distro_test.go
@@ -19,7 +19,7 @@ func TestListOutputFormats(t *testing.T) {
 		"vmdk",
 	}
 
-	f31, err := fedora31.New([]string{"../../../"})
+	f31, err := fedora31.New()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -96,7 +96,7 @@ func TestFilenameFromType(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			f31, err := fedora31.New([]string{"../../../"})
+			f31, err := fedora31.New()
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/internal/distro/fedora32/distro.go
+++ b/internal/distro/fedora32/distro.go
@@ -2,8 +2,6 @@ package fedora32
 
 import (
 	"errors"
-	"fmt"
-	"log"
 	"sort"
 	"strconv"
 
@@ -28,7 +26,6 @@ type arch struct {
 	BootloaderPackages []string
 	BuildPackages      []string
 	UEFI               bool
-	Repositories       []rpmmd.RepoConfig
 }
 
 type output struct {
@@ -47,11 +44,10 @@ type output struct {
 const Distro = common.Fedora32
 const ModulePlatformID = "platform:f32"
 
-func New(confPaths []string) (*Fedora32, error) {
+func New() (*Fedora32, error) {
 	const GigaByte = 1024 * 1024 * 1024
 
 	r := Fedora32{
-		arches:  map[string]arch{},
 		outputs: map[string]output{},
 		buildPackages: []string{
 			"dnf",
@@ -62,45 +58,28 @@ func New(confPaths []string) (*Fedora32, error) {
 			"systemd",
 			"tar",
 		},
-	}
-
-	repoMap, err := rpmmd.LoadRepositories(confPaths, r.Name())
-	if err != nil {
-		return nil, fmt.Errorf("Could not load repository data for %s: %s", r.Name(), err.Error())
-	}
-
-	repos, exists := repoMap["x86_64"]
-	if !exists {
-		log.Printf("Could not load architecture-specific repository data for x86_64 (%s)", r.Name())
-	} else {
-		r.arches["x86_64"] = arch{
-			Name: "x86_64",
-			BootloaderPackages: []string{
-				"grub2-pc",
+		arches: map[string]arch{
+			"x86_64": arch{
+				Name: "x86_64",
+				BootloaderPackages: []string{
+					"grub2-pc",
+				},
+				BuildPackages: []string{
+					"grub2-pc",
+				},
 			},
-			BuildPackages: []string{
-				"grub2-pc",
+			"aarch64": arch{
+				Name: "aarch64",
+				BootloaderPackages: []string{
+					"dracut-config-generic",
+					"efibootmgr",
+					"grub2-efi-aa64",
+					"grub2-tools",
+					"shim-aa64",
+				},
+				UEFI: true,
 			},
-			Repositories: repos,
-		}
-	}
-
-	repos, exists = repoMap["aarch64"]
-	if !exists {
-		log.Printf("Could not load architecture-specific repository data for aarch64 (%s)", r.Name())
-	} else {
-		r.arches["aarch64"] = arch{
-			Name: "aarch64",
-			BootloaderPackages: []string{
-				"dracut-config-generic",
-				"efibootmgr",
-				"grub2-efi-aa64",
-				"grub2-tools",
-				"shim-aa64",
-			},
-			UEFI:         true,
-			Repositories: repos,
-		}
+		},
 	}
 
 	r.outputs["ami"] = output{
@@ -326,10 +305,6 @@ func (r *Fedora32) ModulePlatformID() string {
 	return ModulePlatformID
 }
 
-func (r *Fedora32) Repositories(arch string) []rpmmd.RepoConfig {
-	return r.arches[arch].Repositories
-}
-
 func (r *Fedora32) ListOutputFormats() []string {
 	formats := make([]string, 0, len(r.outputs))
 	for name := range r.outputs {
@@ -386,7 +361,7 @@ func (r *Fedora32) BuildPackages(outputArchitecture string) ([]string, error) {
 	return append(r.buildPackages, arch.BuildPackages...), nil
 }
 
-func (r *Fedora32) pipeline(c *blueprint.Customizations, additionalRepos []rpmmd.RepoConfig, packageSpecs, buildPackageSpecs []rpmmd.PackageSpec, outputArchitecture, outputFormat string, size uint64) (*osbuild.Pipeline, error) {
+func (r *Fedora32) pipeline(c *blueprint.Customizations, repos []rpmmd.RepoConfig, packageSpecs, buildPackageSpecs []rpmmd.PackageSpec, outputArchitecture, outputFormat string, size uint64) (*osbuild.Pipeline, error) {
 	output, exists := r.outputs[outputFormat]
 	if !exists {
 		return nil, errors.New("invalid output format: " + outputFormat)
@@ -398,9 +373,9 @@ func (r *Fedora32) pipeline(c *blueprint.Customizations, additionalRepos []rpmmd
 	}
 
 	p := &osbuild.Pipeline{}
-	p.SetBuild(r.buildPipeline(arch, buildPackageSpecs), "org.osbuild.fedora32")
+	p.SetBuild(r.buildPipeline(repos, arch, buildPackageSpecs), "org.osbuild.fedora32")
 
-	p.AddStage(osbuild.NewRPMStage(r.rpmStageOptions(arch, additionalRepos, packageSpecs)))
+	p.AddStage(osbuild.NewRPMStage(r.rpmStageOptions(arch, repos, packageSpecs)))
 	p.AddStage(osbuild.NewFixBLSStage())
 
 	// TODO support setting all languages and install corresponding langpack-* package
@@ -475,8 +450,8 @@ func (r *Fedora32) sources(packages []rpmmd.PackageSpec) *osbuild.Sources {
 	}
 }
 
-func (r *Fedora32) Manifest(c *blueprint.Customizations, additionalRepos []rpmmd.RepoConfig, packageSpecs, buildPackageSpecs []rpmmd.PackageSpec, outputArchitecture, outputFormat string, size uint64) (*osbuild.Manifest, error) {
-	pipeline, err := r.pipeline(c, additionalRepos, packageSpecs, buildPackageSpecs, outputArchitecture, outputFormat, size)
+func (r *Fedora32) Manifest(c *blueprint.Customizations, repos []rpmmd.RepoConfig, packageSpecs, buildPackageSpecs []rpmmd.PackageSpec, outputArchitecture, outputFormat string, size uint64) (*osbuild.Manifest, error) {
+	pipeline, err := r.pipeline(c, repos, packageSpecs, buildPackageSpecs, outputArchitecture, outputFormat, size)
 	if err != nil {
 		return nil, err
 	}
@@ -491,15 +466,14 @@ func (r *Fedora32) Runner() string {
 	return "org.osbuild.fedora32"
 }
 
-func (r *Fedora32) buildPipeline(arch arch, buildPackageSpecs []rpmmd.PackageSpec) *osbuild.Pipeline {
+func (r *Fedora32) buildPipeline(repos []rpmmd.RepoConfig, arch arch, buildPackageSpecs []rpmmd.PackageSpec) *osbuild.Pipeline {
 	p := &osbuild.Pipeline{}
-	p.AddStage(osbuild.NewRPMStage(r.rpmStageOptions(arch, nil, buildPackageSpecs)))
+	p.AddStage(osbuild.NewRPMStage(r.rpmStageOptions(arch, repos, buildPackageSpecs)))
 	return p
 }
 
-func (r *Fedora32) rpmStageOptions(arch arch, additionalRepos []rpmmd.RepoConfig, specs []rpmmd.PackageSpec) *osbuild.RPMStageOptions {
+func (r *Fedora32) rpmStageOptions(arch arch, repos []rpmmd.RepoConfig, specs []rpmmd.PackageSpec) *osbuild.RPMStageOptions {
 	var gpgKeys []string
-	repos := append(arch.Repositories, additionalRepos...)
 	for _, repo := range repos {
 		if repo.GPGKey == "" {
 			continue

--- a/internal/distro/fedora32/distro_test.go
+++ b/internal/distro/fedora32/distro_test.go
@@ -19,7 +19,7 @@ func TestListOutputFormats(t *testing.T) {
 		"vmdk",
 	}
 
-	f32, err := fedora32.New([]string{"../../../"})
+	f32, err := fedora32.New()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -96,7 +96,7 @@ func TestFilenameFromType(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			f32, err := fedora32.New([]string{"../../../"})
+			f32, err := fedora32.New()
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/internal/distro/fedoratest/distro.go
+++ b/internal/distro/fedoratest/distro.go
@@ -29,15 +29,6 @@ func (d *FedoraTestDistro) ModulePlatformID() string {
 	return ModulePlatformID
 }
 
-func (d *FedoraTestDistro) Repositories(arch string) []rpmmd.RepoConfig {
-	return []rpmmd.RepoConfig{
-		{
-			Id:      "test-id",
-			BaseURL: "http://example.com/test/os/" + arch,
-		},
-	}
-}
-
 func (d *FedoraTestDistro) ListOutputFormats() []string {
 	return []string{"qcow2"}
 }
@@ -62,7 +53,7 @@ func (d *FedoraTestDistro) BuildPackages(outputArchitecture string) ([]string, e
 	return nil, nil
 }
 
-func (d *FedoraTestDistro) pipeline(c *blueprint.Customizations, additionalRepos []rpmmd.RepoConfig, buildPackages, basePackages []rpmmd.PackageSpec, outputArch, outputFormat string, size uint64) (*osbuild.Pipeline, error) {
+func (d *FedoraTestDistro) pipeline(c *blueprint.Customizations, repos []rpmmd.RepoConfig, buildPackages, basePackages []rpmmd.PackageSpec, outputArch, outputFormat string, size uint64) (*osbuild.Pipeline, error) {
 	if outputFormat == "qcow2" && outputArch == "x86_64" {
 		return &osbuild.Pipeline{}, nil
 	} else {
@@ -74,8 +65,8 @@ func (r *FedoraTestDistro) sources(packages []rpmmd.PackageSpec) *osbuild.Source
 	return &osbuild.Sources{}
 }
 
-func (r *FedoraTestDistro) Manifest(c *blueprint.Customizations, additionalRepos []rpmmd.RepoConfig, packageSpecs, buildPackageSpecs []rpmmd.PackageSpec, outputArchitecture, outputFormat string, size uint64) (*osbuild.Manifest, error) {
-	pipeline, err := r.pipeline(c, additionalRepos, packageSpecs, buildPackageSpecs, outputArchitecture, outputFormat, size)
+func (r *FedoraTestDistro) Manifest(c *blueprint.Customizations, repos []rpmmd.RepoConfig, packageSpecs, buildPackageSpecs []rpmmd.PackageSpec, outputArchitecture, outputFormat string, size uint64) (*osbuild.Manifest, error) {
+	pipeline, err := r.pipeline(c, repos, packageSpecs, buildPackageSpecs, outputArchitecture, outputFormat, size)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/distro/rhel81/distro.go
+++ b/internal/distro/rhel81/distro.go
@@ -2,8 +2,6 @@ package rhel81
 
 import (
 	"errors"
-	"fmt"
-	"log"
 	"sort"
 	"strconv"
 
@@ -28,7 +26,6 @@ type arch struct {
 	BootloaderPackages []string
 	BuildPackages      []string
 	UEFI               bool
-	Repositories       []rpmmd.RepoConfig
 }
 
 type output struct {
@@ -48,11 +45,10 @@ type output struct {
 const Distro = common.RHEL81
 const ModulePlatformID = "platform:el8"
 
-func New(confPaths []string) (*RHEL81, error) {
+func New() (*RHEL81, error) {
 	const GigaByte = 1024 * 1024 * 1024
 
 	r := RHEL81{
-		arches:  map[string]arch{},
 		outputs: map[string]output{},
 		buildPackages: []string{
 			"dnf",
@@ -67,45 +63,28 @@ func New(confPaths []string) (*RHEL81, error) {
 			"tar",
 			"xfsprogs",
 		},
-	}
-
-	repoMap, err := rpmmd.LoadRepositories(confPaths, r.Name())
-	if err != nil {
-		return nil, fmt.Errorf("Could not load repository data for %s: %s", r.Name(), err.Error())
-	}
-
-	repos, exists := repoMap["x86_64"]
-	if !exists {
-		log.Printf("Could not load architecture-specific repository data for x86_64 (%s)", r.Name())
-	} else {
-		r.arches["x86_64"] = arch{
-			Name: "x86_64",
-			BootloaderPackages: []string{
-				"grub2-pc",
+		arches: map[string]arch{
+			"x86_64": arch{
+				Name: "x86_64",
+				BootloaderPackages: []string{
+					"grub2-pc",
+				},
+				BuildPackages: []string{
+					"grub2-pc",
+				},
 			},
-			BuildPackages: []string{
-				"grub2-pc",
+			"aarch64": arch{
+				Name: "aarch64",
+				BootloaderPackages: []string{
+					"dracut-config-generic",
+					"efibootmgr",
+					"grub2-efi-aa64",
+					"grub2-tools",
+					"shim-aa64",
+				},
+				UEFI: true,
 			},
-			Repositories: repos,
-		}
-	}
-
-	repos, exists = repoMap["aarch64"]
-	if !exists {
-		log.Printf("Could not load architecture-specific repository data for aarch64 (%s)", r.Name())
-	} else {
-		r.arches["aarch64"] = arch{
-			Name: "aarch64",
-			BootloaderPackages: []string{
-				"dracut-config-generic",
-				"efibootmgr",
-				"grub2-efi-aa64",
-				"grub2-tools",
-				"shim-aa64",
-			},
-			UEFI:         true,
-			Repositories: repos,
-		}
+		},
 	}
 
 	r.outputs["ami"] = output{
@@ -465,10 +444,6 @@ func (r *RHEL81) ModulePlatformID() string {
 	return ModulePlatformID
 }
 
-func (r *RHEL81) Repositories(arch string) []rpmmd.RepoConfig {
-	return r.arches[arch].Repositories
-}
-
 func (r *RHEL81) ListOutputFormats() []string {
 	formats := make([]string, 0, len(r.outputs))
 	for name := range r.outputs {
@@ -525,7 +500,7 @@ func (r *RHEL81) BuildPackages(outputArchitecture string) ([]string, error) {
 	return append(r.buildPackages, arch.BuildPackages...), nil
 }
 
-func (r *RHEL81) pipeline(c *blueprint.Customizations, additionalRepos []rpmmd.RepoConfig, packageSpecs, buildPackageSpecs []rpmmd.PackageSpec, outputArchitecture, outputFormat string, size uint64) (*osbuild.Pipeline, error) {
+func (r *RHEL81) pipeline(c *blueprint.Customizations, repos []rpmmd.RepoConfig, packageSpecs, buildPackageSpecs []rpmmd.PackageSpec, outputArchitecture, outputFormat string, size uint64) (*osbuild.Pipeline, error) {
 	output, exists := r.outputs[outputFormat]
 	if !exists {
 		return nil, errors.New("invalid output format: " + outputFormat)
@@ -537,9 +512,9 @@ func (r *RHEL81) pipeline(c *blueprint.Customizations, additionalRepos []rpmmd.R
 	}
 
 	p := &osbuild.Pipeline{}
-	p.SetBuild(r.buildPipeline(arch, buildPackageSpecs), "org.osbuild.rhel81")
+	p.SetBuild(r.buildPipeline(repos, arch, buildPackageSpecs), "org.osbuild.rhel81")
 
-	p.AddStage(osbuild.NewRPMStage(r.rpmStageOptions(arch, additionalRepos, packageSpecs)))
+	p.AddStage(osbuild.NewRPMStage(r.rpmStageOptions(arch, repos, packageSpecs)))
 	p.AddStage(osbuild.NewFixBLSStage())
 
 	if output.Bootable {
@@ -619,8 +594,8 @@ func (r *RHEL81) sources(packages []rpmmd.PackageSpec) *osbuild.Sources {
 	}
 }
 
-func (r *RHEL81) Manifest(c *blueprint.Customizations, additionalRepos []rpmmd.RepoConfig, packageSpecs, buildPackageSpecs []rpmmd.PackageSpec, outputArchitecture, outputFormat string, size uint64) (*osbuild.Manifest, error) {
-	pipeline, err := r.pipeline(c, additionalRepos, packageSpecs, buildPackageSpecs, outputArchitecture, outputFormat, size)
+func (r *RHEL81) Manifest(c *blueprint.Customizations, repos []rpmmd.RepoConfig, packageSpecs, buildPackageSpecs []rpmmd.PackageSpec, outputArchitecture, outputFormat string, size uint64) (*osbuild.Manifest, error) {
+	pipeline, err := r.pipeline(c, repos, packageSpecs, buildPackageSpecs, outputArchitecture, outputFormat, size)
 	if err != nil {
 		return nil, err
 	}
@@ -635,15 +610,14 @@ func (r *RHEL81) Runner() string {
 	return "org.osbuild.rhel81"
 }
 
-func (r *RHEL81) buildPipeline(arch arch, buildPackageSpecs []rpmmd.PackageSpec) *osbuild.Pipeline {
+func (r *RHEL81) buildPipeline(repos []rpmmd.RepoConfig, arch arch, buildPackageSpecs []rpmmd.PackageSpec) *osbuild.Pipeline {
 	p := &osbuild.Pipeline{}
-	p.AddStage(osbuild.NewRPMStage(r.rpmStageOptions(arch, nil, buildPackageSpecs)))
+	p.AddStage(osbuild.NewRPMStage(r.rpmStageOptions(arch, repos, buildPackageSpecs)))
 	return p
 }
 
-func (r *RHEL81) rpmStageOptions(arch arch, additionalRepos []rpmmd.RepoConfig, specs []rpmmd.PackageSpec) *osbuild.RPMStageOptions {
+func (r *RHEL81) rpmStageOptions(arch arch, repos []rpmmd.RepoConfig, specs []rpmmd.PackageSpec) *osbuild.RPMStageOptions {
 	var gpgKeys []string
-	repos := append(arch.Repositories, additionalRepos...)
 	for _, repo := range repos {
 		if repo.GPGKey == "" {
 			continue

--- a/internal/distro/rhel81/distro_test.go
+++ b/internal/distro/rhel81/distro_test.go
@@ -19,7 +19,7 @@ func TestListOutputFormats(t *testing.T) {
 		"vmdk",
 	}
 
-	el81, err := rhel81.New([]string{"../../../"})
+	el81, err := rhel81.New()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -96,7 +96,7 @@ func TestFilenameFromType(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			el81, err := rhel81.New([]string{"../../../"})
+			el81, err := rhel81.New()
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/internal/distro/rhel82/distro_test.go
+++ b/internal/distro/rhel82/distro_test.go
@@ -19,7 +19,7 @@ func TestListOutputFormats(t *testing.T) {
 		"vmdk",
 	}
 
-	el82, err := rhel82.New([]string{"../../../"})
+	el82, err := rhel82.New()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -96,7 +96,7 @@ func TestFilenameFromType(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			el82, err := rhel82.New([]string{"../../../"})
+			el82, err := rhel82.New()
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/internal/distro/test/distro.go
+++ b/internal/distro/test/distro.go
@@ -25,15 +25,6 @@ func (d *TestDistro) ModulePlatformID() string {
 	return ModulePlatformID
 }
 
-func (d *TestDistro) Repositories(arch string) []rpmmd.RepoConfig {
-	return []rpmmd.RepoConfig{
-		{
-			Id:      "test-id",
-			BaseURL: "http://example.com/test/os/" + arch,
-		},
-	}
-}
-
 func (d *TestDistro) ListOutputFormats() []string {
 	return []string{"test_format"}
 }
@@ -54,7 +45,7 @@ func (d *TestDistro) BuildPackages(outputArchitecture string) ([]string, error) 
 	return nil, nil
 }
 
-func (d *TestDistro) pipeline(c *blueprint.Customizations, additionalRepos []rpmmd.RepoConfig, packageSpecs, buildPackageSpecs []rpmmd.PackageSpec, outputArch, outputFormat string, size uint64) (*osbuild.Pipeline, error) {
+func (d *TestDistro) pipeline(c *blueprint.Customizations, repos []rpmmd.RepoConfig, packageSpecs, buildPackageSpecs []rpmmd.PackageSpec, outputArch, outputFormat string, size uint64) (*osbuild.Pipeline, error) {
 	if outputFormat == "test_output" && outputArch == "test_arch" {
 		return &osbuild.Pipeline{}, nil
 	}
@@ -66,8 +57,8 @@ func (d *TestDistro) sources(packages []rpmmd.PackageSpec) *osbuild.Sources {
 	return &osbuild.Sources{}
 }
 
-func (r *TestDistro) Manifest(c *blueprint.Customizations, additionalRepos []rpmmd.RepoConfig, packageSpecs, buildPackageSpecs []rpmmd.PackageSpec, outputArchitecture, outputFormat string, size uint64) (*osbuild.Manifest, error) {
-	pipeline, err := r.pipeline(c, additionalRepos, packageSpecs, buildPackageSpecs, outputArchitecture, outputFormat, size)
+func (r *TestDistro) Manifest(c *blueprint.Customizations, repos []rpmmd.RepoConfig, packageSpecs, buildPackageSpecs []rpmmd.PackageSpec, outputArchitecture, outputFormat string, size uint64) (*osbuild.Manifest, error) {
+	pipeline, err := r.pipeline(c, repos, packageSpecs, buildPackageSpecs, outputArchitecture, outputFormat, size)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/weldr/api_test.go
+++ b/internal/weldr/api_test.go
@@ -31,9 +31,10 @@ import (
 func createWeldrAPI(fixtureGenerator rpmmd_mock.FixtureGenerator) (*API, *store.Store) {
 	fixture := fixtureGenerator()
 	rpm := rpmmd_mock.NewRPMMDMock(fixture)
+	repos := []rpmmd.RepoConfig{{Id: "test-id", BaseURL: "http://example.com/test/os/x86_64"}}
 	d := test_distro.New()
 
-	return New(rpm, "x86_64", d, nil, fixture.Store), fixture.Store
+	return New(rpm, "x86_64", d, repos, nil, fixture.Store), fixture.Store
 }
 
 func TestBasic(t *testing.T) {


### PR DESCRIPTION
Mixing the way to build a distribution with where to get the source
packages from is wrong: it breaks pre-release repos, local mirrors, and
other use cases. To accommodate those, we introduced
`/etc/osbuild-composer/repositories`.

However, that doesn't work for the RCM API, which receives repository
URLs to use from outside requests. This API has been wrongly using the
`additionalRepos` parameter to inject those repos. That's broken,
because the resulting manifests contained both the installed repos and
the repos from the request.

To fix this, stop exposing repositories from the distros, but require
passing them on every call to `Manifest()`. This makes `additionalRepos`
redundant.

Fixes #341