### PR TITLE
osbuild-image-tests: add missing build constraints

### DIFF
--- a/cmd/osbuild-image-tests/constants.go
+++ b/cmd/osbuild-image-tests/constants.go
@@ -1,4 +1,4 @@
-// +build !travis
+// +build integration,!travis
 
 package main
 

--- a/cmd/osbuild-image-tests/context-managers.go
+++ b/cmd/osbuild-image-tests/context-managers.go
@@ -1,3 +1,5 @@
+// +build integration
+
 package main
 
 import (

--- a/cmd/osbuild-image-tests/helpers.go
+++ b/cmd/osbuild-image-tests/helpers.go
@@ -1,3 +1,5 @@
+// +build integration
+
 package main
 
 import (

--- a/cmd/osbuild-image-tests/netns.go
+++ b/cmd/osbuild-image-tests/netns.go
@@ -1,3 +1,5 @@
+// +build integration
+
 package main
 
 import (


### PR DESCRIPTION
Build constraints must be added to every file. We only want to build
this package when the `integration` tag is set.

Without this, every build prints this warning:

    # github.com/osbuild/osbuild-composer/cmd/osbuild-image-tests
    runtime.main_main·f: function main is undeclared in the main package