### PR TITLE
job: get image name from target

### DIFF
--- a/internal/jobqueue/job.go
+++ b/internal/jobqueue/job.go
@@ -97,23 +97,7 @@ func (job *Job) Run(uploader LocalTargetUploader) (*common.ComposeResult, error)
 	for _, t := range job.Targets {
 		switch options := t.Options.(type) {
 		case *target.LocalTargetOptions:
-			outputDir := path.Join(tmpStore, "refs", result.OutputID)
-
-			files, err := ioutil.ReadDir(outputDir)
-			if err != nil {
-				r = append(r, err)
-				continue
-			}
-
-			// TODO osbuild pipelines can have multiple outputs. All the pipelines we
-			// are currently generating have exactly one, but we should support
-			// uploading all results in the future.
-			if len(files) != 1 {
-				r = append(r, fmt.Errorf("expected exactly one resulting image file"))
-				continue
-			}
-
-			f, err := os.Open(path.Join(outputDir, files[0].Name()))
+			f, err := os.Open(path.Join(tmpStore, "refs", result.OutputID, t.ImageName))
 			if err != nil {
 				r = append(r, err)
 				continue

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -595,9 +595,12 @@ func (s *Store) PushCompose(distro distro.Distro, composeID uuid.UUID, bp *bluep
 			return fmt.Errorf("cannot create output directory for job %v: %#v", composeID, err)
 		}
 
-		targets = append(targets, target.NewLocalTarget(
-			&target.LocalTargetOptions{},
-		))
+		target := target.NewLocalTarget(&target.LocalTargetOptions{})
+		target.ImageName, _, err = distro.FilenameFromType(composeType)
+		if err != nil {
+			return fmt.Errorf("cannot get filename for output type: %v", err)
+		}
+		targets = append(targets, target)
 	}
 
 	size = distro.GetSizeForOutputType(composeType, size)


### PR DESCRIPTION
1b7cb6c changed workers so that they don't have access to the distro
that was used to create a manifest anymore. I thought this meant that
they also don't know what the filename of the final image in the store
is. That commit worked around this by picking the only file that
resulted in that build. That was a bit of a hack.

Turns out, the `Target` struct already has an ImageName field.

Fixes #348