### PR TITLE
store: Fix setting interrupted composes to failed at startup

### DIFF
--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -154,12 +154,12 @@ func New(stateDir *string) *Store {
 			if len(compose.ImageBuilds) == 0 {
 				panic("the was a compose with zero image builds, that is forbidden")
 			}
-			for _, imgBuild := range compose.ImageBuilds {
+			for imgID, imgBuild := range compose.ImageBuilds {
 				switch imgBuild.QueueStatus {
 				case common.IBRunning:
 					// We do not support resuming an in-flight build
-					imgBuild.QueueStatus = common.IBFailed
-					// s.Composes[composeID] = compose
+					compose.ImageBuilds[imgID].QueueStatus = common.IBFailed
+					s.Composes[composeID] = compose
 				case common.IBWaiting:
 					// Push waiting composes back into the pending jobs queue
 					s.pendingJobs <- Job{


### PR DESCRIPTION
If a compose was interrupted by restarting osbuild-composer it should be
set to failed at startup. This was not working because imgBuild is a
temporary variable, the value stored in ImageBuild needs to be modified
directly.