### PR TITLE
Request specific architecture from dnf

### DIFF
--- a/cmd/osbuild-dnf-json-tests/main_test.go
+++ b/cmd/osbuild-dnf-json-tests/main_test.go
@@ -6,12 +6,18 @@ package main
 
 import (
 	"fmt"
-	"github.com/stretchr/testify/assert"
-	"path"
-	"testing"
-
+	"github.com/osbuild/osbuild-composer/internal/distro"
+	"github.com/osbuild/osbuild-composer/internal/distro/fedora30"
+	"github.com/osbuild/osbuild-composer/internal/distro/fedora31"
+	"github.com/osbuild/osbuild-composer/internal/distro/fedora32"
 	"github.com/osbuild/osbuild-composer/internal/rpmmd"
 	"github.com/osbuild/osbuild-composer/internal/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"io/ioutil"
+	"os"
+	"path"
+	"testing"
 )
 
 func TestFetchChecksum(t *testing.T) {
@@ -31,4 +37,51 @@ func TestFetchChecksum(t *testing.T) {
 	_, c, err := rpmMetadata.FetchMetadata([]rpmmd.RepoConfig{repoCfg}, "platform:f31", "x86_64")
 	assert.Nilf(t, err, "Failed to fetch checksum: %v", err)
 	assert.NotEqual(t, "", c["repo"], "The checksum is empty")
+}
+
+// This test loads all the repositories available in /repositories directory
+// and tries to run depsolve for each architecture. With N architectures available
+// this should run cross-arch dependency solving N-1 times.
+func TestCrossArchDepsolve(t *testing.T) {
+	// Set up temporary directory for rpm/dnf cache
+	dir, err := ioutil.TempDir("/tmp", "rpmmd-test-")
+	require.Nilf(t, err, "Failed to create tmp dir for depsolve test: %v", err)
+	defer os.RemoveAll(dir)
+	rpm := rpmmd.NewRPMMD(dir)
+
+	// Load repositories from the definition we provide in the RPM package
+	repositories := "/usr/share/osbuild-composer"
+
+	// NOTE: we can add RHEL, but don't make it hard requirement because it will fail outside of VPN
+	for _, distroStruct := range []distro.Distro{fedora30.New(), fedora31.New(), fedora32.New()} {
+		repoConfig, err := rpmmd.LoadRepositories([]string{repositories}, distroStruct.Name())
+		assert.Nilf(t, err, "Failed to LoadRepositories from %v for %v: %v", repositories, distroStruct.Name(), err)
+		if err != nil {
+			// There is no point in running the tests without having repositories, but we can still run tests
+			// for the remaining distros
+			continue
+		}
+		for _, archStr := range distroStruct.ListArchs() {
+			arch, err := distroStruct.GetArch(archStr)
+			assert.Nilf(t, err, "Failed to GetArch from %v structure: %v", distroStruct.Name(), err)
+			if err != nil {
+				continue
+			}
+			for _, imgTypeStr := range arch.ListImageTypes() {
+				imgType, err := arch.GetImageType(imgTypeStr)
+				assert.Nilf(t, err, "Failed to GetImageType for %v on %v: %v", distroStruct.Name(), arch.Name(), err)
+				if err != nil {
+					continue
+				}
+
+				buildPackages := imgType.BuildPackages()
+				_, _, err = rpm.Depsolve(buildPackages, []string{}, repoConfig[archStr], distroStruct.ModulePlatformID(), archStr)
+				assert.Nilf(t, err, "Failed to Depsolve build packages for %v %v %v image: %v", distroStruct.Name(), imgType.Name(), arch.Name(), err)
+
+				basePackagesInclude, basePackagesExclude := imgType.BasePackages()
+				_, _, err = rpm.Depsolve(basePackagesInclude, basePackagesExclude, repoConfig[archStr], distroStruct.ModulePlatformID(), archStr)
+				assert.Nilf(t, err, "Failed to Depsolve base packages for %v %v %v image: %v", distroStruct.Name(), imgType.Name(), arch.Name(), err)
+			}
+		}
+	}
 }

--- a/cmd/osbuild-dnf-json-tests/main_test.go
+++ b/cmd/osbuild-dnf-json-tests/main_test.go
@@ -28,7 +28,7 @@ func TestFetchChecksum(t *testing.T) {
 		IgnoreSSL: true,
 	}
 	rpmMetadata := rpmmd.NewRPMMD(path.Join(dir, "rpmmd"))
-	_, c, err := rpmMetadata.FetchMetadata([]rpmmd.RepoConfig{repoCfg}, "platform:f31")
+	_, c, err := rpmMetadata.FetchMetadata([]rpmmd.RepoConfig{repoCfg}, "platform:f31", "x86_64")
 	assert.Nilf(t, err, "Failed to fetch checksum: %v", err)
 	assert.NotEqual(t, "", c["repo"], "The checksum is empty")
 }

