### PR TITLE
crypt_test: don't run on macOS

### DIFF
--- a/internal/crypt/crypt_test.go
+++ b/internal/crypt/crypt_test.go
@@ -1,3 +1,5 @@
+// +build !macos
+
 package crypt
 
 import (


### PR DESCRIPTION
The new crypt tests cannot be run on macOS. Making them conditional for
non-macOS platforms fixes running unit tests in the internal directory
on macOS.