### PR TITLE
osbuild requirement: bump to version 11

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ provided infrastructure and services.
 
 The requirements for this project are:
 
- * `osbuild >= 7`
+ * `osbuild >= 11`
  * `systemd >= 244`
 
 At build-time, the following software is required:

--- a/golang-github-osbuild-composer.spec
+++ b/golang-github-osbuild-composer.spec
@@ -39,7 +39,7 @@ BuildRequires:  golang(github.com/stretchr/testify)
 
 Requires: golang-github-osbuild-composer-worker
 Requires: systemd
-Requires: osbuild >= 7
+Requires: osbuild >= 11
 
 Provides: osbuild-composer
 Provides: weldr

--- a/osbuild-composer.spec
+++ b/osbuild-composer.spec
@@ -43,7 +43,7 @@ BuildRequires:  golang(github.com/stretchr/testify/assert)
 
 Requires: osbuild-composer-worker
 Requires: systemd
-Requires: osbuild >= 7
+Requires: osbuild >= 11
 
 Provides: weldr
 


### PR DESCRIPTION
The newest osbuild is needed for support for aarch64. The aarch64 images
are using GPT which requires stable partuuid which was included in the
latest osbuild release (11). This will be used to produce stable
image-info tests.