### PR TITLE
worker: move ComposerClient to jobqueue and defaults to unit files

### DIFF
--- a/cmd/osbuild-worker/main.go
+++ b/cmd/osbuild-worker/main.go
@@ -142,7 +142,7 @@ func (c *ComposerClient) UpdateJob(job *jobqueue.Job, status common.ImageBuildSt
 
 func (c *ComposerClient) UploadImage(job *jobqueue.Job, reader io.Reader) error {
 	// content type doesn't really matter
-	url := fmt.Sprintf("http://localhost/job-queue/v1/jobs/%s/builds/%d/image", job.ID.String(), job.ImageBuildID)
+	url := c.createURL(fmt.Sprintf("/job-queue/v1/jobs/%s/builds/%d/image", job.ID.String(), job.ImageBuildID))
 	_, err := c.client.Post(url, "application/octet-stream", reader)
 
 	return err

--- a/cmd/osbuild-worker/main.go
+++ b/cmd/osbuild-worker/main.go
@@ -56,7 +56,7 @@ func createTLSConfig(config *connectionConfig) (*tls.Config, error) {
 	}, nil
 }
 
-func NewClient(remoteAddress string, conf *tls.Config) *ComposerClient {
+func NewClient(address string, conf *tls.Config) *ComposerClient {
 	client := &http.Client{
 		Transport: &http.Transport{
 			TLSClientConfig: conf,
@@ -70,7 +70,7 @@ func NewClient(remoteAddress string, conf *tls.Config) *ComposerClient {
 		scheme = "https"
 	}
 
-	return &ComposerClient{client, scheme, remoteAddress}
+	return &ComposerClient{client, scheme, address}
 }
 
 func NewClientUnix(path string) *ComposerClient {
@@ -177,13 +177,13 @@ func handleJob(client *ComposerClient) error {
 }
 
 func main() {
-	var remoteAddress string
-	flag.StringVar(&remoteAddress, "remote", "", "Connect to a remote composer using the specified address")
+	var address string
+	flag.StringVar(&address, "remote", "", "Connect to a remote composer using the specified address")
 	flag.Parse()
 
 	var client *ComposerClient
-	if remoteAddress != "" {
-		remoteAddress = fmt.Sprintf("%s:%d", remoteAddress, RemoteWorkerPort)
+	if address != "" {
+		address = fmt.Sprintf("%s:%d", address, RemoteWorkerPort)
 
 		conf, err := createTLSConfig(&connectionConfig{
 			CACertFile:     "/etc/osbuild-composer/ca-crt.pem",
@@ -194,7 +194,7 @@ func main() {
 			log.Fatalf("Error creating TLS config: %v", err)
 		}
 
-		client = NewClient(remoteAddress, conf)
+		client = NewClient(address, conf)
 	} else {
 		client = NewClientUnix("/run/osbuild-composer/job.socket")
 	}

--- a/cmd/osbuild-worker/main.go
+++ b/cmd/osbuild-worker/main.go
@@ -1,31 +1,19 @@
 package main
 
 import (
-	"bytes"
-	"context"
 	"crypto/tls"
 	"crypto/x509"
-	"encoding/json"
 	"errors"
 	"flag"
 	"fmt"
-	"io"
 	"io/ioutil"
 	"log"
-	"net"
-	"net/http"
 
 	"github.com/osbuild/osbuild-composer/internal/common"
 	"github.com/osbuild/osbuild-composer/internal/jobqueue"
 )
 
 const RemoteWorkerPort = 8700
-
-type ComposerClient struct {
-	client   *http.Client
-	scheme   string
-	hostname string
-}
 
 type connectionConfig struct {
 	CACertFile     string
@@ -56,105 +44,7 @@ func createTLSConfig(config *connectionConfig) (*tls.Config, error) {
 	}, nil
 }
 
-func NewClient(address string, conf *tls.Config) *ComposerClient {
-	client := &http.Client{
-		Transport: &http.Transport{
-			TLSClientConfig: conf,
-		},
-	}
-
-	var scheme string
-	if conf != nil {
-		scheme = "http"
-	} else {
-		scheme = "https"
-	}
-
-	return &ComposerClient{client, scheme, address}
-}
-
-func NewClientUnix(path string) *ComposerClient {
-	client := &http.Client{
-		Transport: &http.Transport{
-			DialContext: func(context context.Context, network, addr string) (net.Conn, error) {
-				return net.Dial("unix", path)
-			},
-		},
-	}
-
-	return &ComposerClient{client, "http", "localhost"}
-}
-
-func (c *ComposerClient) AddJob() (*jobqueue.Job, error) {
-	type request struct {
-	}
-
-	var b bytes.Buffer
-	err := json.NewEncoder(&b).Encode(request{})
-	if err != nil {
-		panic(err)
-	}
-	response, err := c.client.Post(c.createURL("/job-queue/v1/jobs"), "application/json", &b)
-	if err != nil {
-		return nil, err
-	}
-	defer response.Body.Close()
-
-	if response.StatusCode != http.StatusCreated {
-		rawR, _ := ioutil.ReadAll(response.Body)
-		r := string(rawR)
-		return nil, fmt.Errorf("couldn't create job, got %d: %s", response.StatusCode, r)
-	}
-
-	job := &jobqueue.Job{}
-	err = json.NewDecoder(response.Body).Decode(job)
-	if err != nil {
-		return nil, err
-	}
-
-	return job, nil
-}
-
-func (c *ComposerClient) UpdateJob(job *jobqueue.Job, status common.ImageBuildState, result *common.ComposeResult) error {
-	var b bytes.Buffer
-	err := json.NewEncoder(&b).Encode(&jobqueue.JobStatus{status, result})
-	if err != nil {
-		panic(err)
-	}
-	urlPath := fmt.Sprintf("/job-queue/v1/jobs/%s/builds/%d", job.ID.String(), job.ImageBuildID)
-	url := c.createURL(urlPath)
-	req, err := http.NewRequest("PATCH", url, &b)
-	if err != nil {
-		return err
-	}
-
-	req.Header.Set("Content-Type", "application/json")
-	response, err := c.client.Do(req)
-	if err != nil {
-		return err
-	}
-	defer response.Body.Close()
-
-	if response.StatusCode != http.StatusOK {
-		return errors.New("error setting job status")
-	}
-
-	return nil
-}
-
-func (c *ComposerClient) UploadImage(job *jobqueue.Job, reader io.Reader) error {
-	// content type doesn't really matter
-	url := c.createURL(fmt.Sprintf("/job-queue/v1/jobs/%s/builds/%d/image", job.ID.String(), job.ImageBuildID))
-	_, err := c.client.Post(url, "application/octet-stream", reader)
-
-	return err
-}
-
-func (c *ComposerClient) createURL(path string) string {
-	return c.scheme + "://" + c.hostname + path
-}
-
-func handleJob(client *ComposerClient) error {
+func handleJob(client *jobqueue.Client) error {
 	fmt.Println("Waiting for a new job...")
 	job, err := client.AddJob()
 	if err != nil {
@@ -181,7 +71,7 @@ func main() {
 	flag.StringVar(&address, "remote", "", "Connect to a remote composer using the specified address")
 	flag.Parse()
 
-	var client *ComposerClient
+	var client *jobqueue.Client
 	if address != "" {
 		address = fmt.Sprintf("%s:%d", address, RemoteWorkerPort)
 
@@ -194,9 +84,9 @@ func main() {
 			log.Fatalf("Error creating TLS config: %v", err)
 		}
 
-		client = NewClient(address, conf)
+		client = jobqueue.NewClient(address, conf)
 	} else {
-		client = NewClientUnix("/run/osbuild-composer/job.socket")
+		client = jobqueue.NewClientUnix(address)
 	}
 
 	for {

--- a/cmd/osbuild-worker/main.go
+++ b/cmd/osbuild-worker/main.go
@@ -67,9 +67,7 @@ func newConnection(remoteAddress string) (net.Conn, error) {
 			return nil, err
 		}
 
-		address := fmt.Sprintf("%s:%d", remoteAddress, RemoteWorkerPort)
-
-		return tls.Dial("tcp", address, conf)
+		return tls.Dial("tcp", remoteAddress, conf)
 	}
 
 	// plain non-encrypted connection
@@ -190,6 +188,10 @@ func main() {
 	var remoteAddress string
 	flag.StringVar(&remoteAddress, "remote", "", "Connect to a remote composer using the specified address")
 	flag.Parse()
+
+	if remoteAddress != "" {
+		remoteAddress = fmt.Sprintf("%s:%d", remoteAddress, RemoteWorkerPort)
+	}
 
 	client := NewClient(remoteAddress)
 	for {

--- a/cmd/osbuild-worker/main.go
+++ b/cmd/osbuild-worker/main.go
@@ -14,8 +14,6 @@ import (
 	"github.com/osbuild/osbuild-composer/internal/jobqueue"
 )
 
-const RemoteWorkerPort = 8700
-
 type connectionConfig struct {
 	CACertFile     string
 	ClientKeyFile  string
@@ -88,8 +86,6 @@ func main() {
 	if unix {
 		client = jobqueue.NewClientUnix(address)
 	} else {
-		address = fmt.Sprintf("%s:%d", address, RemoteWorkerPort)
-
 		conf, err := createTLSConfig(&connectionConfig{
 			CACertFile:     "/etc/osbuild-composer/ca-crt.pem",
 			ClientKeyFile:  "/etc/osbuild-composer/worker-key.pem",

--- a/distribution/osbuild-remote-worker@.service
+++ b/distribution/osbuild-remote-worker@.service
@@ -5,7 +5,7 @@ After=multi-user.target
 [Service]
 Type=simple
 PrivateTmp=true
-ExecStart=/usr/libexec/osbuild-composer/osbuild-worker --remote %i
+ExecStart=/usr/libexec/osbuild-composer/osbuild-worker %i
 CacheDirectory=osbuild-composer
 Restart=on-failure
 RestartSec=10s

--- a/distribution/osbuild-worker@.service
+++ b/distribution/osbuild-worker@.service
@@ -6,7 +6,7 @@ After=multi-user.target osbuild-composer.socket
 [Service]
 Type=simple
 PrivateTmp=true
-ExecStart=/usr/libexec/osbuild-composer/osbuild-worker
+ExecStart=/usr/libexec/osbuild-composer/osbuild-worker -unix /run/osbuild-composer/job.socket
 Restart=on-failure
 RestartSec=10s
 CPUSchedulingPolicy=batch

--- a/internal/jobqueue/client.go
+++ b/internal/jobqueue/client.go
@@ -1,0 +1,120 @@
+package jobqueue
+
+import (
+	"bytes"
+	"context"
+	"crypto/tls"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net"
+	"net/http"
+
+	"github.com/osbuild/osbuild-composer/internal/common"
+)
+
+type Client struct {
+	client   *http.Client
+	scheme   string
+	hostname string
+}
+
+func NewClient(address string, conf *tls.Config) *Client {
+	client := &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: conf,
+		},
+	}
+
+	var scheme string
+	if conf != nil {
+		scheme = "http"
+	} else {
+		scheme = "https"
+	}
+
+	return &Client{client, scheme, address}
+}
+
+func NewClientUnix(path string) *Client {
+	client := &http.Client{
+		Transport: &http.Transport{
+			DialContext: func(context context.Context, network, addr string) (net.Conn, error) {
+				return net.Dial("unix", path)
+			},
+		},
+	}
+
+	return &Client{client, "http", "localhost"}
+}
+
+func (c *Client) AddJob() (*Job, error) {
+	type request struct {
+	}
+
+	var b bytes.Buffer
+	err := json.NewEncoder(&b).Encode(request{})
+	if err != nil {
+		panic(err)
+	}
+	response, err := c.client.Post(c.createURL("/job-queue/v1/jobs"), "application/json", &b)
+	if err != nil {
+		return nil, err
+	}
+	defer response.Body.Close()
+
+	if response.StatusCode != http.StatusCreated {
+		rawR, _ := ioutil.ReadAll(response.Body)
+		r := string(rawR)
+		return nil, fmt.Errorf("couldn't create job, got %d: %s", response.StatusCode, r)
+	}
+
+	job := &Job{}
+	err = json.NewDecoder(response.Body).Decode(job)
+	if err != nil {
+		return nil, err
+	}
+
+	return job, nil
+}
+
+func (c *Client) UpdateJob(job *Job, status common.ImageBuildState, result *common.ComposeResult) error {
+	var b bytes.Buffer
+	err := json.NewEncoder(&b).Encode(&JobStatus{status, result})
+	if err != nil {
+		panic(err)
+	}
+	urlPath := fmt.Sprintf("/job-queue/v1/jobs/%s/builds/%d", job.ID.String(), job.ImageBuildID)
+	url := c.createURL(urlPath)
+	req, err := http.NewRequest("PATCH", url, &b)
+	if err != nil {
+		return err
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	response, err := c.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer response.Body.Close()
+
+	if response.StatusCode != http.StatusOK {
+		return errors.New("error setting job status")
+	}
+
+	return nil
+}
+
+func (c *Client) UploadImage(job *Job, reader io.Reader) error {
+	// content type doesn't really matter
+	url := c.createURL(fmt.Sprintf("/job-queue/v1/jobs/%s/builds/%d/image", job.ID.String(), job.ImageBuildID))
+	_, err := c.client.Post(url, "application/octet-stream", reader)
+
+	return err
+}
+
+func (c *Client) createURL(path string) string {
+	return c.scheme + "://" + c.hostname + path
+}


### PR DESCRIPTION
See individual commits.

More is coming for `jobqueue.Client` if people think this it the right direction. This is a good first chunk that's ready for review.

It changes how `osbuild-worker`'s command line arguments. I don't think we treat those as stable API, right?