### PR TITLE
Specify image filenames in upload targets

### DIFF
--- a/cmd/osbuild-composer/main.go
+++ b/cmd/osbuild-composer/main.go
@@ -104,7 +104,7 @@ func main() {
 		logger = log.New(os.Stdout, "", 0)
 	}
 
-	store := store.New(&stateDir, *distros)
+	store := store.New(&stateDir)
 
 	jobAPI := jobqueue.New(logger, store)
 	weldrAPI := weldr.New(rpm, common.CurrentArch(), distribution, repoMap[common.CurrentArch()], logger, store)

--- a/internal/compose/compose.go
+++ b/internal/compose/compose.go
@@ -60,14 +60,15 @@ func (ib *ImageBuild) DeepCopy() ImageBuild {
 	}
 }
 
-func (ib *ImageBuild) HasLocalTarget() bool {
+func (ib *ImageBuild) GetLocalTargetOptions() *target.LocalTargetOptions {
 	for _, t := range ib.Targets {
-		if _, ok := t.Options.(*target.LocalTargetOptions); ok {
-			return true
+		switch options := t.Options.(type) {
+		case *target.LocalTargetOptions:
+			return options
 		}
 	}
 
-	return false
+	return nil
 }
 
 // A Compose represent the task of building a set of images from a single blueprint.

--- a/internal/jobqueue/api_test.go
+++ b/internal/jobqueue/api_test.go
@@ -4,8 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	distro_mock "github.com/osbuild/osbuild-composer/internal/mocks/distro"
-
 	"github.com/osbuild/osbuild-composer/internal/blueprint"
 	test_distro "github.com/osbuild/osbuild-composer/internal/distro/fedoratest"
 	"github.com/osbuild/osbuild-composer/internal/jobqueue"
@@ -34,11 +32,7 @@ func TestBasic(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		registry, err := distro_mock.NewDefaultRegistry()
-		if err != nil {
-			t.Fatal(err)
-		}
-		api := jobqueue.New(nil, store.New(nil, *registry))
+		api := jobqueue.New(nil, store.New(nil))
 
 		test.TestNonJsonRoute(t, api, false, c.Method, c.Path, c.Body, c.ExpectedStatus, c.ExpectedResponse)
 	}
@@ -47,14 +41,10 @@ func TestBasic(t *testing.T) {
 func TestCreate(t *testing.T) {
 	id, _ := uuid.Parse("ffffffff-ffff-ffff-ffff-ffffffffffff")
 	distroStruct := test_distro.New()
-	registry, err := distro_mock.NewDefaultRegistry()
-	if err != nil {
-		t.Fatal(err)
-	}
-	store := store.New(nil, *registry)
+	store := store.New(nil)
 	api := jobqueue.New(nil, store)
 
-	err = store.PushCompose(distroStruct, id, &blueprint.Blueprint{}, nil, nil, nil, "x86_64", "qcow2", 0, nil)
+	err := store.PushCompose(distroStruct, id, &blueprint.Blueprint{}, nil, nil, nil, "x86_64", "qcow2", 0, nil)
 	if err != nil {
 		t.Fatalf("error pushing compose: %v", err)
 	}
@@ -66,11 +56,7 @@ func TestCreate(t *testing.T) {
 func testUpdateTransition(t *testing.T, from, to string, expectedStatus int, expectedResponse string) {
 	id, _ := uuid.Parse("ffffffff-ffff-ffff-ffff-ffffffffffff")
 	distroStruct := test_distro.New()
-	registry, err := distro_mock.NewDefaultRegistry()
-	if err != nil {
-		t.Fatal(err)
-	}
-	store := store.New(nil, *registry)
+	store := store.New(nil)
 	api := jobqueue.New(nil, store)
 
 	if from != "VOID" {

--- a/internal/jobqueue/job.go
+++ b/internal/jobqueue/job.go
@@ -97,23 +97,7 @@ func (job *Job) Run(uploader LocalTargetUploader) (*common.ComposeResult, error)
 	for _, t := range job.Targets {
 		switch options := t.Options.(type) {
 		case *target.LocalTargetOptions:
-			outputDir := path.Join(tmpStore, "refs", result.OutputID)
-
-			files, err := ioutil.ReadDir(outputDir)
-			if err != nil {
-				r = append(r, err)
-				continue
-			}
-
-			// TODO osbuild pipelines can have multiple outputs. All the pipelines we
-			// are currently generating have exactly one, but we should support
-			// uploading all results in the future.
-			if len(files) != 1 {
-				r = append(r, fmt.Errorf("expected exactly one resulting image file"))
-				continue
-			}
-
-			f, err := os.Open(path.Join(outputDir, files[0].Name()))
+			f, err := os.Open(path.Join(tmpStore, "refs", result.OutputID, options.Filename))
 			if err != nil {
 				r = append(r, err)
 				continue
@@ -137,7 +121,7 @@ func (job *Job) Run(uploader LocalTargetUploader) (*common.ComposeResult, error)
 				options.Key = job.ID.String()
 			}
 
-			_, err = a.Upload(tmpStore+"/refs/"+result.OutputID+"/image.raw.xz", options.Bucket, options.Key)
+			_, err = a.Upload(path.Join(tmpStore, "refs", result.OutputID, options.Filename), options.Bucket, options.Key)
 			if err != nil {
 				r = append(r, err)
 				continue

--- a/internal/mocks/rpmmd/fixtures.go
+++ b/internal/mocks/rpmmd/fixtures.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/osbuild/osbuild-composer/internal/common"
 	"github.com/osbuild/osbuild-composer/internal/compose"
-	distro_mock "github.com/osbuild/osbuild-composer/internal/mocks/distro"
 
 	"github.com/google/uuid"
 	"github.com/osbuild/osbuild-composer/internal/blueprint"
@@ -93,8 +92,7 @@ func createBaseStoreFixture() *store.Store {
 		},
 	}
 
-	r, _ := distro_mock.NewDefaultRegistry()
-	s := store.New(nil, *r)
+	s := store.New(nil)
 
 	s.Blueprints[bName] = b
 	s.Composes = map[uuid.UUID]compose.Compose{
@@ -189,8 +187,7 @@ func createStoreWithoutComposesFixture() *store.Store {
 		Customizations: nil,
 	}
 
-	r, _ := distro_mock.NewDefaultRegistry()
-	s := store.New(nil, *r)
+	s := store.New(nil)
 
 	s.Blueprints[bName] = b
 

--- a/internal/mocks/rpmmd/fixtures.go
+++ b/internal/mocks/rpmmd/fixtures.go
@@ -2,11 +2,12 @@ package rpmmd_mock
 
 import (
 	"fmt"
+	"sort"
+	"time"
+
 	"github.com/osbuild/osbuild-composer/internal/common"
 	"github.com/osbuild/osbuild-composer/internal/compose"
 	distro_mock "github.com/osbuild/osbuild-composer/internal/mocks/distro"
-	"sort"
-	"time"
 
 	"github.com/google/uuid"
 	"github.com/osbuild/osbuild-composer/internal/blueprint"

--- a/internal/rcm/api_test.go
+++ b/internal/rcm/api_test.go
@@ -3,11 +3,12 @@ package rcm_test
 import (
 	"bytes"
 	"encoding/json"
-	"github.com/google/uuid"
 	"net/http"
 	"net/http/httptest"
 	"regexp"
 	"testing"
+
+	"github.com/google/uuid"
 
 	distro_mock "github.com/osbuild/osbuild-composer/internal/mocks/distro"
 	rpmmd_mock "github.com/osbuild/osbuild-composer/internal/mocks/rpmmd"
@@ -52,7 +53,7 @@ func TestBasicRcmAPI(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	api := rcm.New(nil, store.New(nil, *registry), rpmmd_mock.NewRPMMDMock(rpmmd_mock.BaseFixture()), registry)
+	api := rcm.New(nil, store.New(nil), rpmmd_mock.NewRPMMDMock(rpmmd_mock.BaseFixture()), registry)
 
 	for _, c := range cases {
 		resp := internalRequest(api, c.Method, c.Path, c.Body, c.ContentType)
@@ -78,7 +79,7 @@ func TestSubmitCompose(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	api := rcm.New(nil, store.New(nil, *registry), rpmmd_mock.NewRPMMDMock(rpmmd_mock.BaseFixture()), registry)
+	api := rcm.New(nil, store.New(nil), rpmmd_mock.NewRPMMDMock(rpmmd_mock.BaseFixture()), registry)
 
 	var submit_reply struct {
 		UUID uuid.UUID `json:"compose_id"`

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -595,8 +595,15 @@ func (s *Store) PushCompose(distro distro.Distro, composeID uuid.UUID, bp *bluep
 			return fmt.Errorf("cannot create output directory for job %v: %#v", composeID, err)
 		}
 
+		filename, _, err := distro.FilenameFromType(composeType)
+		if err != nil {
+			return fmt.Errorf("cannot query filename from image type %s: %#v", composeType, err)
+		}
+
 		targets = append(targets, target.NewLocalTarget(
-			&target.LocalTargetOptions{},
+			&target.LocalTargetOptions{
+				Filename: filename,
+			},
 		))
 	}
 

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -42,11 +42,10 @@ type Store struct {
 	BlueprintsChanges map[string]map[string]blueprint.Change `json:"changes"`
 	BlueprintsCommits map[string][]string                    `json:"commits"`
 
-	mu             sync.RWMutex // protects all fields
-	pendingJobs    chan Job
-	stateChannel   chan []byte
-	distroRegistry distro.Registry
-	stateDir       *string
+	mu           sync.RWMutex // protects all fields
+	pendingJobs  chan Job
+	stateChannel chan []byte
+	stateDir     *string
 }
 
 // A Job contains the information about a compose a worker needs to process it.
@@ -107,7 +106,7 @@ func (e *NoLocalTargetError) Error() string {
 	return e.message
 }
 
-func New(stateDir *string, distroRegistryArg distro.Registry) *Store {
+func New(stateDir *string) *Store {
 	var s Store
 
 	if stateDir != nil {
@@ -141,7 +140,6 @@ func New(stateDir *string, distroRegistryArg distro.Registry) *Store {
 	}
 
 	s.pendingJobs = make(chan Job, 200)
-	s.distroRegistry = distroRegistryArg
 	s.stateDir = stateDir
 
 	if s.Blueprints == nil {

--- a/internal/target/aws_target.go
+++ b/internal/target/aws_target.go
@@ -1,6 +1,7 @@
 package target
 
 type AWSTargetOptions struct {
+	Filename        string `json:"filename"`
 	Region          string `json:"region"`
 	AccessKeyID     string `json:"accessKeyID"`
 	SecretAccessKey string `json:"secretAccessKey"`

--- a/internal/target/azure_target.go
+++ b/internal/target/azure_target.go
@@ -1,6 +1,7 @@
 package target
 
 type AzureTargetOptions struct {
+	Filename  string `json:"filename"`
 	Account   string `json:"account"`
 	AccessKey string `json:"accessKey"`
 	Container string `json:"container"`

--- a/internal/target/local_target.go
+++ b/internal/target/local_target.go
@@ -1,6 +1,7 @@
 package target
 
 type LocalTargetOptions struct {
+	Filename string `json:"filename"`
 }
 
 func (LocalTargetOptions) isTargetOptions() {}

--- a/internal/weldr/api.go
+++ b/internal/weldr/api.go
@@ -1360,7 +1360,7 @@ func (api *API) composeHandler(writer http.ResponseWriter, request *http.Request
 		ComposeType   string         `json:"compose_type"`
 		Size          uint64         `json:"size"`
 		Branch        string         `json:"branch"`
-		Upload        *UploadRequest `json:"upload"`
+		Upload        *uploadRequest `json:"upload"`
 	}
 	type ComposeReply struct {
 		BuildID uuid.UUID `json:"build_id"`
@@ -1396,8 +1396,7 @@ func (api *API) composeHandler(writer http.ResponseWriter, request *http.Request
 
 	var uploadTarget *target.Target
 	if isRequestVersionAtLeast(params, 1) && cr.Upload != nil {
-		uploadTarget, err = UploadRequestToTarget(*cr.Upload)
-
+		uploadTarget, err = uploadRequestToTarget(*cr.Upload)
 		if err != nil {
 			errors := responseError{
 				ID:  "UploadError",
@@ -1661,7 +1660,7 @@ func (api *API) composeInfoHandler(writer http.ResponseWriter, request *http.Req
 		ComposeType string               `json:"compose_type"`
 		QueueStatus string               `json:"queue_status"`
 		ImageSize   uint64               `json:"image_size"`
-		Uploads     []UploadResponse     `json:"uploads,omitempty"`
+		Uploads     []uploadResponse     `json:"uploads,omitempty"`
 	}
 
 	reply.ID = id
@@ -1676,7 +1675,7 @@ func (api *API) composeInfoHandler(writer http.ResponseWriter, request *http.Req
 	reply.ImageSize = compose.ImageBuilds[0].Size
 
 	if isRequestVersionAtLeast(params, 1) {
-		reply.Uploads = TargetsToUploadResponses(compose.ImageBuilds[0].Targets)
+		reply.Uploads = targetsToUploadResponses(compose.ImageBuilds[0].Targets)
 	}
 
 	err = json.NewEncoder(writer).Encode(reply)

--- a/internal/weldr/api.go
+++ b/internal/weldr/api.go
@@ -1396,7 +1396,7 @@ func (api *API) composeHandler(writer http.ResponseWriter, request *http.Request
 
 	var uploadTarget *target.Target
 	if isRequestVersionAtLeast(params, 1) && cr.Upload != nil {
-		uploadTarget, err = uploadRequestToTarget(*cr.Upload)
+		uploadTarget, err = uploadRequestToTarget(*cr.Upload, api.distro, cr.ComposeType)
 		if err != nil {
 			errors := responseError{
 				ID:  "UploadError",

--- a/internal/weldr/api_test.go
+++ b/internal/weldr/api_test.go
@@ -495,6 +495,7 @@ func TestCompose(t *testing.T) {
 						Status:    common.IBWaiting,
 						ImageName: "test_upload",
 						Options: &target.AWSTargetOptions{
+							Filename:        "test.img",
 							Region:          "frankfurt",
 							AccessKeyID:     "accesskey",
 							SecretAccessKey: "secretkey",

--- a/internal/weldr/compose.go
+++ b/internal/weldr/compose.go
@@ -1,10 +1,11 @@
 package weldr
 
 import (
+	"sort"
+
 	"github.com/google/uuid"
 	"github.com/osbuild/osbuild-composer/internal/common"
 	"github.com/osbuild/osbuild-composer/internal/compose"
-	"sort"
 )
 
 type ComposeEntry struct {
@@ -17,7 +18,7 @@ type ComposeEntry struct {
 	JobCreated  float64                `json:"job_created"`
 	JobStarted  float64                `json:"job_started,omitempty"`
 	JobFinished float64                `json:"job_finished,omitempty"`
-	Uploads     []UploadResponse       `json:"uploads,omitempty"`
+	Uploads     []uploadResponse       `json:"uploads,omitempty"`
 }
 
 func composeToComposeEntry(id uuid.UUID, compose compose.Compose, includeUploads bool) *ComposeEntry {
@@ -30,7 +31,7 @@ func composeToComposeEntry(id uuid.UUID, compose compose.Compose, includeUploads
 	composeEntry.QueueStatus = compose.ImageBuilds[0].QueueStatus
 
 	if includeUploads {
-		composeEntry.Uploads = TargetsToUploadResponses(compose.ImageBuilds[0].Targets)
+		composeEntry.Uploads = targetsToUploadResponses(compose.ImageBuilds[0].Targets)
 	}
 
 	switch compose.ImageBuilds[0].QueueStatus {

--- a/internal/weldr/upload.go
+++ b/internal/weldr/upload.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/osbuild/osbuild-composer/internal/common"
+	"github.com/osbuild/osbuild-composer/internal/distro"
 
 	"github.com/google/uuid"
 	"github.com/osbuild/osbuild-composer/internal/target"
@@ -117,8 +118,13 @@ func targetsToUploadResponses(targets []*target.Target) []uploadResponse {
 	return uploads
 }
 
-func uploadRequestToTarget(u uploadRequest) (*target.Target, error) {
+func uploadRequestToTarget(u uploadRequest, d distro.Distro, imageType string) (*target.Target, error) {
 	var t target.Target
+
+	filename, _, err := d.FilenameFromType(imageType)
+	if err != nil {
+		return nil, err
+	}
 
 	t.Uuid = uuid.New()
 	t.ImageName = u.ImageName
@@ -129,6 +135,7 @@ func uploadRequestToTarget(u uploadRequest) (*target.Target, error) {
 	case *awsUploadSettings:
 		t.Name = "org.osbuild.aws"
 		t.Options = &target.AWSTargetOptions{
+			Filename:        filename,
 			Region:          options.Region,
 			AccessKeyID:     options.AccessKeyID,
 			SecretAccessKey: options.SecretAccessKey,
@@ -138,6 +145,7 @@ func uploadRequestToTarget(u uploadRequest) (*target.Target, error) {
 	case *azureUploadSettings:
 		t.Name = "org.osbuild.azure"
 		t.Options = &target.AzureTargetOptions{
+			Filename:  filename,
 			Account:   options.Account,
 			AccessKey: options.AccessKey,
 			Container: options.Container,


### PR DESCRIPTION
Drop any assumptions about the name or number of output files that osbuild produces from the worker.

Inspired by #370, fixes #348.