### PR TITLE
tests: Make TestSources distro independent. Refs #315

### DIFF
--- a/cmd/osbuild-tests/main_test.go
+++ b/cmd/osbuild-tests/main_test.go
@@ -77,10 +77,8 @@ gpgkey_urls = ["https://url/path/to/gpg-key"]
 	require.NoError(t, err)
 
 	runComposerCLI(t, false, "sources", "list")
-	// todo: this will fail on RHEL
-	runComposerCLI(t, false, "sources", "info", "fedora")
-
 	runComposerCLI(t, false, "sources", "add", sources_toml.Name())
+	runComposerCLI(t, false, "sources", "info", "osbuild-test-addon-source")
 	runComposerCLI(t, false, "sources", "change", sources_toml.Name())
 	runComposerCLI(t, false, "sources", "delete", "osbuild-test-addon-source")
 }


### PR DESCRIPTION
by loading repositories configuration first and then running `composer-cli sources info <repo>` on the first repository found.

@teg I took a different approach for this. Please review.