### PR TITLE
Distro interfaces

### DIFF
--- a/cmd/osbuild-composer/main.go
+++ b/cmd/osbuild-composer/main.go
@@ -4,11 +4,17 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"flag"
-	"github.com/osbuild/osbuild-composer/internal/rcm"
 	"io/ioutil"
 	"log"
 	"os"
 	"path"
+
+	"github.com/osbuild/osbuild-composer/internal/distro/fedora30"
+	"github.com/osbuild/osbuild-composer/internal/distro/fedora31"
+	"github.com/osbuild/osbuild-composer/internal/distro/fedora32"
+	"github.com/osbuild/osbuild-composer/internal/distro/rhel81"
+	"github.com/osbuild/osbuild-composer/internal/distro/rhel82"
+	"github.com/osbuild/osbuild-composer/internal/rcm"
 
 	"github.com/osbuild/osbuild-composer/internal/common"
 	"github.com/osbuild/osbuild-composer/internal/distro"
@@ -84,7 +90,7 @@ func main() {
 
 	rpm := rpmmd.NewRPMMD(path.Join(cacheDirectory, "rpmmd"))
 
-	distros, err := distro.NewDefaultRegistry()
+	distros, err := distro.NewRegistry(fedora30.New(), fedora31.New(), fedora32.New(), rhel81.New(), rhel82.New())
 	if err != nil {
 		log.Fatalf("Error loading distros: %v", err)
 	}

--- a/cmd/osbuild-composer/main.go
+++ b/cmd/osbuild-composer/main.go
@@ -100,6 +100,11 @@ func main() {
 		log.Fatalf("Could not determine distro from host: " + err.Error())
 	}
 
+	arch, err := distribution.GetArch(common.CurrentArch())
+	if err != nil {
+		log.Fatalf("Host distro does not support host architecture: " + err.Error())
+	}
+
 	repoMap, err := rpmmd.LoadRepositories([]string{"/etc/osbuild-composer", "/usr/share/osbuild-composer"}, distribution.Name())
 	if err != nil {
 		log.Fatalf("Could not load repositories for %s: %v", distribution.Name(), err)
@@ -113,7 +118,7 @@ func main() {
 	store := store.New(&stateDir)
 
 	jobAPI := jobqueue.New(logger, store)
-	weldrAPI := weldr.New(rpm, common.CurrentArch(), distribution, repoMap[common.CurrentArch()], logger, store)
+	weldrAPI := weldr.New(rpm, arch, distribution, repoMap[common.CurrentArch()], logger, store)
 
 	go func() {
 		err := jobAPI.Serve(jobListener)

--- a/cmd/osbuild-pipeline/main.go
+++ b/cmd/osbuild-pipeline/main.go
@@ -10,6 +10,11 @@ import (
 	"path"
 
 	"github.com/osbuild/osbuild-composer/internal/common"
+	"github.com/osbuild/osbuild-composer/internal/distro/fedora30"
+	"github.com/osbuild/osbuild-composer/internal/distro/fedora31"
+	"github.com/osbuild/osbuild-composer/internal/distro/fedora32"
+	"github.com/osbuild/osbuild-composer/internal/distro/rhel81"
+	"github.com/osbuild/osbuild-composer/internal/distro/rhel82"
 
 	"github.com/osbuild/osbuild-composer/internal/blueprint"
 	"github.com/osbuild/osbuild-composer/internal/distro"
@@ -74,7 +79,7 @@ func main() {
 		}
 	}
 
-	distros, err := distro.NewDefaultRegistry()
+	distros, err := distro.NewRegistry(fedora30.New(), fedora31.New(), fedora32.New(), rhel81.New(), rhel82.New())
 	if err != nil {
 		panic(err)
 	}

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -13,7 +13,7 @@ import (
 	"testing"
 	"time"
 
-	test_distro "github.com/osbuild/osbuild-composer/internal/distro/fedoratest"
+	"github.com/osbuild/osbuild-composer/internal/distro/fedoratest"
 	rpmmd_mock "github.com/osbuild/osbuild-composer/internal/mocks/rpmmd"
 	"github.com/osbuild/osbuild-composer/internal/rpmmd"
 	"github.com/osbuild/osbuild-composer/internal/weldr"
@@ -209,10 +209,14 @@ func TestMain(m *testing.M) {
 	// Create a mock API server listening on the temporary socket
 	fixture := rpmmd_mock.BaseFixture()
 	rpm := rpmmd_mock.NewRPMMDMock(fixture)
-	distro := test_distro.New()
+	distro := fedoratest.New()
+	arch, err := distro.GetArch("x86_64")
+	if err != nil {
+		panic(err)
+	}
 	repos := []rpmmd.RepoConfig{{Id: "test-id", BaseURL: "http://example.com/test/os/test_arch"}}
 	logger := log.New(os.Stdout, "", 0)
-	api := weldr.New(rpm, "test_arch", distro, repos, logger, fixture.Store)
+	api := weldr.New(rpm, arch, distro, repos, logger, fixture.Store)
 	server := http.Server{Handler: api}
 	defer server.Close()
 

--- a/internal/distro/distro.go
+++ b/internal/distro/distro.go
@@ -16,9 +16,9 @@ import (
 	"github.com/osbuild/osbuild-composer/internal/rpmmd"
 )
 
+// A Distro represents composer's notion of what a given distribution is.
 type Distro interface {
-	// Returns the name of the distro. This is the same name that was
-	// passed to New().
+	// Returns the name of the distro.
 	Name() string
 
 	// Return strong-typed distribution
@@ -27,6 +27,10 @@ type Distro interface {
 	// Returns the module platform id of the distro. This is used by DNF
 	// for modularity support.
 	ModulePlatformID() string
+
+	// Returns an object representing the given architecture as support
+	// by this distro.
+	GetArch(arch string) (Arch, error)
 
 	// Returns a sorted list of the output formats this distro supports.
 	ListOutputFormats() []string
@@ -52,6 +56,49 @@ type Distro interface {
 
 	// Returns a osbuild runner that can be used on this distro.
 	Runner() string
+}
+
+// An Arch represents a given distribution's support for a given architecture.
+type Arch interface {
+	// Returns the name of the architecture.
+	Name() string
+
+	// Returns a sorted list of the names of the image types this architecture
+	// supports.
+	ListImageTypes() []string
+
+	// Returns an object representing a given image format for this architecture,
+	// on this distro.
+	GetImageType(imageType string) (ImageType, error)
+}
+
+// An ImageType represents a given distribution's support for a given Image Type
+// for a given architecture.
+type ImageType interface {
+	// Returns the name of the image type.
+	Name() string
+
+	// Returns the canonical filename for the image type.
+	Filename() string
+
+	// Retrns the MIME-type for the image type.
+	MIMEType() string
+
+	// Returns the proper image size for a given output format. If the input size
+	// is 0 the default value for the format will be returned.
+	Size(size uint64) uint64
+
+	// Returns the default packages to include and exclude when making the image
+	// type.
+	BasePackages() ([]string, []string)
+
+	// Returns the build packages for the output type.
+	BuildPackages() []string
+
+	// Returns an osbuild manifest, containing the sources and pipeline necessary
+	// to build an image, given output format with all packages and customizations
+	// specified in the given blueprint.
+	Manifest(b *blueprint.Customizations, repos []rpmmd.RepoConfig, packageSpecs, buildPackageSpecs []rpmmd.PackageSpec, size uint64) (*osbuild.Manifest, error)
 }
 
 type Registry struct {

--- a/internal/distro/distro.go
+++ b/internal/distro/distro.go
@@ -78,29 +78,9 @@ func NewRegistry(distros ...Distro) (*Registry, error) {
 	return reg, nil
 }
 
-// Create a new Registry containing all known distros.
+// NewDefaultRegistry creates a new Registry containing all known distros.
 func NewDefaultRegistry() (*Registry, error) {
-	f30, err := fedora30.New()
-	if err != nil {
-		return nil, fmt.Errorf("error loading fedora30: %v", err)
-	}
-	f31, err := fedora31.New()
-	if err != nil {
-		return nil, fmt.Errorf("error loading fedora31: %v", err)
-	}
-	f32, err := fedora32.New()
-	if err != nil {
-		return nil, fmt.Errorf("error loading fedora32: %v", err)
-	}
-	el81, err := rhel81.New()
-	if err != nil {
-		return nil, fmt.Errorf("error loading rhel81: %v", err)
-	}
-	el82, err := rhel82.New()
-	if err != nil {
-		return nil, fmt.Errorf("error loading rhel82: %v", err)
-	}
-	return NewRegistry(f30, f31, f32, el81, el82)
+	return NewRegistry(fedora30.New(), fedora31.New(), fedora32.New(), rhel81.New(), rhel82.New())
 }
 
 func (r *Registry) GetDistro(name string) Distro {
@@ -116,7 +96,7 @@ func (r *Registry) GetDistro(name string) Distro {
 	return distro
 }
 
-// Returns the names of all distros in a Registry, sorted alphabetically.
+// List returns the names of all distros in a Registry, sorted alphabetically.
 func (r *Registry) List() []string {
 	list := []string{}
 	for _, distro := range r.distros {

--- a/internal/distro/distro.go
+++ b/internal/distro/distro.go
@@ -14,12 +14,6 @@ import (
 
 	"github.com/osbuild/osbuild-composer/internal/blueprint"
 	"github.com/osbuild/osbuild-composer/internal/rpmmd"
-
-	"github.com/osbuild/osbuild-composer/internal/distro/fedora30"
-	"github.com/osbuild/osbuild-composer/internal/distro/fedora31"
-	"github.com/osbuild/osbuild-composer/internal/distro/fedora32"
-	"github.com/osbuild/osbuild-composer/internal/distro/rhel81"
-	"github.com/osbuild/osbuild-composer/internal/distro/rhel82"
 )
 
 type Distro interface {
@@ -76,11 +70,6 @@ func NewRegistry(distros ...Distro) (*Registry, error) {
 		reg.distros[distroTag] = distro
 	}
 	return reg, nil
-}
-
-// NewDefaultRegistry creates a new Registry containing all known distros.
-func NewDefaultRegistry() (*Registry, error) {
-	return NewRegistry(fedora30.New(), fedora31.New(), fedora32.New(), rhel81.New(), rhel82.New())
 }
 
 func (r *Registry) GetDistro(name string) Distro {

--- a/internal/distro/distro.go
+++ b/internal/distro/distro.go
@@ -9,7 +9,6 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/osbuild/osbuild-composer/internal/common"
 	"github.com/osbuild/osbuild-composer/internal/osbuild"
 
 	"github.com/osbuild/osbuild-composer/internal/blueprint"
@@ -102,29 +101,25 @@ type ImageType interface {
 }
 
 type Registry struct {
-	distros map[common.Distribution]Distro
+	distros map[string]Distro
 }
 
 func NewRegistry(distros ...Distro) (*Registry, error) {
 	reg := &Registry{
-		distros: make(map[common.Distribution]Distro),
+		distros: make(map[string]Distro),
 	}
 	for _, distro := range distros {
-		distroTag := distro.Distribution()
-		if _, exists := reg.distros[distroTag]; exists {
+		name := distro.Name()
+		if _, exists := reg.distros[name]; exists {
 			return nil, fmt.Errorf("NewRegistry: passed two distros with the same name: %s", distro.Name())
 		}
-		reg.distros[distroTag] = distro
+		reg.distros[name] = distro
 	}
 	return reg, nil
 }
 
 func (r *Registry) GetDistro(name string) Distro {
-	distroTag, exists := common.DistributionFromString(name)
-	if !exists {
-		return nil
-	}
-	distro, ok := r.distros[distroTag]
+	distro, ok := r.distros[name]
 	if !ok {
 		return nil
 	}

--- a/internal/distro/distro.go
+++ b/internal/distro/distro.go
@@ -20,9 +20,6 @@ type Distro interface {
 	// Returns the name of the distro.
 	Name() string
 
-	// Return strong-typed distribution
-	Distribution() common.Distribution
-
 	// Returns the module platform id of the distro. This is used by DNF
 	// for modularity support.
 	ModulePlatformID() string
@@ -31,30 +28,10 @@ type Distro interface {
 	// by this distro.
 	GetArch(arch string) (Arch, error)
 
-	// Returns a sorted list of the output formats this distro supports.
-	ListOutputFormats() []string
-
 	// Returns the canonical filename and MIME type for a given output
 	// format. `outputFormat` must be one returned by
+	// TODO: remove when redundant
 	FilenameFromType(outputFormat string) (string, string, error)
-
-	// Returns the proper image size for a given output format. If the size
-	// is 0 the default value for the format will be returned.
-	GetSizeForOutputType(outputFormat string, size uint64) uint64
-
-	// Returns the base packages for a given output type and architecture
-	BasePackages(outputFormat, outputArchitecture string) ([]string, []string, error)
-
-	// Returns the build packages for a given output architecture
-	BuildPackages(outputArchitecture string) ([]string, error)
-
-	// Returns an osbuild manifest, containing the sources and pipeline necessary
-	// to generates an image in the given output format with all packages and
-	// customizations specified in the given blueprint.
-	Manifest(b *blueprint.Customizations, repos []rpmmd.RepoConfig, packageSpecs, buildPackageSpecs []rpmmd.PackageSpec, outputArchitecture, imageFormat string, size uint64) (*osbuild.Manifest, error)
-
-	// Returns a osbuild runner that can be used on this distro.
-	Runner() string
 }
 
 // An Arch represents a given distribution's support for a given architecture.

--- a/internal/distro/distro_test.go
+++ b/internal/distro/distro_test.go
@@ -9,6 +9,11 @@ import (
 
 	"github.com/osbuild/osbuild-composer/internal/blueprint"
 	"github.com/osbuild/osbuild-composer/internal/distro"
+	"github.com/osbuild/osbuild-composer/internal/distro/fedora30"
+	"github.com/osbuild/osbuild-composer/internal/distro/fedora31"
+	"github.com/osbuild/osbuild-composer/internal/distro/fedora32"
+	"github.com/osbuild/osbuild-composer/internal/distro/rhel81"
+	"github.com/osbuild/osbuild-composer/internal/distro/rhel82"
 	"github.com/osbuild/osbuild-composer/internal/osbuild"
 	"github.com/osbuild/osbuild-composer/internal/rpmmd"
 )
@@ -52,7 +57,7 @@ func TestDistro_Manifest(t *testing.T) {
 			t.Fatalf("rpmmd.LoadRepositories: %v", err)
 		}
 		t.Run(tt.ComposeRequest.OutputFormat, func(t *testing.T) {
-			distros, err := distro.NewDefaultRegistry()
+			distros, err := distro.NewRegistry(fedora30.New(), fedora31.New(), fedora32.New(), rhel81.New(), rhel82.New())
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -92,7 +97,7 @@ func TestDistro_RegistryList(t *testing.T) {
 		"rhel-8.2",
 	}
 
-	distros, err := distro.NewDefaultRegistry()
+	distros, err := distro.NewRegistry(fedora30.New(), fedora31.New(), fedora32.New(), rhel81.New(), rhel82.New())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/distro/distro_test.go
+++ b/internal/distro/distro_test.go
@@ -66,14 +66,21 @@ func TestDistro_Manifest(t *testing.T) {
 				t.Errorf("unknown distro: %v", tt.ComposeRequest.Distro)
 				return
 			}
-			size := d.GetSizeForOutputType(tt.ComposeRequest.OutputFormat, 0)
-			got, err := d.Manifest(tt.ComposeRequest.Blueprint.Customizations,
+			arch, err := d.GetArch(tt.ComposeRequest.Arch)
+			if err != nil {
+				t.Errorf("unknown arch: %v", tt.ComposeRequest.Arch)
+				return
+			}
+			imageType, err := arch.GetImageType(tt.ComposeRequest.OutputFormat)
+			if err != nil {
+				t.Errorf("unknown image type: %v", tt.ComposeRequest.OutputFormat)
+				return
+			}
+			got, err := imageType.Manifest(tt.ComposeRequest.Blueprint.Customizations,
 				repoMap[tt.ComposeRequest.Arch],
 				tt.RpmMD.Packages,
 				tt.RpmMD.BuildPackages,
-				tt.ComposeRequest.Arch,
-				tt.ComposeRequest.OutputFormat,
-				size)
+				imageType.Size(0))
 			if (err != nil) != (tt.Manifest == nil) {
 				t.Errorf("distro.Manifest() error = %v", err)
 				return

--- a/internal/distro/fedora30/distro.go
+++ b/internal/distro/fedora30/distro.go
@@ -44,7 +44,7 @@ type output struct {
 const Distro = common.Fedora30
 const ModulePlatformID = "platform:f30"
 
-func New() (*Fedora30, error) {
+func New() *Fedora30 {
 	const GigaByte = 1024 * 1024 * 1024
 
 	r := Fedora30{
@@ -286,7 +286,7 @@ func New() (*Fedora30, error) {
 		},
 	}
 
-	return &r, nil
+	return &r
 }
 
 func (r *Fedora30) Name() string {

--- a/internal/distro/fedora30/distro_test.go
+++ b/internal/distro/fedora30/distro_test.go
@@ -19,10 +19,7 @@ func TestListOutputFormats(t *testing.T) {
 		"vmdk",
 	}
 
-	f30, err := fedora30.New()
-	if err != nil {
-		t.Fatal(err)
-	}
+	f30 := fedora30.New()
 
 	if got := f30.ListOutputFormats(); !reflect.DeepEqual(got, want) {
 		t.Errorf("ListOutputFormats() = %v, want %v", got, want)
@@ -96,10 +93,7 @@ func TestFilenameFromType(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			f30, err := fedora30.New()
-			if err != nil {
-				t.Fatal(err)
-			}
+			f30 := fedora30.New()
 			got, got1, err := f30.FilenameFromType(tt.args.outputFormat)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("FilenameFromType() error = %v, wantErr %v", err, tt.wantErr)

--- a/internal/distro/fedora31/distro.go
+++ b/internal/distro/fedora31/distro.go
@@ -44,7 +44,7 @@ type output struct {
 const Distro = common.Fedora31
 const ModulePlatformID = "platform:f31"
 
-func New() (*Fedora31, error) {
+func New() *Fedora31 {
 	const GigaByte = 1024 * 1024 * 1024
 
 	r := Fedora31{
@@ -286,7 +286,7 @@ func New() (*Fedora31, error) {
 		},
 	}
 
-	return &r, nil
+	return &r
 }
 
 func (r *Fedora31) Name() string {

--- a/internal/distro/fedora31/distro.go
+++ b/internal/distro/fedora31/distro.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 
 	"github.com/osbuild/osbuild-composer/internal/common"
+	"github.com/osbuild/osbuild-composer/internal/distro"
 	"github.com/osbuild/osbuild-composer/internal/osbuild"
 
 	"github.com/google/uuid"
@@ -14,12 +15,6 @@ import (
 	"github.com/osbuild/osbuild-composer/internal/crypt"
 	"github.com/osbuild/osbuild-composer/internal/rpmmd"
 )
-
-type Fedora31 struct {
-	arches        map[string]arch
-	outputs       map[string]output
-	buildPackages []string
-}
 
 type arch struct {
 	Name               string
@@ -43,6 +38,103 @@ type output struct {
 
 const Distro = common.Fedora31
 const ModulePlatformID = "platform:f31"
+
+type Fedora31 struct {
+	arches        map[string]arch
+	outputs       map[string]output
+	buildPackages []string
+}
+
+type Fedora31Arch struct {
+	name   string
+	distro *Fedora31
+	arch   *arch
+}
+
+type Fedora31ImageType struct {
+	name   string
+	arch   *Fedora31Arch
+	output *output
+}
+
+func (d *Fedora31) GetArch(arch string) (distro.Arch, error) {
+	a, exists := d.arches[arch]
+	if !exists {
+		return nil, errors.New("invalid architecture: " + arch)
+	}
+
+	return &Fedora31Arch{
+		name:   arch,
+		distro: d,
+		arch:   &a,
+	}, nil
+}
+
+func (a *Fedora31Arch) Name() string {
+	return a.name
+}
+
+func (a *Fedora31Arch) ListImageTypes() []string {
+	return a.distro.ListOutputFormats()
+}
+
+func (a *Fedora31Arch) GetImageType(imageType string) (distro.ImageType, error) {
+	t, exists := a.distro.outputs[imageType]
+	if !exists {
+		return nil, errors.New("invalid image type: " + imageType)
+	}
+
+	return &Fedora31ImageType{
+		name:   imageType,
+		arch:   a,
+		output: &t,
+	}, nil
+}
+
+func (t *Fedora31ImageType) Name() string {
+	return t.name
+}
+
+func (t *Fedora31ImageType) Filename() string {
+	return t.output.Name
+}
+
+func (t *Fedora31ImageType) MIMEType() string {
+	return t.output.MimeType
+}
+
+func (t *Fedora31ImageType) Size(size uint64) uint64 {
+	return t.arch.distro.GetSizeForOutputType(t.name, size)
+}
+
+func (t *Fedora31ImageType) BasePackages() ([]string, []string) {
+	packages := t.output.Packages
+	if t.output.Bootable {
+		packages = append(packages, t.arch.arch.BootloaderPackages...)
+	}
+
+	return packages, t.output.ExcludedPackages
+}
+
+func (t *Fedora31ImageType) BuildPackages() []string {
+	return append(t.arch.distro.buildPackages, t.arch.arch.BuildPackages...)
+}
+
+func (t *Fedora31ImageType) Manifest(c *blueprint.Customizations,
+	repos []rpmmd.RepoConfig,
+	packageSpecs,
+	buildPackageSpecs []rpmmd.PackageSpec,
+	size uint64) (*osbuild.Manifest, error) {
+	pipeline, err := t.arch.distro.pipeline(c, repos, packageSpecs, buildPackageSpecs, t.arch.name, t.name, size)
+	if err != nil {
+		return nil, err
+	}
+
+	return &osbuild.Manifest{
+		Sources:  *t.arch.distro.sources(append(packageSpecs, buildPackageSpecs...)),
+		Pipeline: *pipeline,
+	}, nil
+}
 
 func New() *Fedora31 {
 	const GigaByte = 1024 * 1024 * 1024

--- a/internal/distro/fedora31/distro_test.go
+++ b/internal/distro/fedora31/distro_test.go
@@ -19,10 +19,7 @@ func TestListOutputFormats(t *testing.T) {
 		"vmdk",
 	}
 
-	f31, err := fedora31.New()
-	if err != nil {
-		t.Fatal(err)
-	}
+	f31 := fedora31.New()
 
 	if got := f31.ListOutputFormats(); !reflect.DeepEqual(got, want) {
 		t.Errorf("ListOutputFormats() = %v, want %v", got, want)
@@ -96,10 +93,7 @@ func TestFilenameFromType(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			f31, err := fedora31.New()
-			if err != nil {
-				t.Fatal(err)
-			}
+			f31 := fedora31.New()
 			got, got1, err := f31.FilenameFromType(tt.args.outputFormat)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("FilenameFromType() error = %v, wantErr %v", err, tt.wantErr)

--- a/internal/distro/fedora32/distro.go
+++ b/internal/distro/fedora32/distro.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 
 	"github.com/osbuild/osbuild-composer/internal/common"
+	"github.com/osbuild/osbuild-composer/internal/distro"
 	"github.com/osbuild/osbuild-composer/internal/osbuild"
 
 	"github.com/google/uuid"
@@ -14,12 +15,6 @@ import (
 	"github.com/osbuild/osbuild-composer/internal/crypt"
 	"github.com/osbuild/osbuild-composer/internal/rpmmd"
 )
-
-type Fedora32 struct {
-	arches        map[string]arch
-	outputs       map[string]output
-	buildPackages []string
-}
 
 type arch struct {
 	Name               string
@@ -43,6 +38,103 @@ type output struct {
 
 const Distro = common.Fedora32
 const ModulePlatformID = "platform:f32"
+
+type Fedora32 struct {
+	arches        map[string]arch
+	outputs       map[string]output
+	buildPackages []string
+}
+
+type Fedora32Arch struct {
+	name   string
+	distro *Fedora32
+	arch   *arch
+}
+
+type Fedora32ImageType struct {
+	name   string
+	arch   *Fedora32Arch
+	output *output
+}
+
+func (d *Fedora32) GetArch(arch string) (distro.Arch, error) {
+	a, exists := d.arches[arch]
+	if !exists {
+		return nil, errors.New("invalid architecture: " + arch)
+	}
+
+	return &Fedora32Arch{
+		name:   arch,
+		distro: d,
+		arch:   &a,
+	}, nil
+}
+
+func (a *Fedora32Arch) Name() string {
+	return a.name
+}
+
+func (a *Fedora32Arch) ListImageTypes() []string {
+	return a.distro.ListOutputFormats()
+}
+
+func (a *Fedora32Arch) GetImageType(imageType string) (distro.ImageType, error) {
+	t, exists := a.distro.outputs[imageType]
+	if !exists {
+		return nil, errors.New("invalid image type: " + imageType)
+	}
+
+	return &Fedora32ImageType{
+		name:   imageType,
+		arch:   a,
+		output: &t,
+	}, nil
+}
+
+func (t *Fedora32ImageType) Name() string {
+	return t.name
+}
+
+func (t *Fedora32ImageType) Filename() string {
+	return t.output.Name
+}
+
+func (t *Fedora32ImageType) MIMEType() string {
+	return t.output.MimeType
+}
+
+func (t *Fedora32ImageType) Size(size uint64) uint64 {
+	return t.arch.distro.GetSizeForOutputType(t.name, size)
+}
+
+func (t *Fedora32ImageType) BasePackages() ([]string, []string) {
+	packages := t.output.Packages
+	if t.output.Bootable {
+		packages = append(packages, t.arch.arch.BootloaderPackages...)
+	}
+
+	return packages, t.output.ExcludedPackages
+}
+
+func (t *Fedora32ImageType) BuildPackages() []string {
+	return append(t.arch.distro.buildPackages, t.arch.arch.BuildPackages...)
+}
+
+func (t *Fedora32ImageType) Manifest(c *blueprint.Customizations,
+	repos []rpmmd.RepoConfig,
+	packageSpecs,
+	buildPackageSpecs []rpmmd.PackageSpec,
+	size uint64) (*osbuild.Manifest, error) {
+	pipeline, err := t.arch.distro.pipeline(c, repos, packageSpecs, buildPackageSpecs, t.arch.name, t.name, size)
+	if err != nil {
+		return nil, err
+	}
+
+	return &osbuild.Manifest{
+		Sources:  *t.arch.distro.sources(append(packageSpecs, buildPackageSpecs...)),
+		Pipeline: *pipeline,
+	}, nil
+}
 
 func New() *Fedora32 {
 	const GigaByte = 1024 * 1024 * 1024

--- a/internal/distro/fedora32/distro.go
+++ b/internal/distro/fedora32/distro.go
@@ -44,7 +44,7 @@ type output struct {
 const Distro = common.Fedora32
 const ModulePlatformID = "platform:f32"
 
-func New() (*Fedora32, error) {
+func New() *Fedora32 {
 	const GigaByte = 1024 * 1024 * 1024
 
 	r := Fedora32{
@@ -286,7 +286,7 @@ func New() (*Fedora32, error) {
 		},
 	}
 
-	return &r, nil
+	return &r
 }
 
 func (r *Fedora32) Name() string {

--- a/internal/distro/fedora32/distro_test.go
+++ b/internal/distro/fedora32/distro_test.go
@@ -19,10 +19,7 @@ func TestListOutputFormats(t *testing.T) {
 		"vmdk",
 	}
 
-	f32, err := fedora32.New()
-	if err != nil {
-		t.Fatal(err)
-	}
+	f32 := fedora32.New()
 
 	if got := f32.ListOutputFormats(); !reflect.DeepEqual(got, want) {
 		t.Errorf("ListOutputFormats() = %v, want %v", got, want)
@@ -96,10 +93,8 @@ func TestFilenameFromType(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			f32, err := fedora32.New()
-			if err != nil {
-				t.Fatal(err)
-			}
+			f32 := fedora32.New()
+
 			got, got1, err := f32.FilenameFromType(tt.args.outputFormat)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("FilenameFromType() error = %v, wantErr %v", err, tt.wantErr)

--- a/internal/distro/rhel81/distro.go
+++ b/internal/distro/rhel81/distro.go
@@ -45,7 +45,7 @@ type output struct {
 const Distro = common.RHEL81
 const ModulePlatformID = "platform:el8"
 
-func New() (*RHEL81, error) {
+func New() *RHEL81 {
 	const GigaByte = 1024 * 1024 * 1024
 
 	r := RHEL81{
@@ -425,7 +425,7 @@ func New() (*RHEL81, error) {
 		},
 	}
 
-	return &r, nil
+	return &r
 }
 
 func (r *RHEL81) Name() string {

--- a/internal/distro/rhel81/distro.go
+++ b/internal/distro/rhel81/distro.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 
 	"github.com/osbuild/osbuild-composer/internal/common"
+	"github.com/osbuild/osbuild-composer/internal/distro"
 	"github.com/osbuild/osbuild-composer/internal/osbuild"
 
 	"github.com/google/uuid"
@@ -14,12 +15,6 @@ import (
 	"github.com/osbuild/osbuild-composer/internal/crypt"
 	"github.com/osbuild/osbuild-composer/internal/rpmmd"
 )
-
-type RHEL81 struct {
-	arches        map[string]arch
-	outputs       map[string]output
-	buildPackages []string
-}
 
 type arch struct {
 	Name               string
@@ -44,6 +39,103 @@ type output struct {
 
 const Distro = common.RHEL81
 const ModulePlatformID = "platform:el8"
+
+type RHEL81 struct {
+	arches        map[string]arch
+	outputs       map[string]output
+	buildPackages []string
+}
+
+type RHEL81Arch struct {
+	name   string
+	distro *RHEL81
+	arch   *arch
+}
+
+type RHEL81ImageType struct {
+	name   string
+	arch   *RHEL81Arch
+	output *output
+}
+
+func (d *RHEL81) GetArch(arch string) (distro.Arch, error) {
+	a, exists := d.arches[arch]
+	if !exists {
+		return nil, errors.New("invalid architecture: " + arch)
+	}
+
+	return &RHEL81Arch{
+		name:   arch,
+		distro: d,
+		arch:   &a,
+	}, nil
+}
+
+func (a *RHEL81Arch) Name() string {
+	return a.name
+}
+
+func (a *RHEL81Arch) ListImageTypes() []string {
+	return a.distro.ListOutputFormats()
+}
+
+func (a *RHEL81Arch) GetImageType(imageType string) (distro.ImageType, error) {
+	t, exists := a.distro.outputs[imageType]
+	if !exists {
+		return nil, errors.New("invalid image type: " + imageType)
+	}
+
+	return &RHEL81ImageType{
+		name:   imageType,
+		arch:   a,
+		output: &t,
+	}, nil
+}
+
+func (t *RHEL81ImageType) Name() string {
+	return t.name
+}
+
+func (t *RHEL81ImageType) Filename() string {
+	return t.output.Name
+}
+
+func (t *RHEL81ImageType) MIMEType() string {
+	return t.output.MimeType
+}
+
+func (t *RHEL81ImageType) Size(size uint64) uint64 {
+	return t.arch.distro.GetSizeForOutputType(t.name, size)
+}
+
+func (t *RHEL81ImageType) BasePackages() ([]string, []string) {
+	packages := t.output.Packages
+	if t.output.Bootable {
+		packages = append(packages, t.arch.arch.BootloaderPackages...)
+	}
+
+	return packages, t.output.ExcludedPackages
+}
+
+func (t *RHEL81ImageType) BuildPackages() []string {
+	return append(t.arch.distro.buildPackages, t.arch.arch.BuildPackages...)
+}
+
+func (t *RHEL81ImageType) Manifest(c *blueprint.Customizations,
+	repos []rpmmd.RepoConfig,
+	packageSpecs,
+	buildPackageSpecs []rpmmd.PackageSpec,
+	size uint64) (*osbuild.Manifest, error) {
+	pipeline, err := t.arch.distro.pipeline(c, repos, packageSpecs, buildPackageSpecs, t.arch.name, t.name, size)
+	if err != nil {
+		return nil, err
+	}
+
+	return &osbuild.Manifest{
+		Sources:  *t.arch.distro.sources(append(packageSpecs, buildPackageSpecs...)),
+		Pipeline: *pipeline,
+	}, nil
+}
 
 func New() *RHEL81 {
 	const GigaByte = 1024 * 1024 * 1024

--- a/internal/distro/rhel81/distro_test.go
+++ b/internal/distro/rhel81/distro_test.go
@@ -19,10 +19,7 @@ func TestListOutputFormats(t *testing.T) {
 		"vmdk",
 	}
 
-	el81, err := rhel81.New()
-	if err != nil {
-		t.Fatal(err)
-	}
+	el81 := rhel81.New()
 
 	if got := el81.ListOutputFormats(); !reflect.DeepEqual(got, want) {
 		t.Errorf("ListOutputFormats() = %v, want %v", got, want)
@@ -96,10 +93,7 @@ func TestFilenameFromType(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			el81, err := rhel81.New()
-			if err != nil {
-				t.Fatal(err)
-			}
+			el81 := rhel81.New()
 			got, got1, err := el81.FilenameFromType(tt.args.outputFormat)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("FilenameFromType() error = %v, wantErr %v", err, tt.wantErr)

--- a/internal/distro/rhel82/distro.go
+++ b/internal/distro/rhel82/distro.go
@@ -45,7 +45,7 @@ type output struct {
 const Distro = common.RHEL82
 const ModulePlatformID = "platform:el8"
 
-func New() (*RHEL82, error) {
+func New() *RHEL82 {
 	const GigaByte = 1024 * 1024 * 1024
 
 	r := RHEL82{
@@ -425,7 +425,7 @@ func New() (*RHEL82, error) {
 		},
 	}
 
-	return &r, nil
+	return &r
 }
 
 func (r *RHEL82) Name() string {

--- a/internal/distro/rhel82/distro_test.go
+++ b/internal/distro/rhel82/distro_test.go
@@ -19,10 +19,7 @@ func TestListOutputFormats(t *testing.T) {
 		"vmdk",
 	}
 
-	el82, err := rhel82.New()
-	if err != nil {
-		t.Fatal(err)
-	}
+	el82 := rhel82.New()
 
 	if got := el82.ListOutputFormats(); !reflect.DeepEqual(got, want) {
 		t.Errorf("ListOutputFormats() = %v, want %v", got, want)
@@ -96,10 +93,7 @@ func TestFilenameFromType(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			el82, err := rhel82.New()
-			if err != nil {
-				t.Fatal(err)
-			}
+			el82 := rhel82.New()
 			got, got1, err := el82.FilenameFromType(tt.args.outputFormat)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("FilenameFromType() error = %v, wantErr %v", err, tt.wantErr)

--- a/internal/distro/test/distro.go
+++ b/internal/distro/test/distro.go
@@ -4,14 +4,67 @@ import (
 	"errors"
 
 	"github.com/osbuild/osbuild-composer/internal/blueprint"
+	"github.com/osbuild/osbuild-composer/internal/distro"
 	"github.com/osbuild/osbuild-composer/internal/osbuild"
 	"github.com/osbuild/osbuild-composer/internal/rpmmd"
 )
 
 type TestDistro struct{}
+type TestArch struct{}
+type TestImageType struct{}
 
 const Name = "test-distro"
 const ModulePlatformID = "platform:test"
+
+func (d *TestDistro) GetArch(arch string) (distro.Arch, error) {
+	if arch != "test_arch" {
+		return nil, errors.New("invalid arch: " + arch)
+	}
+	return &TestArch{}, nil
+}
+
+func (a *TestArch) Name() string {
+	return Name
+}
+
+func (a *TestArch) ListImageTypes() []string {
+	return []string{"test-format"}
+}
+
+func (a *TestArch) GetImageType(imageType string) (distro.ImageType, error) {
+	if imageType != "test_output" {
+		return nil, errors.New("invalid image type: " + imageType)
+	}
+	return &TestImageType{}, nil
+}
+
+func (t *TestImageType) Name() string {
+	return "test-format"
+}
+
+func (t *TestImageType) Filename() string {
+	return "test.img"
+}
+
+func (t *TestImageType) MIMEType() string {
+	return "application/x-test"
+}
+
+func (t *TestImageType) Size(size uint64) uint64 {
+	return 0
+}
+
+func (t *TestImageType) BasePackages() ([]string, []string) {
+	return nil, nil
+}
+
+func (t *TestImageType) BuildPackages() []string {
+	return nil
+}
+
+func (t *TestImageType) Manifest(b *blueprint.Customizations, repos []rpmmd.RepoConfig, packageSpecs, buildPackageSpecs []rpmmd.PackageSpec, size uint64) (*osbuild.Manifest, error) {
+	return &osbuild.Manifest{}, nil
+}
 
 func New() *TestDistro {
 	return &TestDistro{}

--- a/internal/jobqueue/api_test.go
+++ b/internal/jobqueue/api_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/osbuild/osbuild-composer/internal/blueprint"
-	test_distro "github.com/osbuild/osbuild-composer/internal/distro/fedoratest"
+	"github.com/osbuild/osbuild-composer/internal/distro/fedoratest"
 	"github.com/osbuild/osbuild-composer/internal/jobqueue"
 	"github.com/osbuild/osbuild-composer/internal/store"
 	"github.com/osbuild/osbuild-composer/internal/test"
@@ -40,11 +40,19 @@ func TestBasic(t *testing.T) {
 
 func TestCreate(t *testing.T) {
 	id, _ := uuid.Parse("ffffffff-ffff-ffff-ffff-ffffffffffff")
-	distroStruct := test_distro.New()
+	distroStruct := fedoratest.New()
+	arch, err := distroStruct.GetArch("x86_64")
+	if err != nil {
+		t.Fatalf("error getting arch from distro")
+	}
+	imageType, err := arch.GetImageType("qcow2")
+	if err != nil {
+		t.Fatalf("error getting image type from arch")
+	}
 	store := store.New(nil)
 	api := jobqueue.New(nil, store)
 
-	err := store.PushCompose(distroStruct, id, &blueprint.Blueprint{}, nil, nil, nil, "x86_64", "qcow2", 0, nil)
+	err = store.PushCompose(distroStruct, arch, imageType, id, &blueprint.Blueprint{}, nil, nil, nil, 0, nil)
 	if err != nil {
 		t.Fatalf("error pushing compose: %v", err)
 	}
@@ -55,12 +63,20 @@ func TestCreate(t *testing.T) {
 
 func testUpdateTransition(t *testing.T, from, to string, expectedStatus int, expectedResponse string) {
 	id, _ := uuid.Parse("ffffffff-ffff-ffff-ffff-ffffffffffff")
-	distroStruct := test_distro.New()
+	distroStruct := fedoratest.New()
+	arch, err := distroStruct.GetArch("x86_64")
+	if err != nil {
+		t.Fatalf("error getting arch from distro")
+	}
+	imageType, err := arch.GetImageType("qcow2")
+	if err != nil {
+		t.Fatalf("error getting image type from arch")
+	}
 	store := store.New(nil)
 	api := jobqueue.New(nil, store)
 
 	if from != "VOID" {
-		err := store.PushCompose(distroStruct, id, &blueprint.Blueprint{}, nil, nil, nil, "x86_64", "qcow2", 0, nil)
+		err := store.PushCompose(distroStruct, arch, imageType, id, &blueprint.Blueprint{}, nil, nil, nil, 0, nil)
 		if err != nil {
 			t.Fatalf("error pushing compose: %v", err)
 		}

--- a/internal/rcm/api.go
+++ b/internal/rcm/api.go
@@ -135,7 +135,7 @@ func (api *API) submit(writer http.ResponseWriter, request *http.Request, _ http
 	decoder := json.NewDecoder(request.Body)
 	decoder.DisallowUnknownFields()
 	err := decoder.Decode(&composeRequest)
-	if err != nil || len(composeRequest.Architectures) == 0 || len(composeRequest.Repositories) == 0 || len(composeRequest.ImageTypes) == 0 {
+	if err != nil || len(composeRequest.Architectures) != 1 || len(composeRequest.ImageTypes) != 1 || len(composeRequest.Repositories) == 0 {
 		writer.WriteHeader(http.StatusBadRequest)
 		errors := []string{}
 		if err != nil {

--- a/internal/rcm/api.go
+++ b/internal/rcm/api.go
@@ -208,7 +208,7 @@ func (api *API) submit(writer http.ResponseWriter, request *http.Request, _ http
 	// Push the requested compose to the store
 	composeUUID := uuid.New()
 	// nil is used as an upload target, because LocalTarget is already used in the PushCompose function
-	err = api.store.PushCompose(distro, composeUUID, &blueprint.Blueprint{}, repoConfigs, packages, buildPackages, arch.Name(), imageType.Name(), 0, nil)
+	err = api.store.PushCompose(distro, arch, imageType, composeUUID, &blueprint.Blueprint{}, repoConfigs, packages, buildPackages, 0, nil)
 	if err != nil {
 		if api.logger != nil {
 			api.logger.Println("RCM API failed to push compose:", err)

--- a/internal/weldr/api.go
+++ b/internal/weldr/api.go
@@ -1532,7 +1532,7 @@ func (api *API) composeTypesHandler(writer http.ResponseWriter, request *http.Re
 		Types []composeType `json:"types"`
 	}
 
-	for _, format := range api.distro.ListOutputFormats() {
+	for _, format := range api.arch.ListImageTypes() {
 		reply.Types = append(reply.Types, composeType{format, true})
 	}
 

--- a/internal/weldr/api.go
+++ b/internal/weldr/api.go
@@ -1409,36 +1409,36 @@ func (api *API) composeHandler(writer http.ResponseWriter, request *http.Request
 	}
 
 	bp := api.store.GetBlueprintCommitted(cr.BlueprintName)
-	if bp != nil {
-		packages, buildPackages, err := api.depsolveBlueprint(bp, cr.ComposeType, api.arch.Name())
-		if err != nil {
-			errors := responseError{
-				ID:  "DepsolveError",
-				Msg: err.Error(),
-			}
-			statusResponseError(writer, http.StatusInternalServerError, errors)
-			return
-		}
-
-		err = api.store.PushCompose(api.distro, reply.BuildID, bp, api.repos, packages, buildPackages, api.arch.Name(), cr.ComposeType, cr.Size, uploadTarget)
-
-		// TODO: we should probably do some kind of blueprint validation in future
-		// for now, let's just 500 and bail out
-		if err != nil {
-			log.Println("error when pushing new compose: ", err.Error())
-			errors := responseError{
-				ID:  "ComposePushErrored",
-				Msg: err.Error(),
-			}
-			statusResponseError(writer, http.StatusInternalServerError, errors)
-			return
-		}
-	} else {
+	if bp == nil {
 		errors := responseError{
 			ID:  "UnknownBlueprint",
 			Msg: fmt.Sprintf("Unknown blueprint name: %s", cr.BlueprintName),
 		}
 		statusResponseError(writer, http.StatusBadRequest, errors)
+		return
+	}
+
+	packages, buildPackages, err := api.depsolveBlueprint(bp, cr.ComposeType, api.arch.Name())
+	if err != nil {
+		errors := responseError{
+			ID:  "DepsolveError",
+			Msg: err.Error(),
+		}
+		statusResponseError(writer, http.StatusInternalServerError, errors)
+		return
+	}
+
+	err = api.store.PushCompose(api.distro, reply.BuildID, bp, api.repos, packages, buildPackages, api.arch.Name(), cr.ComposeType, cr.Size, uploadTarget)
+
+	// TODO: we should probably do some kind of blueprint validation in future
+	// for now, let's just 500 and bail out
+	if err != nil {
+		log.Println("error when pushing new compose: ", err.Error())
+		errors := responseError{
+			ID:  "ComposePushErrored",
+			Msg: err.Error(),
+		}
+		statusResponseError(writer, http.StatusInternalServerError, errors)
 		return
 	}
 

--- a/internal/weldr/api.go
+++ b/internal/weldr/api.go
@@ -1438,7 +1438,7 @@ func (api *API) composeHandler(writer http.ResponseWriter, request *http.Request
 		Status:  true,
 	}
 
-	err = api.store.PushCompose(api.distro, reply.BuildID, bp, api.repos, packages, buildPackages, api.arch.Name(), cr.ComposeType, cr.Size, uploadTarget)
+	err = api.store.PushCompose(api.distro, api.arch, imageType, reply.BuildID, bp, api.repos, packages, buildPackages, cr.Size, uploadTarget)
 
 	// TODO: we should probably do some kind of blueprint validation in future
 	// for now, let's just 500 and bail out

--- a/internal/weldr/api_test.go
+++ b/internal/weldr/api_test.go
@@ -33,8 +33,12 @@ func createWeldrAPI(fixtureGenerator rpmmd_mock.FixtureGenerator) (*API, *store.
 	rpm := rpmmd_mock.NewRPMMDMock(fixture)
 	repos := []rpmmd.RepoConfig{{Id: "test-id", BaseURL: "http://example.com/test/os/x86_64"}}
 	d := test_distro.New()
+	arch, err := d.GetArch("x86_64")
+	if err != nil {
+		panic(err)
+	}
 
-	return New(rpm, "x86_64", d, repos, nil, fixture.Store), fixture.Store
+	return New(rpm, arch, d, repos, nil, fixture.Store), fixture.Store
 }
 
 func TestBasic(t *testing.T) {

--- a/internal/weldr/upload.go
+++ b/internal/weldr/upload.go
@@ -118,13 +118,8 @@ func targetsToUploadResponses(targets []*target.Target) []uploadResponse {
 	return uploads
 }
 
-func uploadRequestToTarget(u uploadRequest, d distro.Distro, imageType string) (*target.Target, error) {
+func uploadRequestToTarget(u uploadRequest, imageType distro.ImageType) (*target.Target, error) {
 	var t target.Target
-
-	filename, _, err := d.FilenameFromType(imageType)
-	if err != nil {
-		return nil, err
-	}
 
 	t.Uuid = uuid.New()
 	t.ImageName = u.ImageName
@@ -135,7 +130,7 @@ func uploadRequestToTarget(u uploadRequest, d distro.Distro, imageType string) (
 	case *awsUploadSettings:
 		t.Name = "org.osbuild.aws"
 		t.Options = &target.AWSTargetOptions{
-			Filename:        filename,
+			Filename:        imageType.Filename(),
 			Region:          options.Region,
 			AccessKeyID:     options.AccessKeyID,
 			SecretAccessKey: options.SecretAccessKey,
@@ -145,7 +140,7 @@ func uploadRequestToTarget(u uploadRequest, d distro.Distro, imageType string) (
 	case *azureUploadSettings:
 		t.Name = "org.osbuild.azure"
 		t.Options = &target.AzureTargetOptions{
-			Filename:  filename,
+			Filename:  imageType.Filename(),
 			Account:   options.Account,
 			AccessKey: options.AccessKey,
 			Container: options.Container,


### PR DESCRIPTION
Introduce new interfaces to represent a distro at a given architecture, and each image type for a architecture/distro pair. Methods on the ImageType object are used rather than passing in architecture and image type to methods on the distro objects, simplifying the code and making the need for much of the `common` package redundant.

As discussed with @msehnout and @larskarlitski .