### PR TITLE
test-case-generators: use unxz also for aws

### DIFF
--- a/tools/test-case-generators/generate-test-case
+++ b/tools/test-case-generators/generate-test-case
@@ -56,7 +56,7 @@ def main(test_case, store):
         image_file = os.path.join(store, "refs", output_id, test_case["compose-request"]["filename"])
 
         # we don't yet support image-info on directory trees
-        if boot_type == "qemu-extract":
+        if boot_type in {"qemu-extract", "aws"}:
             fn, ex = os.path.splitext(image_file)
             if ex == ".xz":
                 with open(fn, "w") as f:


### PR DESCRIPTION
In PR #400:
https://github.com/osbuild/osbuild-composer/pull/400
we changed the boot type of AWS images from qemu-extract to aws, which
resulted in a bug in the generate-test-case script. It tried to attach
xz archive using qemu-nbd which works just fine from qemu-nbd
perspective but sfdisk and blkid of course failed, because the xz
archive is not a disk image.

This patch makes sure we extract the image before attaching it to
/dev/nbdX.