### PR TITLE
Make initramfs generation host independent

### DIFF
--- a/internal/distro/fedora30/distro.go
+++ b/internal/distro/fedora30/distro.go
@@ -344,7 +344,6 @@ func New() *Fedora30 {
 			"libxcrypt-compat",
 			"initscripts",
 			"glibc-all-langpacks",
-			"dracut-config-generic",
 		},
 		excludedPackages: []string{
 			"dracut-config-rescue",
@@ -407,6 +406,7 @@ func New() *Fedora30 {
 		distro: &r,
 		name:   "x86_64",
 		bootloaderPackages: []string{
+			"dracut-config-generic",
 			"grub2-pc",
 		},
 		buildPackages: []string{

--- a/internal/distro/fedora31/distro.go
+++ b/internal/distro/fedora31/distro.go
@@ -343,7 +343,6 @@ func New() *Fedora31 {
 			"libxcrypt-compat",
 			"initscripts",
 			"glibc-all-langpacks",
-			"dracut-config-generic",
 		},
 		excludedPackages: []string{
 			"dracut-config-rescue",
@@ -405,6 +404,7 @@ func New() *Fedora31 {
 		distro: &r,
 		name:   "x86_64",
 		bootloaderPackages: []string{
+			"dracut-config-generic",
 			"grub2-pc",
 		},
 		buildPackages: []string{

--- a/internal/distro/fedora32/distro.go
+++ b/internal/distro/fedora32/distro.go
@@ -344,7 +344,6 @@ func New() *Fedora32 {
 			"libxcrypt-compat",
 			"initscripts",
 			"glibc-all-langpacks",
-			"dracut-config-generic",
 		},
 		excludedPackages: []string{
 			"dracut-config-rescue",
@@ -407,6 +406,7 @@ func New() *Fedora32 {
 		distro: &r,
 		name:   "x86_64",
 		bootloaderPackages: []string{
+			"dracut-config-generic",
 			"grub2-pc",
 		},
 		buildPackages: []string{

--- a/internal/distro/rhel81/distro.go
+++ b/internal/distro/rhel81/distro.go
@@ -181,6 +181,7 @@ func New() *RHEL81 {
 			"x86_64": arch{
 				name: "x86_64",
 				bootloaderPackages: []string{
+					"dracut-config-generic",
 					"grub2-pc",
 				},
 				buildPackages: []string{
@@ -212,7 +213,6 @@ func New() *RHEL81 {
 			"cloud-utils-growpart",
 			"@core",
 			"dhcp-client",
-			"dracut-config-generic",
 			"gdisk",
 			"insights-client",
 			"kernel",
@@ -287,7 +287,6 @@ func New() *RHEL81 {
 			"kernel",
 			"firewalld",
 			"chrony",
-			"dracut-config-generic",
 			"langpacks-en",
 		},
 		excludedPackages: []string{
@@ -309,7 +308,6 @@ func New() *RHEL81 {
 		packages: []string{
 			"@core",
 			"chrony",
-			"dracut-config-generic",
 			"firewalld",
 			"kernel",
 			"langpacks-en",
@@ -345,7 +343,6 @@ func New() *RHEL81 {
 			"python3-jsonschema",
 			"qemu-guest-agent",
 			"cloud-utils-growpart",
-			"dracut-config-generic",
 			"dracut-norescue",
 			"tar",
 			"tcpdump",
@@ -422,10 +419,6 @@ func New() *RHEL81 {
 			"@Core",
 			"langpacks-en",
 
-			// Don't run dracut in host-only mode, in order to pull in
-			// the hv_vmbus, hv_netvsc and hv_storvsc modules into the initrd.
-			"dracut-config-generic",
-
 			// From the lorax kickstart
 			"kernel",
 			"selinux-policy-targeted",
@@ -453,7 +446,6 @@ func New() *RHEL81 {
 			"kernel",
 			"firewalld",
 			"chrony",
-			"dracut-config-generic",
 			"langpacks-en",
 		},
 		excludedPackages: []string{
@@ -475,10 +467,6 @@ func New() *RHEL81 {
 			// Defaults
 			"@Core",
 			"langpacks-en",
-
-			// Don't run dracut in host-only mode, in order to pull in
-			// the hv_vmbus, hv_netvsc and hv_storvsc modules into the initrd.
-			"dracut-config-generic",
 
 			// From the lorax kickstart
 			"kernel",
@@ -517,7 +505,6 @@ func New() *RHEL81 {
 		packages: []string{
 			"@core",
 			"chrony",
-			"dracut-config-generic",
 			"firewalld",
 			"kernel",
 			"langpacks-en",

--- a/internal/distro/rhel81/distro.go
+++ b/internal/distro/rhel81/distro.go
@@ -166,7 +166,6 @@ func New() *RHEL81 {
 		buildPackages: []string{
 			"dnf",
 			"dosfstools",
-			"dracut-config-generic",
 			"e2fsprogs",
 			"glibc",
 			"policycoreutils",

--- a/internal/distro/rhel82/distro.go
+++ b/internal/distro/rhel82/distro.go
@@ -166,7 +166,6 @@ func New() *RHEL82 {
 		buildPackages: []string{
 			"dnf",
 			"dosfstools",
-			"dracut-config-generic",
 			"e2fsprogs",
 			"glibc",
 			"policycoreutils",

--- a/internal/distro/rhel82/distro.go
+++ b/internal/distro/rhel82/distro.go
@@ -181,6 +181,7 @@ func New() *RHEL82 {
 			"x86_64": arch{
 				name: "x86_64",
 				bootloaderPackages: []string{
+					"dracut-config-generic",
 					"grub2-pc",
 				},
 				buildPackages: []string{
@@ -212,7 +213,6 @@ func New() *RHEL82 {
 			"cloud-utils-growpart",
 			"@core",
 			"dhcp-client",
-			"dracut-config-generic",
 			"gdisk",
 			"insights-client",
 			"kernel",
@@ -287,7 +287,6 @@ func New() *RHEL82 {
 			"kernel",
 			"firewalld",
 			"chrony",
-			"dracut-config-generic",
 			"langpacks-en",
 		},
 		excludedPackages: []string{
@@ -309,7 +308,6 @@ func New() *RHEL82 {
 		packages: []string{
 			"@core",
 			"chrony",
-			"dracut-config-generic",
 			"firewalld",
 			"kernel",
 			"langpacks-en",
@@ -345,7 +343,6 @@ func New() *RHEL82 {
 			"python3-jsonschema",
 			"qemu-guest-agent",
 			"cloud-utils-growpart",
-			"dracut-config-generic",
 			"dracut-norescue",
 			"tar",
 			"tcpdump",
@@ -422,10 +419,6 @@ func New() *RHEL82 {
 			"@Core",
 			"langpacks-en",
 
-			// Don't run dracut in host-only mode, in order to pull in
-			// the hv_vmbus, hv_netvsc and hv_storvsc modules into the initrd.
-			"dracut-config-generic",
-
 			// From the lorax kickstart
 			"kernel",
 			"selinux-policy-targeted",
@@ -453,7 +446,6 @@ func New() *RHEL82 {
 			"kernel",
 			"firewalld",
 			"chrony",
-			"dracut-config-generic",
 			"langpacks-en",
 		},
 		excludedPackages: []string{
@@ -475,10 +467,6 @@ func New() *RHEL82 {
 			// Defaults
 			"@Core",
 			"langpacks-en",
-
-			// Don't run dracut in host-only mode, in order to pull in
-			// the hv_vmbus, hv_netvsc and hv_storvsc modules into the initrd.
-			"dracut-config-generic",
 
 			// From the lorax kickstart
 			"kernel",
@@ -517,7 +505,6 @@ func New() *RHEL82 {
 		packages: []string{
 			"@core",
 			"chrony",
-			"dracut-config-generic",
 			"firewalld",
 			"kernel",
 			"langpacks-en",

--- a/test/cases/f30-x86_64-ami-boot.json
+++ b/test/cases/f30-x86_64-ami-boot.json
@@ -182,6 +182,7 @@
           "sha256:7efe8696caf1e8b1471225cf3be33c95ace91b2b58443efa6d16fb744754874c": "http://dl.fedoraproject.org/pub/fedora/linux/releases/30/Everything/x86_64/os/Packages/c/chrony-3.4-2.fc30.x86_64.rpm",
           "sha256:806617532d01219c819194085466aab3a6bc4a0b16da7d5851370576861116b0": "http://dl.fedoraproject.org/pub/fedora/linux/releases/30/Everything/x86_64/os/Packages/g/grep-3.1-9.fc30.x86_64.rpm",
           "sha256:81560ff4cd2a766c691fc733a98b0ba6c99d1ea48fc3a1414d49c6c82826b984": "http://dl.fedoraproject.org/pub/fedora/linux/releases/30/Everything/x86_64/os/Packages/c/checkpolicy-2.9-1.fc30.x86_64.rpm",
+          "sha256:8185411da358027837a036579f2336e627d7e65cb8e15a3fe79f7e9f1a2286ba": "http://dl.fedoraproject.org/pub/fedora/linux/releases/30/Everything/x86_64/os/Packages/d/dracut-config-generic-049-26.git20181204.fc30.x86_64.rpm",
           "sha256:82b7ab937022da773f88246233f2e806460a534e74cb3a30c6554e7e568f962f": "http://dl.fedoraproject.org/pub/fedora/linux/releases/30/Everything/x86_64/os/Packages/l/libedit-3.1-26.20181209cvs.fc30.x86_64.rpm",
           "sha256:83106462e3330c682a5f3c8ddee487131666f6692fa6c7e071be61c831ee3766": "http://dl.fedoraproject.org/pub/fedora/linux/releases/30/Everything/x86_64/os/Packages/f/file-5.36-2.fc30.x86_64.rpm",
           "sha256:835813f87c48afef832488374fa1517a175626a5b8a36836f0abd73fe298b581": "http://dl.fedoraproject.org/pub/fedora/linux/releases/30/Everything/x86_64/os/Packages/l/libsemanage-2.9-1.fc30.x86_64.rpm",
@@ -656,6 +657,7 @@
               "sha256:a8e1a237699150c2eb2196079e7af1690c89297ab99b0696389cb4d2058e6ee2",
               "sha256:44d6eac48fdf84e2577d7ba97cf50409051d8882f86f9f001140a210b0ea6c1d",
               "sha256:76962ec5ea720cb22eb43f808013d8c974fb6862ebd6c193a76e49c987341856",
+              "sha256:8185411da358027837a036579f2336e627d7e65cb8e15a3fe79f7e9f1a2286ba",
               "sha256:109f8a9036587d3df953290ef6424780f81b11f4fc162f44d1f1bd20fa8f90a7",
               "sha256:4eefc58e32aca46c0b3d64da2454ffd52aa0beb03a7ce5e00c3cff0e49736639",
               "sha256:d342deb7dc135e1056185670b89989225fdf898101d26b70abbe6cfacfe507e9",
@@ -3347,6 +3349,15 @@
         "arch": "x86_64",
         "remote_location": "http://dl.fedoraproject.org/pub/fedora/linux/releases/30/Everything/x86_64/os/Packages/d/dracut-049-26.git20181204.fc30.x86_64.rpm",
         "checksum": "sha256:76962ec5ea720cb22eb43f808013d8c974fb6862ebd6c193a76e49c987341856"
+      },
+      {
+        "name": "dracut-config-generic",
+        "epoch": 0,
+        "version": "049",
+        "release": "26.git20181204.fc30",
+        "arch": "x86_64",
+        "remote_location": "http://dl.fedoraproject.org/pub/fedora/linux/releases/30/Everything/x86_64/os/Packages/d/dracut-config-generic-049-26.git20181204.fc30.x86_64.rpm",
+        "checksum": "sha256:8185411da358027837a036579f2336e627d7e65cb8e15a3fe79f7e9f1a2286ba"
       },
       {
         "name": "e2fsprogs",
@@ -6202,6 +6213,7 @@
       "dnf-plugins-core-4.0.6-1.fc30.noarch",
       "dnf-yum-4.2.2-2.fc30.noarch",
       "dracut-049-26.git20181204.fc30.x86_64",
+      "dracut-config-generic-049-26.git20181204.fc30.x86_64",
       "e2fsprogs-1.44.6-1.fc30.x86_64",
       "e2fsprogs-libs-1.44.6-1.fc30.x86_64",
       "ebtables-2.0.10-31.fc30.x86_64",

--- a/test/cases/f30-x86_64-openstack-boot.json
+++ b/test/cases/f30-x86_64-openstack-boot.json
@@ -198,6 +198,7 @@
           "sha256:7efe8696caf1e8b1471225cf3be33c95ace91b2b58443efa6d16fb744754874c": "http://dl.fedoraproject.org/pub/fedora/linux/releases/30/Everything/x86_64/os/Packages/c/chrony-3.4-2.fc30.x86_64.rpm",
           "sha256:806617532d01219c819194085466aab3a6bc4a0b16da7d5851370576861116b0": "http://dl.fedoraproject.org/pub/fedora/linux/releases/30/Everything/x86_64/os/Packages/g/grep-3.1-9.fc30.x86_64.rpm",
           "sha256:81560ff4cd2a766c691fc733a98b0ba6c99d1ea48fc3a1414d49c6c82826b984": "http://dl.fedoraproject.org/pub/fedora/linux/releases/30/Everything/x86_64/os/Packages/c/checkpolicy-2.9-1.fc30.x86_64.rpm",
+          "sha256:8185411da358027837a036579f2336e627d7e65cb8e15a3fe79f7e9f1a2286ba": "http://dl.fedoraproject.org/pub/fedora/linux/releases/30/Everything/x86_64/os/Packages/d/dracut-config-generic-049-26.git20181204.fc30.x86_64.rpm",
           "sha256:82b7ab937022da773f88246233f2e806460a534e74cb3a30c6554e7e568f962f": "http://dl.fedoraproject.org/pub/fedora/linux/releases/30/Everything/x86_64/os/Packages/l/libedit-3.1-26.20181209cvs.fc30.x86_64.rpm",
           "sha256:83106462e3330c682a5f3c8ddee487131666f6692fa6c7e071be61c831ee3766": "http://dl.fedoraproject.org/pub/fedora/linux/releases/30/Everything/x86_64/os/Packages/f/file-5.36-2.fc30.x86_64.rpm",
           "sha256:835813f87c48afef832488374fa1517a175626a5b8a36836f0abd73fe298b581": "http://dl.fedoraproject.org/pub/fedora/linux/releases/30/Everything/x86_64/os/Packages/l/libsemanage-2.9-1.fc30.x86_64.rpm",
@@ -685,6 +686,7 @@
               "sha256:a8e1a237699150c2eb2196079e7af1690c89297ab99b0696389cb4d2058e6ee2",
               "sha256:44d6eac48fdf84e2577d7ba97cf50409051d8882f86f9f001140a210b0ea6c1d",
               "sha256:76962ec5ea720cb22eb43f808013d8c974fb6862ebd6c193a76e49c987341856",
+              "sha256:8185411da358027837a036579f2336e627d7e65cb8e15a3fe79f7e9f1a2286ba",
               "sha256:109f8a9036587d3df953290ef6424780f81b11f4fc162f44d1f1bd20fa8f90a7",
               "sha256:4eefc58e32aca46c0b3d64da2454ffd52aa0beb03a7ce5e00c3cff0e49736639",
               "sha256:d342deb7dc135e1056185670b89989225fdf898101d26b70abbe6cfacfe507e9",
@@ -3403,6 +3405,15 @@
         "arch": "x86_64",
         "remote_location": "http://dl.fedoraproject.org/pub/fedora/linux/releases/30/Everything/x86_64/os/Packages/d/dracut-049-26.git20181204.fc30.x86_64.rpm",
         "checksum": "sha256:76962ec5ea720cb22eb43f808013d8c974fb6862ebd6c193a76e49c987341856"
+      },
+      {
+        "name": "dracut-config-generic",
+        "epoch": 0,
+        "version": "049",
+        "release": "26.git20181204.fc30",
+        "arch": "x86_64",
+        "remote_location": "http://dl.fedoraproject.org/pub/fedora/linux/releases/30/Everything/x86_64/os/Packages/d/dracut-config-generic-049-26.git20181204.fc30.x86_64.rpm",
+        "checksum": "sha256:8185411da358027837a036579f2336e627d7e65cb8e15a3fe79f7e9f1a2286ba"
       },
       {
         "name": "e2fsprogs",
@@ -6404,6 +6415,7 @@
       "dnf-plugins-core-4.0.6-1.fc30.noarch",
       "dnf-yum-4.2.2-2.fc30.noarch",
       "dracut-049-26.git20181204.fc30.x86_64",
+      "dracut-config-generic-049-26.git20181204.fc30.x86_64",
       "e2fsprogs-1.44.6-1.fc30.x86_64",
       "e2fsprogs-libs-1.44.6-1.fc30.x86_64",
       "ebtables-2.0.10-31.fc30.x86_64",

--- a/test/cases/f30-x86_64-partitioned_disk-boot.json
+++ b/test/cases/f30-x86_64-partitioned_disk-boot.json
@@ -182,6 +182,7 @@
           "sha256:7e61fb39689669e2c96909008f7970ea5037046fd4133c9bb38364ce82813966": "http://dl.fedoraproject.org/pub/fedora/linux/releases/30/Everything/x86_64/os/Packages/c/cyrus-sasl-lib-2.1.27-0.6rc7.fc30.x86_64.rpm",
           "sha256:7efe8696caf1e8b1471225cf3be33c95ace91b2b58443efa6d16fb744754874c": "http://dl.fedoraproject.org/pub/fedora/linux/releases/30/Everything/x86_64/os/Packages/c/chrony-3.4-2.fc30.x86_64.rpm",
           "sha256:806617532d01219c819194085466aab3a6bc4a0b16da7d5851370576861116b0": "http://dl.fedoraproject.org/pub/fedora/linux/releases/30/Everything/x86_64/os/Packages/g/grep-3.1-9.fc30.x86_64.rpm",
+          "sha256:8185411da358027837a036579f2336e627d7e65cb8e15a3fe79f7e9f1a2286ba": "http://dl.fedoraproject.org/pub/fedora/linux/releases/30/Everything/x86_64/os/Packages/d/dracut-config-generic-049-26.git20181204.fc30.x86_64.rpm",
           "sha256:82b7ab937022da773f88246233f2e806460a534e74cb3a30c6554e7e568f962f": "http://dl.fedoraproject.org/pub/fedora/linux/releases/30/Everything/x86_64/os/Packages/l/libedit-3.1-26.20181209cvs.fc30.x86_64.rpm",
           "sha256:83106462e3330c682a5f3c8ddee487131666f6692fa6c7e071be61c831ee3766": "http://dl.fedoraproject.org/pub/fedora/linux/releases/30/Everything/x86_64/os/Packages/f/file-5.36-2.fc30.x86_64.rpm",
           "sha256:835813f87c48afef832488374fa1517a175626a5b8a36836f0abd73fe298b581": "http://dl.fedoraproject.org/pub/fedora/linux/releases/30/Everything/x86_64/os/Packages/l/libsemanage-2.9-1.fc30.x86_64.rpm",
@@ -633,6 +634,7 @@
               "sha256:a8e1a237699150c2eb2196079e7af1690c89297ab99b0696389cb4d2058e6ee2",
               "sha256:44d6eac48fdf84e2577d7ba97cf50409051d8882f86f9f001140a210b0ea6c1d",
               "sha256:76962ec5ea720cb22eb43f808013d8c974fb6862ebd6c193a76e49c987341856",
+              "sha256:8185411da358027837a036579f2336e627d7e65cb8e15a3fe79f7e9f1a2286ba",
               "sha256:109f8a9036587d3df953290ef6424780f81b11f4fc162f44d1f1bd20fa8f90a7",
               "sha256:4eefc58e32aca46c0b3d64da2454ffd52aa0beb03a7ce5e00c3cff0e49736639",
               "sha256:d342deb7dc135e1056185670b89989225fdf898101d26b70abbe6cfacfe507e9",
@@ -3277,6 +3279,15 @@
         "checksum": "sha256:76962ec5ea720cb22eb43f808013d8c974fb6862ebd6c193a76e49c987341856"
       },
       {
+        "name": "dracut-config-generic",
+        "epoch": 0,
+        "version": "049",
+        "release": "26.git20181204.fc30",
+        "arch": "x86_64",
+        "remote_location": "http://dl.fedoraproject.org/pub/fedora/linux/releases/30/Everything/x86_64/os/Packages/d/dracut-config-generic-049-26.git20181204.fc30.x86_64.rpm",
+        "checksum": "sha256:8185411da358027837a036579f2336e627d7e65cb8e15a3fe79f7e9f1a2286ba"
+      },
+      {
         "name": "e2fsprogs",
         "epoch": 0,
         "version": "1.44.6",
@@ -5832,6 +5843,7 @@
       "dnf-plugins-core-4.0.6-1.fc30.noarch",
       "dnf-yum-4.2.2-2.fc30.noarch",
       "dracut-049-26.git20181204.fc30.x86_64",
+      "dracut-config-generic-049-26.git20181204.fc30.x86_64",
       "e2fsprogs-1.44.6-1.fc30.x86_64",
       "e2fsprogs-libs-1.44.6-1.fc30.x86_64",
       "ebtables-2.0.10-31.fc30.x86_64",

--- a/test/cases/f30-x86_64-vmdk-boot.json
+++ b/test/cases/f30-x86_64-vmdk-boot.json
@@ -190,6 +190,7 @@
           "sha256:7e61fb39689669e2c96909008f7970ea5037046fd4133c9bb38364ce82813966": "http://dl.fedoraproject.org/pub/fedora/linux/releases/30/Everything/x86_64/os/Packages/c/cyrus-sasl-lib-2.1.27-0.6rc7.fc30.x86_64.rpm",
           "sha256:7efe8696caf1e8b1471225cf3be33c95ace91b2b58443efa6d16fb744754874c": "http://dl.fedoraproject.org/pub/fedora/linux/releases/30/Everything/x86_64/os/Packages/c/chrony-3.4-2.fc30.x86_64.rpm",
           "sha256:806617532d01219c819194085466aab3a6bc4a0b16da7d5851370576861116b0": "http://dl.fedoraproject.org/pub/fedora/linux/releases/30/Everything/x86_64/os/Packages/g/grep-3.1-9.fc30.x86_64.rpm",
+          "sha256:8185411da358027837a036579f2336e627d7e65cb8e15a3fe79f7e9f1a2286ba": "http://dl.fedoraproject.org/pub/fedora/linux/releases/30/Everything/x86_64/os/Packages/d/dracut-config-generic-049-26.git20181204.fc30.x86_64.rpm",
           "sha256:82b7ab937022da773f88246233f2e806460a534e74cb3a30c6554e7e568f962f": "http://dl.fedoraproject.org/pub/fedora/linux/releases/30/Everything/x86_64/os/Packages/l/libedit-3.1-26.20181209cvs.fc30.x86_64.rpm",
           "sha256:83106462e3330c682a5f3c8ddee487131666f6692fa6c7e071be61c831ee3766": "http://dl.fedoraproject.org/pub/fedora/linux/releases/30/Everything/x86_64/os/Packages/f/file-5.36-2.fc30.x86_64.rpm",
           "sha256:835813f87c48afef832488374fa1517a175626a5b8a36836f0abd73fe298b581": "http://dl.fedoraproject.org/pub/fedora/linux/releases/30/Everything/x86_64/os/Packages/l/libsemanage-2.9-1.fc30.x86_64.rpm",
@@ -648,6 +649,7 @@
               "sha256:a8e1a237699150c2eb2196079e7af1690c89297ab99b0696389cb4d2058e6ee2",
               "sha256:44d6eac48fdf84e2577d7ba97cf50409051d8882f86f9f001140a210b0ea6c1d",
               "sha256:76962ec5ea720cb22eb43f808013d8c974fb6862ebd6c193a76e49c987341856",
+              "sha256:8185411da358027837a036579f2336e627d7e65cb8e15a3fe79f7e9f1a2286ba",
               "sha256:109f8a9036587d3df953290ef6424780f81b11f4fc162f44d1f1bd20fa8f90a7",
               "sha256:4eefc58e32aca46c0b3d64da2454ffd52aa0beb03a7ce5e00c3cff0e49736639",
               "sha256:d342deb7dc135e1056185670b89989225fdf898101d26b70abbe6cfacfe507e9",
@@ -3306,6 +3308,15 @@
         "arch": "x86_64",
         "remote_location": "http://dl.fedoraproject.org/pub/fedora/linux/releases/30/Everything/x86_64/os/Packages/d/dracut-049-26.git20181204.fc30.x86_64.rpm",
         "checksum": "sha256:76962ec5ea720cb22eb43f808013d8c974fb6862ebd6c193a76e49c987341856"
+      },
+      {
+        "name": "dracut-config-generic",
+        "epoch": 0,
+        "version": "049",
+        "release": "26.git20181204.fc30",
+        "arch": "x86_64",
+        "remote_location": "http://dl.fedoraproject.org/pub/fedora/linux/releases/30/Everything/x86_64/os/Packages/d/dracut-config-generic-049-26.git20181204.fc30.x86_64.rpm",
+        "checksum": "sha256:8185411da358027837a036579f2336e627d7e65cb8e15a3fe79f7e9f1a2286ba"
       },
       {
         "name": "e2fsprogs",
@@ -6007,6 +6018,7 @@
       "dnf-plugins-core-4.0.6-1.fc30.noarch",
       "dnf-yum-4.2.2-2.fc30.noarch",
       "dracut-049-26.git20181204.fc30.x86_64",
+      "dracut-config-generic-049-26.git20181204.fc30.x86_64",
       "e2fsprogs-1.44.6-1.fc30.x86_64",
       "e2fsprogs-libs-1.44.6-1.fc30.x86_64",
       "ebtables-2.0.10-31.fc30.x86_64",

--- a/test/cases/f31-x86_64-ami-boot.json
+++ b/test/cases/f31-x86_64-ami-boot.json
@@ -105,6 +105,7 @@
           "sha256:33f37ee132feff578bdf50f89f6f6a18c3c7fcc699b5ea7922317087fd210c18": "http://dl.fedoraproject.org/pub/fedora/linux/releases/31/Everything/x86_64/os/Packages/l/libarchive-3.4.0-1.fc31.x86_64.rpm",
           "sha256:3434fe7dfffa29d996d94d2664dd2597ce446abf6b0d75920cc691540e139fcc": "http://dl.fedoraproject.org/pub/fedora/linux/releases/31/Everything/x86_64/os/Packages/l/libXft-2.3.3-2.fc31.x86_64.rpm",
           "sha256:34a182fca42c4cac66aa6186603509b90659076d62147ac735def1adb72883dd": "http://dl.fedoraproject.org/pub/fedora/linux/releases/31/Everything/x86_64/os/Packages/g/gcr-3.33.4-1.fc31.x86_64.rpm",
+          "sha256:34a9986b8b61812ceaf32ce3b189bd0b2cb4adaaf47d76ec1f50ce07c45b5675": "http://dl.fedoraproject.org/pub/fedora/linux/releases/31/Everything/x86_64/os/Packages/d/dracut-config-generic-049-27.git20181204.fc31.1.x86_64.rpm",
           "sha256:34f7954cf6c6ceb4385fdcc587dced94405913ddfe5e3213fcbd72562f286fbc": "http://dl.fedoraproject.org/pub/fedora/linux/releases/31/Everything/x86_64/os/Packages/d/dejavu-fonts-common-2.37-2.fc31.noarch.rpm",
           "sha256:35413dd963ebd9e61467067c18a53c7027dcd95ebcae5a5ffaf4727507e37c8c": "http://dl.fedoraproject.org/pub/fedora/linux/releases/31/Everything/x86_64/os/Packages/p/python-unversioned-command-3.7.4-5.fc31.noarch.rpm",
           "sha256:359d74d5f3988e1c2c5327f9d4ea59d0c49a2383541928084ef00383d70b6d55": "http://dl.fedoraproject.org/pub/fedora/linux/releases/31/Everything/x86_64/os/Packages/p/publicsuffix-list-dafsa-20190417-2.fc31.noarch.rpm",
@@ -790,6 +791,7 @@
               "sha256:02301d2744b96674019251b6c8d2199790960e4cc79d90fbdb946a298fc2c4ea",
               "sha256:16ea1e6ba5bbf16cb6a052b2326d25b9980971fd72c46e7d701e09f267d33063",
               "sha256:ef55145ef56d4d63c0085d04e856943d5c61c11ba10c70a383d8f67b74818159",
+              "sha256:34a9986b8b61812ceaf32ce3b189bd0b2cb4adaaf47d76ec1f50ce07c45b5675",
               "sha256:71c02de0e50e07999d0f4f40bce06ca4904e0ab786220bd7ffebc4a60a4d3cd7",
               "sha256:de678f5a55f5ff690f3587adcbc7a1b7d477fefe85ffd5d91fc1447ddba63c89",
               "sha256:cab1b0c3bdae2a07e15b90b414f50753c759e325b6f0cddfa27895748c77f082",
@@ -4225,6 +4227,15 @@
         "checksum": "sha256:ef55145ef56d4d63c0085d04e856943d5c61c11ba10c70a383d8f67b74818159"
       },
       {
+        "name": "dracut-config-generic",
+        "epoch": 0,
+        "version": "049",
+        "release": "27.git20181204.fc31.1",
+        "arch": "x86_64",
+        "remote_location": "http://dl.fedoraproject.org/pub/fedora/linux/releases/31/Everything/x86_64/os/Packages/d/dracut-config-generic-049-27.git20181204.fc31.1.x86_64.rpm",
+        "checksum": "sha256:34a9986b8b61812ceaf32ce3b189bd0b2cb4adaaf47d76ec1f50ce07c45b5675"
+      },
+      {
         "name": "e2fsprogs",
         "epoch": 0,
         "version": "1.45.3",
@@ -7530,6 +7541,7 @@
       "dnf-data-4.2.9-5.fc31.noarch",
       "dnf-plugins-core-4.0.9-1.fc31.noarch",
       "dracut-049-27.git20181204.fc31.1.x86_64",
+      "dracut-config-generic-049-27.git20181204.fc31.1.x86_64",
       "e2fsprogs-1.45.3-1.fc31.x86_64",
       "e2fsprogs-libs-1.45.3-1.fc31.x86_64",
       "ebtables-legacy-2.0.10-37.fc31.x86_64",

--- a/test/cases/f31-x86_64-openstack-boot.json
+++ b/test/cases/f31-x86_64-openstack-boot.json
@@ -119,6 +119,7 @@
           "sha256:33f37ee132feff578bdf50f89f6f6a18c3c7fcc699b5ea7922317087fd210c18": "http://dl.fedoraproject.org/pub/fedora/linux/releases/31/Everything/x86_64/os/Packages/l/libarchive-3.4.0-1.fc31.x86_64.rpm",
           "sha256:3434fe7dfffa29d996d94d2664dd2597ce446abf6b0d75920cc691540e139fcc": "http://dl.fedoraproject.org/pub/fedora/linux/releases/31/Everything/x86_64/os/Packages/l/libXft-2.3.3-2.fc31.x86_64.rpm",
           "sha256:34a182fca42c4cac66aa6186603509b90659076d62147ac735def1adb72883dd": "http://dl.fedoraproject.org/pub/fedora/linux/releases/31/Everything/x86_64/os/Packages/g/gcr-3.33.4-1.fc31.x86_64.rpm",
+          "sha256:34a9986b8b61812ceaf32ce3b189bd0b2cb4adaaf47d76ec1f50ce07c45b5675": "http://dl.fedoraproject.org/pub/fedora/linux/releases/31/Everything/x86_64/os/Packages/d/dracut-config-generic-049-27.git20181204.fc31.1.x86_64.rpm",
           "sha256:34f7954cf6c6ceb4385fdcc587dced94405913ddfe5e3213fcbd72562f286fbc": "http://dl.fedoraproject.org/pub/fedora/linux/releases/31/Everything/x86_64/os/Packages/d/dejavu-fonts-common-2.37-2.fc31.noarch.rpm",
           "sha256:35413dd963ebd9e61467067c18a53c7027dcd95ebcae5a5ffaf4727507e37c8c": "http://dl.fedoraproject.org/pub/fedora/linux/releases/31/Everything/x86_64/os/Packages/p/python-unversioned-command-3.7.4-5.fc31.noarch.rpm",
           "sha256:3597ed358e421f7dc161d2f263e7e36c61aa1b4c9e547ed94ab5db2bd35f42de": "http://dl.fedoraproject.org/pub/fedora/linux/releases/31/Everything/x86_64/os/Packages/y/yajl-2.1.0-13.fc31.x86_64.rpm",
@@ -814,6 +815,7 @@
               "sha256:02301d2744b96674019251b6c8d2199790960e4cc79d90fbdb946a298fc2c4ea",
               "sha256:16ea1e6ba5bbf16cb6a052b2326d25b9980971fd72c46e7d701e09f267d33063",
               "sha256:ef55145ef56d4d63c0085d04e856943d5c61c11ba10c70a383d8f67b74818159",
+              "sha256:34a9986b8b61812ceaf32ce3b189bd0b2cb4adaaf47d76ec1f50ce07c45b5675",
               "sha256:71c02de0e50e07999d0f4f40bce06ca4904e0ab786220bd7ffebc4a60a4d3cd7",
               "sha256:de678f5a55f5ff690f3587adcbc7a1b7d477fefe85ffd5d91fc1447ddba63c89",
               "sha256:cab1b0c3bdae2a07e15b90b414f50753c759e325b6f0cddfa27895748c77f082",
@@ -4268,6 +4270,15 @@
         "checksum": "sha256:ef55145ef56d4d63c0085d04e856943d5c61c11ba10c70a383d8f67b74818159"
       },
       {
+        "name": "dracut-config-generic",
+        "epoch": 0,
+        "version": "049",
+        "release": "27.git20181204.fc31.1",
+        "arch": "x86_64",
+        "remote_location": "http://dl.fedoraproject.org/pub/fedora/linux/releases/31/Everything/x86_64/os/Packages/d/dracut-config-generic-049-27.git20181204.fc31.1.x86_64.rpm",
+        "checksum": "sha256:34a9986b8b61812ceaf32ce3b189bd0b2cb4adaaf47d76ec1f50ce07c45b5675"
+      },
+      {
         "name": "e2fsprogs",
         "epoch": 0,
         "version": "1.45.3",
@@ -7647,6 +7658,7 @@
       "dnf-data-4.2.9-5.fc31.noarch",
       "dnf-plugins-core-4.0.9-1.fc31.noarch",
       "dracut-049-27.git20181204.fc31.1.x86_64",
+      "dracut-config-generic-049-27.git20181204.fc31.1.x86_64",
       "e2fsprogs-1.45.3-1.fc31.x86_64",
       "e2fsprogs-libs-1.45.3-1.fc31.x86_64",
       "ebtables-legacy-2.0.10-37.fc31.x86_64",

--- a/test/cases/f31-x86_64-partitioned_disk-boot.json
+++ b/test/cases/f31-x86_64-partitioned_disk-boot.json
@@ -111,6 +111,7 @@
           "sha256:33f37ee132feff578bdf50f89f6f6a18c3c7fcc699b5ea7922317087fd210c18": "http://dl.fedoraproject.org/pub/fedora/linux/releases/31/Everything/x86_64/os/Packages/l/libarchive-3.4.0-1.fc31.x86_64.rpm",
           "sha256:3434fe7dfffa29d996d94d2664dd2597ce446abf6b0d75920cc691540e139fcc": "http://dl.fedoraproject.org/pub/fedora/linux/releases/31/Everything/x86_64/os/Packages/l/libXft-2.3.3-2.fc31.x86_64.rpm",
           "sha256:34a182fca42c4cac66aa6186603509b90659076d62147ac735def1adb72883dd": "http://dl.fedoraproject.org/pub/fedora/linux/releases/31/Everything/x86_64/os/Packages/g/gcr-3.33.4-1.fc31.x86_64.rpm",
+          "sha256:34a9986b8b61812ceaf32ce3b189bd0b2cb4adaaf47d76ec1f50ce07c45b5675": "http://dl.fedoraproject.org/pub/fedora/linux/releases/31/Everything/x86_64/os/Packages/d/dracut-config-generic-049-27.git20181204.fc31.1.x86_64.rpm",
           "sha256:34f7954cf6c6ceb4385fdcc587dced94405913ddfe5e3213fcbd72562f286fbc": "http://dl.fedoraproject.org/pub/fedora/linux/releases/31/Everything/x86_64/os/Packages/d/dejavu-fonts-common-2.37-2.fc31.noarch.rpm",
           "sha256:35413dd963ebd9e61467067c18a53c7027dcd95ebcae5a5ffaf4727507e37c8c": "http://dl.fedoraproject.org/pub/fedora/linux/releases/31/Everything/x86_64/os/Packages/p/python-unversioned-command-3.7.4-5.fc31.noarch.rpm",
           "sha256:359d74d5f3988e1c2c5327f9d4ea59d0c49a2383541928084ef00383d70b6d55": "http://dl.fedoraproject.org/pub/fedora/linux/releases/31/Everything/x86_64/os/Packages/p/publicsuffix-list-dafsa-20190417-2.fc31.noarch.rpm",
@@ -769,6 +770,7 @@
               "sha256:02301d2744b96674019251b6c8d2199790960e4cc79d90fbdb946a298fc2c4ea",
               "sha256:16ea1e6ba5bbf16cb6a052b2326d25b9980971fd72c46e7d701e09f267d33063",
               "sha256:ef55145ef56d4d63c0085d04e856943d5c61c11ba10c70a383d8f67b74818159",
+              "sha256:34a9986b8b61812ceaf32ce3b189bd0b2cb4adaaf47d76ec1f50ce07c45b5675",
               "sha256:71c02de0e50e07999d0f4f40bce06ca4904e0ab786220bd7ffebc4a60a4d3cd7",
               "sha256:de678f5a55f5ff690f3587adcbc7a1b7d477fefe85ffd5d91fc1447ddba63c89",
               "sha256:cab1b0c3bdae2a07e15b90b414f50753c759e325b6f0cddfa27895748c77f082",
@@ -4157,6 +4159,15 @@
         "checksum": "sha256:ef55145ef56d4d63c0085d04e856943d5c61c11ba10c70a383d8f67b74818159"
       },
       {
+        "name": "dracut-config-generic",
+        "epoch": 0,
+        "version": "049",
+        "release": "27.git20181204.fc31.1",
+        "arch": "x86_64",
+        "remote_location": "http://dl.fedoraproject.org/pub/fedora/linux/releases/31/Everything/x86_64/os/Packages/d/dracut-config-generic-049-27.git20181204.fc31.1.x86_64.rpm",
+        "checksum": "sha256:34a9986b8b61812ceaf32ce3b189bd0b2cb4adaaf47d76ec1f50ce07c45b5675"
+      },
+      {
         "name": "e2fsprogs",
         "epoch": 0,
         "version": "1.45.3",
@@ -7182,6 +7193,7 @@
       "dnf-data-4.2.9-5.fc31.noarch",
       "dnf-plugins-core-4.0.9-1.fc31.noarch",
       "dracut-049-27.git20181204.fc31.1.x86_64",
+      "dracut-config-generic-049-27.git20181204.fc31.1.x86_64",
       "e2fsprogs-1.45.3-1.fc31.x86_64",
       "e2fsprogs-libs-1.45.3-1.fc31.x86_64",
       "ebtables-legacy-2.0.10-37.fc31.x86_64",

--- a/test/cases/f31-x86_64-vmdk-boot.json
+++ b/test/cases/f31-x86_64-vmdk-boot.json
@@ -115,6 +115,7 @@
           "sha256:33f37ee132feff578bdf50f89f6f6a18c3c7fcc699b5ea7922317087fd210c18": "http://dl.fedoraproject.org/pub/fedora/linux/releases/31/Everything/x86_64/os/Packages/l/libarchive-3.4.0-1.fc31.x86_64.rpm",
           "sha256:3434fe7dfffa29d996d94d2664dd2597ce446abf6b0d75920cc691540e139fcc": "http://dl.fedoraproject.org/pub/fedora/linux/releases/31/Everything/x86_64/os/Packages/l/libXft-2.3.3-2.fc31.x86_64.rpm",
           "sha256:34a182fca42c4cac66aa6186603509b90659076d62147ac735def1adb72883dd": "http://dl.fedoraproject.org/pub/fedora/linux/releases/31/Everything/x86_64/os/Packages/g/gcr-3.33.4-1.fc31.x86_64.rpm",
+          "sha256:34a9986b8b61812ceaf32ce3b189bd0b2cb4adaaf47d76ec1f50ce07c45b5675": "http://dl.fedoraproject.org/pub/fedora/linux/releases/31/Everything/x86_64/os/Packages/d/dracut-config-generic-049-27.git20181204.fc31.1.x86_64.rpm",
           "sha256:34f7954cf6c6ceb4385fdcc587dced94405913ddfe5e3213fcbd72562f286fbc": "http://dl.fedoraproject.org/pub/fedora/linux/releases/31/Everything/x86_64/os/Packages/d/dejavu-fonts-common-2.37-2.fc31.noarch.rpm",
           "sha256:35413dd963ebd9e61467067c18a53c7027dcd95ebcae5a5ffaf4727507e37c8c": "http://dl.fedoraproject.org/pub/fedora/linux/releases/31/Everything/x86_64/os/Packages/p/python-unversioned-command-3.7.4-5.fc31.noarch.rpm",
           "sha256:359d74d5f3988e1c2c5327f9d4ea59d0c49a2383541928084ef00383d70b6d55": "http://dl.fedoraproject.org/pub/fedora/linux/releases/31/Everything/x86_64/os/Packages/p/publicsuffix-list-dafsa-20190417-2.fc31.noarch.rpm",
@@ -784,6 +785,7 @@
               "sha256:02301d2744b96674019251b6c8d2199790960e4cc79d90fbdb946a298fc2c4ea",
               "sha256:16ea1e6ba5bbf16cb6a052b2326d25b9980971fd72c46e7d701e09f267d33063",
               "sha256:ef55145ef56d4d63c0085d04e856943d5c61c11ba10c70a383d8f67b74818159",
+              "sha256:34a9986b8b61812ceaf32ce3b189bd0b2cb4adaaf47d76ec1f50ce07c45b5675",
               "sha256:71c02de0e50e07999d0f4f40bce06ca4904e0ab786220bd7ffebc4a60a4d3cd7",
               "sha256:de678f5a55f5ff690f3587adcbc7a1b7d477fefe85ffd5d91fc1447ddba63c89",
               "sha256:cab1b0c3bdae2a07e15b90b414f50753c759e325b6f0cddfa27895748c77f082",
@@ -4188,6 +4190,15 @@
         "checksum": "sha256:ef55145ef56d4d63c0085d04e856943d5c61c11ba10c70a383d8f67b74818159"
       },
       {
+        "name": "dracut-config-generic",
+        "epoch": 0,
+        "version": "049",
+        "release": "27.git20181204.fc31.1",
+        "arch": "x86_64",
+        "remote_location": "http://dl.fedoraproject.org/pub/fedora/linux/releases/31/Everything/x86_64/os/Packages/d/dracut-config-generic-049-27.git20181204.fc31.1.x86_64.rpm",
+        "checksum": "sha256:34a9986b8b61812ceaf32ce3b189bd0b2cb4adaaf47d76ec1f50ce07c45b5675"
+      },
+      {
         "name": "e2fsprogs",
         "epoch": 0,
         "version": "1.45.3",
@@ -7357,6 +7368,7 @@
       "dnf-data-4.2.9-5.fc31.noarch",
       "dnf-plugins-core-4.0.9-1.fc31.noarch",
       "dracut-049-27.git20181204.fc31.1.x86_64",
+      "dracut-config-generic-049-27.git20181204.fc31.1.x86_64",
       "e2fsprogs-1.45.3-1.fc31.x86_64",
       "e2fsprogs-libs-1.45.3-1.fc31.x86_64",
       "ebtables-legacy-2.0.10-37.fc31.x86_64",


### PR DESCRIPTION
- I added `dracut-config-generic` to Fedora to make initramfs generation host independent
- I clean up its usage in RHEL - it's no longer installed in the build pipeline and in the non-bootable images.