### PR TITLE
dnf-json-tests: split into sub tests

### DIFF
--- a/cmd/osbuild-dnf-json-tests/main_test.go
+++ b/cmd/osbuild-dnf-json-tests/main_test.go
@@ -57,7 +57,7 @@ func TestCrossArchDepsolve(t *testing.T) {
 	// NOTE: we can add RHEL, but don't make it hard requirement because it will fail outside of VPN
 	for _, distroStruct := range []distro.Distro{fedora30.New(), fedora31.New(), fedora32.New()} {
 		repos, err := rpmmd.LoadRepositories([]string{repoDir}, distroStruct.Name())
-		assert.Nilf(t, err, "Failed to LoadRepositories from %v for %v: %v", repoDir, distroStruct.Name(), err)
+		assert.NoErrorf(t, err, "Failed to LoadRepositories %v", distroStruct.Name())
 		if err != nil {
 			// There is no point in running the tests without having repositories, but we can still run tests
 			// for the remaining distros
@@ -65,24 +65,24 @@ func TestCrossArchDepsolve(t *testing.T) {
 		}
 		for _, archStr := range distroStruct.ListArches() {
 			arch, err := distroStruct.GetArch(archStr)
-			assert.Nilf(t, err, "Failed to GetArch from %v structure: %v", distroStruct.Name(), err)
+			assert.NoErrorf(t, err, "Failed to GetArch from %v structure", distroStruct.Name())
 			if err != nil {
 				continue
 			}
 			for _, imgTypeStr := range arch.ListImageTypes() {
 				imgType, err := arch.GetImageType(imgTypeStr)
-				assert.Nilf(t, err, "Failed to GetImageType for %v on %v: %v", distroStruct.Name(), arch.Name(), err)
+				assert.NoErrorf(t, err, "Failed to GetImageType for %v on %v", distroStruct.Name(), arch.Name())
 				if err != nil {
 					continue
 				}
 
 				buildPackages := imgType.BuildPackages()
 				_, _, err = rpm.Depsolve(buildPackages, []string{}, repos[archStr], distroStruct.ModulePlatformID(), archStr)
-				assert.Nilf(t, err, "Failed to Depsolve build packages for %v %v %v image: %v", distroStruct.Name(), imgType.Name(), arch.Name(), err)
+				assert.NoErrorf(t, err, "Failed to Depsolve build packages for %v %v %v image", distroStruct.Name(), imgType.Name(), arch.Name())
 
 				basePackagesInclude, basePackagesExclude := imgType.BasePackages()
 				_, _, err = rpm.Depsolve(basePackagesInclude, basePackagesExclude, repos[archStr], distroStruct.ModulePlatformID(), archStr)
-				assert.Nilf(t, err, "Failed to Depsolve base packages for %v %v %v image: %v", distroStruct.Name(), imgType.Name(), arch.Name(), err)
+				assert.NoErrorf(t, err, "Failed to Depsolve base packages for %v %v %v image", distroStruct.Name(), imgType.Name(), arch.Name())
 			}
 		}
 	}

--- a/cmd/osbuild-dnf-json-tests/main_test.go
+++ b/cmd/osbuild-dnf-json-tests/main_test.go
@@ -52,12 +52,12 @@ func TestCrossArchDepsolve(t *testing.T) {
 	rpm := rpmmd.NewRPMMD(dir)
 
 	// Load repositories from the definition we provide in the RPM package
-	repositories := "/usr/share/osbuild-composer"
+	repoDir := "/usr/share/osbuild-composer"
 
 	// NOTE: we can add RHEL, but don't make it hard requirement because it will fail outside of VPN
 	for _, distroStruct := range []distro.Distro{fedora30.New(), fedora31.New(), fedora32.New()} {
-		repoConfig, err := rpmmd.LoadRepositories([]string{repositories}, distroStruct.Name())
-		assert.Nilf(t, err, "Failed to LoadRepositories from %v for %v: %v", repositories, distroStruct.Name(), err)
+		repos, err := rpmmd.LoadRepositories([]string{repoDir}, distroStruct.Name())
+		assert.Nilf(t, err, "Failed to LoadRepositories from %v for %v: %v", repoDir, distroStruct.Name(), err)
 		if err != nil {
 			// There is no point in running the tests without having repositories, but we can still run tests
 			// for the remaining distros
@@ -77,11 +77,11 @@ func TestCrossArchDepsolve(t *testing.T) {
 				}
 
 				buildPackages := imgType.BuildPackages()
-				_, _, err = rpm.Depsolve(buildPackages, []string{}, repoConfig[archStr], distroStruct.ModulePlatformID(), archStr)
+				_, _, err = rpm.Depsolve(buildPackages, []string{}, repos[archStr], distroStruct.ModulePlatformID(), archStr)
 				assert.Nilf(t, err, "Failed to Depsolve build packages for %v %v %v image: %v", distroStruct.Name(), imgType.Name(), arch.Name(), err)
 
 				basePackagesInclude, basePackagesExclude := imgType.BasePackages()
-				_, _, err = rpm.Depsolve(basePackagesInclude, basePackagesExclude, repoConfig[archStr], distroStruct.ModulePlatformID(), archStr)
+				_, _, err = rpm.Depsolve(basePackagesInclude, basePackagesExclude, repos[archStr], distroStruct.ModulePlatformID(), archStr)
 				assert.Nilf(t, err, "Failed to Depsolve base packages for %v %v %v image: %v", distroStruct.Name(), imgType.Name(), arch.Name(), err)
 			}
 		}

--- a/cmd/osbuild-dnf-json-tests/main_test.go
+++ b/cmd/osbuild-dnf-json-tests/main_test.go
@@ -6,18 +6,20 @@ package main
 
 import (
 	"fmt"
+	"io/ioutil"
+	"os"
+	"path"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/osbuild/osbuild-composer/internal/distro"
 	"github.com/osbuild/osbuild-composer/internal/distro/fedora30"
 	"github.com/osbuild/osbuild-composer/internal/distro/fedora31"
 	"github.com/osbuild/osbuild-composer/internal/distro/fedora32"
 	"github.com/osbuild/osbuild-composer/internal/rpmmd"
 	"github.com/osbuild/osbuild-composer/internal/test"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	"io/ioutil"
-	"os"
-	"path"
-	"testing"
 )
 
 func TestFetchChecksum(t *testing.T) {

--- a/dnf-json
+++ b/dnf-json
@@ -93,7 +93,7 @@ module_platform_id = arguments["module_platform_id"]
 with tempfile.TemporaryDirectory() as persistdir:
     try:
         base = create_base(repos, module_platform_id, persistdir, cachedir, arch)
-    except dnf.exceptions.RepoError as e:
+    except dnf.exceptions.Error as e:
         exit_with_dnf_error("RepoError", f"Error occurred when setting up repo: {e}")
 
     if command == "dump":

--- a/jenkins/run_tests.sh
+++ b/jenkins/run_tests.sh
@@ -21,7 +21,7 @@ pushd ansible-osbuild
 popd
 
 # Run the integration tests.
-# /usr/libexec/tests/osbuild-composer/osbuild-dnf-json-tests
+/usr/libexec/tests/osbuild-composer/osbuild-dnf-json-tests -test.v
 # /usr/libexec/tests/osbuild-composer/osbuild-image-tests
 /usr/libexec/tests/osbuild-composer/osbuild-rcm-tests -test.v
 # /usr/libexec/tests/osbuild-composer/osbuild-tests -test.v


### PR DESCRIPTION
While debugging a modularity error on fedora-32, I noticed that it's hard to find out which distro / arch / image type combination failed. This doesn't fix the actual error (@major turned off testing on fedora-32 for now), but might make things simpler in the future.

There's also a commit that fixes `dnf-json` not print python stacktraces in a few additional cases.

See commits for more details.