### PR TITLE
🐎 Allow qemu to use all available CPUs

### DIFF
--- a/cmd/osbuild-image-tests/context-managers.go
+++ b/cmd/osbuild-image-tests/context-managers.go
@@ -10,6 +10,8 @@ import (
 	"log"
 	"os"
 	"os/exec"
+	"runtime"
+	"strconv"
 	"time"
 )
 
@@ -128,6 +130,8 @@ func withBootedQemuImage(image string, ns netNS, f func() error) error {
 
 		qemuX8664Cmd := ns.NamespacedCommand(
 			"qemu-system-x86_64",
+			"-cpu", "host",
+			"-smp", strconv.Itoa(runtime.NumCPU()),
 			"-m", "1024",
 			"-snapshot",
 			"-accel", "accel=kvm:hvf:tcg",


### PR DESCRIPTION
Speed up the boot tests by allowing qemu to use all of the available
CPUs on the system. Our CI VMs have at least 2 CPUs and this shortens
the time required for a boot test.

Signed-off-by: Major Hayden <major@redhat.com>