### PR TITLE
jobqeue: worker API fixups

### DIFF
--- a/internal/jobqueue/api.go
+++ b/internal/jobqueue/api.go
@@ -66,10 +66,6 @@ func notFoundHandler(writer http.ResponseWriter, request *http.Request) {
 	writer.WriteHeader(http.StatusNotFound)
 }
 
-func statusResponseOK(writer http.ResponseWriter) {
-	writer.WriteHeader(http.StatusOK)
-}
-
 func statusResponseError(writer http.ResponseWriter, code int, errors ...string) {
 	writer.WriteHeader(code)
 
@@ -150,7 +146,6 @@ func (api *API) updateJobHandler(writer http.ResponseWriter, request *http.Reque
 		}
 		return
 	}
-	statusResponseOK(writer)
 }
 
 func (api *API) addJobImageHandler(writer http.ResponseWriter, request *http.Request, params httprouter.Params) {
@@ -180,6 +175,4 @@ func (api *API) addJobImageHandler(writer http.ResponseWriter, request *http.Req
 		}
 		return
 	}
-
-	statusResponseOK(writer)
 }

--- a/internal/jobqueue/api.go
+++ b/internal/jobqueue/api.go
@@ -82,16 +82,13 @@ func statusResponseError(writer http.ResponseWriter, code int, errors ...string)
 }
 
 func (api *API) addJobHandler(writer http.ResponseWriter, request *http.Request, _ httprouter.Params) {
-	type requestBody struct {
-	}
-
 	contentType := request.Header["Content-Type"]
 	if len(contentType) != 1 || contentType[0] != "application/json" {
 		statusResponseError(writer, http.StatusUnsupportedMediaType)
 		return
 	}
 
-	var body requestBody
+	var body addJobRequest
 	err := json.NewDecoder(request.Body).Decode(&body)
 	if err != nil {
 		statusResponseError(writer, http.StatusBadRequest, "invalid request: "+err.Error())

--- a/internal/jobqueue/api.go
+++ b/internal/jobqueue/api.go
@@ -2,6 +2,7 @@ package jobqueue
 
 import (
 	"encoding/json"
+	"fmt"
 	"log"
 	"net"
 	"net/http"
@@ -66,21 +67,19 @@ func notFoundHandler(writer http.ResponseWriter, request *http.Request) {
 	writer.WriteHeader(http.StatusNotFound)
 }
 
-func statusResponseError(writer http.ResponseWriter, code int, errors ...string) {
+func statusResponseError(writer http.ResponseWriter, code int, message string) {
 	writer.WriteHeader(code)
 
-	for _, err := range errors {
-		_, e := writer.Write([]byte(err))
-		if e != nil {
-			panic(e)
-		}
+	if message != "" {
+		// ignore error, because we cannot do anything useful with it
+		fmt.Fprint(writer, message)
 	}
 }
 
 func (api *API) addJobHandler(writer http.ResponseWriter, request *http.Request, _ httprouter.Params) {
 	contentType := request.Header["Content-Type"]
 	if len(contentType) != 1 || contentType[0] != "application/json" {
-		statusResponseError(writer, http.StatusUnsupportedMediaType)
+		statusResponseError(writer, http.StatusUnsupportedMediaType, "")
 		return
 	}
 
@@ -106,7 +105,7 @@ func (api *API) addJobHandler(writer http.ResponseWriter, request *http.Request,
 func (api *API) updateJobHandler(writer http.ResponseWriter, request *http.Request, params httprouter.Params) {
 	contentType := request.Header["Content-Type"]
 	if len(contentType) != 1 || contentType[0] != "application/json" {
-		statusResponseError(writer, http.StatusUnsupportedMediaType)
+		statusResponseError(writer, http.StatusUnsupportedMediaType, "")
 		return
 	}
 

--- a/internal/jobqueue/api_test.go
+++ b/internal/jobqueue/api_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/osbuild/osbuild-composer/internal/test"
 )
 
-func TestBasic(t *testing.T) {
+func TestErrors(t *testing.T) {
 	var cases = []struct {
 		Method           string
 		Path             string
@@ -21,8 +21,12 @@ func TestBasic(t *testing.T) {
 		ExpectedStatus   int
 		ExpectedResponse string
 	}{
+		// Bogus path
+		{"GET", "/foo", ``, http.StatusNotFound, ``},
 		// Create job with invalid body
 		{"POST", "/job-queue/v1/jobs", ``, http.StatusBadRequest, `invalid request: EOF`},
+		// Wrong method
+		{"GET", "/job-queue/v1/jobs", ``, http.StatusMethodNotAllowed, ``},
 		// Update job with invalid ID
 		{"PATCH", "/job-queue/v1/jobs/foo/builds/0", `{"status":"RUNNING"}`, http.StatusBadRequest, `invalid compose id: invalid UUID length: 3`},
 		// Update job that does not exist, with invalid body

--- a/internal/jobqueue/api_test.go
+++ b/internal/jobqueue/api_test.go
@@ -15,30 +15,28 @@ import (
 
 func TestErrors(t *testing.T) {
 	var cases = []struct {
-		Method           string
-		Path             string
-		Body             string
-		ExpectedStatus   int
-		ExpectedResponse string
+		Method         string
+		Path           string
+		Body           string
+		ExpectedStatus int
 	}{
 		// Bogus path
-		{"GET", "/foo", ``, http.StatusNotFound, ``},
+		{"GET", "/foo", ``, http.StatusNotFound},
 		// Create job with invalid body
-		{"POST", "/job-queue/v1/jobs", ``, http.StatusBadRequest, `invalid request: EOF`},
+		{"POST", "/job-queue/v1/jobs", ``, http.StatusBadRequest},
 		// Wrong method
-		{"GET", "/job-queue/v1/jobs", ``, http.StatusMethodNotAllowed, ``},
+		{"GET", "/job-queue/v1/jobs", ``, http.StatusMethodNotAllowed},
 		// Update job with invalid ID
-		{"PATCH", "/job-queue/v1/jobs/foo/builds/0", `{"status":"RUNNING"}`, http.StatusBadRequest, `invalid compose id: invalid UUID length: 3`},
+		{"PATCH", "/job-queue/v1/jobs/foo/builds/0", `{"status":"RUNNING"}`, http.StatusBadRequest},
 		// Update job that does not exist, with invalid body
-		{"PATCH", "/job-queue/v1/jobs/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa/builds/0", ``, http.StatusBadRequest, `invalid status: EOF`},
+		{"PATCH", "/job-queue/v1/jobs/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa/builds/0", ``, http.StatusBadRequest},
 		// Update job that does not exist
-		{"PATCH", "/job-queue/v1/jobs/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa/builds/0", `{"status":"RUNNING"}`, http.StatusNotFound, `compose does not exist`},
+		{"PATCH", "/job-queue/v1/jobs/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa/builds/0", `{"status":"RUNNING"}`, http.StatusNotFound},
 	}
 
 	for _, c := range cases {
 		api := jobqueue.New(nil, store.New(nil))
-
-		test.TestNonJsonRoute(t, api, false, c.Method, c.Path, c.Body, c.ExpectedStatus, c.ExpectedResponse)
+		test.TestRoute(t, api, false, c.Method, c.Path, c.Body, c.ExpectedStatus, "{}", "message")
 	}
 }
 
@@ -64,7 +62,7 @@ func TestCreate(t *testing.T) {
 		`{"compose_id":"`+id.String()+`","image_build_id":0,"manifest":{"sources":{},"pipeline":{}},"targets":[]}`, "created")
 }
 
-func testUpdateTransition(t *testing.T, from, to string, expectedStatus int, expectedResponse string) {
+func testUpdateTransition(t *testing.T, from, to string, expectedStatus int) {
 	distroStruct := fedoratest.New()
 	arch, err := distroStruct.GetArch("x86_64")
 	if err != nil {
@@ -92,39 +90,38 @@ func testUpdateTransition(t *testing.T, from, to string, expectedStatus int, exp
 		}
 	}
 
-	test.TestNonJsonRoute(t, api, false, "PATCH", "/job-queue/v1/jobs/"+id.String()+"/builds/0", `{"status":"`+to+`"}`, expectedStatus, expectedResponse)
+	test.TestRoute(t, api, false, "PATCH", "/job-queue/v1/jobs/"+id.String()+"/builds/0", `{"status":"`+to+`"}`, expectedStatus, "{}", "message")
 }
 
 func TestUpdate(t *testing.T) {
 	var cases = []struct {
-		From             string
-		To               string
-		ExpectedStatus   int
-		ExpectedResponse string
+		From           string
+		To             string
+		ExpectedStatus int
 	}{
-		{"VOID", "WAITING", http.StatusNotFound, "compose does not exist"},
-		{"VOID", "RUNNING", http.StatusNotFound, "compose does not exist"},
-		{"VOID", "FINISHED", http.StatusNotFound, "compose does not exist"},
-		{"VOID", "FAILED", http.StatusNotFound, "compose does not exist"},
-		{"WAITING", "WAITING", http.StatusNotFound, "compose has not been popped"},
-		{"WAITING", "RUNNING", http.StatusNotFound, "compose has not been popped"},
-		{"WAITING", "FINISHED", http.StatusNotFound, "compose has not been popped"},
-		{"WAITING", "FAILED", http.StatusNotFound, "compose has not been popped"},
-		{"RUNNING", "WAITING", http.StatusBadRequest, "invalid state transition: image build cannot be moved into waiting state"},
-		{"RUNNING", "RUNNING", http.StatusOK, ""},
-		{"RUNNING", "FINISHED", http.StatusOK, ""},
-		{"RUNNING", "FAILED", http.StatusOK, ""},
-		{"FINISHED", "WAITING", http.StatusBadRequest, "invalid state transition: image build cannot be moved into waiting state"},
-		{"FINISHED", "RUNNING", http.StatusBadRequest, "invalid state transition: only waiting image build can be transitioned into running state"},
-		{"FINISHED", "FINISHED", http.StatusBadRequest, "invalid state transition: only running image build can be transitioned into finished or failed state"},
-		{"FINISHED", "FAILED", http.StatusBadRequest, "invalid state transition: only running image build can be transitioned into finished or failed state"},
-		{"FAILED", "WAITING", http.StatusBadRequest, "invalid state transition: image build cannot be moved into waiting state"},
-		{"FAILED", "RUNNING", http.StatusBadRequest, "invalid state transition: only waiting image build can be transitioned into running state"},
-		{"FAILED", "FINISHED", http.StatusBadRequest, "invalid state transition: only running image build can be transitioned into finished or failed state"},
-		{"FAILED", "FAILED", http.StatusBadRequest, "invalid state transition: only running image build can be transitioned into finished or failed state"},
+		{"VOID", "WAITING", http.StatusNotFound},
+		{"VOID", "RUNNING", http.StatusNotFound},
+		{"VOID", "FINISHED", http.StatusNotFound},
+		{"VOID", "FAILED", http.StatusNotFound},
+		{"WAITING", "WAITING", http.StatusNotFound},
+		{"WAITING", "RUNNING", http.StatusNotFound},
+		{"WAITING", "FINISHED", http.StatusNotFound},
+		{"WAITING", "FAILED", http.StatusNotFound},
+		{"RUNNING", "WAITING", http.StatusBadRequest},
+		{"RUNNING", "RUNNING", http.StatusOK},
+		{"RUNNING", "FINISHED", http.StatusOK},
+		{"RUNNING", "FAILED", http.StatusOK},
+		{"FINISHED", "WAITING", http.StatusBadRequest},
+		{"FINISHED", "RUNNING", http.StatusBadRequest},
+		{"FINISHED", "FINISHED", http.StatusBadRequest},
+		{"FINISHED", "FAILED", http.StatusBadRequest},
+		{"FAILED", "WAITING", http.StatusBadRequest},
+		{"FAILED", "RUNNING", http.StatusBadRequest},
+		{"FAILED", "FINISHED", http.StatusBadRequest},
+		{"FAILED", "FAILED", http.StatusBadRequest},
 	}
 
 	for _, c := range cases {
-		testUpdateTransition(t, c.From, c.To, c.ExpectedStatus, c.ExpectedResponse)
+		testUpdateTransition(t, c.From, c.To, c.ExpectedStatus)
 	}
 }

--- a/internal/jobqueue/client.go
+++ b/internal/jobqueue/client.go
@@ -62,11 +62,8 @@ func NewClientUnix(path string) *Client {
 }
 
 func (c *Client) AddJob() (*Job, error) {
-	type request struct {
-	}
-
 	var b bytes.Buffer
-	err := json.NewEncoder(&b).Encode(request{})
+	err := json.NewEncoder(&b).Encode(addJobRequest{})
 	if err != nil {
 		panic(err)
 	}

--- a/internal/jobqueue/client.go
+++ b/internal/jobqueue/client.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"net/http"
 
@@ -74,9 +73,9 @@ func (c *Client) AddJob() (*Job, error) {
 	defer response.Body.Close()
 
 	if response.StatusCode != http.StatusCreated {
-		rawR, _ := ioutil.ReadAll(response.Body)
-		r := string(rawR)
-		return nil, fmt.Errorf("couldn't create job, got %d: %s", response.StatusCode, r)
+		var er errorResponse
+		_ = json.NewDecoder(response.Body).Decode(&er)
+		return nil, fmt.Errorf("couldn't create job, got %d: %s", response.StatusCode, er.Message)
 	}
 
 	var jr addJobResponse

--- a/internal/jobqueue/json.go
+++ b/internal/jobqueue/json.go
@@ -8,6 +8,10 @@ import (
 	"github.com/osbuild/osbuild-composer/internal/target"
 )
 
+type errorResponse struct {
+	Message string `json:"message"`
+}
+
 type addJobRequest struct {
 }
 
@@ -21,4 +25,7 @@ type addJobResponse struct {
 type updateJobRequest struct {
 	Status common.ImageBuildState `json:"status"`
 	Result *common.ComposeResult  `json:"result"`
+}
+
+type updateJobResponse struct {
 }

--- a/internal/jobqueue/json.go
+++ b/internal/jobqueue/json.go
@@ -8,6 +8,9 @@ import (
 	"github.com/osbuild/osbuild-composer/internal/target"
 )
 
+type addJobRequest struct {
+}
+
 type addJobResponse struct {
 	ComposeID    uuid.UUID         `json:"compose_id"`
 	ImageBuildID int               `json:"image_build_id"`


### PR DESCRIPTION
Make the worker API behave a bit better, especially not returning plain text when advertising `application/json`. See commits messages for details.