### PR TITLE
common: drop unused image types

### DIFF
--- a/internal/common/types.go
+++ b/internal/common/types.go
@@ -65,11 +65,8 @@ type ImageType int
 
 // NOTE: If you want to add more constants here, don't forget to add a mapping below
 const (
-	Alibaba ImageType = iota
-	Azure
+	Azure ImageType = iota
 	Aws
-	GoogleCloud
-	HyperV
 	LiveISO
 	OpenStack
 	Qcow2Generic
@@ -83,11 +80,8 @@ const (
 // to ImageType.
 func getImageTypeMapping() map[string]int {
 	mapping := map[string]int{
-		"Alibaba":          int(Alibaba),
 		"Azure":            int(Azure),
 		"AWS":              int(Aws),
-		"Google-Cloud":     int(GoogleCloud),
-		"Hyper-V":          int(HyperV),
 		"LiveISO":          int(LiveISO),
 		"OpenStack":        int(OpenStack),
 		"qcow2":            int(Qcow2Generic),
@@ -102,11 +96,8 @@ func getImageTypeMapping() map[string]int {
 // TODO: check the mapping here:
 func getCompatImageTypeMapping() map[int]string {
 	mapping := map[int]string{
-		int(Alibaba):         "ami",
 		int(Azure):           "vhd",
 		int(Aws):             "ami",
-		int(GoogleCloud):     "ami",
-		int(HyperV):          "vhd",
 		int(LiveISO):         "liveiso",
 		int(OpenStack):       "openstack",
 		int(Qcow2Generic):    "qcow2",

--- a/internal/common/types_test.go
+++ b/internal/common/types_test.go
@@ -9,7 +9,7 @@ func TestImageType_UnmarshalJSON(t *testing.T) {
 	dict := struct {
 		ImageTypes []ImageType `json:"image_types"`
 	}{}
-	input := `{"image_types":["qcow2", "Alibaba"]}`
+	input := `{"image_types":["qcow2", "Azure"]}`
 	err := json.Unmarshal([]byte(input), &dict)
 	if err != nil {
 		t.Fatal(err)
@@ -17,7 +17,7 @@ func TestImageType_UnmarshalJSON(t *testing.T) {
 	if dict.ImageTypes[0] != Qcow2Generic {
 		t.Fatal("failed to umarshal image type qcow2; got tag:", dict.ImageTypes[0])
 	}
-	if dict.ImageTypes[1] != Alibaba {
-		t.Fatal("failed to umarshal image type Alibaba; got tag:", dict.ImageTypes[0])
+	if dict.ImageTypes[1] != Azure {
+		t.Fatal("failed to umarshal image type Azure; got tag:", dict.ImageTypes[0])
 	}
 }


### PR DESCRIPTION
The Alibaba and GCE image types were not used, and they were
causing problems when translated from and to strings as they were
mapping to the same internal image type. The end result was that
AWS jobs were shown as Alibaba or GCE in the UI.

This fixes #369.

Signed-off-by: Tom Gundersen <teg@jklm.no>