### PR TITLE
🔌 Plug osbuild-composer into Jenkins

### DIFF
--- a/jenkins/run_tests.sh
+++ b/jenkins/run_tests.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+set -euxo pipefail
+
+# Ensure Ansible is installed.
+sudo dnf -y install ansible
+
+# Clone the latest version of ansible-osbuild.
+git clone https://github.com/osbuild/ansible-osbuild.git ansible-osbuild
+
+# Get the current SHA of osbuild-composer.
+OSBUILD_COMPOSER_VERSION=$(git rev-parse HEAD)
+
+# Run the deployment.
+pushd ansible-osbuild
+  echo -e "[test_instances]\nlocalhost ansible_connection=local" > hosts.ini
+  ansible-playbook \
+    -i hosts.ini \
+    -e osbuild_composer_repo=${WORKSPACE} \
+    -e osbuild_composer_version=${OSBUILD_COMPOSER_VERSION} \
+    playbook.yml
+popd
+
+# Run the integration tests.
+# /usr/libexec/tests/osbuild-composer/osbuild-dnf-json-tests
+# /usr/libexec/tests/osbuild-composer/osbuild-image-tests
+# /usr/libexec/tests/osbuild-composer/osbuild-rcm-tests -test.v
+# /usr/libexec/tests/osbuild-composer/osbuild-tests -test.v
+# /usr/libexec/tests/osbuild-composer/osbuild-weldr-tests -test.v


### PR DESCRIPTION
Let's throw schutz to the wind and add Jenkins to the osbuild-composer
repository. Jenkins will execute the `jenkins/run_tests.sh` script and that
will deploy osbuild, osbuild-composer, and cockpit-composer on Fedora 31
and 32.

We can add extra integration tests gradually after this is merged.

Signed-off-by: Major Hayden <major@redhat.com>