### PR TITLE
tests: add coverage for common/helpers.go

### DIFF
--- a/internal/common/helpers.go
+++ b/internal/common/helpers.go
@@ -2,14 +2,16 @@ package common
 
 import "runtime"
 
+var RuntimeGOARCH = runtime.GOARCH
+
 func CurrentArch() string {
-	if runtime.GOARCH == "amd64" {
+	if RuntimeGOARCH == "amd64" {
 		return "x86_64"
-	} else if runtime.GOARCH == "arm64" {
+	} else if RuntimeGOARCH == "arm64" {
 		return "aarch64"
-	} else if runtime.GOARCH == "ppc64le" {
+	} else if RuntimeGOARCH == "ppc64le" {
 		return "ppc64le"
-	} else if runtime.GOARCH == "s390x" {
+	} else if RuntimeGOARCH == "s390x" {
 		return "s390x"
 	} else {
 		panic("unsupported architecture")

--- a/internal/common/helpers_test.go
+++ b/internal/common/helpers_test.go
@@ -1,0 +1,47 @@
+package common
+
+import (
+	"errors"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestCurrentArchAMD64(t *testing.T) {
+	origRuntimeGOARCH := RuntimeGOARCH
+	defer func() { RuntimeGOARCH = origRuntimeGOARCH }()
+	RuntimeGOARCH = "amd64"
+	assert.Equal(t, "x86_64", CurrentArch())
+}
+
+func TestCurrentArchARM64(t *testing.T) {
+	origRuntimeGOARCH := RuntimeGOARCH
+	defer func() { RuntimeGOARCH = origRuntimeGOARCH }()
+	RuntimeGOARCH = "arm64"
+	assert.Equal(t, "aarch64", CurrentArch())
+}
+
+func TestCurrentArchPPC64LE(t *testing.T) {
+	origRuntimeGOARCH := RuntimeGOARCH
+	defer func() { RuntimeGOARCH = origRuntimeGOARCH }()
+	RuntimeGOARCH = "ppc64le"
+	assert.Equal(t, "ppc64le", CurrentArch())
+}
+
+func TestCurrentArchS390X(t *testing.T) {
+	origRuntimeGOARCH := RuntimeGOARCH
+	defer func() { RuntimeGOARCH = origRuntimeGOARCH }()
+	RuntimeGOARCH = "s390x"
+	assert.Equal(t, "s390x", CurrentArch())
+}
+
+func TestCurrentArchUnsupported(t *testing.T) {
+	origRuntimeGOARCH := RuntimeGOARCH
+	defer func() { RuntimeGOARCH = origRuntimeGOARCH }()
+	RuntimeGOARCH = "UKNOWN"
+	assert.PanicsWithValue(t, "unsupported architecture", func() { CurrentArch() })
+}
+
+func TestPanicOnError(t *testing.T) {
+	err := errors.New("Error message")
+	assert.PanicsWithValue(t, err, func() { PanicOnError(err) })
+}


### PR DESCRIPTION
This also changes the helpers.go to enable mocking all the different architectures.  If you have a better idea for the name of the newly created variable I'll be glad to hear it :)  
The `runtime.GOARCH` is actually a constant that is taken from `sys` package https://golang.org/pkg/runtime/#pkg-constants

Refs #419