### PR TITLE
tests: increase coverage of internal/crypt

### DIFF
--- a/internal/crypt/crypt_test.go
+++ b/internal/crypt/crypt_test.go
@@ -1,6 +1,7 @@
 package crypt
 
 import (
+	"github.com/stretchr/testify/assert"
 	"testing"
 )
 
@@ -40,4 +41,21 @@ func Test_crypt_PasswordIsCrypted(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestCryptSHA512(t *testing.T) {
+	retPassFirst, err := CryptSHA512("testPass")
+	assert.NoError(t, err)
+	retPassSecond, _ := CryptSHA512("testPass")
+	expectedPassStart := "$6$"
+	assert.Equal(t, expectedPassStart, retPassFirst[0:3])
+	assert.NotEqual(t, retPassFirst, retPassSecond)
+}
+
+func TestGenSalt(t *testing.T) {
+	length := 10
+	retSaltFirst, err := genSalt(length)
+	assert.NoError(t, err)
+	retSaltSecond, _ := genSalt(length)
+	assert.NotEqual(t, retSaltFirst, retSaltSecond)
 }


### PR DESCRIPTION
@atodorov could you give me some advice here please? By simply calling the `CryptSHA512` function I get a lot of lines covered which is fine I guess but I am not sure if there's anything else I can do to verify correct functionality of the hash function. I thought about calling it multiple times with the same input and comparing the returned values if they're all unique (each one of them gets random salt). 

But since the actual hashing algorithm is implemented in an external C function I guess simply verifying that this returns a hash value and no errors is enough? What's your opinion on this?