### PR TITLE
tests/image: test ami images on AWS

### DIFF
--- a/cmd/osbuild-image-tests/aws.go
+++ b/cmd/osbuild-image-tests/aws.go
@@ -1,0 +1,281 @@
+// +build integration
+
+package main
+
+import (
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"os"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/osbuild/osbuild-composer/internal/upload/awsupload"
+)
+
+type awsCredentials struct {
+	AccessKeyId     string
+	SecretAccessKey string
+	Region          string
+	Bucket          string
+}
+
+// getAWSCredentialsFromEnv gets the credentials from environment variables
+// If none of the environment variables is set, it returns nil.
+// If some but not all environment variables are set, it returns an error.
+func getAWSCredentialsFromEnv() (*awsCredentials, error) {
+	accessKeyId, akExists := os.LookupEnv("AWS_ACCESS_KEY_ID")
+	secretAccessKey, sakExists := os.LookupEnv("AWS_SECRET_ACCESS_KEY")
+	region, regionExists := os.LookupEnv("AWS_REGION")
+	bucket, bucketExists := os.LookupEnv("AWS_BUCKET")
+
+	// Workaround Travis security feature. If non of the variables is set, just ignore the test
+	if !akExists && !sakExists && !bucketExists && !regionExists {
+		return nil, nil
+	}
+	// If only one/two of them are not set, then fail
+	if !akExists || !sakExists || !bucketExists || !regionExists {
+		return nil, errors.New("not all required env variables were set")
+	}
+
+	return &awsCredentials{
+		AccessKeyId:     accessKeyId,
+		SecretAccessKey: secretAccessKey,
+		Region:          region,
+		Bucket:          bucket,
+	}, nil
+}
+
+// encodeBase64 encodes string to base64-encoded string
+func encodeBase64(input string) string {
+	return base64.StdEncoding.EncodeToString([]byte(input))
+}
+
+// createUserData creates cloud-init's user-data that contains user redhat with
+// the specified public key
+func createUserData(publicKeyFile string) (string, error) {
+	publicKey, err := ioutil.ReadFile(publicKeyFile)
+	if err != nil {
+		return "", fmt.Errorf("cannot read the public key: %#v", err)
+	}
+
+	userData := fmt.Sprintf(`#cloud-config
+user: redhat
+ssh_authorized_keys:
+  - %s
+`, string(publicKey))
+
+	return userData, nil
+}
+
+// wrapErrorf returns error constructed using fmt.Errorf from format and any
+// other args. If innerError != nil, it's appended at the end of the new
+// error.
+func wrapErrorf(innerError error, format string, a ...interface{}) error {
+	if innerError != nil {
+		a = append(a, innerError)
+		return fmt.Errorf(format+"\n\ninner error: %#s", a...)
+	}
+
+	return fmt.Errorf(format, a...)
+}
+
+// uploadImageToAWS mimics the upload feature of osbuild-composer.
+// It takes an image and an image name and creates an ec2 instance from them.
+// The s3 key is never returned - the same thing is done in osbuild-composer,
+// the user has no way of getting the s3 key.
+func uploadImageToAWS(c *awsCredentials, imagePath string, imageName string) error {
+	uploader, err := awsupload.New(c.Region, c.AccessKeyId, c.SecretAccessKey)
+	if err != nil {
+		return fmt.Errorf("cannot create aws uploader: %#v", err)
+	}
+
+	_, err = uploader.Upload(imagePath, c.Bucket, imageName)
+	if err != nil {
+		return fmt.Errorf("cannot upload the image: %#v", err)
+	}
+	_, err = uploader.Register(imageName, c.Bucket, imageName)
+	if err != nil {
+		return fmt.Errorf("cannot register the image: %#v", err)
+	}
+
+	return nil
+}
+
+// newEC2 creates EC2 struct from given credentials
+func newEC2(c *awsCredentials) (*ec2.EC2, error) {
+	creds := credentials.NewStaticCredentials(c.AccessKeyId, c.SecretAccessKey, "")
+	sess, err := session.NewSession(&aws.Config{
+		Credentials: creds,
+		Region:      aws.String(c.Region),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("cannot create aws session: %#v", err)
+	}
+
+	return ec2.New(sess), nil
+}
+
+type imageDescription struct {
+	Id         *string
+	SnapshotId *string
+	// this doesn't support multiple snapshots per one image,
+	// because this feature is not supported in composer
+}
+
+// describeEC2Image searches for EC2 image by its name and returns
+// its id and snapshot id
+func describeEC2Image(e *ec2.EC2, imageName string) (*imageDescription, error) {
+	imageDescriptions, err := e.DescribeImages(&ec2.DescribeImagesInput{
+		Filters: []*ec2.Filter{
+			{
+				Name: aws.String("name"),
+				Values: []*string{
+					aws.String(imageName),
+				},
+			},
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("cannot describe the image: %#v", err)
+	}
+	imageId := imageDescriptions.Images[0].ImageId
+	snapshotId := imageDescriptions.Images[0].BlockDeviceMappings[0].Ebs.SnapshotId
+
+	return &imageDescription{
+		Id:         imageId,
+		SnapshotId: snapshotId,
+	}, nil
+}
+
+// deleteEC2Image deletes the specified image and its associated snapshot
+func deleteEC2Image(e *ec2.EC2, imageDesc *imageDescription) error {
+	var retErr error
+
+	// firstly, deregister the image
+	_, err := e.DeregisterImage(&ec2.DeregisterImageInput{
+		ImageId: imageDesc.Id,
+	})
+
+	if err != nil {
+		retErr = wrapErrorf(retErr, "cannot deregister the image: %#v", err)
+	}
+
+	// now it's possible to delete the snapshot
+	_, err = e.DeleteSnapshot(&ec2.DeleteSnapshotInput{
+		SnapshotId: imageDesc.SnapshotId,
+	})
+
+	if err != nil {
+		retErr = wrapErrorf(retErr, "cannot delete the snapshot: %#v", err)
+	}
+
+	return retErr
+}
+
+// withBootedImageInEC2 runs the function f in the context of booted
+// image in AWS EC2
+func withBootedImageInEC2(e *ec2.EC2, imageDesc *imageDescription, publicKey string, f func(address string) error) (retErr error) {
+	// generate user data with given public key
+	userData, err := createUserData(publicKey)
+	if err != nil {
+		return err
+	}
+
+	// Security group must be now generated, because by default
+	// all traffic to EC2 instance is filtered.
+
+	securityGroupName, err := generateRandomString("osbuild-image-tests-security-group-")
+	if err != nil {
+		return fmt.Errorf("cannot generate a random name for the image: %#v", err)
+	}
+
+	// Firstly create a security group
+	securityGroup, err := e.CreateSecurityGroup(&ec2.CreateSecurityGroupInput{
+		GroupName:   aws.String(securityGroupName),
+		Description: aws.String("image-tests-security-group"),
+	})
+	if err != nil {
+		return fmt.Errorf("cannot create a new security group: %#v", err)
+	}
+
+	defer func() {
+		_, err = e.DeleteSecurityGroup(&ec2.DeleteSecurityGroupInput{
+			GroupId: securityGroup.GroupId,
+		})
+
+		if err != nil {
+			retErr = wrapErrorf(retErr, "cannot delete the security group: %#v", err)
+		}
+	}()
+
+	// Authorize incoming SSH connections.
+	_, err = e.AuthorizeSecurityGroupIngress(&ec2.AuthorizeSecurityGroupIngressInput{
+		CidrIp:     aws.String("0.0.0.0/0"),
+		GroupId:    securityGroup.GroupId,
+		FromPort:   aws.Int64(22),
+		ToPort:     aws.Int64(22),
+		IpProtocol: aws.String("tcp"),
+	})
+	if err != nil {
+		return fmt.Errorf("canot add a rule to the security group: %#v", err)
+	}
+
+	// Finally, run the instance from the given image and with the created security group
+	res, err := e.RunInstances(&ec2.RunInstancesInput{
+		MaxCount:         aws.Int64(1),
+		MinCount:         aws.Int64(1),
+		ImageId:          imageDesc.Id,
+		InstanceType:     aws.String("t3.micro"),
+		SecurityGroupIds: []*string{securityGroup.GroupId},
+		UserData:         aws.String(encodeBase64(userData)),
+	})
+	if err != nil {
+		return fmt.Errorf("cannot create a new instance: %#v", err)
+	}
+
+	describeInstanceInput := &ec2.DescribeInstancesInput{
+		InstanceIds: []*string{
+			res.Instances[0].InstanceId,
+		},
+	}
+
+	defer func() {
+		// We need to terminate the instance now and wait until the termination is done.
+		// Otherwise, it wouldn't be possible to delete the image.
+		_, err = e.TerminateInstances(&ec2.TerminateInstancesInput{
+			InstanceIds: []*string{
+				res.Instances[0].InstanceId,
+			},
+		})
+		if err != nil {
+			retErr = wrapErrorf(retErr, "cannot terminate the instance: %#v", err)
+			return
+		}
+
+		err = e.WaitUntilInstanceTerminated(describeInstanceInput)
+		if err != nil {
+			retErr = wrapErrorf(retErr, "waiting for the instance termination failed: %#v", err)
+		}
+	}()
+
+	// The instance has no IP address yet. It's assigned when the instance
+	// is in the state "EXISTS". However, in this state the instance is not
+	// much usable, therefore wait until "RUNNING" state, in which the instance
+	// actually can do something useful for us.
+	err = e.WaitUntilInstanceRunning(describeInstanceInput)
+	if err != nil {
+		return fmt.Errorf("waiting for the instance to be running failed: %#v", err)
+	}
+
+	// By describing the instance, we can get the ip address.
+	out, err := e.DescribeInstances(describeInstanceInput)
+	if err != nil {
+		return fmt.Errorf("cannot describe the instance: %#v", err)
+	}
+
+	return f(*out.Reservations[0].Instances[0].PublicIpAddress)
+}

--- a/cmd/osbuild-image-tests/constants-travis.go
+++ b/cmd/osbuild-image-tests/constants-travis.go
@@ -17,8 +17,16 @@ func getOsbuildCommand(store string) *exec.Cmd {
 	return cmd
 }
 
-var imageInfoPath = "tools/image-info"
-var privateKeyPath = "test/keyring/id_rsa"
-var testCasesDirectoryPath = "test/cases"
-var userDataPath = "test/cloud-init/user-data"
-var metaDataPath = "test/cloud-init/meta-data"
+var testPaths = struct {
+	imageInfo          string
+	privateKey         string
+	testCasesDirectory string
+	userData           string
+	metaData           string
+}{
+	imageInfo:          "tools/image-info",
+	privateKey:         "test/keyring/id_rsa",
+	testCasesDirectory: "test/cases",
+	userData:           "test/cloud-init/user-data",
+	metaData:           "test/cloud-init/meta-data",
+}

--- a/cmd/osbuild-image-tests/constants.go
+++ b/cmd/osbuild-image-tests/constants.go
@@ -13,8 +13,16 @@ func getOsbuildCommand(store string) *exec.Cmd {
 	)
 }
 
-var imageInfoPath = "/usr/libexec/osbuild-composer/image-info"
-var privateKeyPath = "/usr/share/tests/osbuild-composer/keyring/id_rsa"
-var testCasesDirectoryPath = "/usr/share/tests/osbuild-composer/cases"
-var userDataPath = "/usr/share/tests/osbuild-composer/cloud-init/user-data"
-var metaDataPath = "/usr/share/tests/osbuild-composer/cloud-init/meta-data"
+var testPaths = struct {
+	imageInfo          string
+	privateKey         string
+	testCasesDirectory string
+	userData           string
+	metaData           string
+}{
+	imageInfo:          "/usr/libexec/osbuild-composer/image-info",
+	privateKey:         "/usr/share/tests/osbuild-composer/keyring/id_rsa",
+	testCasesDirectory: "/usr/share/tests/osbuild-composer/cases",
+	userData:           "/usr/share/tests/osbuild-composer/cloud-init/user-data",
+	metaData:           "/usr/share/tests/osbuild-composer/cloud-init/meta-data",
+}

--- a/cmd/osbuild-image-tests/context-managers.go
+++ b/cmd/osbuild-image-tests/context-managers.go
@@ -94,8 +94,8 @@ func withBootedQemuImage(image string, ns netNS, f func() error) error {
 	return withTempFile("", "osbuild-image-tests-cloudinit", func(cloudInitFile *os.File) error {
 		err := writeCloudInitISO(
 			cloudInitFile,
-			userDataPath,
-			metaDataPath,
+			testPaths.userData,
+			testPaths.metaData,
 		)
 		if err != nil {
 			return err

--- a/cmd/osbuild-image-tests/context-managers.go
+++ b/cmd/osbuild-image-tests/context-managers.go
@@ -206,3 +206,24 @@ func withExtractedTarArchive(archive string, f func(dir string) error) error {
 		return f(dir)
 	})
 }
+
+// withSSHKeyPair runs the function f with a newly generated
+// ssh key-pair, they key-pair is deleted immediately after
+// the function f returns
+func withSSHKeyPair(f func(privateKey, publicKey string) error) error {
+	return withTempDir("", "keys", func(dir string) error {
+		privateKey := dir + "/id_rsa"
+		publicKey := dir + "/id_rsa.pub"
+		cmd := exec.Command("ssh-keygen",
+			"-N", "",
+			"-f", privateKey,
+		)
+
+		err := cmd.Run()
+		if err != nil {
+			return fmt.Errorf("ssh-keygen failed: %#v", err)
+		}
+
+		return f(privateKey, publicKey)
+	})
+}

--- a/cmd/osbuild-image-tests/helpers.go
+++ b/cmd/osbuild-image-tests/helpers.go
@@ -7,6 +7,8 @@ import (
 	"os"
 	"syscall"
 	"time"
+
+	"github.com/google/uuid"
 )
 
 // durationMin returns the smaller of two given durations
@@ -49,4 +51,15 @@ func killProcessCleanly(process *os.Process, timeout time.Duration) error {
 	}
 
 	return process.Kill()
+}
+
+// generateRandomString generates a new random string with specified prefix.
+// The random part is based on UUID.
+func generateRandomString(prefix string) (string, error) {
+	id, err := uuid.NewRandom()
+	if err != nil {
+		return "", err
+	}
+
+	return prefix + id.String(), nil
 }

--- a/cmd/osbuild-image-tests/main_test.go
+++ b/cmd/osbuild-image-tests/main_test.go
@@ -125,7 +125,7 @@ func (*timeoutError) Error() string { return "" }
 // that 10 seconds or if systemd-is-running returns starting.
 // It returns nil if systemd-is-running returns running or degraded.
 // It can also return other errors in other error cases.
-func trySSHOnce(ns *netNS) error {
+func trySSHOnce(address string, ns *netNS) error {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
@@ -135,7 +135,7 @@ func trySSHOnce(ns *netNS) error {
 		"-i", privateKeyPath,
 		"-o", "StrictHostKeyChecking=no",
 		"-o", "UserKnownHostsFile=/dev/null",
-		"redhat@localhost",
+		"redhat@" + address,
 		"systemctl --wait is-system-running",
 	}
 
@@ -180,10 +180,10 @@ func trySSHOnce(ns *netNS) error {
 // testSSH tests the running image using ssh.
 // It tries 20 attempts before giving up. If a major error occurs, it might
 // return earlier.
-func testSSH(t *testing.T, ns *netNS) {
+func testSSH(t *testing.T, address string, ns *netNS) {
 	const attempts = 20
 	for i := 0; i < attempts; i++ {
-		err := trySSHOnce(ns)
+		err := trySSHOnce(address, ns)
 		if err == nil {
 			// pass the test
 			return
@@ -212,18 +212,18 @@ func testBoot(t *testing.T, imagePath string, bootType string, outputID string) 
 			fallthrough
 		case "qemu-extract":
 			return withBootedQemuImage(imagePath, ns, func() error {
-				testSSH(t, &ns)
+				testSSH(t, "localhost", &ns)
 				return nil
 			})
 		case "nspawn":
 			return withBootedNspawnImage(imagePath, outputID, ns, func() error {
-				testSSH(t, &ns)
+				testSSH(t, "localhost", &ns)
 				return nil
 			})
 		case "nspawn-extract":
 			return withExtractedTarArchive(imagePath, func(dir string) error {
 				return withBootedNspawnDirectory(dir, outputID, ns, func() error {
-					testSSH(t, &ns)
+					testSSH(t, "localhost", &ns)
 					return nil
 				})
 			})

--- a/cmd/osbuild-image-tests/main_test.go
+++ b/cmd/osbuild-image-tests/main_test.go
@@ -96,7 +96,7 @@ func splitExtension(path string) (string, string) {
 func testImageInfo(t *testing.T, imagePath string, rawImageInfoExpected []byte) {
 	var imageInfoExpected interface{}
 	err := json.Unmarshal(rawImageInfoExpected, &imageInfoExpected)
-	require.Nilf(t, err, "cannot decode expected image info: %#v", err)
+	require.NoErrorf(t, err, "cannot decode expected image info: %#v", err)
 
 	cmd := exec.Command(imageInfoPath, imagePath)
 	cmd.Stderr = os.Stderr
@@ -104,14 +104,14 @@ func testImageInfo(t *testing.T, imagePath string, rawImageInfoExpected []byte) 
 	cmd.Stdout = writer
 
 	err = cmd.Start()
-	require.Nilf(t, err, "image-info cannot start: %#v", err)
+	require.NoErrorf(t, err, "image-info cannot start: %#v", err)
 
 	var imageInfoGot interface{}
 	err = json.NewDecoder(reader).Decode(&imageInfoGot)
-	require.Nilf(t, err, "decoding image-info output failed: %#v", err)
+	require.NoErrorf(t, err, "decoding image-info output failed: %#v", err)
 
 	err = cmd.Wait()
-	require.Nilf(t, err, "running image-info failed: %#v", err)
+	require.NoErrorf(t, err, "running image-info failed: %#v", err)
 
 	assert.Equal(t, imageInfoExpected, imageInfoGot)
 }
@@ -223,7 +223,7 @@ func testBoot(t *testing.T, imagePath string, bootType string, outputID string) 
 		}
 	})
 
-	require.Nil(t, err)
+	require.NoError(t, err)
 }
 
 // testImage performs a series of tests specified in the testcase
@@ -246,7 +246,7 @@ func testImage(t *testing.T, testcase testcaseStruct, imagePath, outputID string
 // tests the result
 func runTestcase(t *testing.T, testcase testcaseStruct) {
 	store, err := ioutil.TempDir("/var/tmp", "osbuild-image-tests-")
-	require.Nilf(t, err, "cannot create temporary store: %#v", err)
+	require.NoErrorf(t, err, "cannot create temporary store: %#v", err)
 
 	defer func() {
 		err := os.RemoveAll(store)
@@ -256,7 +256,7 @@ func runTestcase(t *testing.T, testcase testcaseStruct) {
 	}()
 
 	outputID, err := runOsbuild(testcase.Manifest, store)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	imagePath := fmt.Sprintf("%s/refs/%s/%s", store, outputID, testcase.ComposeRequest.Filename)
 
@@ -266,7 +266,7 @@ func runTestcase(t *testing.T, testcase testcaseStruct) {
 		_, ex = splitExtension(base)
 		if ex != ".tar" {
 			err := extractXZ(imagePath)
-			require.Nil(t, err)
+			require.NoError(t, err)
 			imagePath = base
 		}
 	}
@@ -299,11 +299,11 @@ func runTests(t *testing.T, cases []string) {
 	for _, path := range cases {
 		t.Run(path, func(t *testing.T) {
 			f, err := os.Open(path)
-			require.Nilf(t, err, "%s: cannot open test case: %#v", path, err)
+			require.NoErrorf(t, err, "%s: cannot open test case: %#v", path, err)
 
 			var testcase testcaseStruct
 			err = json.NewDecoder(f).Decode(&testcase)
-			require.Nilf(t, err, "%s: cannot decode test case: %#v", path, err)
+			require.NoErrorf(t, err, "%s: cannot decode test case: %#v", path, err)
 
 			currentArch := common.CurrentArch()
 			if testcase.ComposeRequest.Arch != currentArch {
@@ -322,7 +322,7 @@ func TestImages(t *testing.T) {
 	if len(cases) == 0 {
 		var err error
 		cases, err = getAllCases()
-		require.Nil(t, err)
+		require.NoError(t, err)
 	}
 
 	runTests(t, cases)

--- a/cmd/osbuild-image-tests/main_test.go
+++ b/cmd/osbuild-image-tests/main_test.go
@@ -50,7 +50,9 @@ func runOsbuild(manifest []byte, store string) (string, error) {
 
 	if err != nil {
 		if _, ok := err.(*exec.ExitError); ok {
-			return "", fmt.Errorf("running osbuild failed: %s", outBuffer.String())
+			var formattedOutput bytes.Buffer
+			_ = json.Indent(&formattedOutput, outBuffer.Bytes(), "", "  ")
+			return "", fmt.Errorf("running osbuild failed: %s", formattedOutput.String())
 		}
 		return "", fmt.Errorf("running osbuild failed from an unexpected reason: %#v", err)
 	}

--- a/cmd/osbuild-image-tests/main_test.go
+++ b/cmd/osbuild-image-tests/main_test.go
@@ -98,7 +98,7 @@ func testImageInfo(t *testing.T, imagePath string, rawImageInfoExpected []byte) 
 	err := json.Unmarshal(rawImageInfoExpected, &imageInfoExpected)
 	require.NoErrorf(t, err, "cannot decode expected image info: %#v", err)
 
-	cmd := exec.Command(imageInfoPath, imagePath)
+	cmd := exec.Command(testPaths.imageInfo, imagePath)
 	cmd.Stderr = os.Stderr
 	reader, writer := io.Pipe()
 	cmd.Stdout = writer
@@ -212,7 +212,7 @@ func testBoot(t *testing.T, imagePath string, bootType string, outputID string) 
 	case "qemu-extract":
 		err := withNetworkNamespace(func(ns netNS) error {
 			return withBootedQemuImage(imagePath, ns, func() error {
-				testSSH(t, "localhost", privateKeyPath, &ns)
+				testSSH(t, "localhost", testPaths.privateKey, &ns)
 				return nil
 			})
 		})
@@ -221,7 +221,7 @@ func testBoot(t *testing.T, imagePath string, bootType string, outputID string) 
 	case "nspawn":
 		err := withNetworkNamespace(func(ns netNS) error {
 			return withBootedNspawnImage(imagePath, outputID, ns, func() error {
-				testSSH(t, "localhost", privateKeyPath, &ns)
+				testSSH(t, "localhost", testPaths.privateKey, &ns)
 				return nil
 			})
 		})
@@ -231,7 +231,7 @@ func testBoot(t *testing.T, imagePath string, bootType string, outputID string) 
 		err := withNetworkNamespace(func(ns netNS) error {
 			return withExtractedTarArchive(imagePath, func(dir string) error {
 				return withBootedNspawnDirectory(dir, outputID, ns, func() error {
-					testSSH(t, "localhost", privateKeyPath, &ns)
+					testSSH(t, "localhost", testPaths.privateKey, &ns)
 					return nil
 				})
 			})
@@ -293,7 +293,7 @@ func runTestcase(t *testing.T, testcase testcaseStruct) {
 
 // getAllCases returns paths to all testcases in the testcase directory
 func getAllCases() ([]string, error) {
-	cases, err := ioutil.ReadDir(testCasesDirectoryPath)
+	cases, err := ioutil.ReadDir(testPaths.testCasesDirectory)
 	if err != nil {
 		return nil, fmt.Errorf("cannot list test cases: %#v", err)
 	}
@@ -304,7 +304,7 @@ func getAllCases() ([]string, error) {
 			continue
 		}
 
-		casePath := fmt.Sprintf("%s/%s", testCasesDirectoryPath, c.Name())
+		casePath := fmt.Sprintf("%s/%s", testPaths.testCasesDirectory, c.Name())
 		casesPaths = append(casesPaths, casePath)
 	}
 

--- a/test/cases/f30-x86_64-ami-boot.json
+++ b/test/cases/f30-x86_64-ami-boot.json
@@ -1,6 +1,6 @@
 {
   "boot": {
-    "type": "qemu-extract"
+    "type": "aws"
   },
   "compose-request": {
     "distro": "fedora-30",

--- a/test/cases/f31-x86_64-ami-boot.json
+++ b/test/cases/f31-x86_64-ami-boot.json
@@ -1,6 +1,6 @@
 {
   "boot": {
-    "type": "qemu-extract"
+    "type": "aws"
   },
   "compose-request": {
     "distro": "fedora-31",

--- a/tools/test-case-generators/format-request-map.json
+++ b/tools/test-case-generators/format-request-map.json
@@ -1,7 +1,7 @@
 {
   "ami": {
     "boot": {
-      "type": "qemu-extract"
+      "type": "aws"
     },
     "compose-request": {
       "distro": "",


### PR DESCRIPTION
Blocked by #460, without this, the s3 objects won't be deleted.

This PR adds a lot of small cleanups to the image tests and the support for testing the ami images on the actual AWS. The AWS tests won't be run if secrets are not set as environment variables, qemu is used as a fallback in this case.

It should be fairly simple to switch the aws upload to be done by osbuild-composer when we decide to use it in the image tests.

To answer @atodorov 's question, in the end, I decided to use a freshly generated key-pair for each AWS upload. I think it's definitely better for security purposes. I understand that we may have a use-case for debugging the running instance and this will make it hard, but I feel this should be done as a follow-up when we know how do we want to implement this.

I decided to use cloud-init's userData to insert the public key. We could also use the EC2 key-pairs, but that would require a bit more setup and teardown. Both methods use cloud-init in the end, so I don't think there's a big difference in these two variants and thus I prefer the simpler one.

The tests are designed to be self-contained - nothing apart from valid credentials and correctly set `vmimport` role is required.

Closes #337