--- a/cmd/osbuild-pipeline/main.go
+++ b/cmd/osbuild-pipeline/main.go
@@ -121,13 +121,13 @@ func main() {
 	}
 
 	rpmmd := rpmmd.NewRPMMD(path.Join(home, ".cache/osbuild-composer/rpmmd"))
-	packageSpecs, checksums, err := rpmmd.Depsolve(packages, exclude_pkgs, repos[arch.Name()], distro.ModulePlatformID())
+	packageSpecs, checksums, err := rpmmd.Depsolve(packages, exclude_pkgs, repos[arch.Name()], distro.ModulePlatformID(), arch.Name())
 	if err != nil {
 		panic("Could not depsolve: " + err.Error())
 	}
 
 	buildPkgs := imageType.BuildPackages()
-	buildPackageSpecs, _, err := rpmmd.Depsolve(buildPkgs, nil, repos[arch.Name()], distro.ModulePlatformID())
+	buildPackageSpecs, _, err := rpmmd.Depsolve(buildPkgs, nil, repos[arch.Name()], distro.ModulePlatformID(), arch.Name())
 	if err != nil {
 		panic("Could not depsolve build packages: " + err.Error())
 	}

--- a/dnf-json
+++ b/dnf-json
@@ -37,12 +37,14 @@ def dnfrepo(desc, parent_conf=None):
     return repo
 
 
-def create_base(repos, module_platform_id, persistdir, cachedir):
+def create_base(repos, module_platform_id, persistdir, cachedir, arch):
     base = dnf.Base()
     base.conf.module_platform_id = module_platform_id
     base.conf.config_file_path = "/dev/null"
     base.conf.persistdir = persistdir
     base.conf.cachedir = cachedir
+    base.conf.substitutions['arch'] = arch
+    base.conf.substitutions['basearch'] = dnf.rpm.basearch(arch)
 
     for repo in repos:
         base.repos.add(dnfrepo(repo, base.conf))
@@ -84,12 +86,13 @@ call = json.load(sys.stdin)
 command = call["command"]
 arguments = call["arguments"]
 repos = arguments.get("repos", {})
+arch = arguments["arch"]
 cachedir = arguments["cachedir"]
 module_platform_id = arguments["module_platform_id"]
 
 with tempfile.TemporaryDirectory() as persistdir:
     try:
-        base = create_base(repos, module_platform_id, persistdir, cachedir)
+        base = create_base(repos, module_platform_id, persistdir, cachedir, arch)
     except dnf.exceptions.RepoError as e:
         exit_with_dnf_error("RepoError", f"Error occurred when setting up repo: {e}")
 

