### PR TITLE
Change the format of the ami image type to vhdx

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -70,6 +70,9 @@ jobs:
       - name: "🗄️ Clone the repository"
         uses: actions/checkout@v2
 
+      - name: "🧱 Pre-install osbuild from updates-testing repo"
+        run: dnf -y --enablerepo=updates-testing install osbuild
+
       - name: "🛒 Install RPM build dependencies"
         run: dnf -y builddep golang-github-osbuild-composer.spec
 

--- a/cmd/osbuild-image-tests/main_test.go
+++ b/cmd/osbuild-image-tests/main_test.go
@@ -291,8 +291,6 @@ func testBootUsingAWS(t *testing.T, imagePath string) {
 func testBoot(t *testing.T, imagePath string, bootType string, outputID string) {
 	switch bootType {
 	case "qemu":
-		fallthrough
-	case "qemu-extract":
 		testBootUsingQemu(t, imagePath)
 
 	case "nspawn":

--- a/cmd/osbuild-image-tests/main_test.go
+++ b/cmd/osbuild-image-tests/main_test.go
@@ -13,7 +13,6 @@ import (
 	"log"
 	"os"
 	"os/exec"
-	"path/filepath"
 	"strings"
 	"sync"
 	"testing"
@@ -77,28 +76,6 @@ func runOsbuild(manifest []byte, store string) (string, error) {
 	}
 
 	return result.OutputID, nil
-}
-
-// extractXZ extracts an xz archive, it's just a simple wrapper around unxz(1).
-func extractXZ(archivePath string) error {
-	cmd := exec.Command("unxz", archivePath)
-	cmd.Stderr = os.Stderr
-	cmd.Stdout = os.Stderr
-	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("cannot extract xz archive: %#v", err)
-	}
-
-	return nil
-}
-
-// splitExtension returns a file extension as the second return value and
-// the rest as the first return value.
-// The functionality should be the same as Python splitext's
-func splitExtension(path string) (string, string) {
-	ex := filepath.Ext(path)
-	base := strings.TrimSuffix(path, ex)
-
-	return base, ex
 }
 
 // testImageInfo runs image-info on image specified by imageImage and
@@ -359,17 +336,6 @@ func runTestcase(t *testing.T, testcase testcaseStruct) {
 	require.NoError(t, err)
 
 	imagePath := fmt.Sprintf("%s/refs/%s/%s", store, outputID, testcase.ComposeRequest.Filename)
-
-	// if the result is xz archive but not tar.xz archive, extract it
-	base, ex := splitExtension(imagePath)
-	if ex == ".xz" {
-		_, ex = splitExtension(base)
-		if ex != ".tar" {
-			err := extractXZ(imagePath)
-			require.NoError(t, err)
-			imagePath = base
-		}
-	}
 
 	testImage(t, testcase, imagePath, outputID)
 }

--- a/golang-github-osbuild-composer.spec
+++ b/golang-github-osbuild-composer.spec
@@ -39,7 +39,7 @@ BuildRequires:  golang(github.com/stretchr/testify)
 
 Requires: golang-github-osbuild-composer-worker
 Requires: systemd
-Requires: osbuild >= 11
+Requires: osbuild >= 12
 
 Provides: osbuild-composer
 Provides: weldr

--- a/internal/distro/fedora30/distro.go
+++ b/internal/distro/fedora30/distro.go
@@ -180,7 +180,7 @@ func New() *Fedora30 {
 
 	amiImgType := imageType{
 		name:     "ami",
-		filename: "image.raw.xz",
+		filename: "image.vhdx",
 		mimeType: "application/octet-stream",
 		packages: []string{
 			"@Core",
@@ -204,7 +204,7 @@ func New() *Fedora30 {
 		bootable:      true,
 		defaultSize:   6 * GigaByte,
 		assembler: func(uefi bool, size uint64) *osbuild.Assembler {
-			return qemuAssembler("raw.xz", "image.raw.xz", uefi, size)
+			return qemuAssembler("vhdx", "image.vhdx", uefi, size)
 		},
 	}
 

--- a/internal/distro/fedora30/distro_test.go
+++ b/internal/distro/fedora30/distro_test.go
@@ -23,7 +23,7 @@ func TestFilenameFromType(t *testing.T) {
 		{
 			name:  "ami",
 			args:  args{"ami"},
-			want:  "image.raw.xz",
+			want:  "image.vhdx",
 			want1: "application/octet-stream",
 		},
 		{

--- a/internal/distro/fedora31/distro.go
+++ b/internal/distro/fedora31/distro.go
@@ -179,7 +179,7 @@ func New() *Fedora31 {
 
 	amiImgType := imageType{
 		name:     "ami",
-		filename: "image.raw.xz",
+		filename: "image.vhdx",
 		mimeType: "application/octet-stream",
 		packages: []string{
 			"@Core",
@@ -203,7 +203,7 @@ func New() *Fedora31 {
 		bootable:      true,
 		defaultSize:   6 * GigaByte,
 		assembler: func(uefi bool, size uint64) *osbuild.Assembler {
-			return qemuAssembler("raw.xz", "image.raw.xz", uefi, size)
+			return qemuAssembler("vhdx", "image.vhdx", uefi, size)
 		},
 	}
 

--- a/internal/distro/fedora31/distro_test.go
+++ b/internal/distro/fedora31/distro_test.go
@@ -20,7 +20,7 @@ func TestFilenameFromType(t *testing.T) {
 		{
 			name:  "ami",
 			args:  args{"ami"},
-			want:  "image.raw.xz",
+			want:  "image.vhdx",
 			want1: "application/octet-stream",
 		},
 		{

--- a/internal/distro/fedora32/distro.go
+++ b/internal/distro/fedora32/distro.go
@@ -180,7 +180,7 @@ func New() *Fedora32 {
 
 	amiImgType := imageType{
 		name:     "ami",
-		filename: "image.raw.xz",
+		filename: "image.vhdx",
 		mimeType: "application/octet-stream",
 		packages: []string{
 			"@Core",
@@ -204,7 +204,7 @@ func New() *Fedora32 {
 		bootable:      true,
 		defaultSize:   6 * GigaByte,
 		assembler: func(uefi bool, size uint64) *osbuild.Assembler {
-			return qemuAssembler("raw.xz", "image.raw.xz", uefi, size)
+			return qemuAssembler("vhdx", "image.vhdx", uefi, size)
 		},
 	}
 

--- a/internal/distro/fedora32/distro_test.go
+++ b/internal/distro/fedora32/distro_test.go
@@ -20,7 +20,7 @@ func TestFilenameFromType(t *testing.T) {
 		{
 			name:  "ami",
 			args:  args{"ami"},
-			want:  "image.raw.xz",
+			want:  "image.vhdx",
 			want1: "application/octet-stream",
 		},
 		{

--- a/internal/distro/rhel81/distro.go
+++ b/internal/distro/rhel81/distro.go
@@ -202,7 +202,7 @@ func New() *RHEL81 {
 	}
 
 	r.imageTypes["ami"] = imageType{
-		name:     "image.raw.xz",
+		name:     "image.vhdx",
 		mimeType: "application/octet-stream",
 		packages: []string{
 			"checkpolicy",
@@ -273,7 +273,7 @@ func New() *RHEL81 {
 		kernelOptions: "ro console=ttyS0,115200n8 console=tty0 net.ifnames=0 rd.blacklist=nouveau nvme_core.io_timeout=4294967295 crashkernel=auto",
 		defaultSize:   6 * GigaByte,
 		assembler: func(uefi bool, size uint64) *osbuild.Assembler {
-			return r.qemuAssembler("raw.xz", "image.raw.xz", uefi, size)
+			return r.qemuAssembler("vhdx", "image.vhdx", uefi, size)
 		},
 	}
 

--- a/internal/distro/rhel81/distro_test.go
+++ b/internal/distro/rhel81/distro_test.go
@@ -19,7 +19,7 @@ func TestFilenameFromType(t *testing.T) {
 		{
 			name:  "ami",
 			args:  args{"ami"},
-			want:  "image.raw.xz",
+			want:  "image.vhdx",
 			want1: "application/octet-stream",
 		},
 		{

--- a/internal/distro/rhel82/distro.go
+++ b/internal/distro/rhel82/distro.go
@@ -202,7 +202,7 @@ func New() *RHEL82 {
 	}
 
 	r.imageTypes["ami"] = imageType{
-		name:     "image.raw.xz",
+		name:     "image.vhdx",
 		mimeType: "application/octet-stream",
 		packages: []string{
 			"checkpolicy",
@@ -273,7 +273,7 @@ func New() *RHEL82 {
 		kernelOptions: "ro console=ttyS0,115200n8 console=tty0 net.ifnames=0 rd.blacklist=nouveau nvme_core.io_timeout=4294967295 crashkernel=auto",
 		defaultSize:   6 * GigaByte,
 		assembler: func(uefi bool, size uint64) *osbuild.Assembler {
-			return r.qemuAssembler("raw.xz", "image.raw.xz", uefi, size)
+			return r.qemuAssembler("vhdx", "image.vhdx", uefi, size)
 		},
 	}
 

--- a/internal/distro/rhel82/distro_test.go
+++ b/internal/distro/rhel82/distro_test.go
@@ -20,7 +20,7 @@ func TestFilenameFromType(t *testing.T) {
 		{
 			name:  "ami",
 			args:  args{"ami"},
-			want:  "image.raw.xz",
+			want:  "image.vhdx",
 			want1: "application/octet-stream",
 		},
 		{

--- a/internal/distro/rhel83/distro.go
+++ b/internal/distro/rhel83/distro.go
@@ -202,7 +202,7 @@ func New() *RHEL83 {
 	}
 
 	r.imageTypes["ami"] = imageType{
-		name:     "image.raw.xz",
+		name:     "image.vhdx",
 		mimeType: "application/octet-stream",
 		packages: []string{
 			"checkpolicy",
@@ -273,7 +273,7 @@ func New() *RHEL83 {
 		kernelOptions: "ro console=ttyS0,115200n8 console=tty0 net.ifnames=0 rd.blacklist=nouveau nvme_core.io_timeout=4294967295 crashkernel=auto",
 		defaultSize:   6 * GigaByte,
 		assembler: func(uefi bool, size uint64) *osbuild.Assembler {
-			return r.qemuAssembler("raw.xz", "image.raw.xz", uefi, size)
+			return r.qemuAssembler("vhdx", "image.vhdx", uefi, size)
 		},
 	}
 

--- a/internal/distro/rhel83/distro_test.go
+++ b/internal/distro/rhel83/distro_test.go
@@ -20,7 +20,7 @@ func TestFilenameFromType(t *testing.T) {
 		{
 			name:  "ami",
 			args:  args{"ami"},
-			want:  "image.raw.xz",
+			want:  "image.vhdx",
 			want1: "application/octet-stream",
 		},
 		{

--- a/internal/upload/awsupload/awsupload.go
+++ b/internal/upload/awsupload/awsupload.go
@@ -109,6 +109,7 @@ func (a *AWS) Register(name, bucket, key string) (*string, error) {
 					S3Bucket: aws.String(bucket),
 					S3Key:    aws.String(key),
 				},
+				Format: aws.String("vhdx"),
 			},
 		},
 	)

--- a/osbuild-composer.spec
+++ b/osbuild-composer.spec
@@ -43,7 +43,7 @@ BuildRequires:  golang(github.com/stretchr/testify/assert)
 
 Requires: osbuild-composer-worker
 Requires: systemd
-Requires: osbuild >= 11
+Requires: osbuild >= 12
 
 Provides: weldr
 

--- a/test/cases/fedora_30-aarch64-ami-boot.json
+++ b/test/cases/fedora_30-aarch64-ami-boot.json
@@ -1,6 +1,6 @@
 {
   "boot": {
-    "type": "qemu-extract"
+    "type": "qemu"
   },
   "compose-request": {
     "distro": "fedora-30",
@@ -12,7 +12,7 @@
         "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBFturGcBEACv0xBo91V2n0uEC2vh69ywCiSyvUgN/AQH8EZpCVtM7NyjKgKm\nbbY4G3R0M3ir1xXmvUDvK0493/qOiFrjkplvzXFTGpPTi0ypqGgxc5d0ohRA1M75\nL+0AIlXoOgHQ358/c4uO8X0JAA1NYxCkAW1KSJgFJ3RjukrfqSHWthS1d4o8fhHy\nKJKEnirE5hHqB50dafXrBfgZdaOs3C6ppRIePFe2o4vUEapMTCHFw0woQR8Ah4/R\nn7Z9G9Ln+0Cinmy0nbIDiZJ+pgLAXCOWBfDUzcOjDGKvcpoZharA07c0q1/5ojzO\n4F0Fh4g/BUmtrASwHfcIbjHyCSr1j/3Iz883iy07gJY5Yhiuaqmp0o0f9fgHkG53\n2xCU1owmACqaIBNQMukvXRDtB2GJMuKa/asTZDP6R5re+iXs7+s9ohcRRAKGyAyc\nYKIQKcaA+6M8T7/G+TPHZX6HJWqJJiYB+EC2ERblpvq9TPlLguEWcmvjbVc31nyq\nSDoO3ncFWKFmVsbQPTbP+pKUmlLfJwtb5XqxNR5GEXSwVv4I7IqBmJz1MmRafnBZ\ng0FJUtH668GnldO20XbnSVBr820F5SISMXVwCXDXEvGwwiB8Lt8PvqzXnGIFDAu3\nDlQI5sxSqpPVWSyw08ppKT2Tpmy8adiBotLfaCFl2VTHwOae48X2dMPBvQARAQAB\ntDFGZWRvcmEgKDMwKSA8ZmVkb3JhLTMwLXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQI4BBMBAgAiBQJbbqxnAhsPBgsJCAcDAgYVCAIJCgsEFgIDAQIeAQIXgAAK\nCRDvPBEfz8ZZudTnD/9170LL3nyTVUCFmBjT9wZ4gYnpwtKVPa/pKnxbbS+Bmmac\ng9TrT9pZbqOHrNJLiZ3Zx1Hp+8uxr3Lo6kbYwImLhkOEDrf4aP17HfQ6VYFbQZI8\nf79OFxWJ7si9+3gfzeh9UYFEqOQfzIjLWFyfnas0OnV/P+RMQ1Zr+vPRqO7AR2va\nN9wg+Xl7157dhXPCGYnGMNSoxCbpRs0JNlzvJMuAea5nTTznRaJZtK/xKsqLn51D\nK07k9MHVFXakOH8QtMCUglbwfTfIpO5YRq5imxlWbqsYWVQy1WGJFyW6hWC0+RcJ\nOx5zGtOfi4/dN+xJ+ibnbyvy/il7Qm+vyFhCYqIPyS5m2UVJUuao3eApE38k78/o\n8aQOTnFQZ+U1Sw+6woFTxjqRQBXlQm2+7Bt3bqGATg4sXXWPbmwdL87Ic+mxn/ml\nSMfQux/5k6iAu1kQhwkO2YJn9eII6HIPkW+2m5N1JsUyJQe4cbtZE5Yh3TRA0dm7\n+zoBRfCXkOW4krchbgww/ptVmzMMP7GINJdROrJnsGl5FVeid9qHzV7aZycWSma7\nCxBYB1J8HCbty5NjtD6XMYRrMLxXugvX6Q4NPPH+2NKjzX4SIDejS6JjgrP3KA3O\npMuo7ZHMfveBngv8yP+ZD/1sS6l+dfExvdaJdOdgFCnp4p3gPbw5+Lv70HrMjA==\n=BfZ/\n-----END PGP PUBLIC KEY BLOCK-----\n"
       }
     ],
-    "filename": "image.raw.xz",
+    "filename": "image.vhdx",
     "blueprint": {}
   },
   "manifest": {
@@ -1030,8 +1030,8 @@
       "assembler": {
         "name": "org.osbuild.qemu",
         "options": {
-          "format": "raw.xz",
-          "filename": "image.raw.xz",
+          "format": "vhdx",
+          "filename": "image.vhdx",
           "size": 6442450944,
           "ptuuid": "8DFDFF87-C96E-EA48-A3A6-9408F1F6B1EF",
           "pttype": "gpt",
@@ -7315,7 +7315,7 @@
       "video:x:39:",
       "wheel:x:10:"
     ],
-    "image-format": "raw",
+    "image-format": "vhdx",
     "os-release": {
       "ANSI_COLOR": "0;34",
       "BUG_REPORT_URL": "https://bugzilla.redhat.com/",

--- a/test/cases/fedora_30-x86_64-ami-boot.json
+++ b/test/cases/fedora_30-x86_64-ami-boot.json
@@ -12,7 +12,7 @@
         "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBFturGcBEACv0xBo91V2n0uEC2vh69ywCiSyvUgN/AQH8EZpCVtM7NyjKgKm\nbbY4G3R0M3ir1xXmvUDvK0493/qOiFrjkplvzXFTGpPTi0ypqGgxc5d0ohRA1M75\nL+0AIlXoOgHQ358/c4uO8X0JAA1NYxCkAW1KSJgFJ3RjukrfqSHWthS1d4o8fhHy\nKJKEnirE5hHqB50dafXrBfgZdaOs3C6ppRIePFe2o4vUEapMTCHFw0woQR8Ah4/R\nn7Z9G9Ln+0Cinmy0nbIDiZJ+pgLAXCOWBfDUzcOjDGKvcpoZharA07c0q1/5ojzO\n4F0Fh4g/BUmtrASwHfcIbjHyCSr1j/3Iz883iy07gJY5Yhiuaqmp0o0f9fgHkG53\n2xCU1owmACqaIBNQMukvXRDtB2GJMuKa/asTZDP6R5re+iXs7+s9ohcRRAKGyAyc\nYKIQKcaA+6M8T7/G+TPHZX6HJWqJJiYB+EC2ERblpvq9TPlLguEWcmvjbVc31nyq\nSDoO3ncFWKFmVsbQPTbP+pKUmlLfJwtb5XqxNR5GEXSwVv4I7IqBmJz1MmRafnBZ\ng0FJUtH668GnldO20XbnSVBr820F5SISMXVwCXDXEvGwwiB8Lt8PvqzXnGIFDAu3\nDlQI5sxSqpPVWSyw08ppKT2Tpmy8adiBotLfaCFl2VTHwOae48X2dMPBvQARAQAB\ntDFGZWRvcmEgKDMwKSA8ZmVkb3JhLTMwLXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQI4BBMBAgAiBQJbbqxnAhsPBgsJCAcDAgYVCAIJCgsEFgIDAQIeAQIXgAAK\nCRDvPBEfz8ZZudTnD/9170LL3nyTVUCFmBjT9wZ4gYnpwtKVPa/pKnxbbS+Bmmac\ng9TrT9pZbqOHrNJLiZ3Zx1Hp+8uxr3Lo6kbYwImLhkOEDrf4aP17HfQ6VYFbQZI8\nf79OFxWJ7si9+3gfzeh9UYFEqOQfzIjLWFyfnas0OnV/P+RMQ1Zr+vPRqO7AR2va\nN9wg+Xl7157dhXPCGYnGMNSoxCbpRs0JNlzvJMuAea5nTTznRaJZtK/xKsqLn51D\nK07k9MHVFXakOH8QtMCUglbwfTfIpO5YRq5imxlWbqsYWVQy1WGJFyW6hWC0+RcJ\nOx5zGtOfi4/dN+xJ+ibnbyvy/il7Qm+vyFhCYqIPyS5m2UVJUuao3eApE38k78/o\n8aQOTnFQZ+U1Sw+6woFTxjqRQBXlQm2+7Bt3bqGATg4sXXWPbmwdL87Ic+mxn/ml\nSMfQux/5k6iAu1kQhwkO2YJn9eII6HIPkW+2m5N1JsUyJQe4cbtZE5Yh3TRA0dm7\n+zoBRfCXkOW4krchbgww/ptVmzMMP7GINJdROrJnsGl5FVeid9qHzV7aZycWSma7\nCxBYB1J8HCbty5NjtD6XMYRrMLxXugvX6Q4NPPH+2NKjzX4SIDejS6JjgrP3KA3O\npMuo7ZHMfveBngv8yP+ZD/1sS6l+dfExvdaJdOdgFCnp4p3gPbw5+Lv70HrMjA==\n=BfZ/\n-----END PGP PUBLIC KEY BLOCK-----\n"
       }
     ],
-    "filename": "image.raw.xz",
+    "filename": "image.vhdx",
     "blueprint": {}
   },
   "manifest": {
@@ -1013,8 +1013,8 @@
       "assembler": {
         "name": "org.osbuild.qemu",
         "options": {
-          "format": "raw.xz",
-          "filename": "image.raw.xz",
+          "format": "vhdx",
+          "filename": "image.vhdx",
           "size": 6442450944,
           "ptuuid": "0x14fc63d2",
           "pttype": "mbr",
@@ -7267,7 +7267,7 @@
       "video:x:39:",
       "wheel:x:10:"
     ],
-    "image-format": "raw",
+    "image-format": "vhdx",
     "os-release": {
       "ANSI_COLOR": "0;34",
       "BUG_REPORT_URL": "https://bugzilla.redhat.com/",

--- a/test/cases/fedora_31-aarch64-ami-boot.json
+++ b/test/cases/fedora_31-aarch64-ami-boot.json
@@ -1,6 +1,6 @@
 {
   "boot": {
-    "type": "qemu-extract"
+    "type": "qemu"
   },
   "compose-request": {
     "distro": "fedora-31",
@@ -12,7 +12,7 @@
         "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBFxq3QMBEADUhGfCfP1ijiggBuVbR/pBDSWMC3TWbfC8pt7fhZkYrilzfWUM\nfTsikPymSriScONXP6DNyZ5r7tgrIVdVrJvRIqIFRO0mufp9HyfWKDO//Ctyp7OQ\nzYw6NVthO/aWpyFfJpj6s4iZsYGqf9gByV8brBB8v8jEsCtVOj1BU3bMbLkMsRI9\n+WiLjDYyvopqNBQuIe8ogxSxpYdbUz6+jxzfvhRoBzWdjITd//Gjd90kkrBOMWkO\nLTqO133OD1WMT08G5NuQ4KhjYsVvSbBpfdkTcNuP8gBP9LxCQDc+e1eAhZ95g3qk\nXLeKEK9j+F+wuG/OrEAxBsscCxXRUB38QH6CFe3UxGoSMnBi+jEhicudo+ItpFOy\n7rPaYyRh4Pmu4QHcC83bNjp8NI6zTHrBmVuPqkxMn07GMAQav9ezBXj6umqTX4cU\ndsJUavJrJ3u7rT0lhBdiGrQ9zPbL07u2Kn+OXPAC3dKSf7G8TvwNAdry9esGSpi3\n8aa1myQYVZvAlsIBkbN3fb1wvDJE5czVhzwQ77V2t66jxeg0o9/2OZVH3CozD2Zj\nv28LHuW/jnQHtsQ0fUyQYRmHxNEVkW10GGM7fQwxzpxFFS1O/2XEnfMu7yBHZsgL\nSojfUct0FhLhEN/g/IINX9ZCVrzK5/De27CNjYE1cgYD/lTmQ0SyjfKVwwARAQAB\ntDFGZWRvcmEgKDMxKSA8ZmVkb3JhLTMxLXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQI+BBMBAgAoAhsPBgsJCAcDAgYVCAIJCgsEFgIDAQIeAQIXgAUCXGrkTQUJ\nEs8P/QAKCRBQyzkLPDNZxBmDD/90IFwAfFcQq5ENl7/o2CYQ9k2adTHbV5RoIOWC\n/o9I5/btn1y8WDhPOUNmsgbUqRqz6srlVplg+LkpIj67PVLDBwpVbCJC8o1fztd2\nMryVqdvu562WVhUorII+iW7nfqD0yv55nH9b/JR1qloUa8LpeKw84JgvxF5wVfyR\nid1WjI0DBk2taFR4xCfU5Tb262fbdFj5iB9xskP7oNeS29+SfDjlnybtlFoqr9UA\nnY1uvhBPkGmj45SJkpfP+L+kGYXVaUd29M/q/Pt46X1KDvr6Z0l8bSUEk3zfcNdj\nuEhtHBqSy1UPPAikGX1Q5wGdu7R7+mv/ARqfI6OC44ipoOMNK1Aiu6+slbPYphwX\nighSz9yYuG0EdWt7akfKR0R04Kuej4LXLWcxTR4l8XDzThYgPP0g+z0XQJrAkVhi\nSrzICeC3K1GPSiUtNAxSTL+qWWgwvQyAPNoPV/OYmY+wUxUnKCZpEWPkL79lh6CM\nbJx/zlrOMzRumSzaOnKW9AOliviH4Rj89OmDifBEsQ0CewdHN9ly6g4ZFJJGYXJ5\nHTb5jdButTC3tDfvH8Z7dtXKdC4iqJCIxj698Xn8UjVefZQ2nbv5eXcZLfHtvbNB\nTTv1vvBV4G7aiHKYRSj7HmxhLBZC8Y/nmFAemOoOYDpR5eUmPmSbFayoLfRsFXmC\nHLs7cw==\n=6hRW\n-----END PGP PUBLIC KEY BLOCK-----\n"
       }
     ],
-    "filename": "image.raw.xz",
+    "filename": "image.vhdx",
     "blueprint": {}
   },
   "manifest": {
@@ -1188,8 +1188,8 @@
       "assembler": {
         "name": "org.osbuild.qemu",
         "options": {
-          "format": "raw.xz",
-          "filename": "image.raw.xz",
+          "format": "vhdx",
+          "filename": "image.vhdx",
           "size": 6442450944,
           "ptuuid": "8DFDFF87-C96E-EA48-A3A6-9408F1F6B1EF",
           "pttype": "gpt",
@@ -8594,7 +8594,7 @@
       "video:x:39:",
       "wheel:x:10:"
     ],
-    "image-format": "raw",
+    "image-format": "vhdx",
     "os-release": {
       "ANSI_COLOR": "0;34",
       "BUG_REPORT_URL": "https://bugzilla.redhat.com/",

--- a/test/cases/fedora_31-x86_64-ami-boot.json
+++ b/test/cases/fedora_31-x86_64-ami-boot.json
@@ -12,7 +12,7 @@
         "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBFxq3QMBEADUhGfCfP1ijiggBuVbR/pBDSWMC3TWbfC8pt7fhZkYrilzfWUM\nfTsikPymSriScONXP6DNyZ5r7tgrIVdVrJvRIqIFRO0mufp9HyfWKDO//Ctyp7OQ\nzYw6NVthO/aWpyFfJpj6s4iZsYGqf9gByV8brBB8v8jEsCtVOj1BU3bMbLkMsRI9\n+WiLjDYyvopqNBQuIe8ogxSxpYdbUz6+jxzfvhRoBzWdjITd//Gjd90kkrBOMWkO\nLTqO133OD1WMT08G5NuQ4KhjYsVvSbBpfdkTcNuP8gBP9LxCQDc+e1eAhZ95g3qk\nXLeKEK9j+F+wuG/OrEAxBsscCxXRUB38QH6CFe3UxGoSMnBi+jEhicudo+ItpFOy\n7rPaYyRh4Pmu4QHcC83bNjp8NI6zTHrBmVuPqkxMn07GMAQav9ezBXj6umqTX4cU\ndsJUavJrJ3u7rT0lhBdiGrQ9zPbL07u2Kn+OXPAC3dKSf7G8TvwNAdry9esGSpi3\n8aa1myQYVZvAlsIBkbN3fb1wvDJE5czVhzwQ77V2t66jxeg0o9/2OZVH3CozD2Zj\nv28LHuW/jnQHtsQ0fUyQYRmHxNEVkW10GGM7fQwxzpxFFS1O/2XEnfMu7yBHZsgL\nSojfUct0FhLhEN/g/IINX9ZCVrzK5/De27CNjYE1cgYD/lTmQ0SyjfKVwwARAQAB\ntDFGZWRvcmEgKDMxKSA8ZmVkb3JhLTMxLXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQI+BBMBAgAoAhsPBgsJCAcDAgYVCAIJCgsEFgIDAQIeAQIXgAUCXGrkTQUJ\nEs8P/QAKCRBQyzkLPDNZxBmDD/90IFwAfFcQq5ENl7/o2CYQ9k2adTHbV5RoIOWC\n/o9I5/btn1y8WDhPOUNmsgbUqRqz6srlVplg+LkpIj67PVLDBwpVbCJC8o1fztd2\nMryVqdvu562WVhUorII+iW7nfqD0yv55nH9b/JR1qloUa8LpeKw84JgvxF5wVfyR\nid1WjI0DBk2taFR4xCfU5Tb262fbdFj5iB9xskP7oNeS29+SfDjlnybtlFoqr9UA\nnY1uvhBPkGmj45SJkpfP+L+kGYXVaUd29M/q/Pt46X1KDvr6Z0l8bSUEk3zfcNdj\nuEhtHBqSy1UPPAikGX1Q5wGdu7R7+mv/ARqfI6OC44ipoOMNK1Aiu6+slbPYphwX\nighSz9yYuG0EdWt7akfKR0R04Kuej4LXLWcxTR4l8XDzThYgPP0g+z0XQJrAkVhi\nSrzICeC3K1GPSiUtNAxSTL+qWWgwvQyAPNoPV/OYmY+wUxUnKCZpEWPkL79lh6CM\nbJx/zlrOMzRumSzaOnKW9AOliviH4Rj89OmDifBEsQ0CewdHN9ly6g4ZFJJGYXJ5\nHTb5jdButTC3tDfvH8Z7dtXKdC4iqJCIxj698Xn8UjVefZQ2nbv5eXcZLfHtvbNB\nTTv1vvBV4G7aiHKYRSj7HmxhLBZC8Y/nmFAemOoOYDpR5eUmPmSbFayoLfRsFXmC\nHLs7cw==\n=6hRW\n-----END PGP PUBLIC KEY BLOCK-----\n"
       }
     ],
-    "filename": "image.raw.xz",
+    "filename": "image.vhdx",
     "blueprint": {}
   },
   "manifest": {
@@ -1196,8 +1196,8 @@
       "assembler": {
         "name": "org.osbuild.qemu",
         "options": {
-          "format": "raw.xz",
-          "filename": "image.raw.xz",
+          "format": "vhdx",
+          "filename": "image.vhdx",
           "size": 6442450944,
           "ptuuid": "0x14fc63d2",
           "pttype": "mbr",
@@ -8835,7 +8835,7 @@
       "video:x:39:",
       "wheel:x:10:"
     ],
-    "image-format": "raw",
+    "image-format": "vhdx",
     "os-release": {
       "ANSI_COLOR": "0;34",
       "BUG_REPORT_URL": "https://bugzilla.redhat.com/",

--- a/tools/test-case-generators/format-request-map.json
+++ b/tools/test-case-generators/format-request-map.json
@@ -8,7 +8,7 @@
       "arch": "",
       "image-type": "ami",
       "repositories": [],
-      "filename": "image.raw.xz",
+      "filename": "image.vhdx",
       "blueprint": {}
     }
   },

--- a/tools/test-case-generators/generate-test-case
+++ b/tools/test-case-generators/generate-test-case
@@ -54,14 +54,6 @@ def main(test_case, store):
     if boot_type != "nspawn-extract":
         output_id = run_osbuild(test_case["manifest"], store)
         image_file = os.path.join(store, "refs", output_id, test_case["compose-request"]["filename"])
-
-        # we don't yet support image-info on directory trees
-        if boot_type in {"qemu-extract"}:
-            fn, ex = os.path.splitext(image_file)
-            if ex == ".xz":
-                with open(fn, "w") as f:
-                    subprocess.run(["xz", "--decompress", "--stdout", image_file], stdout=f)
-                image_file = fn
         test_case["image-info"] = json.loads(get_subprocess_stdout(["tools/image-info", image_file], encoding="utf-8"))
 
     return test_case

--- a/tools/test-case-generators/generate-test-case
+++ b/tools/test-case-generators/generate-test-case
@@ -56,7 +56,7 @@ def main(test_case, store):
         image_file = os.path.join(store, "refs", output_id, test_case["compose-request"]["filename"])
 
         # we don't yet support image-info on directory trees
-        if boot_type in {"qemu-extract", "aws"}:
+        if boot_type in {"qemu-extract"}:
             fn, ex = os.path.splitext(image_file)
             if ex == ".xz":
                 with open(fn, "w") as f:


### PR DESCRIPTION
Prior this commit the ami image type produced raw.xz images. This was bad for
two reasons:

- The upload was broken because AWS doesn't support tar.xz format
- XZ compression is terribly slow

This commit changes the format to vhdx, which is supported by AWS and also
quite quick. See #257
why vhdx was chosen.

The osbuild requirement is bumped to 12, because that's the first version
that supports vhdx.

Also, I removed the code for handling the `raw.xz` images, so cool!