### PR TITLE
dnf-json: always check for new metadata

### DIFF
--- a/dnf-json
+++ b/dnf-json
@@ -34,6 +34,21 @@ def dnfrepo(desc, parent_conf=None):
     if desc.get("ignoressl", False):
         repo.sslverify = False
 
+    # The default metadata expiration time is 48 hours. This is not enough for
+    # all repositories we want to support (in particular fedora updates needs
+    # it set to at most 6h in order to guarantee the backing rpms are still
+    # available). The time rpms are guaranteed to stay around is not indicated
+    # in the repo metadata, but must be set by the caller. We would really
+    # rather not have to keep knowledge about this, but just as importantly,
+    # we may want to set the expiration timeout to a smaller value, so that
+    # we would pick up updates as soon as they hit the repos. Otherwise, we
+    # would need some mechanism for flushing the cache. For now, force a
+    # check for fresh metadata on every call. If the metadata did not change
+    # this just means a roundtrip on the network, if it did change it means
+    # redownloading all the metadata, possibly sooner than we would have
+    # liked.
+    repo.metadata_expire = "0"
+
     return repo
 
 


### PR DESCRIPTION
After including the fedora updates repository, we were hitting issues
due to expired metadata. The updates repository requires metadata to
be expired at most every six hours, and the default was to do so every
48h.

On further reflection, it was not clear to me what the right value
here is. The values set in the repo files are the maximums, but
users may want to have the ability to access updated content sooner
than that (especially if they are pushing content to a repo and
immediately pulling into osbuild for testing purposes).

For now, we do like lorax and always check for new metadata, rather
than try to come up with some compromise value or (possibly worse)
expose this to the caller to figure out. I imagine this is something
we eventually will want to revisit.

Signed-off-by: Tom Gundersen <teg@jklm.no>