### PR TITLE
distro: require passing a filename in Manifest()

### DIFF
--- a/cmd/osbuild-pipeline/main.go
+++ b/cmd/osbuild-pipeline/main.go
@@ -144,7 +144,7 @@ func main() {
 		}
 	} else {
 		size := d.GetSizeForOutputType(imageType, 0)
-		manifest, err := d.Manifest(blueprint.Customizations, repos[archArg], packageSpecs, buildPackageSpecs, archArg, imageType, size)
+		manifest, err := d.Manifest(blueprint.Customizations, repos[archArg], packageSpecs, buildPackageSpecs, archArg, "image", imageType, size)
 		if err != nil {
 			panic(err.Error())
 		}

--- a/internal/distro/distro.go
+++ b/internal/distro/distro.go
@@ -54,7 +54,7 @@ type Distro interface {
 	// Returns an osbuild manifest, containing the sources and pipeline necessary
 	// to generates an image in the given output format with all packages and
 	// customizations specified in the given blueprint.
-	Manifest(b *blueprint.Customizations, repos []rpmmd.RepoConfig, packageSpecs, buildPackageSpecs []rpmmd.PackageSpec, outputArchitecture, imageFormat string, size uint64) (*osbuild.Manifest, error)
+	Manifest(b *blueprint.Customizations, repos []rpmmd.RepoConfig, packageSpecs, buildPackageSpecs []rpmmd.PackageSpec, outputArchitecture, filename, imageFormat string, size uint64) (*osbuild.Manifest, error)
 
 	// Returns a osbuild runner that can be used on this distro.
 	Runner() string

--- a/internal/distro/distro_test.go
+++ b/internal/distro/distro_test.go
@@ -67,6 +67,7 @@ func TestDistro_Manifest(t *testing.T) {
 				tt.RpmMD.Packages,
 				tt.RpmMD.BuildPackages,
 				tt.ComposeRequest.Arch,
+				"image",
 				tt.ComposeRequest.OutputFormat,
 				size)
 			if (err != nil) != (tt.Manifest == nil) {

--- a/internal/distro/fedora30/distro.go
+++ b/internal/distro/fedora30/distro.go
@@ -38,7 +38,7 @@ type output struct {
 	KernelOptions    string
 	Bootable         bool
 	DefaultSize      uint64
-	Assembler        func(uefi bool, size uint64) *osbuild.Assembler
+	Assembler        func(filename string, uefi bool, size uint64) *osbuild.Assembler
 }
 
 const Distro = common.Fedora30
@@ -106,8 +106,8 @@ func New() (*Fedora30, error) {
 		KernelOptions: "ro no_timer_check console=ttyS0,115200n8 console=tty1 biosdevname=0 net.ifnames=0 console=ttyS0,115200",
 		Bootable:      true,
 		DefaultSize:   6 * GigaByte,
-		Assembler: func(uefi bool, size uint64) *osbuild.Assembler {
-			return r.qemuAssembler("raw.xz", "image.raw.xz", uefi, size)
+		Assembler: func(filename string, uefi bool, size uint64) *osbuild.Assembler {
+			return r.qemuAssembler("raw.xz", filename, uefi, size)
 		},
 	}
 
@@ -128,7 +128,9 @@ func New() (*Fedora30, error) {
 		KernelOptions: "ro biosdevname=0 net.ifnames=0",
 		Bootable:      false,
 		DefaultSize:   2 * GigaByte,
-		Assembler:     func(uefi bool, size uint64) *osbuild.Assembler { return r.rawFSAssembler("filesystem.img", size) },
+		Assembler: func(filename string, uefi bool, size uint64) *osbuild.Assembler {
+			return r.rawFSAssembler(filename, size)
+		},
 	}
 
 	r.outputs["partitioned-disk"] = output{
@@ -148,8 +150,8 @@ func New() (*Fedora30, error) {
 		KernelOptions: "ro biosdevname=0 net.ifnames=0",
 		Bootable:      true,
 		DefaultSize:   2 * GigaByte,
-		Assembler: func(uefi bool, size uint64) *osbuild.Assembler {
-			return r.qemuAssembler("raw", "disk.img", uefi, size)
+		Assembler: func(filename string, uefi bool, size uint64) *osbuild.Assembler {
+			return r.qemuAssembler("raw", filename, uefi, size)
 		},
 	}
 
@@ -175,8 +177,8 @@ func New() (*Fedora30, error) {
 		KernelOptions: "ro biosdevname=0 net.ifnames=0",
 		Bootable:      true,
 		DefaultSize:   2 * GigaByte,
-		Assembler: func(uefi bool, size uint64) *osbuild.Assembler {
-			return r.qemuAssembler("qcow2", "disk.qcow2", uefi, size)
+		Assembler: func(filename string, uefi bool, size uint64) *osbuild.Assembler {
+			return r.qemuAssembler("qcow2", filename, uefi, size)
 		},
 	}
 
@@ -201,8 +203,8 @@ func New() (*Fedora30, error) {
 		KernelOptions: "ro biosdevname=0 net.ifnames=0",
 		Bootable:      true,
 		DefaultSize:   2 * GigaByte,
-		Assembler: func(uefi bool, size uint64) *osbuild.Assembler {
-			return r.qemuAssembler("qcow2", "disk.qcow2", uefi, size)
+		Assembler: func(filename string, uefi bool, size uint64) *osbuild.Assembler {
+			return r.qemuAssembler("qcow2", filename, uefi, size)
 		},
 	}
 
@@ -223,7 +225,9 @@ func New() (*Fedora30, error) {
 		KernelOptions: "ro biosdevname=0 net.ifnames=0",
 		Bootable:      false,
 		DefaultSize:   2 * GigaByte,
-		Assembler:     func(uefi bool, size uint64) *osbuild.Assembler { return r.tarAssembler("root.tar.xz", "xz") },
+		Assembler: func(filename string, uefi bool, size uint64) *osbuild.Assembler {
+			return r.tarAssembler(filename, "xz")
+		},
 	}
 
 	r.outputs["vhd"] = output{
@@ -258,8 +262,8 @@ func New() (*Fedora30, error) {
 		KernelOptions: "ro biosdevname=0 rootdelay=300 console=ttyS0 earlyprintk=ttyS0 net.ifnames=0",
 		Bootable:      true,
 		DefaultSize:   2 * GigaByte,
-		Assembler: func(uefi bool, size uint64) *osbuild.Assembler {
-			return r.qemuAssembler("vpc", "disk.vhd", uefi, size)
+		Assembler: func(filename string, uefi bool, size uint64) *osbuild.Assembler {
+			return r.qemuAssembler("vpc", filename, uefi, size)
 		},
 	}
 
@@ -281,8 +285,8 @@ func New() (*Fedora30, error) {
 		KernelOptions: "ro biosdevname=0 net.ifnames=0",
 		Bootable:      true,
 		DefaultSize:   2 * GigaByte,
-		Assembler: func(uefi bool, size uint64) *osbuild.Assembler {
-			return r.qemuAssembler("vmdk", "disk.vmdk", uefi, size)
+		Assembler: func(filename string, uefi bool, size uint64) *osbuild.Assembler {
+			return r.qemuAssembler("vmdk", filename, uefi, size)
 		},
 	}
 
@@ -361,7 +365,7 @@ func (r *Fedora30) BuildPackages(outputArchitecture string) ([]string, error) {
 	return append(r.buildPackages, arch.BuildPackages...), nil
 }
 
-func (r *Fedora30) pipeline(c *blueprint.Customizations, repos []rpmmd.RepoConfig, packageSpecs, buildPackageSpecs []rpmmd.PackageSpec, outputArchitecture, outputFormat string, size uint64) (*osbuild.Pipeline, error) {
+func (r *Fedora30) pipeline(c *blueprint.Customizations, repos []rpmmd.RepoConfig, packageSpecs, buildPackageSpecs []rpmmd.PackageSpec, outputArchitecture, filename, outputFormat string, size uint64) (*osbuild.Pipeline, error) {
 	output, exists := r.outputs[outputFormat]
 	if !exists {
 		return nil, errors.New("invalid output format: " + outputFormat)
@@ -433,7 +437,7 @@ func (r *Fedora30) pipeline(c *blueprint.Customizations, repos []rpmmd.RepoConfi
 
 	p.AddStage(osbuild.NewSELinuxStage(r.selinuxStageOptions()))
 
-	p.Assembler = output.Assembler(arch.UEFI, size)
+	p.Assembler = output.Assembler(filename, arch.UEFI, size)
 
 	return p, nil
 }
@@ -450,8 +454,8 @@ func (r *Fedora30) sources(packages []rpmmd.PackageSpec) *osbuild.Sources {
 	}
 }
 
-func (r *Fedora30) Manifest(c *blueprint.Customizations, repos []rpmmd.RepoConfig, packageSpecs, buildPackageSpecs []rpmmd.PackageSpec, outputArchitecture, outputFormat string, size uint64) (*osbuild.Manifest, error) {
-	pipeline, err := r.pipeline(c, repos, packageSpecs, buildPackageSpecs, outputArchitecture, outputFormat, size)
+func (r *Fedora30) Manifest(c *blueprint.Customizations, repos []rpmmd.RepoConfig, packageSpecs, buildPackageSpecs []rpmmd.PackageSpec, outputArchitecture, filename, outputFormat string, size uint64) (*osbuild.Manifest, error) {
+	pipeline, err := r.pipeline(c, repos, packageSpecs, buildPackageSpecs, outputArchitecture, filename, outputFormat, size)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/distro/fedora31/distro.go
+++ b/internal/distro/fedora31/distro.go
@@ -38,7 +38,7 @@ type output struct {
 	KernelOptions    string
 	Bootable         bool
 	DefaultSize      uint64
-	Assembler        func(uefi bool, size uint64) *osbuild.Assembler
+	Assembler        func(filename string, uefi bool, size uint64) *osbuild.Assembler
 }
 
 const Distro = common.Fedora31
@@ -106,8 +106,8 @@ func New() (*Fedora31, error) {
 		KernelOptions: "ro no_timer_check console=ttyS0,115200n8 console=tty1 biosdevname=0 net.ifnames=0 console=ttyS0,115200",
 		Bootable:      true,
 		DefaultSize:   6 * GigaByte,
-		Assembler: func(uefi bool, size uint64) *osbuild.Assembler {
-			return r.qemuAssembler("raw.xz", "image.raw.xz", uefi, size)
+		Assembler: func(filename string, uefi bool, size uint64) *osbuild.Assembler {
+			return r.qemuAssembler("raw.xz", filename, uefi, size)
 		},
 	}
 
@@ -128,7 +128,9 @@ func New() (*Fedora31, error) {
 		KernelOptions: "ro biosdevname=0 net.ifnames=0",
 		Bootable:      false,
 		DefaultSize:   2 * GigaByte,
-		Assembler:     func(uefi bool, size uint64) *osbuild.Assembler { return r.rawFSAssembler("filesystem.img", size) },
+		Assembler: func(filename string, uefi bool, size uint64) *osbuild.Assembler {
+			return r.rawFSAssembler(filename, size)
+		},
 	}
 
 	r.outputs["partitioned-disk"] = output{
@@ -148,8 +150,8 @@ func New() (*Fedora31, error) {
 		KernelOptions: "ro biosdevname=0 net.ifnames=0",
 		Bootable:      true,
 		DefaultSize:   2 * GigaByte,
-		Assembler: func(uefi bool, size uint64) *osbuild.Assembler {
-			return r.qemuAssembler("raw", "disk.img", uefi, size)
+		Assembler: func(filename string, uefi bool, size uint64) *osbuild.Assembler {
+			return r.qemuAssembler("raw", filename, uefi, size)
 		},
 	}
 
@@ -175,8 +177,8 @@ func New() (*Fedora31, error) {
 		KernelOptions: "ro biosdevname=0 net.ifnames=0",
 		Bootable:      true,
 		DefaultSize:   2 * GigaByte,
-		Assembler: func(uefi bool, size uint64) *osbuild.Assembler {
-			return r.qemuAssembler("qcow2", "disk.qcow2", uefi, size)
+		Assembler: func(filename string, uefi bool, size uint64) *osbuild.Assembler {
+			return r.qemuAssembler("qcow2", filename, uefi, size)
 		},
 	}
 
@@ -201,8 +203,8 @@ func New() (*Fedora31, error) {
 		KernelOptions: "ro biosdevname=0 net.ifnames=0",
 		Bootable:      true,
 		DefaultSize:   2 * GigaByte,
-		Assembler: func(uefi bool, size uint64) *osbuild.Assembler {
-			return r.qemuAssembler("qcow2", "disk.qcow2", uefi, size)
+		Assembler: func(filename string, uefi bool, size uint64) *osbuild.Assembler {
+			return r.qemuAssembler("qcow2", filename, uefi, size)
 		},
 	}
 
@@ -223,7 +225,9 @@ func New() (*Fedora31, error) {
 		KernelOptions: "ro biosdevname=0 net.ifnames=0",
 		Bootable:      false,
 		DefaultSize:   2 * GigaByte,
-		Assembler:     func(uefi bool, size uint64) *osbuild.Assembler { return r.tarAssembler("root.tar.xz", "xz") },
+		Assembler: func(filename string, uefi bool, size uint64) *osbuild.Assembler {
+			return r.tarAssembler(filename, "xz")
+		},
 	}
 
 	r.outputs["vhd"] = output{
@@ -258,8 +262,8 @@ func New() (*Fedora31, error) {
 		KernelOptions: "ro biosdevname=0 rootdelay=300 console=ttyS0 earlyprintk=ttyS0 net.ifnames=0",
 		Bootable:      true,
 		DefaultSize:   2 * GigaByte,
-		Assembler: func(uefi bool, size uint64) *osbuild.Assembler {
-			return r.qemuAssembler("vpc", "disk.vhd", uefi, size)
+		Assembler: func(filename string, uefi bool, size uint64) *osbuild.Assembler {
+			return r.qemuAssembler("vpc", filename, uefi, size)
 		},
 	}
 
@@ -281,8 +285,8 @@ func New() (*Fedora31, error) {
 		KernelOptions: "ro biosdevname=0 net.ifnames=0",
 		Bootable:      true,
 		DefaultSize:   2 * GigaByte,
-		Assembler: func(uefi bool, size uint64) *osbuild.Assembler {
-			return r.qemuAssembler("vmdk", "disk.vmdk", uefi, size)
+		Assembler: func(filename string, uefi bool, size uint64) *osbuild.Assembler {
+			return r.qemuAssembler("vmdk", filename, uefi, size)
 		},
 	}
 
@@ -361,7 +365,7 @@ func (r *Fedora31) BuildPackages(outputArchitecture string) ([]string, error) {
 	return append(r.buildPackages, arch.BuildPackages...), nil
 }
 
-func (r *Fedora31) pipeline(c *blueprint.Customizations, repos []rpmmd.RepoConfig, packageSpecs, buildPackageSpecs []rpmmd.PackageSpec, outputArchitecture, outputFormat string, size uint64) (*osbuild.Pipeline, error) {
+func (r *Fedora31) pipeline(c *blueprint.Customizations, repos []rpmmd.RepoConfig, packageSpecs, buildPackageSpecs []rpmmd.PackageSpec, outputArchitecture, filename, outputFormat string, size uint64) (*osbuild.Pipeline, error) {
 	output, exists := r.outputs[outputFormat]
 	if !exists {
 		return nil, errors.New("invalid output format: " + outputFormat)
@@ -433,7 +437,7 @@ func (r *Fedora31) pipeline(c *blueprint.Customizations, repos []rpmmd.RepoConfi
 
 	p.AddStage(osbuild.NewSELinuxStage(r.selinuxStageOptions()))
 
-	p.Assembler = output.Assembler(arch.UEFI, size)
+	p.Assembler = output.Assembler(filename, arch.UEFI, size)
 
 	return p, nil
 }
@@ -450,8 +454,8 @@ func (r *Fedora31) sources(packages []rpmmd.PackageSpec) *osbuild.Sources {
 	}
 }
 
-func (r *Fedora31) Manifest(c *blueprint.Customizations, repos []rpmmd.RepoConfig, packageSpecs, buildPackageSpecs []rpmmd.PackageSpec, outputArchitecture, outputFormat string, size uint64) (*osbuild.Manifest, error) {
-	pipeline, err := r.pipeline(c, repos, packageSpecs, buildPackageSpecs, outputArchitecture, outputFormat, size)
+func (r *Fedora31) Manifest(c *blueprint.Customizations, repos []rpmmd.RepoConfig, packageSpecs, buildPackageSpecs []rpmmd.PackageSpec, outputArchitecture, filename, outputFormat string, size uint64) (*osbuild.Manifest, error) {
+	pipeline, err := r.pipeline(c, repos, packageSpecs, buildPackageSpecs, outputArchitecture, filename, outputFormat, size)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/distro/fedoratest/distro.go
+++ b/internal/distro/fedoratest/distro.go
@@ -53,7 +53,7 @@ func (d *FedoraTestDistro) BuildPackages(outputArchitecture string) ([]string, e
 	return nil, nil
 }
 
-func (d *FedoraTestDistro) pipeline(c *blueprint.Customizations, repos []rpmmd.RepoConfig, buildPackages, basePackages []rpmmd.PackageSpec, outputArch, outputFormat string, size uint64) (*osbuild.Pipeline, error) {
+func (d *FedoraTestDistro) pipeline(c *blueprint.Customizations, repos []rpmmd.RepoConfig, buildPackages, basePackages []rpmmd.PackageSpec, outputArch, filename, outputFormat string, size uint64) (*osbuild.Pipeline, error) {
 	if outputFormat == "qcow2" && outputArch == "x86_64" {
 		return &osbuild.Pipeline{}, nil
 	} else {
@@ -65,8 +65,8 @@ func (r *FedoraTestDistro) sources(packages []rpmmd.PackageSpec) *osbuild.Source
 	return &osbuild.Sources{}
 }
 
-func (r *FedoraTestDistro) Manifest(c *blueprint.Customizations, repos []rpmmd.RepoConfig, packageSpecs, buildPackageSpecs []rpmmd.PackageSpec, outputArchitecture, outputFormat string, size uint64) (*osbuild.Manifest, error) {
-	pipeline, err := r.pipeline(c, repos, packageSpecs, buildPackageSpecs, outputArchitecture, outputFormat, size)
+func (r *FedoraTestDistro) Manifest(c *blueprint.Customizations, repos []rpmmd.RepoConfig, packageSpecs, buildPackageSpecs []rpmmd.PackageSpec, outputArchitecture, filename, outputFormat string, size uint64) (*osbuild.Manifest, error) {
+	pipeline, err := r.pipeline(c, repos, packageSpecs, buildPackageSpecs, outputArchitecture, filename, outputFormat, size)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/distro/rhel81/distro.go
+++ b/internal/distro/rhel81/distro.go
@@ -39,7 +39,7 @@ type output struct {
 	DefaultTarget    string
 	KernelOptions    string
 	DefaultSize      uint64
-	Assembler        func(uefi bool, size uint64) *osbuild.Assembler
+	Assembler        func(filename string, uefi bool, size uint64) *osbuild.Assembler
 }
 
 const Distro = common.RHEL81
@@ -159,8 +159,8 @@ func New() (*RHEL81, error) {
 		Bootable:      true,
 		KernelOptions: "ro console=ttyS0,115200n8 console=tty0 net.ifnames=0 rd.blacklist=nouveau nvme_core.io_timeout=4294967295 crashkernel=auto",
 		DefaultSize:   6 * GigaByte,
-		Assembler: func(uefi bool, size uint64) *osbuild.Assembler {
-			return r.qemuAssembler("raw.xz", "image.raw.xz", uefi, size)
+		Assembler: func(filename string, uefi bool, size uint64) *osbuild.Assembler {
+			return r.qemuAssembler("raw.xz", filename, uefi, size)
 		},
 	}
 
@@ -186,7 +186,9 @@ func New() (*RHEL81, error) {
 		Bootable:      false,
 		KernelOptions: "ro net.ifnames=0",
 		DefaultSize:   2 * GigaByte,
-		Assembler:     func(uefi bool, size uint64) *osbuild.Assembler { return r.rawFSAssembler("filesystem.img", size) },
+		Assembler: func(filename string, uefi bool, size uint64) *osbuild.Assembler {
+			return r.rawFSAssembler(filename, size)
+		},
 	}
 
 	r.outputs["partitioned-disk"] = output{
@@ -211,8 +213,8 @@ func New() (*RHEL81, error) {
 		Bootable:      true,
 		KernelOptions: "ro net.ifnames=0",
 		DefaultSize:   2 * GigaByte,
-		Assembler: func(uefi bool, size uint64) *osbuild.Assembler {
-			return r.qemuAssembler("raw", "disk.img", uefi, size)
+		Assembler: func(filename string, uefi bool, size uint64) *osbuild.Assembler {
+			return r.qemuAssembler("raw", filename, uefi, size)
 		},
 	}
 
@@ -295,8 +297,8 @@ func New() (*RHEL81, error) {
 		Bootable:      true,
 		KernelOptions: "console=ttyS0 console=ttyS0,115200n8 no_timer_check crashkernel=auto net.ifnames=0",
 		DefaultSize:   2 * GigaByte,
-		Assembler: func(uefi bool, size uint64) *osbuild.Assembler {
-			return r.qemuAssembler("qcow2", "disk.qcow2", uefi, size)
+		Assembler: func(filename string, uefi bool, size uint64) *osbuild.Assembler {
+			return r.qemuAssembler("qcow2", filename, uefi, size)
 		},
 	}
 
@@ -325,8 +327,8 @@ func New() (*RHEL81, error) {
 		Bootable:      true,
 		KernelOptions: "ro net.ifnames=0",
 		DefaultSize:   2 * GigaByte,
-		Assembler: func(uefi bool, size uint64) *osbuild.Assembler {
-			return r.qemuAssembler("qcow2", "disk.qcow2", uefi, size)
+		Assembler: func(filename string, uefi bool, size uint64) *osbuild.Assembler {
+			return r.qemuAssembler("qcow2", filename, uefi, size)
 		},
 	}
 
@@ -351,7 +353,9 @@ func New() (*RHEL81, error) {
 		},
 		Bootable:      false,
 		KernelOptions: "ro net.ifnames=0",
-		Assembler:     func(uefi bool, size uint64) *osbuild.Assembler { return r.tarAssembler("root.tar.xz", "xz") },
+		Assembler: func(filename string, uefi bool, size uint64) *osbuild.Assembler {
+			return r.tarAssembler(filename, "xz")
+		},
 	}
 
 	r.outputs["vhd"] = output{
@@ -392,8 +396,8 @@ func New() (*RHEL81, error) {
 		Bootable:      true,
 		KernelOptions: "ro biosdevname=0 rootdelay=300 console=ttyS0 earlyprintk=ttyS0 net.ifnames=0",
 		DefaultSize:   2 * GigaByte,
-		Assembler: func(uefi bool, size uint64) *osbuild.Assembler {
-			return r.qemuAssembler("vpc", "disk.vhd", uefi, size)
+		Assembler: func(filename string, uefi bool, size uint64) *osbuild.Assembler {
+			return r.qemuAssembler("vpc", filename, uefi, size)
 		},
 	}
 
@@ -420,8 +424,8 @@ func New() (*RHEL81, error) {
 		Bootable:      true,
 		KernelOptions: "ro net.ifnames=0",
 		DefaultSize:   2 * GigaByte,
-		Assembler: func(uefi bool, size uint64) *osbuild.Assembler {
-			return r.qemuAssembler("vmdk", "disk.vmdk", uefi, size)
+		Assembler: func(filename string, uefi bool, size uint64) *osbuild.Assembler {
+			return r.qemuAssembler("vmdk", filename, uefi, size)
 		},
 	}
 
@@ -500,7 +504,7 @@ func (r *RHEL81) BuildPackages(outputArchitecture string) ([]string, error) {
 	return append(r.buildPackages, arch.BuildPackages...), nil
 }
 
-func (r *RHEL81) pipeline(c *blueprint.Customizations, repos []rpmmd.RepoConfig, packageSpecs, buildPackageSpecs []rpmmd.PackageSpec, outputArchitecture, outputFormat string, size uint64) (*osbuild.Pipeline, error) {
+func (r *RHEL81) pipeline(c *blueprint.Customizations, repos []rpmmd.RepoConfig, packageSpecs, buildPackageSpecs []rpmmd.PackageSpec, outputArchitecture, filename, outputFormat string, size uint64) (*osbuild.Pipeline, error) {
 	output, exists := r.outputs[outputFormat]
 	if !exists {
 		return nil, errors.New("invalid output format: " + outputFormat)
@@ -577,7 +581,7 @@ func (r *RHEL81) pipeline(c *blueprint.Customizations, repos []rpmmd.RepoConfig,
 
 	p.AddStage(osbuild.NewSELinuxStage(r.selinuxStageOptions()))
 
-	p.Assembler = output.Assembler(arch.UEFI, size)
+	p.Assembler = output.Assembler(filename, arch.UEFI, size)
 
 	return p, nil
 }
@@ -594,8 +598,8 @@ func (r *RHEL81) sources(packages []rpmmd.PackageSpec) *osbuild.Sources {
 	}
 }
 
-func (r *RHEL81) Manifest(c *blueprint.Customizations, repos []rpmmd.RepoConfig, packageSpecs, buildPackageSpecs []rpmmd.PackageSpec, outputArchitecture, outputFormat string, size uint64) (*osbuild.Manifest, error) {
-	pipeline, err := r.pipeline(c, repos, packageSpecs, buildPackageSpecs, outputArchitecture, outputFormat, size)
+func (r *RHEL81) Manifest(c *blueprint.Customizations, repos []rpmmd.RepoConfig, packageSpecs, buildPackageSpecs []rpmmd.PackageSpec, outputArchitecture, filename, outputFormat string, size uint64) (*osbuild.Manifest, error) {
+	pipeline, err := r.pipeline(c, repos, packageSpecs, buildPackageSpecs, outputArchitecture, filename, outputFormat, size)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/jobqueue/job.go
+++ b/internal/jobqueue/job.go
@@ -97,23 +97,7 @@ func (job *Job) Run(uploader LocalTargetUploader) (*common.ComposeResult, error)
 	for _, t := range job.Targets {
 		switch options := t.Options.(type) {
 		case *target.LocalTargetOptions:
-			outputDir := path.Join(tmpStore, "refs", result.OutputID)
-
-			files, err := ioutil.ReadDir(outputDir)
-			if err != nil {
-				r = append(r, err)
-				continue
-			}
-
-			// TODO osbuild pipelines can have multiple outputs. All the pipelines we
-			// are currently generating have exactly one, but we should support
-			// uploading all results in the future.
-			if len(files) != 1 {
-				r = append(r, fmt.Errorf("expected exactly one resulting image file"))
-				continue
-			}
-
-			f, err := os.Open(path.Join(outputDir, files[0].Name()))
+			f, err := os.Open(path.Join(tmpStore, "refs", result.OutputID, "image"))
 			if err != nil {
 				r = append(r, err)
 				continue
@@ -137,7 +121,7 @@ func (job *Job) Run(uploader LocalTargetUploader) (*common.ComposeResult, error)
 				options.Key = job.ID.String()
 			}
 
-			_, err = a.Upload(tmpStore+"/refs/"+result.OutputID+"/image.raw.xz", options.Bucket, options.Key)
+			_, err = a.Upload(path.Join(tmpStore, "refs", result.OutputID, "image"), options.Bucket, options.Key)
 			if err != nil {
 				r = append(r, err)
 				continue

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -611,7 +611,7 @@ func (s *Store) PushCompose(distro distro.Distro, composeID uuid.UUID, bp *bluep
 		repos = append(repos, source.RepoConfig())
 	}
 
-	manifestStruct, err := distro.Manifest(bp.Customizations, repos, packages, buildPackages, arch, composeType, size)
+	manifestStruct, err := distro.Manifest(bp.Customizations, repos, packages, buildPackages, arch, "image", composeType, size)
 	if err != nil {
 		return err
 	}

--- a/test/cases/f30-x86_64-ami-boot.json
+++ b/test/cases/f30-x86_64-ami-boot.json
@@ -1006,7 +1006,7 @@
         "name": "org.osbuild.qemu",
         "options": {
           "format": "raw.xz",
-          "filename": "image.raw.xz",
+          "filename": "image",
           "size": 6442450944,
           "ptuuid": "0x14fc63d2",
           "pttype": "mbr",

--- a/test/cases/f30-x86_64-ext4_filesystem-boot.json
+++ b/test/cases/f30-x86_64-ext4_filesystem-boot.json
@@ -782,7 +782,7 @@
       "assembler": {
         "name": "org.osbuild.rawfs",
         "options": {
-          "filename": "filesystem.img",
+          "filename": "image",
           "root_fs_uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
           "size": 2147483648
         }

--- a/test/cases/f30-x86_64-openstack-boot.json
+++ b/test/cases/f30-x86_64-openstack-boot.json
@@ -1053,7 +1053,7 @@
         "name": "org.osbuild.qemu",
         "options": {
           "format": "qcow2",
-          "filename": "disk.qcow2",
+          "filename": "image",
           "size": 2147483648,
           "ptuuid": "0x14fc63d2",
           "pttype": "mbr",

--- a/test/cases/f30-x86_64-partitioned_disk-boot.json
+++ b/test/cases/f30-x86_64-partitioned_disk-boot.json
@@ -952,7 +952,7 @@
         "name": "org.osbuild.qemu",
         "options": {
           "format": "raw",
-          "filename": "disk.img",
+          "filename": "image",
           "size": 2147483648,
           "ptuuid": "0x14fc63d2",
           "pttype": "mbr",

--- a/test/cases/f30-x86_64-qcow2-boot.json
+++ b/test/cases/f30-x86_64-qcow2-boot.json
@@ -1012,7 +1012,7 @@
         "name": "org.osbuild.qemu",
         "options": {
           "format": "qcow2",
-          "filename": "disk.qcow2",
+          "filename": "image",
           "size": 2147483648,
           "ptuuid": "0x14fc63d2",
           "pttype": "mbr",

--- a/test/cases/f30-x86_64-tar-boot.json
+++ b/test/cases/f30-x86_64-tar-boot.json
@@ -782,7 +782,7 @@
       "assembler": {
         "name": "org.osbuild.tar",
         "options": {
-          "filename": "root.tar.xz",
+          "filename": "image",
           "size": 0,
           "compression": "xz"
         }

--- a/test/cases/f30-x86_64-vhd-boot.json
+++ b/test/cases/f30-x86_64-vhd-boot.json
@@ -984,7 +984,7 @@
         "name": "org.osbuild.qemu",
         "options": {
           "format": "vpc",
-          "filename": "disk.vhd",
+          "filename": "image",
           "size": 2147483648,
           "ptuuid": "0x14fc63d2",
           "pttype": "mbr",

--- a/test/cases/f30-x86_64-vmdk-boot.json
+++ b/test/cases/f30-x86_64-vmdk-boot.json
@@ -983,7 +983,7 @@
         "name": "org.osbuild.qemu",
         "options": {
           "format": "vmdk",
-          "filename": "disk.vmdk",
+          "filename": "image",
           "size": 2147483648,
           "ptuuid": "0x14fc63d2",
           "pttype": "mbr",

--- a/test/cases/f31-x86_64-ami-boot.json
+++ b/test/cases/f31-x86_64-ami-boot.json
@@ -1189,7 +1189,7 @@
         "name": "org.osbuild.qemu",
         "options": {
           "format": "raw.xz",
-          "filename": "image.raw.xz",
+          "filename": "image",
           "size": 6442450944,
           "ptuuid": "0x14fc63d2",
           "pttype": "mbr",

--- a/test/cases/f31-x86_64-ext4_filesystem-boot.json
+++ b/test/cases/f31-x86_64-ext4_filesystem-boot.json
@@ -894,7 +894,7 @@
       "assembler": {
         "name": "org.osbuild.rawfs",
         "options": {
-          "filename": "filesystem.img",
+          "filename": "image",
           "root_fs_uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
           "size": 2147483648
         }

--- a/test/cases/f31-x86_64-openstack-boot.json
+++ b/test/cases/f31-x86_64-openstack-boot.json
@@ -1223,7 +1223,7 @@
         "name": "org.osbuild.qemu",
         "options": {
           "format": "qcow2",
-          "filename": "disk.qcow2",
+          "filename": "image",
           "size": 2147483648,
           "ptuuid": "0x14fc63d2",
           "pttype": "mbr",

--- a/test/cases/f31-x86_64-partitioned_disk-boot.json
+++ b/test/cases/f31-x86_64-partitioned_disk-boot.json
@@ -1139,7 +1139,7 @@
         "name": "org.osbuild.qemu",
         "options": {
           "format": "raw",
-          "filename": "disk.img",
+          "filename": "image",
           "size": 2147483648,
           "ptuuid": "0x14fc63d2",
           "pttype": "mbr",

--- a/test/cases/f31-x86_64-qcow2-boot.json
+++ b/test/cases/f31-x86_64-qcow2-boot.json
@@ -1205,7 +1205,7 @@
         "name": "org.osbuild.qemu",
         "options": {
           "format": "qcow2",
-          "filename": "disk.qcow2",
+          "filename": "image",
           "size": 2147483648,
           "ptuuid": "0x14fc63d2",
           "pttype": "mbr",

--- a/test/cases/f31-x86_64-tar-boot.json
+++ b/test/cases/f31-x86_64-tar-boot.json
@@ -894,7 +894,7 @@
       "assembler": {
         "name": "org.osbuild.tar",
         "options": {
-          "filename": "root.tar.xz",
+          "filename": "image",
           "size": 0,
           "compression": "xz"
         }

--- a/test/cases/f31-x86_64-vhd-boot.json
+++ b/test/cases/f31-x86_64-vhd-boot.json
@@ -1167,7 +1167,7 @@
         "name": "org.osbuild.qemu",
         "options": {
           "format": "vpc",
-          "filename": "disk.vhd",
+          "filename": "image",
           "size": 2147483648,
           "ptuuid": "0x14fc63d2",
           "pttype": "mbr",

--- a/test/cases/f31-x86_64-vmdk-boot.json
+++ b/test/cases/f31-x86_64-vmdk-boot.json
@@ -1170,7 +1170,7 @@
         "name": "org.osbuild.qemu",
         "options": {
           "format": "vmdk",
-          "filename": "disk.vmdk",
+          "filename": "image",
           "size": 2147483648,
           "ptuuid": "0x14fc63d2",
           "pttype": "mbr",


### PR DESCRIPTION
1b7cb6c11 changed workers so that they don't have access to the distro
that was used to create a manifest anymore. This means that they also
don't know what the filename of the final image in the store is. That
commit worked around this by picking the only file that resulted in that
build. That was a bit of a hack.

Really, image filenames are a user-facing concept. Internally, we're
better of fixing the name to something well-known.

Add a filename parameter to Distro.Manifest() that is independent of the
output type. Set it to "image" from weldr, osbuild-pipeline, and the rcm
API.

Use that name in the worker as well.

Fixes #348