### PR TITLE
🤦 [WIP] blueprints: drop unsued returns

### DIFF
--- a/internal/blueprint/blueprint.go
+++ b/internal/blueprint/blueprint.go
@@ -41,17 +41,12 @@ type Group struct {
 // DeepCopy returns a deep copy of the blueprint
 // This uses json.Marshal and Unmarshal which are not very efficient
 func (b *Blueprint) DeepCopy() (Blueprint, error) {
-	bpJSON, err := json.Marshal(b)
-	if err != nil {
-		return Blueprint{}, err
-	}
+	bpJSON, err1 := json.Marshal(b)
 
 	var bp Blueprint
-	err = json.Unmarshal(bpJSON, &bp)
-	if err != nil {
-		return Blueprint{}, err
-	}
-	return bp, nil
+	err2 = json.Unmarshal(bpJSON, &bp)
+
+	return bp, err1, err2
 }
 
 // Initialize ensures that the blueprint has sane defaults for any missing fields


### PR DESCRIPTION
This drops unsued returns in the function which could not be covered the way it's written now.