### PR TITLE
ci/github: bump the checkout action to version 2

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,7 +23,7 @@ jobs:
         id: go
 
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
 
       - name: Check that source has been prepared
         run: |


### PR DESCRIPTION
actions/checkout@v1 sometimes fails, bumping the version should fix it. See:
https://github.com/actions/checkout/issues/23

This issue is currently preventing running the checks on #443 