### PR TITLE
distro: don't include grub2 stage in ext4 images

### DIFF
--- a/internal/distro/fedora30/distro.go
+++ b/internal/distro/fedora30/distro.go
@@ -519,8 +519,8 @@ func (t *imageType) pipeline(c *blueprint.Customizations, repos []rpmmd.RepoConf
 
 	if t.bootable {
 		p.AddStage(osbuild.NewFSTabStage(t.fsTabStageOptions(t.arch.uefi)))
+		p.AddStage(osbuild.NewGRUB2Stage(t.grub2StageOptions(t.kernelOptions, c.GetKernel(), t.arch.uefi)))
 	}
-	p.AddStage(osbuild.NewGRUB2Stage(t.grub2StageOptions(t.kernelOptions, c.GetKernel(), t.arch.uefi)))
 
 	if services := c.GetServices(); services != nil || t.enabledServices != nil {
 		p.AddStage(osbuild.NewSystemdStage(t.systemdStageOptions(t.enabledServices, t.disabledServices, services)))

--- a/internal/distro/fedora31/distro.go
+++ b/internal/distro/fedora31/distro.go
@@ -517,8 +517,8 @@ func (t *imageType) pipeline(c *blueprint.Customizations, repos []rpmmd.RepoConf
 
 	if t.bootable {
 		p.AddStage(osbuild.NewFSTabStage(t.fsTabStageOptions(t.arch.uefi)))
+		p.AddStage(osbuild.NewGRUB2Stage(t.grub2StageOptions(t.kernelOptions, c.GetKernel(), t.arch.uefi)))
 	}
-	p.AddStage(osbuild.NewGRUB2Stage(t.grub2StageOptions(t.kernelOptions, c.GetKernel(), t.arch.uefi)))
 
 	if services := c.GetServices(); services != nil || t.enabledServices != nil {
 		p.AddStage(osbuild.NewSystemdStage(t.systemdStageOptions(t.enabledServices, t.disabledServices, services)))

--- a/internal/distro/fedora32/distro.go
+++ b/internal/distro/fedora32/distro.go
@@ -519,8 +519,8 @@ func (t *imageType) pipeline(c *blueprint.Customizations, repos []rpmmd.RepoConf
 
 	if t.bootable {
 		p.AddStage(osbuild.NewFSTabStage(t.fsTabStageOptions(t.arch.uefi)))
+		p.AddStage(osbuild.NewGRUB2Stage(t.grub2StageOptions(t.kernelOptions, c.GetKernel(), t.arch.uefi)))
 	}
-	p.AddStage(osbuild.NewGRUB2Stage(t.grub2StageOptions(t.kernelOptions, c.GetKernel(), t.arch.uefi)))
 
 	if services := c.GetServices(); services != nil || t.enabledServices != nil {
 		p.AddStage(osbuild.NewSystemdStage(t.systemdStageOptions(t.enabledServices, t.disabledServices, services)))

--- a/test/cases/f30-x86_64-ext4_filesystem-boot.json
+++ b/test/cases/f30-x86_64-ext4_filesystem-boot.json
@@ -771,14 +771,6 @@
           }
         },
         {
-          "name": "org.osbuild.grub2",
-          "options": {
-            "root_fs_uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
-            "kernel_opts": "ro biosdevname=0 net.ifnames=0",
-            "legacy": true
-          }
-        },
-        {
           "name": "org.osbuild.selinux",
           "options": {
             "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
@@ -5447,10 +5439,6 @@
     }
   },
   "image-info": {
-    "boot-environment": {
-      "GRUB2_ROOT_FS_UUID": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
-      "kernelopts": "root=UUID=76a22bf4-f153-4541-b6c7-0332c0dfaeac ro biosdevname=0 net.ifnames=0"
-    },
     "bootloader": "unknown",
     "bootmenu": [
       {

--- a/test/cases/f30-x86_64-tar-boot.json
+++ b/test/cases/f30-x86_64-tar-boot.json
@@ -771,14 +771,6 @@
           }
         },
         {
-          "name": "org.osbuild.grub2",
-          "options": {
-            "root_fs_uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
-            "kernel_opts": "ro biosdevname=0 net.ifnames=0",
-            "legacy": true
-          }
-        },
-        {
           "name": "org.osbuild.selinux",
           "options": {
             "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/cases/f31-x86_64-ext4_filesystem-boot.json
+++ b/test/cases/f31-x86_64-ext4_filesystem-boot.json
@@ -883,14 +883,6 @@
           }
         },
         {
-          "name": "org.osbuild.grub2",
-          "options": {
-            "root_fs_uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
-            "kernel_opts": "ro biosdevname=0 net.ifnames=0",
-            "legacy": true
-          }
-        },
-        {
           "name": "org.osbuild.selinux",
           "options": {
             "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
@@ -6142,10 +6134,6 @@
     }
   },
   "image-info": {
-    "boot-environment": {
-      "GRUB2_ROOT_FS_UUID": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
-      "kernelopts": "root=UUID=76a22bf4-f153-4541-b6c7-0332c0dfaeac ro biosdevname=0 net.ifnames=0"
-    },
     "bootloader": "unknown",
     "bootmenu": [],
     "firewall-enabled": [

--- a/test/cases/f31-x86_64-tar-boot.json
+++ b/test/cases/f31-x86_64-tar-boot.json
@@ -883,14 +883,6 @@
           }
         },
         {
-          "name": "org.osbuild.grub2",
-          "options": {
-            "root_fs_uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
-            "kernel_opts": "ro biosdevname=0 net.ifnames=0",
-            "legacy": true
-          }
-        },
-        {
           "name": "org.osbuild.selinux",
           "options": {
             "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/tools/image-info
+++ b/tools/image-info
@@ -228,8 +228,11 @@ def append_filesystem(report, tree):
 
         if os.path.exists(f"{tree}/boot") and len(os.listdir(f"{tree}/boot")) > 0:
             assert "bootmenu" not in report
-            with open(f"{tree}/boot/grub2/grubenv") as f:
-                report["boot-environment"] = parse_environment_vars(f.read())
+            try:
+                with open(f"{tree}/boot/grub2/grubenv") as f:
+                    report["boot-environment"] = parse_environment_vars(f.read())
+            except FileNotFoundError:
+                pass
             report["bootmenu"] = read_boot_entries(f"{tree}/boot")
 
     elif len(glob.glob(f"{tree}/vmlinuz-*")) > 0:


### PR DESCRIPTION
@larskarlitski , @jgiardino is it ok to change the ext4 image type like this? I'm really unsure about its definition. The image type is declared non-bootable here:
https://github.com/osbuild/osbuild-composer/blob/7dd09443cf22b4cb3a9f15f6fe3d34eb02d8d3ac/internal/distro/fedora31/distro.go#L226


There is no point in having the grub2 stage in pipelines for image types
that are not bootable. The current version is probably a result of
previous refactoring where the member variable was named `IncludeFSTab`.

Moving the grub2 stage into the conditional branch should also fix test
generation on aarch64.

TODO:
 - [x] Regenerate all ext4 test cases