### PR TITLE
osbuild: remove dead code

### DIFF
--- a/internal/blueprint/blueprint_test.go
+++ b/internal/blueprint/blueprint_test.go
@@ -1,9 +1,10 @@
 package blueprint
 
 import (
+	"testing"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"testing"
 )
 
 func TestDeepCopy(t *testing.T) {

--- a/internal/osbuild/locale_stage.go
+++ b/internal/osbuild/locale_stage.go
@@ -10,14 +10,6 @@ type LocaleStageOptions struct {
 
 func (LocaleStageOptions) isStageOptions() {}
 
-// NewLocaleStageOptions creates a new locale stage options object, with
-// the mandatory fields set.
-func NewLocaleStageOptions(language string) *LocaleStageOptions {
-	return &LocaleStageOptions{
-		Language: language,
-	}
-}
-
 // NewLocaleStage creates a new Locale Stage object.
 func NewLocaleStage(options *LocaleStageOptions) *Stage {
 	return &Stage{

--- a/internal/osbuild/tar_assembler.go
+++ b/internal/osbuild/tar_assembler.go
@@ -12,25 +12,10 @@ type TarAssemblerOptions struct {
 
 func (TarAssemblerOptions) isAssemblerOptions() {}
 
-// NewTarAssemblerOptions creates a new TarAssemblerOptions object, with the
-// mandatory options set.
-func NewTarAssemblerOptions(filename string, size uint64) *TarAssemblerOptions {
-	return &TarAssemblerOptions{
-		Filename: filename,
-		Size:     size,
-	}
-}
-
 // NewTarAssembler creates a new Tar Assembler object.
 func NewTarAssembler(options *TarAssemblerOptions) *Assembler {
 	return &Assembler{
 		Name:    "org.osbuild.tar",
 		Options: options,
 	}
-}
-
-// SetCompression sets the compression type for a given TarAssemblerOptions
-// object.
-func (options *TarAssemblerOptions) SetCompression(compression string) {
-	options.Compression = compression
 }


### PR DESCRIPTION
The helper functions were never used, we should aim to use the
osbuild types just as regular structs for serialization purposes.

Signed-off-by: Tom Gundersen <teg@jklm.no>