### PR TITLE
🥊 Resilient testing + log gathering

### DIFF
--- a/jenkins/test.yml
+++ b/jenkins/test.yml
@@ -1,0 +1,27 @@
+---
+
+- hosts: localhost
+  vars:
+    passed_tests: []
+    failed_tests: []
+    journald_cursor: "{{ ansible_env.JOURNALD_CURSOR"
+  vars_files:
+    - vars.yml
+  tasks:
+
+    - name: Run osbuild-composer tests
+      include_tasks: test_runner.yml
+      loop: "{{ osbuild_composer_base_tests }}"
+      loop_control:
+        loop_var: test
+
+    - name: Show failed and passed tests
+      debug:
+        msg: |
+          Passed tests: "{{ passed_tests }}"
+          Failed tests: "{{ failed_tests }}"
+
+    - name: Fail the test run if a test failed
+      fail:
+        msg: One or more tests failed.
+      when: failed_tests

--- a/jenkins/test_runner.yml
+++ b/jenkins/test_runner.yml
@@ -1,0 +1,37 @@
+---
+
+- block:
+
+    # NOTE(mhayden): Running tests from the workspace dirt
+    - name: "Run {{ test.name }} test"
+      command: "{{ tests_path }}/{{ test.name }} -test.v"
+      args:
+        chdir: "{{ tests_working_directory }}"
+      register: async_test
+      async: "{{ test.timeout * 60 }}"
+      poll: "{{ polling_interval }}"
+
+    - name: "Mark {{ test.name }} as passed"
+      set_fact:
+        passed_tests: "{{ passed_tests + [test.name] }}"
+
+  rescue:
+
+    - name: "Mark {{ test.name }} as failed"
+      set_fact:
+        failed_tests: "{{ failed_tests + [test.name] }}"
+
+  always:
+
+    - name: "Write log for {{ test.name }}"
+      copy:
+        dest: "{{ workspace }}/{{ test.name }}.log"
+        content: |
+          Logs from {{ test.name }}
+          ----------------------------------------------------------------------
+          stderr:
+          {{ async_test.stderr }}
+          ----------------------------------------------------------------------
+          stdout:
+          {{ async_test.stdout }}
+

--- a/jenkins/vars.yml
+++ b/jenkins/vars.yml
@@ -1,0 +1,20 @@
+# Tests should use this as their working directory. This part is critical
+# since dnf-json must be in $PATH.
+tests_working_directory: /usr/libexec/osbuild-composer
+
+# The test executables are here.
+tests_path: /usr/libexec/tests/osbuild-composer
+
+# Set each test executable name and its timeout (in minutes).
+osbuild_composer_base_tests:
+  - name: osbuild-rcm-tests
+    timeout: 5
+  - name: osbuild-weldr-tests
+    timeout: 5
+  - name: osbuild-dnf-json-tests
+    timeout: 15
+  - name: osbuild-tests
+    timeout: 30
+
+# Frequency to check for completed tests.
+polling_interval: 15


### PR DESCRIPTION
Convert the bash script to an ansible playbook so we can gracefully
handle testing failures and gather logs reliably. Colorful output
is nice, too.

Signed-off-by: Major Hayden <major@redhat.com>