### PR TITLE
codecov: disable codecov/patch status

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,3 +1,6 @@
+coverage:
+  status:
+    patch: no
 codecov:
   require_ci_to_pass: no
 comment: no


### PR DESCRIPTION
Codecov's patch status measures lines covered in a given pull request,
which fails when moving code around.

Adding code with no coverage still fails the codecov/project status,
which fails if coverage has gone down.