### PR TITLE
🐎 Run dnf-json tests in parallel

### DIFF
--- a/cmd/osbuild-dnf-json-tests/main_test.go
+++ b/cmd/osbuild-dnf-json-tests/main_test.go
@@ -57,6 +57,10 @@ func TestCrossArchDepsolve(t *testing.T) {
 	// NOTE: we can add RHEL, but don't make it hard requirement because it will fail outside of VPN
 	for _, distroStruct := range []distro.Distro{fedora30.New(), fedora31.New(), fedora32.New()} {
 		t.Run(distroStruct.Name(), func(t *testing.T) {
+
+			// Run tests in parallel to speed up run times.
+			t.Parallel()
+
 			repos, err := rpmmd.LoadRepositories([]string{repoDir}, distroStruct.Name())
 			require.NoErrorf(t, err, "Failed to LoadRepositories %v", distroStruct.Name())
 


### PR DESCRIPTION
Run multiple dnf-json tests in parallel to speed up execution. The total number of parallel tests is limited by the number of CPUs in the machine that is running the tests.

This reduces dnf-json test runtime in PSI from 14-15 minutes down to 5-6 minutes.