### PR TITLE
🎲 Enable rcm integration tests

### DIFF
--- a/jenkins/run_tests.sh
+++ b/jenkins/run_tests.sh
@@ -23,6 +23,6 @@ popd
 # Run the integration tests.
 # /usr/libexec/tests/osbuild-composer/osbuild-dnf-json-tests
 # /usr/libexec/tests/osbuild-composer/osbuild-image-tests
-# /usr/libexec/tests/osbuild-composer/osbuild-rcm-tests -test.v
+/usr/libexec/tests/osbuild-composer/osbuild-rcm-tests -test.v
 # /usr/libexec/tests/osbuild-composer/osbuild-tests -test.v
 # /usr/libexec/tests/osbuild-composer/osbuild-weldr-tests -test.v


### PR DESCRIPTION
Now that Jenkins is hooked up to the repository, let's run the rcm
tests after we deploy all of the services into a VM.

Signed-off-by: Major Hayden <major@redhat.com>