### PR TITLE
store: Set JobStarted time when PopJob is called

### DIFF
--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -607,6 +607,7 @@ func (s *Store) PopJob() Job {
 		}
 		// Change queue status to running for the image build as well as for the targets
 		compose.ImageBuilds[job.ImageBuildID].QueueStatus = common.IBRunning
+		compose.ImageBuilds[job.ImageBuildID].JobStarted = time.Now()
 		for m := range compose.ImageBuilds[job.ImageBuildID].Targets {
 			compose.ImageBuilds[job.ImageBuildID].Targets[m].Status = common.IBRunning
 		}


### PR DESCRIPTION
If you don't set the time it ends up being the default Go time which is
1/1/1 and when you convert that using UnixNano() you get a nice big
negative number (-6795364578871345152) which then eventually shows up in
the queue, finished, and failed output as 'Fri Aug 30 17:47:39 1754'
and since the Time Travel feature is not yet complete this is
impossible.

The fix is to set it when the job is started.