### PR TITLE
store: pass repos to PushCompose

### DIFF
--- a/internal/jobqueue/api_test.go
+++ b/internal/jobqueue/api_test.go
@@ -54,7 +54,7 @@ func TestCreate(t *testing.T) {
 	store := store.New(nil, *registry)
 	api := jobqueue.New(nil, store)
 
-	err = store.PushCompose(distroStruct, id, &blueprint.Blueprint{}, nil, nil, "x86_64", "qcow2", 0, nil)
+	err = store.PushCompose(distroStruct, id, &blueprint.Blueprint{}, nil, nil, nil, "x86_64", "qcow2", 0, nil)
 	if err != nil {
 		t.Fatalf("error pushing compose: %v", err)
 	}
@@ -74,7 +74,7 @@ func testUpdateTransition(t *testing.T, from, to string, expectedStatus int, exp
 	api := jobqueue.New(nil, store)
 
 	if from != "VOID" {
-		err := store.PushCompose(distroStruct, id, &blueprint.Blueprint{}, nil, nil, "x86_64", "qcow2", 0, nil)
+		err := store.PushCompose(distroStruct, id, &blueprint.Blueprint{}, nil, nil, nil, "x86_64", "qcow2", 0, nil)
 		if err != nil {
 			t.Fatalf("error pushing compose: %v", err)
 		}

--- a/internal/rcm/api.go
+++ b/internal/rcm/api.go
@@ -205,7 +205,7 @@ func (api *API) submit(writer http.ResponseWriter, request *http.Request, _ http
 	// Push the requested compose to the store
 	composeUUID := uuid.New()
 	// nil is used as an upload target, because LocalTarget is already used in the PushCompose function
-	err = api.store.PushCompose(distro, composeUUID, &blueprint.Blueprint{}, packages, buildPackages, arch, imageType, 0, nil)
+	err = api.store.PushCompose(distro, composeUUID, &blueprint.Blueprint{}, repoConfigs, packages, buildPackages, arch, imageType, 0, nil)
 	if err != nil {
 		if api.logger != nil {
 			api.logger.Println("RCM API failed to push compose:", err)

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -578,7 +578,7 @@ func (s *Store) getImageBuildDirectory(composeID uuid.UUID, imageBuildID int) st
 	return fmt.Sprintf("%s/%d", s.getComposeDirectory(composeID), imageBuildID)
 }
 
-func (s *Store) PushCompose(distro distro.Distro, composeID uuid.UUID, bp *blueprint.Blueprint, packages, buildPackages []rpmmd.PackageSpec, arch, composeType string, size uint64, uploadTarget *target.Target) error {
+func (s *Store) PushCompose(distro distro.Distro, composeID uuid.UUID, bp *blueprint.Blueprint, repos []rpmmd.RepoConfig, packages, buildPackages []rpmmd.PackageSpec, arch, composeType string, size uint64, uploadTarget *target.Target) error {
 	targets := []*target.Target{}
 
 	// Compatibility layer for image types in Weldr API v0
@@ -606,12 +606,12 @@ func (s *Store) PushCompose(distro distro.Distro, composeID uuid.UUID, bp *bluep
 		targets = append(targets, uploadTarget)
 	}
 
-	repos := []rpmmd.RepoConfig{}
+	allRepos := append([]rpmmd.RepoConfig{}, repos...)
 	for _, source := range s.Sources {
-		repos = append(repos, source.RepoConfig())
+		allRepos = append(allRepos, source.RepoConfig())
 	}
 
-	manifestStruct, err := distro.Manifest(bp.Customizations, repos, packages, buildPackages, arch, composeType, size)
+	manifestStruct, err := distro.Manifest(bp.Customizations, allRepos, packages, buildPackages, arch, composeType, size)
 	if err != nil {
 		return err
 	}

--- a/internal/weldr/api.go
+++ b/internal/weldr/api.go
@@ -1421,7 +1421,7 @@ func (api *API) composeHandler(writer http.ResponseWriter, request *http.Request
 			return
 		}
 
-		err = api.store.PushCompose(api.distro, reply.BuildID, bp, packages, buildPackages, api.arch, cr.ComposeType, cr.Size, uploadTarget)
+		err = api.store.PushCompose(api.distro, reply.BuildID, bp, api.repos, packages, buildPackages, api.arch, cr.ComposeType, cr.Size, uploadTarget)
 
 		// TODO: we should probably do some kind of blueprint validation in future
 		// for now, let's just 500 and bail out


### PR DESCRIPTION
Repositories were not passed down into `Distro.Manifest()`. This makes
all builds fail, because these repositories are use to access gpgkeys.