### PR TITLE
Documentation Improvements

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,10 +1,14 @@
 # Contributing to osbuild-composer
 
-First of all, thank you for taking the time to contribute to osbuild-composer. In this document you will find information that can help you with your contribution.
+First of all, thank you for taking the time to contribute to osbuild-composer.
+In this document you will find information that can help you with your
+contribution.
 
 ### Running from sources
 
-We recommend using the latest stable Fedora for development but latest minor release of RHEL/CentOS 8 should work just fine as well. To run osbuild-composer from sources, follow these steps:
+We recommend using the latest stable Fedora for development but latest minor
+release of RHEL/CentOS 8 should work just fine as well. To run osbuild-composer
+from sources, follow these steps:
 
 1. Clone the repository and create a local checkout:
 
@@ -22,7 +26,8 @@ $ sudo dnf -y install cockpit-composer             # Optional: Install cockpit i
 $ sudo systemctl start cockpit.socket              # Optional: Start cockpit
 ```
 
-3. Finally, use the following to compile the project from the working directory, install it, and then run it:
+3. Finally, use the following to compile the project from the working
+directory, install it, and then run it:
 
 ```
 $ make rpm
@@ -30,11 +35,15 @@ $ sudo dnf -y install rpmbuild/RPMS/x86_64/*
 $ sudo systemctl start osbuild-composer.socket
 ```
 
-You can now open https://localhost:9090 in your browser to open cockpit console and check the "Image Builder" section.
+You can now open https://localhost:9090 in your browser to open cockpit console
+and check the "Image Builder" section.
 
-Alternatively you can use `composer-cli` to interact with the Weldr API. We don't have any client for the RCM API, so the only option there is a plain `curl`.
+Alternatively you can use `composer-cli` to interact with the Weldr API. We
+don't have any client for the RCM API, so the only option there is a
+plain `curl`.
 
-When developing the code, use `go` executable to build, run, and test you code [1]:
+When developing the code, use `go` executable to build, run, and test you
+code [1]:
 
 ```
 $ go test ./...
@@ -48,21 +57,29 @@ See [test/README.md](test/README.md) for more information about testing.
 
 ### Planning the work
 
-In general we encourage you to first fill in an issue and discuss the feature you would like to work on before you start. This can prevent the scenario where you work on something we don't want to include in our code.
+In general we encourage you to first fill in an issue and discuss the feature
+you would like to work on before you start. This can prevent the scenario where
+you work on something we don't want to include in our code.
 
-That being said, you are of course welcome to implement an example of what you would like to achieve.
+That being said, you are of course welcome to implement an example of what you
+would like to achieve.
 
 ### Creating a PR
 
 The commits in the PR should have these properties:
 
 * Preferably minimal and well documented
-  * Where minimal means: don't do unrelated changes even if the code is obviously wrong
+  * Where minimal means: don't do unrelated changes even if the code is
+    obviously wrong
   * Well documented: both code and commit message
-  * The commit message should start with the module you work on, like: `weldr: `, or `rcm:`
-* The code should compile and the composer should start, so that we can run `git bisect` on it
+  * The commit message should start with the module you work on,
+    like: `weldr: `, or `rcm:`
+* The code should compile and the composer should start, so that we can run
+  `git bisect` on it
 * All code should be covered by unit-tests
 
 ### Notes:
 
-[1] If you are running macOS, you can still compile osbuild-composer. If it doesn't work out of the box, use `-tags macos` together with any `go` command, for example: `go test -tags macos ./...`
+[1] If you are running macOS, you can still compile osbuild-composer. If it
+    doesn't work out of the box, use `-tags macos` together with any `go`
+    command, for example: `go test -tags macos ./...`

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,104 @@
-COMMIT=$(shell git rev-parse HEAD)
+#
+# Maintenance Helpers
+#
+# This makefile contains targets used for development, as well as helpers to
+# aid automatization of maintenance. Unless a target is documented in
+# `make help`, it is not supported and is only meant to be used by developers
+# to aid their daily development work.
+#
+# All supported targets honor the `SRCDIR` variable to find the source-tree.
+# For most unsupported targets, you are expected to have the source-tree as
+# your working directory. To specify a different source-tree, simply override
+# the variable via `SRCDIR=<path>` on the commandline. By default, the working
+# directory is used for build output, but `BUILDDIR=<path>` allows overriding
+# it.
+#
+
+BUILDDIR ?= .
+SRCDIR ?= .
+
+RST2MAN ?= rst2man
+
+#
+# Automatic Variables
+#
+# This section contains a bunch of automatic variables used all over the place.
+# They mostly try to fetch information from the repository sources to avoid
+# hard-coding them in this makefile.
+#
+# Most of the variables here are pre-fetched so they will only ever be
+# evaluated once. This, however, means they are always executed regardless of
+# which target is run.
+#
+#     COMMIT:
+#         This evaluates to the latest git commit sha. This will not work if
+#         the source is not a git checkout. Hence, this variable is not
+#         pre-fetched but evaluated at time of use.
+#
+
+COMMIT = $(shell (cd "$(SRCDIR)" && git rev-parse HEAD))
+
+#
+# Generic Targets
+#
+# The following is a set of generic targets used across the makefile. The
+# following targets are defined:
+#
+#     help
+#         This target prints all supported targets. It is meant as
+#         documentation of targets we support and might use outside of this
+#         repository.
+#         This is also the default target.
+#
+#     $(BUILDDIR)/
+#     $(BUILDDIR)/%/
+#         This target simply creates the specified directory. It is limited to
+#         the build-dir as a safety measure. Note that this requires you to use
+#         a trailing slash after the directory to not mix it up with regular
+#         files. Lastly, you mostly want this as order-only dependency, since
+#         timestamps on directories do not affect their content.
+#
+
+.PHONY: help
+help:
+	@echo "make [TARGETS...]"
+	@echo
+	@echo "This is the maintenance makefile of osbuild. The following"
+	@echo "targets are available:"
+	@echo
+	@echo "    help:               Print this usage information."
+	@echo "    man:                Generate all man-pages"
+
+$(BUILDDIR)/:
+	mkdir -p "$@"
+
+$(BUILDDIR)/%/:
+	mkdir -p "$@"
+
+#
+# Documentation
+#
+# The following targets build the included documentation. This includes the
+# packaged man-pages, but also all other kinds of documentation that needs to
+# be generated. Note that these targets are relied upon by automatic
+# deployments to our website, as well as package manager scripts.
+#
+
+MANPAGES_RST = $(wildcard $(SRCDIR)/docs/*.[0123456789].rst)
+MANPAGES_TROFF = $(patsubst $(SRCDIR)/%.rst,$(BUILDDIR)/%,$(MANPAGES_RST))
+
+$(MANPAGES_TROFF): $(BUILDDIR)/docs/%: $(SRCDIR)/docs/%.rst | $(BUILDDIR)/docs/
+	$(RST2MAN) "$<" "$@"
+
+.PHONY: man
+man: $(MANPAGES_TROFF)
+
+#
+# Maintenance Targets
+#
+# The following targets are meant for development and repository maintenance.
+# They are not supported nor is their use recommended in scripts.
+#
 
 .PHONY: build
 build:

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,0 +1,47 @@
+# OSBuild Composer - Operating System Image Composition Services
+
+## CHANGES WITH 8:
+
+        * All generated pipelines now use the `org.osbuild.rpm` stage of
+          *osbuild*, rather than `org.osbuild.dnf`. This improves on splitting
+          resource acquisition from image building and should make image
+          composition more reliable and faster.
+
+        * The `STATE_DIRECTORY` environment variable now allows changing the
+          state directory path of `osbuild-composer`. This is to support older
+          systemd versions that do not pass in `StateDirectory=` to the service
+          executable.
+
+        * Minor fixes and improvements all over the place.
+
+        Contributions from: Alexander Todorov, Brian C. Lane, Jacob Kozol, Jakub
+                            Rusz, Lars Karlitski, Major Hayden, Martin
+                            Sehnoutka, Ondřej Budai, Tom Gundersen
+
+        - Berlin, 2020-03-18
+
+## CHANGES WITH 7:
+
+        * Support for `RHEL 8.1` as image type is now available.
+
+        * Semantic versioning of blueprints in the lorax API is now enforced.
+          This was always the case for the original lorax API, and *Composer*
+          now follows this as well.
+
+        * Lots of internal improvements, including many automatic tests,
+          improved error handling, better cache directory management, as well
+          as preparations to move over from `org.osbuild.dnf` to
+          `org.osbuild.rpm` in all build pipelines.
+
+        Contributions from: Alexander Todorov, Brian C. Lane, Jacob Kozol, Lars
+                            Karlitski, Major Hayden, Ondřej Budai, Tom Gundersen
+
+        - Berlin, 2020-03-05
+
+## CHANGES BEFORE 7:
+
+        * Initial implementation of 'osbuild-composer'.
+
+        Contributions from: Alexander Todorov, Brian C. Lane, Christian Kellner,
+                            Jacob Kozol, Jakub Rusz, Lars Karlitski, Martin
+                            Sehnoutka, Ondřej Budai, Tom Gundersen

--- a/README.md
+++ b/README.md
@@ -1,62 +1,82 @@
-# osbuild-composer
+OSBuild Composer
+================
 
-An HTTP service for building bootable OS images. It provides the same API as [lorax-composer](https://github.com/weldr/lorax) but in the background it uses [osbuild](https://github.com/osbuild/osbuild) to create the images.
+Operating System Image Composition Services
 
-You can control it in [Cockpit](https://github.com/weldr/cockpit-composer) or using the [composer-cli](https://weldr.io/lorax/composer-cli.html). To get started on Fedora, run:
+The composer project is a set of HTTP services for composing operating system
+images. It builds on the pipeline execution engine of *osbuild* and defines
+its own class of images that it supports building.
 
-```
-# dnf install cockpit-composer osbuild-composer composer-cli
-# systemctl enable --now cockpit.socket
-# systemctl enable --now osbuild-composer.socket
-```
+Multiple APIs are available to access a composer service. This includes
+support for the [lorax-composer](https://github.com/weldr/lorax) API, and as
+such can serve as drop-in replacement for lorax-composer.
 
-Now you can access the service using `composer-cli`, for example:
+You can control a composer instance either directly via the provided APIs, or
+through higher-level user-interfaces from external projects. This, for
+instance, includes a
+[Cockpit Module](https://github.com/weldr/cockpit-composer) or using the
+[composer-cli](https://weldr.io/lorax/composer-cli.html) command-line tool.
 
-```
-composer-cli status show
-```
+### Project
 
-or using a browser: `http://localhost:9090`
+ * **Website**: <https://www.osbuild.org>
+ * **Bug Tracker**: <https://github.com/osbuild/osbuild-composer/issues>
 
-## API documentation
+### About
 
-Please refer to the [lorax-composer](https://github.com/weldr/lorax)'s documenation as osbuild-composer is a drop-in replacement.
+Composer is a middleman between the workhorses from *osbuild* and the
+user-interfaces like *cockpit-composer*, *composer-cli*, or others. It defines
+a set of high-level image compositions that it supports building. Builds of
+these compositions can be requested via the different APIs of *Composer*, which
+will then translate the requests into pipeline-descriptions for *osbuild*. The
+pipeline output is then either provided back to the user, or uploaded to a user
+specified target.
 
-## High-level overview
+The following image visualizes the overall architecture of the OSBuild
+infrastructure and the place that *Composer* takes:
 
 ![overview](docs/osbuild-composer.svg)
 
-### Frontends
+Consult the `osbuild-composer(7)` man-page for an introduction into composer,
+information on running your own composer instance, as well as details on the
+provided infrastructure and services.
 
-`osbuild-composer` is meant to be used with 2 different front-ends. The primary one, which is meant for general use, is cockpit-composer. It is part of the Cockpit project and unless you have a strong reason not to use it, you should use it. `composer-cli` is a command line tool that can be used with `osbuild-composer`.
+### Requirements
 
-### Compose
-* Compose is what the user submits over one of the frontends
-* It contains of one or more **image builds**
-* It contains zero or more **upload actions**
+The requirements for this project are:
 
-### Image build
-* The resulting *image* has a *type*: https://github.com/osbuild/osbuild-composer/blob/master/internal/distro/fedora30/distro.go#L19
-* Running build in osbuild-composer is referred to as a "job" (internal terminology, not related to end-user experience)
+ * `osbuild >= 7`
+ * `systemd >= 244`
 
-### Job
-* What composer submits to a worker
-* Is a unit of work performed by `osbuild` (internally it is a single execution of `osbuild`)
-* Consists of **one** image build and **zero or more** Upload actions
+At build-time, the following software is required:
 
-### Image type
-* In the cockpit-composer, for examples these are image types:
-  * Openstack
-  * Azure
-  * AWS
-* As of now, we name them internally by their file format: vhd, ami, etc.
-* You can see a list of types by executing: `composer-cli compose types`
+ * `go >= 1.14`
+ * `python-docutils >= 0.13`
 
-### Upload action
-* Each image can be, but does not have to be, uploaded to a remote location
-* One image can be uploaded to multiple locations
+### Build
 
+The standard go package system is used. Consult upstream documentation for
+detailed help. In most situations the following commands are sufficient to
+build and install from source:
 
-## Testing
+```sh
+mkdir build
+go build -o build ./...
+```
 
-See [test/README.md](test/README.md)
+The man-pages require `python-docutils` and can be built via:
+
+```sh
+make man
+```
+
+### Repository:
+
+ - **web**:   <https://github.com/osbuild/osbuild-composer>
+ - **https**: `https://github.com/osbuild/osbuild-composer.git`
+ - **ssh**:   `git@github.com:osbuild/osbuild-composer.git`
+
+### License:
+
+ - **Apache-2.0**
+ - See LICENSE file for details.

--- a/docs/osbuild-composer.7.rst
+++ b/docs/osbuild-composer.7.rst
@@ -1,0 +1,77 @@
+================
+osbuild-composer
+================
+
+------------------------
+OSBuild Composer Service
+------------------------
+
+:Manual section: 7
+:Manual group: Miscellaneous
+
+DESCRIPTION
+===========
+
+The composer project is a set of HTTP services for composing operating system
+images. It builds on the pipeline execution engine of *osbuild* [#osbuild]_ and
+defines its own class of images that it supports building.
+
+Multiple APIs are available to access a composer service. This includes
+support for the *lorax-composer* [#lorax-github]_ API, and as
+such can serve as drop-in replacement for lorax-composer.
+
+You can control a composer instance either directly via the provided APIs, or
+through higher-level user-interfaces from external projects. This, for
+instance, includes a *Cockpit Module* [#cockpit-composer]_ or using the
+*composer-cli* [#composer-cli]_ command-line tool.
+
+Frontends
+---------
+
+*Composer* does not ship with frontends itself. However, several external
+frontends for *Composer* already exist. These include:
+
+**Cockpit Composer**
+    This module for *Cockpit* [#cockpit]_ allows a great level of control of a
+    *Composer* instance running on a cockpit-managed machine.
+
+**Composer CLI**
+    This command-line tool originated in the *lorax* [#lorax-github]_ project,
+    but can be used with *Composer* just as well.
+
+RUNNING
+=======
+
+To deploy a composer instance, all you need is to 
+
+    |
+    | # systemctl start osbuild-composer.socket
+    |
+
+Now you can access the service using `composer-cli`, for example:
+
+    |
+    | # composer-cli status show
+    |
+
+or using *Cockpit* with the *Cockpit Composer* module from a
+browser: `http://localhost:9090`
+
+SEE ALSO
+========
+
+``osbuild``\(1), ``osbuild-manifest``\(5)
+
+NOTES
+=====
+
+.. [#osbuild] OSBuild:
+              https://www.osbuild.org
+.. [#lorax-github] Lorax Composer:
+                   https://github.com/weldr/lorax
+.. [#cockpit-composer] Cockpit Composer:
+                       https://github.com/weldr/cockpit-composer
+.. [#composer-cli] Composer CLI:
+                   https://weldr.io/lorax/composer-cli.html
+.. [#cockpit] Cockpit Project:
+              https://www.cockpit-project.org/


### PR DESCRIPTION
This improves a bit on the documentation all over the place. It mostly follows what we did in *osbuild*, as it looks like everyone liked it so far:

 * reformat markdown files in the repo (CONTIRBUTING, README, ..)
 * create new osbuild-composer(7) man-page
 * minor reshuffling in Makefile
 * create a NEWS.md file with changelogs