### PR TITLE
distro: define valid image types for the arches

### DIFF
--- a/internal/distro/distro.go
+++ b/internal/distro/distro.go
@@ -31,11 +31,6 @@ type Distro interface {
 	// Returns an object representing the given architecture as support
 	// by this distro.
 	GetArch(arch string) (Arch, error)
-
-	// Returns the canonical filename and MIME type for a given output
-	// format. `outputFormat` must be one returned by
-	// TODO: remove when redundant
-	FilenameFromType(outputFormat string) (string, string, error)
 }
 
 // An Arch represents a given distribution's support for a given architecture.

--- a/internal/distro/fedora30/distro.go
+++ b/internal/distro/fedora30/distro.go
@@ -25,14 +25,17 @@ type Fedora30 struct {
 }
 
 type arch struct {
+	distro             *Fedora30
 	name               string
 	bootloaderPackages []string
 	buildPackages      []string
 	uefi               bool
+	imageTypes         map[string]imageType
 }
 
 type imageType struct {
 	name             string
+	filename         string
 	mimeType         string
 	packages         []string
 	excludedPackages []string
@@ -44,15 +47,9 @@ type imageType struct {
 	assembler        func(uefi bool, size uint64) *osbuild.Assembler
 }
 
-type fedora30Arch struct {
-	name   string
-	distro *Fedora30
-	arch   *arch
-}
-
 type fedora30ImageType struct {
 	name      string
-	arch      *fedora30Arch
+	arch      *arch
 	imageType *imageType
 }
 
@@ -71,28 +68,38 @@ func (d *Fedora30) GetArch(arch string) (distro.Arch, error) {
 		return nil, errors.New("invalid architecture: " + arch)
 	}
 
-	return &fedora30Arch{
-		name:   arch,
-		distro: d,
-		arch:   &a,
-	}, nil
+	return &a, nil
 }
 
