### PR TITLE
osbuild: make grub2 "legacy" parameter a union

### DIFF
--- a/internal/distro/fedora30/distro.go
+++ b/internal/distro/fedora30/distro.go
@@ -673,7 +673,7 @@ func (r *imageType) grub2StageOptions(kernelOptions string, kernel *blueprint.Ke
 	return &osbuild.GRUB2StageOptions{
 		RootFilesystemUUID: id,
 		KernelOptions:      kernelOptions,
-		Legacy:             !uefi,
+		Legacy:             osbuild.GRUB2LegacyFromBool(!uefi),
 		UEFI:               uefiOptions,
 	}
 }

--- a/internal/distro/fedora31/distro.go
+++ b/internal/distro/fedora31/distro.go
@@ -671,7 +671,7 @@ func (r *imageType) grub2StageOptions(kernelOptions string, kernel *blueprint.Ke
 	return &osbuild.GRUB2StageOptions{
 		RootFilesystemUUID: id,
 		KernelOptions:      kernelOptions,
-		Legacy:             !uefi,
+		Legacy:             osbuild.GRUB2LegacyFromBool(!uefi),
 		UEFI:               uefiOptions,
 	}
 }

--- a/internal/distro/fedora32/distro.go
+++ b/internal/distro/fedora32/distro.go
@@ -673,7 +673,7 @@ func (r *imageType) grub2StageOptions(kernelOptions string, kernel *blueprint.Ke
 	return &osbuild.GRUB2StageOptions{
 		RootFilesystemUUID: id,
 		KernelOptions:      kernelOptions,
-		Legacy:             !uefi,
+		Legacy:             osbuild.GRUB2LegacyFromBool(!uefi),
 		UEFI:               uefiOptions,
 	}
 }

--- a/internal/distro/rhel81/distro.go
+++ b/internal/distro/rhel81/distro.go
@@ -753,7 +753,7 @@ func (r *rhel81ImageType) grub2StageOptions(kernelOptions string, uefi bool) *os
 	return &osbuild.GRUB2StageOptions{
 		RootFilesystemUUID: id,
 		KernelOptions:      kernelOptions,
-		Legacy:             !uefi,
+		Legacy:             osbuild.GRUB2LegacyFromBool(!uefi),
 		UEFI:               uefiOptions,
 	}
 }

--- a/internal/distro/rhel82/distro.go
+++ b/internal/distro/rhel82/distro.go
@@ -780,7 +780,7 @@ func (r *rhel82ImageType) grub2StageOptions(kernelOptions string, uefi bool) *os
 	return &osbuild.GRUB2StageOptions{
 		RootFilesystemUUID: id,
 		KernelOptions:      kernelOptions,
-		Legacy:             !uefi,
+		Legacy:             osbuild.GRUB2LegacyFromBool(!uefi),
 		UEFI:               uefiOptions,
 	}
 }


### PR DESCRIPTION
The "legacy" entry in grub2 stage from osbuild can be both bool and
string as you can see for example here:
https://github.com/osbuild/osbuild/blob/b53de35b0aebd52b38b979d491731aa589548b03/samples/f30-ppc64le.json#L60
In order to support that we need to make it a union but since go
does not have any unions I made a struct with a tag (IsString) so it is
like the classic tagged union pattern in C except for the union part.

The reason why a choose IsString instead of IsBool is that in case of
IsString the structure defaults to bool because bool defaults to false.
If I choose IsBool instead it would default to string, which would
require more rewriting of the code as code supports only partially
initialized structures.