### PR TITLE
upload/aws: double the timeout for snapshot import

### DIFF
--- a/internal/upload/awsupload/awsupload.go
+++ b/internal/upload/awsupload/awsupload.go
@@ -74,7 +74,7 @@ func WaitUntilImportSnapshotTaskCompleted(c *ec2.EC2, input *ec2.DescribeImportS
 func WaitUntilImportSnapshotTaskCompletedWithContext(c *ec2.EC2, ctx aws.Context, input *ec2.DescribeImportSnapshotTasksInput, opts ...request.WaiterOption) error {
 	w := request.Waiter{
 		Name:        "WaitUntilImportSnapshotTaskCompleted",
-		MaxAttempts: 40,
+		MaxAttempts: 80, // this can take up to 15 minutes, therefore set the timeout to 20 minutes
 		Delay:       request.ConstantWaiterDelay(15 * time.Second),
 		Acceptors: []request.WaiterAcceptor{
 			{


### PR DESCRIPTION
us-east-1 seems to very slow these days, some imports can take up to
15 minutes. This commit raises the timeout from 10 to 20 minutes.