### PR TITLE
.github: switch to codecov.io

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,19 +40,14 @@ jobs:
       - name: Install golangci-lint
         run: curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b $(go env GOPATH)/bin v1.23.7
 
-      - name: Install goveralls
-        run: GO111MODULE=off go get github.com/mattn/goveralls
-
       - name: Run golangci-lint
         run: $(go env GOPATH)/bin/golangci-lint run
 
       - name: Run unit tests
-        run: go test -v -race -covermode atomic -coverprofile=profile.cov ./...
+        run: go test -v -race -covermode atomic -coverprofile=coverage.txt ./...
 
-      - name: Send coverage to coveralls.io
-        env:
-          COVERALLS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: $(go env GOPATH)/bin/goveralls -coverprofile=profile.cov -service=github
+      - name: Send coverage to codecov.io
+        run: bash <(curl -s https://codecov.io/bash)
 
   old_rpm_build:
     name: "📦 RPM (golang-github-osbuild-composer)"

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,3 @@
+codecov:
+  require_ci_to_pass: no
+comment: no

--- a/test/README.md
+++ b/test/README.md
@@ -40,10 +40,10 @@ Stand-alone test binaries also have the `-test.failfast` option.
 ## Notes on code coverage
 
 Code coverage is recorded in
-[Coveralls.io](https://coveralls.io/github/osbuild/osbuild-composer).
+[codecov.io](https://codecov.io/github/osbuild/osbuild-composer).
 This information comes only from unit tests and for the time being
 we're not concerned with collecting coverage information from integration
-tests, see `.github/workflows/coverage.yml`.
+tests, see `.github/workflows/tests.yml`.
 
 
 ## Integration testing


### PR DESCRIPTION
coveralls doesn't work from GitHub actions. Its "github" service type
uses the GITHUB_TOKEN from the action, which only has read access when
invoked from a forked repository.

codecov gets this right: it validates that an uploaded coverage file
originated from a GitHub action run by asking GitHub, and then uses its
OAuth credentials (through the Marketplace App) to comment and set
status.

Also, coveralls requires a third-party package to convert go's coverage
report to a format it understands. codecov detects the format
server-side. It also handles go's coverage format better: it highlights
lines with "some coverage" in yellow (coveralls has no concept of this).