### PR TITLE
store: use default size in image build

### DIFF
--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -590,7 +590,7 @@ func (s *Store) PushCompose(imageType distro.ImageType, bp *blueprint.Blueprint,
 					ImageType:   imageTypeCommon,
 					Targets:     targets,
 					JobCreated:  time.Now(),
-					Size:        size,
+					Size:        imageType.Size(size),
 				},
 			},
 		}


### PR DESCRIPTION
If a user creates a compose with a size of 0, the default image size for the image type should be used. Also, certain image types have requirements for the image size. In order to ensure that the proper image size is stored in the compose object, the compose's ImageBuild object uses ImageType.Size() to get the correct image size for the image type.