--- a/internal/distro/fedora30/distro.go
+++ b/internal/distro/fedora30/distro.go
@@ -170,6 +170,7 @@ func New() *Fedora30 {
 			"qemu-img",
 			"systemd",
 			"tar",
+			"xz",
 		},
 		arches: map[string]arch{
 			"x86_64": arch{

--- a/internal/distro/fedora31/distro.go
+++ b/internal/distro/fedora31/distro.go
@@ -170,6 +170,7 @@ func New() *Fedora31 {
 			"qemu-img",
 			"systemd",
 			"tar",
+			"xz",
 		},
 		arches: map[string]arch{
 			"x86_64": arch{

--- a/internal/distro/fedora32/distro.go
+++ b/internal/distro/fedora32/distro.go
@@ -170,6 +170,7 @@ func New() *Fedora32 {
 			"qemu-img",
 			"systemd",
 			"tar",
+			"xz",
 		},
 		arches: map[string]arch{
 			"x86_64": arch{

--- a/internal/distro/rhel81/distro.go
+++ b/internal/distro/rhel81/distro.go
@@ -175,6 +175,7 @@ func New() *RHEL81 {
 			"systemd",
 			"tar",
 			"xfsprogs",
+			"xz",
 		},
 		arches: map[string]arch{
 			"x86_64": arch{

--- a/internal/distro/rhel82/distro.go
+++ b/internal/distro/rhel82/distro.go
@@ -175,6 +175,7 @@ func New() *RHEL82 {
 			"systemd",
 			"tar",
 			"xfsprogs",
+			"xz",
 		},
 		arches: map[string]arch{
 			"x86_64": arch{

--- a/internal/mocks/rpmmd/rpmmd_mock.go
+++ b/internal/mocks/rpmmd/rpmmd_mock.go
@@ -30,10 +30,10 @@ func NewRPMMDMock(fixture Fixture) rpmmd.RPMMD {
 	return &rpmmdMock{Fixture: fixture}
 }
 
-func (r *rpmmdMock) FetchMetadata(repos []rpmmd.RepoConfig, modulePlatformID string) (rpmmd.PackageList, map[string]string, error) {
+func (r *rpmmdMock) FetchMetadata(repos []rpmmd.RepoConfig, modulePlatformID string, arch string) (rpmmd.PackageList, map[string]string, error) {
 	return r.Fixture.fetchPackageList.ret, r.Fixture.fetchPackageList.checksums, r.Fixture.fetchPackageList.err
 }
 
-func (r *rpmmdMock) Depsolve(specs, excludeSpecs []string, repos []rpmmd.RepoConfig, modulePlatformID string) ([]rpmmd.PackageSpec, map[string]string, error) {
+func (r *rpmmdMock) Depsolve(specs, excludeSpecs []string, repos []rpmmd.RepoConfig, modulePlatformID, arch string) ([]rpmmd.PackageSpec, map[string]string, error) {
 	return r.Fixture.depsolve.ret, r.Fixture.fetchPackageList.checksums, r.Fixture.depsolve.err
 }

--- a/internal/rcm/api.go
+++ b/internal/rcm/api.go
@@ -83,15 +83,15 @@ func notFoundHandler(writer http.ResponseWriter, request *http.Request) {
 
 // Depsolves packages and build packages for building an image for a given
 // distro, in the given architecture
-func depsolve(rpmmd rpmmd.RPMMD, distro distro.Distro, imageType distro.ImageType, repos []rpmmd.RepoConfig) ([]rpmmd.PackageSpec, []rpmmd.PackageSpec, error) {
+func depsolve(rpmmd rpmmd.RPMMD, distro distro.Distro, imageType distro.ImageType, repos []rpmmd.RepoConfig, arch distro.Arch) ([]rpmmd.PackageSpec, []rpmmd.PackageSpec, error) {
 	specs, excludeSpecs := imageType.BasePackages()
-	packages, _, err := rpmmd.Depsolve(specs, excludeSpecs, repos, distro.ModulePlatformID())
+	packages, _, err := rpmmd.Depsolve(specs, excludeSpecs, repos, distro.ModulePlatformID(), arch.Name())
 	if err != nil {
 		return nil, nil, fmt.Errorf("RPMMD.Depsolve: %v", err)
 	}
 
 	specs = imageType.BuildPackages()
-	buildPackages, _, err := rpmmd.Depsolve(specs, nil, repos, distro.ModulePlatformID())
+	buildPackages, _, err := rpmmd.Depsolve(specs, nil, repos, distro.ModulePlatformID(), arch.Name())
 	if err != nil {
 		return nil, nil, fmt.Errorf("RPMMD.Depsolve: %v", err)
 	}
@@ -195,7 +195,7 @@ func (api *API) submit(writer http.ResponseWriter, request *http.Request, _ http
 		})
 	}
 
-	packages, buildPackages, err := depsolve(api.rpmMetadata, distro, imageType, repoConfigs)
+	packages, buildPackages, err := depsolve(api.rpmMetadata, distro, imageType, repoConfigs, arch)
 	if err != nil {
 		writer.WriteHeader(http.StatusBadRequest)
 		_, err := writer.Write([]byte(err.Error()))

--- a/internal/weldr/api.go
+++ b/internal/weldr/api.go
@@ -632,7 +632,7 @@ func (api *API) modulesInfoHandler(writer http.ResponseWriter, request *http.Req
 
 	if modulesRequested {
 		for i := range packageInfos {
-			err := packageInfos[i].FillDependencies(api.rpmmd, api.repos, api.distro.ModulePlatformID())
+			err := packageInfos[i].FillDependencies(api.rpmmd, api.repos, api.distro.ModulePlatformID(), api.arch.Name())
 			if err != nil {
 				errors := responseError{
 					ID:  errorId,
@@ -663,7 +663,7 @@ func (api *API) projectsDepsolveHandler(writer http.ResponseWriter, request *htt
 
 	names := strings.Split(params.ByName("projects"), ",")
 
-	packages, _, err := api.rpmmd.Depsolve(names, nil, api.repos, api.distro.ModulePlatformID())
+	packages, _, err := api.rpmmd.Depsolve(names, nil, api.repos, api.distro.ModulePlatformID(), api.arch.Name())
 
 	if err != nil {
 		errors := responseError{
@@ -1963,7 +1963,7 @@ func (api *API) fetchPackageList() (rpmmd.PackageList, error) {
 		repos = append(repos, source.RepoConfig())
 	}
 
-	packages, _, err := api.rpmmd.FetchMetadata(repos, api.distro.ModulePlatformID())
+	packages, _, err := api.rpmmd.FetchMetadata(repos, api.distro.ModulePlatformID(), api.arch.Name())
 	return packages, err
 }
 
@@ -1999,7 +1999,7 @@ func (api *API) depsolveBlueprint(bp *blueprint.Blueprint, imageType distro.Imag
 		excludeSpecs = append(excludePackages, excludeSpecs...)
 	}
 
-	packages, _, err := api.rpmmd.Depsolve(specs, excludeSpecs, repos, api.distro.ModulePlatformID())
+	packages, _, err := api.rpmmd.Depsolve(specs, excludeSpecs, repos, api.distro.ModulePlatformID(), api.arch.Name())
 	if err != nil {
 		return nil, nil, err
 	}
@@ -2007,7 +2007,7 @@ func (api *API) depsolveBlueprint(bp *blueprint.Blueprint, imageType distro.Imag
 	buildPackages := []rpmmd.PackageSpec{}
 	if imageType != nil {
 		buildSpecs := imageType.BuildPackages()
-		buildPackages, _, err = api.rpmmd.Depsolve(buildSpecs, nil, repos, api.distro.ModulePlatformID())
+		buildPackages, _, err = api.rpmmd.Depsolve(buildSpecs, nil, repos, api.distro.ModulePlatformID(), api.arch.Name())
 		if err != nil {
 			return nil, nil, err
 		}


### PR DESCRIPTION
The depsolving currently does not work cross-arch. Also when passing repos with multiple architectures it does not work but we already have the information about required architecture, so we can just pass it to dnf.

See individual commits for further explanation.