### PR TITLE
tools/prepare-source: use a well-defined go version

### DIFF
--- a/tools/prepare-source.sh
+++ b/tools/prepare-source.sh
@@ -2,6 +2,15 @@
 
 set -eux
 
-go fmt ./...
-go mod tidy
-go mod vendor
+GO_VERSION=1.12.17
+GO_BINARY=$(go env GOPATH)/bin/go$GO_VERSION
+
+# this is the official way to get a different version of golang
+# see https://golang.org/doc/install#extra_versions
+go get golang.org/dl/go$GO_VERSION
+$GO_BINARY download
+
+# prepare the sources
+$GO_BINARY fmt ./...
+$GO_BINARY mod tidy
+$GO_BINARY mod vendor


### PR DESCRIPTION
go mod works differently in go 1.12 and go 1.13. When someone uses the
prepare-source tool with go >= 1.13, the ci complains because it uses
go 1.12. This commit changes the script to use a well-defined go version.