### PR TITLE
Update cockpit-composer urls for organization change

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ such can serve as drop-in replacement for lorax-composer.
 You can control a composer instance either directly via the provided APIs, or
 through higher-level user-interfaces from external projects. This, for
 instance, includes a
-[Cockpit Module](https://github.com/weldr/cockpit-composer) or using the
+[Cockpit Module](https://github.com/osbuild/cockpit-composer) or using the
 [composer-cli](https://weldr.io/lorax/composer-cli.html) command-line tool.
 
 ### Project

--- a/docs/osbuild-composer.7.rst
+++ b/docs/osbuild-composer.7.rst
@@ -70,7 +70,7 @@ NOTES
 .. [#lorax-github] Lorax Composer:
                    https://github.com/weldr/lorax
 .. [#cockpit-composer] Cockpit Composer:
-                       https://github.com/weldr/cockpit-composer
+                       https://github.com/osbuild/cockpit-composer
 .. [#composer-cli] Composer CLI:
                    https://weldr.io/lorax/composer-cli.html
 .. [#cockpit] Cockpit Project:


### PR DESCRIPTION
Cockpit-composer is moving from the weldr github organization to the osbuild organization and its github url has changed. I have updated cockpit-composer's url. 

This PR should not be merged until after cockpit-composer has moved to the osbuild organization.