-func (a *fedora30Arch) Name() string {
+func (d *Fedora30) setArches(arches ...arch) {
+	d.arches = map[string]arch{}
+	for _, a := range arches {
+		d.arches[a.name] = arch{
+			distro:             d,
+			name:               a.name,
+			bootloaderPackages: a.bootloaderPackages,
+			buildPackages:      a.buildPackages,
+			uefi:               a.uefi,
+			imageTypes:         a.imageTypes,
+		}
+	}
+}
+
+func (a *arch) Name() string {
 	return a.name
 }
 
-func (a *fedora30Arch) ListImageTypes() []string {
-	formats := make([]string, 0, len(a.distro.imageTypes))
-	for name := range a.distro.imageTypes {
+func (a *arch) ListImageTypes() []string {
+	formats := make([]string, 0, len(a.imageTypes))
+	for name := range a.imageTypes {
 		formats = append(formats, name)
 	}
 	sort.Strings(formats)
 	return formats
 }
 
-func (a *fedora30Arch) GetImageType(imageType string) (distro.ImageType, error) {
-	t, exists := a.distro.imageTypes[imageType]
+func (a *arch) GetImageType(imageType string) (distro.ImageType, error) {
+	t, exists := a.imageTypes[imageType]
 	if !exists {
 		return nil, errors.New("invalid image type: " + imageType)
 	}
@@ -104,12 +111,31 @@ func (a *fedora30Arch) GetImageType(imageType string) (distro.ImageType, error) 
 	}, nil
 }
 
+func (a *arch) setImageTypes(imageTypes ...imageType) {
+	a.imageTypes = map[string]imageType{}
+	for _, it := range imageTypes {
+		a.imageTypes[it.name] = imageType{
+			name:             it.name,
+			filename:         it.filename,
+			mimeType:         it.mimeType,
+			packages:         it.packages,
+			excludedPackages: it.excludedPackages,
+			enabledServices:  it.enabledServices,
+			disabledServices: it.disabledServices,
+			kernelOptions:    it.kernelOptions,
+			bootable:         it.bootable,
+			defaultSize:      it.defaultSize,
+			assembler:        it.assembler,
+		}
+	}
+}
+
 func (t *fedora30ImageType) Name() string {
 	return t.name
 }
 
 func (t *fedora30ImageType) Filename() string {
-	return t.imageType.name
+	return t.imageType.filename
 }
 
 func (t *fedora30ImageType) MIMEType() string {
@@ -131,14 +157,14 @@ func (t *fedora30ImageType) Size(size uint64) uint64 {
 func (t *fedora30ImageType) BasePackages() ([]string, []string) {
 	packages := t.imageType.packages
 	if t.imageType.bootable {
-		packages = append(packages, t.arch.arch.bootloaderPackages...)
+		packages = append(packages, t.arch.bootloaderPackages...)
 	}
 
 	return packages, t.imageType.excludedPackages
 }
 
 func (t *fedora30ImageType) BuildPackages() []string {
-	return append(t.arch.distro.buildPackages, t.arch.arch.buildPackages...)
+	return append(t.arch.distro.buildPackages, t.arch.buildPackages...)
 }
 
 func (t *fedora30ImageType) Manifest(c *blueprint.Customizations,
@@ -160,44 +186,9 @@ func (t *fedora30ImageType) Manifest(c *blueprint.Customizations,
 func New() *Fedora30 {
 	const GigaByte = 1024 * 1024 * 1024
 
-	r := Fedora30{
-		imageTypes: map[string]imageType{},
-		buildPackages: []string{
-			"dnf",
-			"dosfstools",
-			"e2fsprogs",
-			"policycoreutils",
-			"qemu-img",
-			"systemd",
-			"tar",
-			"xz",
-		},
-		arches: map[string]arch{
-			"x86_64": arch{
-				name: "x86_64",
-				bootloaderPackages: []string{
-					"grub2-pc",
-				},
-				buildPackages: []string{
-					"grub2-pc",
-				},
-			},
-			"aarch64": arch{
-				name: "aarch64",
-				bootloaderPackages: []string{
-					"dracut-config-generic",
-					"efibootmgr",
-					"grub2-efi-aa64",
-					"grub2-tools",
-					"shim-aa64",
-				},
-				uefi: true,
-			},
-		},
-	}
-
-	r.imageTypes["ami"] = imageType{
-		name:     "image.raw.xz",
+	amiImgType := imageType{
+		name:     "ami",
+		filename: "image.raw.xz",
 		mimeType: "application/octet-stream",
 		packages: []string{
 			"@Core",
@@ -221,12 +212,13 @@ func New() *Fedora30 {
 		bootable:      true,
 		defaultSize:   6 * GigaByte,
 		assembler: func(uefi bool, size uint64) *osbuild.Assembler {
-			return r.qemuAssembler("raw.xz", "image.raw.xz", uefi, size)
+			return qemuAssembler("raw.xz", "image.raw.xz", uefi, size)
 		},
 	}
 
-	r.imageTypes["ext4-filesystem"] = imageType{
-		name:     "filesystem.img",
+	ext4FilesystemType := imageType{
+		name:     "ext4-filesystem",
+		filename: "filesystem.img",
 		mimeType: "application/octet-stream",
 		packages: []string{
 			"policycoreutils",
@@ -242,11 +234,12 @@ func New() *Fedora30 {
 		kernelOptions: "ro biosdevname=0 net.ifnames=0",
 		bootable:      false,
 		defaultSize:   2 * GigaByte,
-		assembler:     func(uefi bool, size uint64) *osbuild.Assembler { return r.rawFSAssembler("filesystem.img", size) },
+		assembler:     func(uefi bool, size uint64) *osbuild.Assembler { return rawFSAssembler("filesystem.img", size) },
 	}
 
-	r.imageTypes["partitioned-disk"] = imageType{
-		name:     "disk.img",
+	partitionedDisk := imageType{
+		name:     "partitioned-disk",
+		filename: "disk.img",
 		mimeType: "application/octet-stream",
 		packages: []string{
 			"@core",
@@ -263,12 +256,13 @@ func New() *Fedora30 {
 		bootable:      true,
 		defaultSize:   2 * GigaByte,
 		assembler: func(uefi bool, size uint64) *osbuild.Assembler {
-			return r.qemuAssembler("raw", "disk.img", uefi, size)
+			return qemuAssembler("raw", "disk.img", uefi, size)
 		},
 	}
 
-	r.imageTypes["qcow2"] = imageType{
-		name:     "disk.qcow2",
+	qcow2ImageType := imageType{
+		name:     "qcow2",
+		filename: "disk.qcow2",
 		mimeType: "application/x-qemu-disk",
 		packages: []string{
 			"kernel-core",
@@ -290,12 +284,13 @@ func New() *Fedora30 {
 		bootable:      true,
 		defaultSize:   2 * GigaByte,
 		assembler: func(uefi bool, size uint64) *osbuild.Assembler {
-			return r.qemuAssembler("qcow2", "disk.qcow2", uefi, size)
+			return qemuAssembler("qcow2", "disk.qcow2", uefi, size)
 		},
 	}
 
-	r.imageTypes["openstack"] = imageType{
-		name:     "disk.qcow2",
+	openstackImgType := imageType{
+		name:     "openstack",
+		filename: "disk.qcow2",
 		mimeType: "application/x-qemu-disk",
 		packages: []string{
 			"@Core",
@@ -316,12 +311,13 @@ func New() *Fedora30 {
 		bootable:      true,
 		defaultSize:   2 * GigaByte,
 		assembler: func(uefi bool, size uint64) *osbuild.Assembler {
-			return r.qemuAssembler("qcow2", "disk.qcow2", uefi, size)
+			return qemuAssembler("qcow2", "disk.qcow2", uefi, size)
 		},
 	}
 
-	r.imageTypes["tar"] = imageType{
-		name:     "root.tar.xz",
+	tarImgType := imageType{
+		name:     "tar",
+		filename: "root.tar.xz",
 		mimeType: "application/x-tar",
 		packages: []string{
 			"policycoreutils",
@@ -337,11 +333,12 @@ func New() *Fedora30 {
 		kernelOptions: "ro biosdevname=0 net.ifnames=0",
 		bootable:      false,
 		defaultSize:   2 * GigaByte,
-		assembler:     func(uefi bool, size uint64) *osbuild.Assembler { return r.tarAssembler("root.tar.xz", "xz") },
+		assembler:     func(uefi bool, size uint64) *osbuild.Assembler { return tarAssembler("root.tar.xz", "xz") },
 	}
 
-	r.imageTypes["vhd"] = imageType{
-		name:     "disk.vhd",
+	vhdImgType := imageType{
+		name:     "vhd",
+		filename: "disk.vhd",
 		mimeType: "application/x-vhd",
 		packages: []string{
 			"@Core",
@@ -373,12 +370,13 @@ func New() *Fedora30 {
 		bootable:      true,
 		defaultSize:   2 * GigaByte,
 		assembler: func(uefi bool, size uint64) *osbuild.Assembler {
-			return r.qemuAssembler("vpc", "disk.vhd", uefi, size)
+			return qemuAssembler("vpc", "disk.vhd", uefi, size)
 		},
 	}
 
-	r.imageTypes["vmdk"] = imageType{
-		name:     "disk.vmdk",
+	vmdkImgType := imageType{
+		name:     "vmdk",
+		filename: "disk.vmdk",
 		mimeType: "application/x-vmdk",
 		packages: []string{
 			"@core",
@@ -396,9 +394,66 @@ func New() *Fedora30 {
 		bootable:      true,
 		defaultSize:   2 * GigaByte,
 		assembler: func(uefi bool, size uint64) *osbuild.Assembler {
-			return r.qemuAssembler("vmdk", "disk.vmdk", uefi, size)
+			return qemuAssembler("vmdk", "disk.vmdk", uefi, size)
 		},
 	}
+
+	r := Fedora30{
+		imageTypes: map[string]imageType{},
+		buildPackages: []string{
+			"dnf",
+			"dosfstools",
+			"e2fsprogs",
+			"policycoreutils",
+			"qemu-img",
+			"systemd",
+			"tar",
+			"xz",
+		},
+	}
+	x8664 := arch{
+		distro: &r,
+		name:   "x86_64",
+		bootloaderPackages: []string{
+			"grub2-pc",
+		},
+		buildPackages: []string{
+			"grub2-pc",
+		},
+	}
+	x8664.setImageTypes(
+		amiImgType,
+		ext4FilesystemType,
+		partitionedDisk,
+		qcow2ImageType,
+		openstackImgType,
+		tarImgType,
+		vhdImgType,
+		vmdkImgType,
+	)
+
+	aarch64 := arch{
+		distro: &r,
+		name:   "aarch64",
+		bootloaderPackages: []string{
+			"dracut-config-generic",
+			"efibootmgr",
+			"grub2-efi-aa64",
+			"grub2-tools",
+			"shim-aa64",
+		},
+		uefi: true,
+	}
+	aarch64.setImageTypes(
+		amiImgType,
+		ext4FilesystemType,
+		partitionedDisk,
+		qcow2ImageType,
+		openstackImgType,
+		tarImgType,
+	)
+
+	r.setArches(x8664, aarch64)
 
 	return &r
 }
@@ -425,9 +480,9 @@ func sources(packages []rpmmd.PackageSpec) *osbuild.Sources {
 
 func (t *fedora30ImageType) pipeline(c *blueprint.Customizations, repos []rpmmd.RepoConfig, packageSpecs, buildPackageSpecs []rpmmd.PackageSpec, size uint64) (*osbuild.Pipeline, error) {
 	p := &osbuild.Pipeline{}
-	p.SetBuild(t.buildPipeline(repos, *t.arch.arch, buildPackageSpecs), "org.osbuild.fedora30")
+	p.SetBuild(t.buildPipeline(repos, *t.arch, buildPackageSpecs), "org.osbuild.fedora30")
 
-	p.AddStage(osbuild.NewRPMStage(t.rpmStageOptions(*t.arch.arch, repos, packageSpecs)))
+	p.AddStage(osbuild.NewRPMStage(t.rpmStageOptions(*t.arch, repos, packageSpecs)))
 	p.AddStage(osbuild.NewFixBLSStage())
 
 	// TODO support setting all languages and install corresponding langpack-* package
@@ -471,9 +526,9 @@ func (t *fedora30ImageType) pipeline(c *blueprint.Customizations, repos []rpmmd.
 	}
 
 	if t.imageType.bootable {
-		p.AddStage(osbuild.NewFSTabStage(t.fsTabStageOptions(t.arch.arch.uefi)))
+		p.AddStage(osbuild.NewFSTabStage(t.fsTabStageOptions(t.arch.uefi)))
 	}
-	p.AddStage(osbuild.NewGRUB2Stage(t.grub2StageOptions(t.imageType.kernelOptions, c.GetKernel(), t.arch.arch.uefi)))
+	p.AddStage(osbuild.NewGRUB2Stage(t.grub2StageOptions(t.imageType.kernelOptions, c.GetKernel(), t.arch.uefi)))
 
 	if services := c.GetServices(); services != nil || t.imageType.enabledServices != nil {
 		p.AddStage(osbuild.NewSystemdStage(t.systemdStageOptions(t.imageType.enabledServices, t.imageType.disabledServices, services)))
@@ -485,7 +540,7 @@ func (t *fedora30ImageType) pipeline(c *blueprint.Customizations, repos []rpmmd.
 
 	p.AddStage(osbuild.NewSELinuxStage(t.selinuxStageOptions()))
 
-	p.Assembler = t.imageType.assembler(t.arch.arch.uefi, size)
+	p.Assembler = t.imageType.assembler(t.arch.uefi, size)
 
 	return p, nil
 }
@@ -637,7 +692,7 @@ func (r *fedora30ImageType) selinuxStageOptions() *osbuild.SELinuxStageOptions {
 	}
 }
 
-func (r *Fedora30) qemuAssembler(format string, filename string, uefi bool, size uint64) *osbuild.Assembler {
+func qemuAssembler(format string, filename string, uefi bool, size uint64) *osbuild.Assembler {
 	var options osbuild.QEMUAssemblerOptions
 	if uefi {
 		fstype := uuid.MustParse("C12A7328-F81F-11D2-BA4B-00A0C93EC93B")
@@ -692,7 +747,7 @@ func (r *Fedora30) qemuAssembler(format string, filename string, uefi bool, size
 	return osbuild.NewQEMUAssembler(&options)
 }
 
-func (r *Fedora30) tarAssembler(filename, compression string) *osbuild.Assembler {
+func tarAssembler(filename, compression string) *osbuild.Assembler {
 	return osbuild.NewTarAssembler(
 		&osbuild.TarAssemblerOptions{
 			Filename:    filename,
@@ -700,7 +755,7 @@ func (r *Fedora30) tarAssembler(filename, compression string) *osbuild.Assembler
 		})
 }
 
-func (r *Fedora30) rawFSAssembler(filename string, size uint64) *osbuild.Assembler {
+func rawFSAssembler(filename string, size uint64) *osbuild.Assembler {
 	id := uuid.MustParse("76a22bf4-f153-4541-b6c7-0332c0dfaeac")
 	return osbuild.NewRawFSAssembler(
 		&osbuild.RawFSAssemblerOptions{

--- a/internal/distro/fedora30/distro.go
+++ b/internal/distro/fedora30/distro.go
@@ -411,13 +411,6 @@ func (r *Fedora30) ModulePlatformID() string {
 	return modulePlatformID
 }
 
-func (r *Fedora30) FilenameFromType(outputFormat string) (string, string, error) {
-	if output, exists := r.imageTypes[outputFormat]; exists {
-		return output.name, output.mimeType, nil
-	}
-	return "", "", errors.New("invalid output format: " + outputFormat)
-}
-
 func sources(packages []rpmmd.PackageSpec) *osbuild.Sources {
 	files := &osbuild.FilesSource{
 		URLs: make(map[string]string),

--- a/internal/distro/fedora30/distro_test.go
+++ b/internal/distro/fedora30/distro_test.go
@@ -2,6 +2,7 @@ package fedora30_test
 
 import (
 	"github.com/osbuild/osbuild-composer/internal/distro/fedora30"
+	"reflect"
 	"testing"
 )
 
@@ -90,5 +91,49 @@ func TestFilenameFromType(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestImageType_BuildPackages(t *testing.T) {
+	x8664BuildPackages := []string{
+		"dnf",
+		"dosfstools",
+		"e2fsprogs",
+		"grub2-pc",
+		"policycoreutils",
+		"qemu-img",
+		"systemd",
+		"tar",
+		"xz",
+	}
+	aarch64BuildPackages := []string{
+		"dnf",
+		"dosfstools",
+		"e2fsprogs",
+		"policycoreutils",
+		"qemu-img",
+		"systemd",
+		"tar",
+		"xz",
+	}
+	buildPackages := map[string][]string{
+		"x86_64":  x8664BuildPackages,
+		"aarch64": aarch64BuildPackages,
+	}
+	d := fedora30.New()
+	for _, archLabel := range d.ListArchs() {
+		archStruct, err := d.GetArch(archLabel)
+		if err != nil {
+			t.Errorf("d.GetArch(%v) returned err = %v; expected nil", archLabel, err)
+			continue
+		}
+		for _, itLabel := range archStruct.ListImageTypes() {
+			itStruct, err := archStruct.GetImageType(itLabel)
+			if err != nil {
+				t.Errorf("d.GetArch(%v) returned err = %v; expected nil", archLabel, err)
+				continue
+			}
+			reflect.DeepEqual(itStruct.BuildPackages(), buildPackages[archLabel])
+		}
 	}
 }

--- a/internal/distro/fedora30/distro_test.go
+++ b/internal/distro/fedora30/distro_test.go
@@ -1,9 +1,8 @@
 package fedora30_test
 
 import (
-	"testing"
-
 	"github.com/osbuild/osbuild-composer/internal/distro/fedora30"
+	"testing"
 )
 
 func TestFilenameFromType(t *testing.T) {
@@ -73,18 +72,21 @@ func TestFilenameFromType(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			f30 := fedora30.New()
-			got, got1, err := f30.FilenameFromType(tt.args.outputFormat)
+			dist := fedora30.New()
+			arch, _ := dist.GetArch("x86_64")
+			imgType, err := arch.GetImageType(tt.args.outputFormat)
 			if (err != nil) != tt.wantErr {
-				t.Errorf("FilenameFromType() error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("Arch.GetImageType() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
 			if !tt.wantErr {
+				got := imgType.Filename()
+				got1 := imgType.MIMEType()
 				if got != tt.want {
-					t.Errorf("FilenameFromType() got = %v, want %v", got, tt.want)
+					t.Errorf("ImageType.Filename()  got = %v, want %v", got, tt.want)
 				}
 				if got1 != tt.want1 {
-					t.Errorf("FilenameFromType() got1 = %v, want %v", got1, tt.want1)
+					t.Errorf("ImageType.MIMEType() got1 = %v, want %v", got1, tt.want1)
 				}
 			}
 		})

--- a/internal/distro/fedora31/distro.go
+++ b/internal/distro/fedora31/distro.go
@@ -411,13 +411,6 @@ func (r *Fedora31) ModulePlatformID() string {
 	return modulePlatformID
 }
 
-func (r *Fedora31) FilenameFromType(outputFormat string) (string, string, error) {
-	if output, exists := r.imageTypes[outputFormat]; exists {
-		return output.name, output.mimeType, nil
-	}
-	return "", "", errors.New("invalid output format: " + outputFormat)
-}
-
 func sources(packages []rpmmd.PackageSpec) *osbuild.Sources {
 	files := &osbuild.FilesSource{
 		URLs: make(map[string]string),

--- a/internal/distro/fedora31/distro_test.go
+++ b/internal/distro/fedora31/distro_test.go
@@ -2,6 +2,7 @@ package fedora31_test
 
 import (
 	"github.com/osbuild/osbuild-composer/internal/distro/fedora31"
+	"reflect"
 	"testing"
 )
 
@@ -90,5 +91,49 @@ func TestFilenameFromType(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestImageType_BuildPackages(t *testing.T) {
+	x8664BuildPackages := []string{
+		"dnf",
+		"dosfstools",
+		"e2fsprogs",
+		"grub2-pc",
+		"policycoreutils",
+		"qemu-img",
+		"systemd",
+		"tar",
+		"xz",
+	}
+	aarch64BuildPackages := []string{
+		"dnf",
+		"dosfstools",
+		"e2fsprogs",
+		"policycoreutils",
+		"qemu-img",
+		"systemd",
+		"tar",
+		"xz",
+	}
+	buildPackages := map[string][]string{
+		"x86_64":  x8664BuildPackages,
+		"aarch64": aarch64BuildPackages,
+	}
+	d := fedora31.New()
+	for _, archLabel := range d.ListArchs() {
+		archStruct, err := d.GetArch(archLabel)
+		if err != nil {
+			t.Errorf("d.GetArch(%v) returned err = %v; expected nil", archLabel, err)
+			continue
+		}
+		for _, itLabel := range archStruct.ListImageTypes() {
+			itStruct, err := archStruct.GetImageType(itLabel)
+			if err != nil {
+				t.Errorf("d.GetArch(%v) returned err = %v; expected nil", archLabel, err)
+				continue
+			}
+			reflect.DeepEqual(itStruct.BuildPackages(), buildPackages[archLabel])
+		}
 	}
 }

--- a/internal/distro/fedora31/distro_test.go
+++ b/internal/distro/fedora31/distro_test.go
@@ -1,9 +1,8 @@
 package fedora31_test
 
 import (
-	"testing"
-
 	"github.com/osbuild/osbuild-composer/internal/distro/fedora31"
+	"testing"
 )
 
 func TestFilenameFromType(t *testing.T) {
@@ -73,18 +72,21 @@ func TestFilenameFromType(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			f31 := fedora31.New()
-			got, got1, err := f31.FilenameFromType(tt.args.outputFormat)
+			dist := fedora31.New()
+			arch, _ := dist.GetArch("x86_64")
+			imgType, err := arch.GetImageType(tt.args.outputFormat)
 			if (err != nil) != tt.wantErr {
-				t.Errorf("FilenameFromType() error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("Arch.GetImageType() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
 			if !tt.wantErr {
+				got := imgType.Filename()
+				got1 := imgType.MIMEType()
 				if got != tt.want {
-					t.Errorf("FilenameFromType() got = %v, want %v", got, tt.want)
+					t.Errorf("ImageType.Filename()  got = %v, want %v", got, tt.want)
 				}
 				if got1 != tt.want1 {
-					t.Errorf("FilenameFromType() got1 = %v, want %v", got1, tt.want1)
+					t.Errorf("ImageType.MIMEType() got1 = %v, want %v", got1, tt.want1)
 				}
 			}
 		})

--- a/internal/distro/fedora32/distro.go
+++ b/internal/distro/fedora32/distro.go
@@ -34,6 +34,7 @@ type arch struct {
 }
 
 type imageType struct {
+	arch             *arch
 	name             string
 	filename         string
 	mimeType         string
@@ -45,12 +46,6 @@ type imageType struct {
 	bootable         bool
 	defaultSize      uint64
 	assembler        func(uefi bool, size uint64) *osbuild.Assembler
-}
-
-type fedora32ImageType struct {
-	name      string
-	arch      *arch
-	imageType *imageType
 }
 
 func (d *Fedora32) ListArchs() []string {
@@ -104,17 +99,14 @@ func (a *arch) GetImageType(imageType string) (distro.ImageType, error) {
 		return nil, errors.New("invalid image type: " + imageType)
 	}
 
-	return &fedora32ImageType{
-		name:      imageType,
-		arch:      a,
-		imageType: &t,
-	}, nil
+	return &t, nil
 }
 
 func (a *arch) setImageTypes(imageTypes ...imageType) {
 	a.imageTypes = map[string]imageType{}
 	for _, it := range imageTypes {
 		a.imageTypes[it.name] = imageType{
+			arch:             a,
 			name:             it.name,
 			filename:         it.filename,
 			mimeType:         it.mimeType,
@@ -130,44 +122,44 @@ func (a *arch) setImageTypes(imageTypes ...imageType) {
 	}
 }
 
-func (t *fedora32ImageType) Name() string {
+func (t *imageType) Name() string {
 	return t.name
 }
 
-func (t *fedora32ImageType) Filename() string {
-	return t.imageType.filename
+func (t *imageType) Filename() string {
+	return t.filename
 }
 
-func (t *fedora32ImageType) MIMEType() string {
-	return t.imageType.mimeType
+func (t *imageType) MIMEType() string {
+	return t.mimeType
 }
 
-func (t *fedora32ImageType) Size(size uint64) uint64 {
+func (t *imageType) Size(size uint64) uint64 {
 	const MegaByte = 1024 * 1024
 	// Microsoft Azure requires vhd images to be rounded up to the nearest MB
 	if t.name == "vhd" && size%MegaByte != 0 {
 		size = (size/MegaByte + 1) * MegaByte
 	}
 	if size == 0 {
-		size = t.imageType.defaultSize
+		size = t.defaultSize
 	}
 	return size
 }
 
-func (t *fedora32ImageType) BasePackages() ([]string, []string) {
-	packages := t.imageType.packages
-	if t.imageType.bootable {
+func (t *imageType) BasePackages() ([]string, []string) {
+	packages := t.packages
+	if t.bootable {
 		packages = append(packages, t.arch.bootloaderPackages...)
 	}
 
-	return packages, t.imageType.excludedPackages
+	return packages, t.excludedPackages
 }
 
-func (t *fedora32ImageType) BuildPackages() []string {
+func (t *imageType) BuildPackages() []string {
 	return append(t.arch.distro.buildPackages, t.arch.buildPackages...)
 }
 
-func (t *fedora32ImageType) Manifest(c *blueprint.Customizations,
+func (t *imageType) Manifest(c *blueprint.Customizations,
 	repos []rpmmd.RepoConfig,
 	packageSpecs,
 	buildPackageSpecs []rpmmd.PackageSpec,
@@ -478,7 +470,7 @@ func sources(packages []rpmmd.PackageSpec) *osbuild.Sources {
 	}
 }
 
-func (t *fedora32ImageType) pipeline(c *blueprint.Customizations, repos []rpmmd.RepoConfig, packageSpecs, buildPackageSpecs []rpmmd.PackageSpec, size uint64) (*osbuild.Pipeline, error) {
+func (t *imageType) pipeline(c *blueprint.Customizations, repos []rpmmd.RepoConfig, packageSpecs, buildPackageSpecs []rpmmd.PackageSpec, size uint64) (*osbuild.Pipeline, error) {
 	p := &osbuild.Pipeline{}
 	p.SetBuild(t.buildPipeline(repos, *t.arch, buildPackageSpecs), "org.osbuild.fedora32")
 
@@ -525,13 +517,13 @@ func (t *fedora32ImageType) pipeline(c *blueprint.Customizations, repos []rpmmd.
 		p.AddStage(osbuild.NewGroupsStage(t.groupStageOptions(groups)))
 	}
 
-	if t.imageType.bootable {
+	if t.bootable {
 		p.AddStage(osbuild.NewFSTabStage(t.fsTabStageOptions(t.arch.uefi)))
 	}
-	p.AddStage(osbuild.NewGRUB2Stage(t.grub2StageOptions(t.imageType.kernelOptions, c.GetKernel(), t.arch.uefi)))
+	p.AddStage(osbuild.NewGRUB2Stage(t.grub2StageOptions(t.kernelOptions, c.GetKernel(), t.arch.uefi)))
 
-	if services := c.GetServices(); services != nil || t.imageType.enabledServices != nil {
-		p.AddStage(osbuild.NewSystemdStage(t.systemdStageOptions(t.imageType.enabledServices, t.imageType.disabledServices, services)))
+	if services := c.GetServices(); services != nil || t.enabledServices != nil {
+		p.AddStage(osbuild.NewSystemdStage(t.systemdStageOptions(t.enabledServices, t.disabledServices, services)))
 	}
 
 	if firewall := c.GetFirewall(); firewall != nil {
@@ -540,18 +532,18 @@ func (t *fedora32ImageType) pipeline(c *blueprint.Customizations, repos []rpmmd.
 
 	p.AddStage(osbuild.NewSELinuxStage(t.selinuxStageOptions()))
 
-	p.Assembler = t.imageType.assembler(t.arch.uefi, size)
+	p.Assembler = t.assembler(t.arch.uefi, size)
 
 	return p, nil
 }
 
-func (r *fedora32ImageType) buildPipeline(repos []rpmmd.RepoConfig, arch arch, buildPackageSpecs []rpmmd.PackageSpec) *osbuild.Pipeline {
+func (r *imageType) buildPipeline(repos []rpmmd.RepoConfig, arch arch, buildPackageSpecs []rpmmd.PackageSpec) *osbuild.Pipeline {
 	p := &osbuild.Pipeline{}
 	p.AddStage(osbuild.NewRPMStage(r.rpmStageOptions(arch, repos, buildPackageSpecs)))
 	return p
 }
 
-func (r *fedora32ImageType) rpmStageOptions(arch arch, repos []rpmmd.RepoConfig, specs []rpmmd.PackageSpec) *osbuild.RPMStageOptions {
+func (r *imageType) rpmStageOptions(arch arch, repos []rpmmd.RepoConfig, specs []rpmmd.PackageSpec) *osbuild.RPMStageOptions {
 	var gpgKeys []string
 	for _, repo := range repos {
 		if repo.GPGKey == "" {
@@ -571,7 +563,7 @@ func (r *fedora32ImageType) rpmStageOptions(arch arch, repos []rpmmd.RepoConfig,
 	}
 }
 
-func (r *fedora32ImageType) userStageOptions(users []blueprint.UserCustomization) (*osbuild.UsersStageOptions, error) {
+func (r *imageType) userStageOptions(users []blueprint.UserCustomization) (*osbuild.UsersStageOptions, error) {
 	options := osbuild.UsersStageOptions{
 		Users: make(map[string]osbuild.UsersStageOptionsUser),
 	}
@@ -611,7 +603,7 @@ func (r *fedora32ImageType) userStageOptions(users []blueprint.UserCustomization
 	return &options, nil
 }
 
-func (r *fedora32ImageType) groupStageOptions(groups []blueprint.GroupCustomization) *osbuild.GroupsStageOptions {
+func (r *imageType) groupStageOptions(groups []blueprint.GroupCustomization) *osbuild.GroupsStageOptions {
 	options := osbuild.GroupsStageOptions{
 		Groups: map[string]osbuild.GroupsStageOptionsGroup{},
 	}
@@ -631,7 +623,7 @@ func (r *fedora32ImageType) groupStageOptions(groups []blueprint.GroupCustomizat
 	return &options
 }
 
-func (r *fedora32ImageType) firewallStageOptions(firewall *blueprint.FirewallCustomization) *osbuild.FirewallStageOptions {
+func (r *imageType) firewallStageOptions(firewall *blueprint.FirewallCustomization) *osbuild.FirewallStageOptions {
 	options := osbuild.FirewallStageOptions{
 		Ports: firewall.Ports,
 	}
@@ -644,7 +636,7 @@ func (r *fedora32ImageType) firewallStageOptions(firewall *blueprint.FirewallCus
 	return &options
 }
 
-func (r *fedora32ImageType) systemdStageOptions(enabledServices, disabledServices []string, s *blueprint.ServicesCustomization) *osbuild.SystemdStageOptions {
+func (r *imageType) systemdStageOptions(enabledServices, disabledServices []string, s *blueprint.ServicesCustomization) *osbuild.SystemdStageOptions {
 	if s != nil {
 		enabledServices = append(enabledServices, s.Enabled...)
 		disabledServices = append(disabledServices, s.Disabled...)
@@ -655,7 +647,7 @@ func (r *fedora32ImageType) systemdStageOptions(enabledServices, disabledService
 	}
 }
 
-func (r *fedora32ImageType) fsTabStageOptions(uefi bool) *osbuild.FSTabStageOptions {
+func (r *imageType) fsTabStageOptions(uefi bool) *osbuild.FSTabStageOptions {
 	options := osbuild.FSTabStageOptions{}
 	options.AddFilesystem("76a22bf4-f153-4541-b6c7-0332c0dfaeac", "ext4", "/", "defaults", 1, 1)
 	if uefi {
@@ -664,7 +656,7 @@ func (r *fedora32ImageType) fsTabStageOptions(uefi bool) *osbuild.FSTabStageOpti
 	return &options
 }
 
-func (r *fedora32ImageType) grub2StageOptions(kernelOptions string, kernel *blueprint.KernelCustomization, uefi bool) *osbuild.GRUB2StageOptions {
+func (r *imageType) grub2StageOptions(kernelOptions string, kernel *blueprint.KernelCustomization, uefi bool) *osbuild.GRUB2StageOptions {
 	id := uuid.MustParse("76a22bf4-f153-4541-b6c7-0332c0dfaeac")
 
 	if kernel != nil {
@@ -686,7 +678,7 @@ func (r *fedora32ImageType) grub2StageOptions(kernelOptions string, kernel *blue
 	}
 }
 
-func (r *fedora32ImageType) selinuxStageOptions() *osbuild.SELinuxStageOptions {
+func (r *imageType) selinuxStageOptions() *osbuild.SELinuxStageOptions {
 	return &osbuild.SELinuxStageOptions{
 		FileContexts: "etc/selinux/targeted/contexts/files/file_contexts",
 	}

--- a/internal/distro/fedora32/distro.go
+++ b/internal/distro/fedora32/distro.go
@@ -411,13 +411,6 @@ func (r *Fedora32) ModulePlatformID() string {
 	return modulePlatformID
 }
 
-func (r *Fedora32) FilenameFromType(outputFormat string) (string, string, error) {
-	if output, exists := r.imageTypes[outputFormat]; exists {
-		return output.name, output.mimeType, nil
-	}
-	return "", "", errors.New("invalid output format: " + outputFormat)
-}
-
 func sources(packages []rpmmd.PackageSpec) *osbuild.Sources {
 	files := &osbuild.FilesSource{
 		URLs: make(map[string]string),

--- a/internal/distro/fedora32/distro_test.go
+++ b/internal/distro/fedora32/distro_test.go
@@ -2,6 +2,7 @@ package fedora32_test
 
 import (
 	"github.com/osbuild/osbuild-composer/internal/distro/fedora32"
+	"reflect"
 	"testing"
 )
 
@@ -90,5 +91,49 @@ func TestFilenameFromType(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestImageType_BuildPackages(t *testing.T) {
+	x8664BuildPackages := []string{
+		"dnf",
+		"dosfstools",
+		"e2fsprogs",
+		"grub2-pc",
+		"policycoreutils",
+		"qemu-img",
+		"systemd",
+		"tar",
+		"xz",
+	}
+	aarch64BuildPackages := []string{
+		"dnf",
+		"dosfstools",
+		"e2fsprogs",
+		"policycoreutils",
+		"qemu-img",
+		"systemd",
+		"tar",
+		"xz",
+	}
+	buildPackages := map[string][]string{
+		"x86_64":  x8664BuildPackages,
+		"aarch64": aarch64BuildPackages,
+	}
+	d := fedora32.New()
+	for _, archLabel := range d.ListArchs() {
+		archStruct, err := d.GetArch(archLabel)
+		if err != nil {
+			t.Errorf("d.GetArch(%v) returned err = %v; expected nil", archLabel, err)
+			continue
+		}
+		for _, itLabel := range archStruct.ListImageTypes() {
+			itStruct, err := archStruct.GetImageType(itLabel)
+			if err != nil {
+				t.Errorf("d.GetArch(%v) returned err = %v; expected nil", archLabel, err)
+				continue
+			}
+			reflect.DeepEqual(itStruct.BuildPackages(), buildPackages[archLabel])
+		}
 	}
 }

--- a/internal/distro/fedora32/distro_test.go
+++ b/internal/distro/fedora32/distro_test.go
@@ -1,9 +1,8 @@
 package fedora32_test
 
 import (
-	"testing"
-
 	"github.com/osbuild/osbuild-composer/internal/distro/fedora32"
+	"testing"
 )
 
 func TestFilenameFromType(t *testing.T) {
@@ -73,19 +72,21 @@ func TestFilenameFromType(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			f32 := fedora32.New()
-
-			got, got1, err := f32.FilenameFromType(tt.args.outputFormat)
+			dist := fedora32.New()
+			arch, _ := dist.GetArch("x86_64")
+			imgType, err := arch.GetImageType(tt.args.outputFormat)
 			if (err != nil) != tt.wantErr {
-				t.Errorf("FilenameFromType() error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("Arch.GetImageType() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
 			if !tt.wantErr {
+				got := imgType.Filename()
+				got1 := imgType.MIMEType()
 				if got != tt.want {
-					t.Errorf("FilenameFromType() got = %v, want %v", got, tt.want)
+					t.Errorf("ImageType.Filename()  got = %v, want %v", got, tt.want)
 				}
 				if got1 != tt.want1 {
-					t.Errorf("FilenameFromType() got1 = %v, want %v", got1, tt.want1)
+					t.Errorf("ImageType.MIMEType() got1 = %v, want %v", got1, tt.want1)
 				}
 			}
 		})

--- a/internal/distro/fedoratest/distro.go
+++ b/internal/distro/fedoratest/distro.go
@@ -104,11 +104,3 @@ func (d *FedoraTestDistro) Name() string {
 func (d *FedoraTestDistro) ModulePlatformID() string {
 	return modulePlatformID
 }
-
-func (d *FedoraTestDistro) FilenameFromType(outputFormat string) (string, string, error) {
-	if outputFormat == "qcow2" {
-		return "test.img", "application/x-test", nil
-	} else {
-		return "", "", errors.New("invalid output format: " + outputFormat)
-	}
-}

--- a/internal/distro/rhel81/distro.go
+++ b/internal/distro/rhel81/distro.go
@@ -550,13 +550,6 @@ func (r *RHEL81) ModulePlatformID() string {
 	return modulePlatformID
 }
 
-func (r *RHEL81) FilenameFromType(outputFormat string) (string, string, error) {
-	if output, exists := r.imageTypes[outputFormat]; exists {
-		return output.name, output.mimeType, nil
-	}
-	return "", "", errors.New("invalid output format: " + outputFormat)
-}
-
 func sources(packages []rpmmd.PackageSpec) *osbuild.Sources {
 	files := &osbuild.FilesSource{
 		URLs: make(map[string]string),

--- a/internal/distro/rhel81/distro_test.go
+++ b/internal/distro/rhel81/distro_test.go
@@ -1,9 +1,8 @@
 package rhel81_test
 
 import (
-	"testing"
-
 	"github.com/osbuild/osbuild-composer/internal/distro/rhel81"
+	"testing"
 )
 
 func TestFilenameFromType(t *testing.T) {
@@ -73,18 +72,21 @@ func TestFilenameFromType(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			el81 := rhel81.New()
-			got, got1, err := el81.FilenameFromType(tt.args.outputFormat)
+			dist := rhel81.New()
+			arch, _ := dist.GetArch("x86_64")
+			imgType, err := arch.GetImageType(tt.args.outputFormat)
 			if (err != nil) != tt.wantErr {
-				t.Errorf("FilenameFromType() error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("Arch.GetImageType() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
 			if !tt.wantErr {
+				got := imgType.Filename()
+				got1 := imgType.MIMEType()
 				if got != tt.want {
-					t.Errorf("FilenameFromType() got = %v, want %v", got, tt.want)
+					t.Errorf("ImageType.Filename()  got = %v, want %v", got, tt.want)
 				}
 				if got1 != tt.want1 {
-					t.Errorf("FilenameFromType() got1 = %v, want %v", got1, tt.want1)
+					t.Errorf("ImageType.MIMEType() got1 = %v, want %v", got1, tt.want1)
 				}
 			}
 		})

--- a/internal/distro/rhel82/distro.go
+++ b/internal/distro/rhel82/distro.go
@@ -550,13 +550,6 @@ func (r *RHEL82) ModulePlatformID() string {
 	return modulePlatformID
 }
 
-func (r *RHEL82) FilenameFromType(outputFormat string) (string, string, error) {
-	if output, exists := r.imageTypes[outputFormat]; exists {
-		return output.name, output.mimeType, nil
-	}
-	return "", "", errors.New("invalid output format: " + outputFormat)
-}
-
 func (r *RHEL82) BasePackages(outputFormat string, outputArchitecture string) ([]string, []string, error) {
 	output, exists := r.imageTypes[outputFormat]
 	if !exists {

--- a/internal/distro/rhel82/distro_test.go
+++ b/internal/distro/rhel82/distro_test.go
@@ -73,18 +73,21 @@ func TestFilenameFromType(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			el82 := rhel82.New()
-			got, got1, err := el82.FilenameFromType(tt.args.outputFormat)
+			dist := rhel82.New()
+			arch, _ := dist.GetArch("x86_64")
+			imgType, err := arch.GetImageType(tt.args.outputFormat)
 			if (err != nil) != tt.wantErr {
-				t.Errorf("FilenameFromType() error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("Arch.GetImageType() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
 			if !tt.wantErr {
+				got := imgType.Filename()
+				got1 := imgType.MIMEType()
 				if got != tt.want {
-					t.Errorf("FilenameFromType() got = %v, want %v", got, tt.want)
+					t.Errorf("ImageType.Filename()  got = %v, want %v", got, tt.want)
 				}
 				if got1 != tt.want1 {
-					t.Errorf("FilenameFromType() got1 = %v, want %v", got1, tt.want1)
+					t.Errorf("ImageType.MIMEType() got1 = %v, want %v", got1, tt.want1)
 				}
 			}
 		})

--- a/internal/weldr/api.go
+++ b/internal/weldr/api.go
@@ -1749,16 +1749,18 @@ func (api *API) composeImageHandler(writer http.ResponseWriter, request *http.Re
 
 	imageBuild := compose.ImageBuilds[0]
 	imageType, _ := imageBuild.ImageType.ToCompatString()
-	imageName, imageMime, err := api.distro.FilenameFromType(imageType)
-
+	imageTypeStruct, err := api.arch.GetImageType(imageType)
 	if err != nil {
 		errors := responseError{
-			ID:  "BadCompose",
-			Msg: fmt.Sprintf("Compose %s is ill-formed: output type %v is invalid for distro %s", uuidString, imageBuild.ImageType, api.distro.Name()),
+			ID: "BadCompose",
+			Msg: fmt.Sprintf("Compose %s is ill-formed: output type %v is invalid for distro %s on %s",
+				uuidString, imageBuild.ImageType, api.distro.Name(), api.arch.Name()),
 		}
 		statusResponseError(writer, http.StatusInternalServerError, errors)
 		return
 	}
+	imageName := imageTypeStruct.Filename()
+	imageMime := imageTypeStruct.MIMEType()
 
 	reader, fileSize, err := api.store.GetImageBuildImage(uuid, 0)
 


### PR DESCRIPTION
Certain image types are not supported on certain architectures. For
example VMWare works only on x86_64, so it is not possible nor necessary
to produce vmdk images for any other architecture. The same goes to
cloud-provider specific images, we only support architectures they
support, e.g. AWS: x86_64 and aarch64, but not ppc64le or s390x.

This patch move the imageTypes dictionary to the appropriate place which
is in the architecture specific structure. It also merges the two "arch"
structures because it wasn't clear which one to use for this purpose.
It does the same for the imageType structures.

Only Fedora distros are covered in this PR.