### PR TITLE
workflow: enable updates-testing repo when installing osbuild

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -111,6 +111,9 @@ jobs:
       - name: "🗄️ Clone the repository"
         uses: actions/checkout@v2
 
+      - name: "🧱 Pre-install osbuild from updates-testing repo"
+        run: dnf -y --enablerepo=updates-testing install osbuild
+
       - name: "🛒 Install RPM build dependencies"
         run: dnf -y builddep osbuild-composer.spec
 


### PR DESCRIPTION
The source of issue here is that our release cycles are synchronized and
if we want to use the latest released osbuild we need to wait for the
bodhi process. It makes sense that we don't want to use latest osbuild
from git master but we should be confident enough in the version we
submit to bodhi.

Using the version from updates-testing therefore fixes the issue with
synchronization and avoids using unreleased versions.