### PR TITLE
image-info: report errors from subprocess calls

### DIFF
--- a/tools/image-info
+++ b/tools/image-info
@@ -75,7 +75,14 @@ def parse_unit_files(s, expected_state):
 
 
 def subprocess_check_output(argv, parse_fn=None):
-    output = subprocess.check_output(argv, encoding="utf-8")
+    try:
+        output = subprocess.check_output(argv, encoding="utf-8")
+    except subprocess.CalledProcessError as e:
+        sys.stderr.write(f"--- Output from {argv}:\n")
+        sys.stderr.write(e.stdout)
+        sys.stderr.write("\n--- End of the output\n")
+        raise
+
     return parse_fn(output) if parse_fn else output
 
 


### PR DESCRIPTION
The subproces.check_output function hides the output of the subprocess
it runs, using subprocess.run directly enable us to see the errors.