### PR TITLE
distro: rename ListArchs to ListArches

### DIFF
--- a/cmd/osbuild-dnf-json-tests/main_test.go
+++ b/cmd/osbuild-dnf-json-tests/main_test.go
@@ -61,7 +61,7 @@ func TestCrossArchDepsolve(t *testing.T) {
 			// for the remaining distros
 			continue
 		}
-		for _, archStr := range distroStruct.ListArchs() {
+		for _, archStr := range distroStruct.ListArches() {
 			arch, err := distroStruct.GetArch(archStr)
 			assert.Nilf(t, err, "Failed to GetArch from %v structure: %v", distroStruct.Name(), err)
 			if err != nil {

--- a/cmd/osbuild-pipeline/main.go
+++ b/cmd/osbuild-pipeline/main.go
@@ -88,7 +88,7 @@ func main() {
 	arch, err := distro.GetArch(composeRequest.Arch)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "The provided architecture '%s' is not supported by %s. Use one of these:\n", composeRequest.Arch, distro.Name())
-		for _, a := range distro.ListArchs() {
+		for _, a := range distro.ListArches() {
 			_, _ = fmt.Fprintln(os.Stderr, " *", a)
 		}
 		return

--- a/internal/distro/distro.go
+++ b/internal/distro/distro.go
@@ -26,7 +26,7 @@ type Distro interface {
 
 	// Returns a sorted list of the names of the architectures this distro
 	// supports.
-	ListArchs() []string
+	ListArches() []string
 
 	// Returns an object representing the given architecture as support
 	// by this distro.

--- a/internal/distro/fedora30/distro.go
+++ b/internal/distro/fedora30/distro.go
@@ -48,7 +48,7 @@ type imageType struct {
 	assembler        func(uefi bool, size uint64) *osbuild.Assembler
 }
 
-func (d *Fedora30) ListArchs() []string {
+func (d *Fedora30) ListArches() []string {
 	archs := make([]string, 0, len(d.arches))
 	for name := range d.arches {
 		archs = append(archs, name)

--- a/internal/distro/fedora30/distro_test.go
+++ b/internal/distro/fedora30/distro_test.go
@@ -121,7 +121,7 @@ func TestImageType_BuildPackages(t *testing.T) {
 		"aarch64": aarch64BuildPackages,
 	}
 	d := fedora30.New()
-	for _, archLabel := range d.ListArchs() {
+	for _, archLabel := range d.ListArches() {
 		archStruct, err := d.GetArch(archLabel)
 		if err != nil {
 			t.Errorf("d.GetArch(%v) returned err = %v; expected nil", archLabel, err)

--- a/internal/distro/fedora31/distro.go
+++ b/internal/distro/fedora31/distro.go
@@ -47,7 +47,7 @@ type arch struct {
 	imageTypes         map[string]imageType
 }
 
-func (d *Fedora31) ListArchs() []string {
+func (d *Fedora31) ListArches() []string {
 	archs := make([]string, 0, len(d.arches))
 	for name := range d.arches {
 		archs = append(archs, name)

--- a/internal/distro/fedora31/distro_test.go
+++ b/internal/distro/fedora31/distro_test.go
@@ -121,7 +121,7 @@ func TestImageType_BuildPackages(t *testing.T) {
 		"aarch64": aarch64BuildPackages,
 	}
 	d := fedora31.New()
-	for _, archLabel := range d.ListArchs() {
+	for _, archLabel := range d.ListArches() {
 		archStruct, err := d.GetArch(archLabel)
 		if err != nil {
 			t.Errorf("d.GetArch(%v) returned err = %v; expected nil", archLabel, err)

--- a/internal/distro/fedora32/distro.go
+++ b/internal/distro/fedora32/distro.go
@@ -48,7 +48,7 @@ type imageType struct {
 	assembler        func(uefi bool, size uint64) *osbuild.Assembler
 }
 
-func (d *Fedora32) ListArchs() []string {
+func (d *Fedora32) ListArches() []string {
 	archs := make([]string, 0, len(d.arches))
 	for name := range d.arches {
 		archs = append(archs, name)

--- a/internal/distro/fedora32/distro_test.go
+++ b/internal/distro/fedora32/distro_test.go
@@ -121,7 +121,7 @@ func TestImageType_BuildPackages(t *testing.T) {
 		"aarch64": aarch64BuildPackages,
 	}
 	d := fedora32.New()
-	for _, archLabel := range d.ListArchs() {
+	for _, archLabel := range d.ListArches() {
 		archStruct, err := d.GetArch(archLabel)
 		if err != nil {
 			t.Errorf("d.GetArch(%v) returned err = %v; expected nil", archLabel, err)

--- a/internal/distro/fedoratest/distro.go
+++ b/internal/distro/fedoratest/distro.go
@@ -24,7 +24,7 @@ type fedoraTestDistroImageType struct {
 	arch *fedoraTestDistroArch
 }
 
-func (d *FedoraTestDistro) ListArchs() []string {
+func (d *FedoraTestDistro) ListArches() []string {
 	return []string{"x86_64"}
 }
 

--- a/internal/distro/rhel81/distro.go
+++ b/internal/distro/rhel81/distro.go
@@ -57,7 +57,7 @@ type rhel81ImageType struct {
 	imageType *imageType
 }
 
-func (d *RHEL81) ListArchs() []string {
+func (d *RHEL81) ListArches() []string {
 	archs := make([]string, 0, len(d.arches))
 	for name := range d.arches {
 		archs = append(archs, name)

--- a/internal/distro/rhel82/distro.go
+++ b/internal/distro/rhel82/distro.go
@@ -57,7 +57,7 @@ type rhel82ImageType struct {
 	imageType *imageType
 }
 
-func (d *RHEL82) ListArchs() []string {
+func (d *RHEL82) ListArches() []string {
 	archs := make([]string, 0, len(d.arches))
 	for name := range d.arches {
 		archs = append(archs, name)

--- a/internal/distro/test/distro.go
+++ b/internal/distro/test/distro.go
@@ -16,7 +16,7 @@ type testImageType struct{}
 const name = "test-distro"
 const modulePlatformID = "platform:test"
 
-func (d *TestDistro) ListArchs() []string {
+func (d *TestDistro) ListArches() []string {
 	return []string{"test_arch"}
 }
 


### PR DESCRIPTION
In PR#395 we discussed the spelling of archs vs. arches and we agreed to
use arches. This patch only renames the public method `ListArchs`in the
`Distro` interface.