### PR TITLE
Instruct Jenkins to collect coverage data from integration tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -113,11 +113,11 @@ build:
 	go build -o osbuild-pipeline ./cmd/osbuild-pipeline/
 	go build -o osbuild-upload-azure ./cmd/osbuild-upload-azure/
 	go build -o osbuild-upload-aws ./cmd/osbuild-upload-aws/
-	go test -c -tags=integration -o osbuild-tests ./cmd/osbuild-tests/main_test.go
-	go test -c -tags=integration -o osbuild-weldr-tests ./internal/client/
-	go test -c -tags=integration -o osbuild-dnf-json-tests ./cmd/osbuild-dnf-json-tests/main_test.go
-	go test -c -tags=integration -o osbuild-rcm-tests ./cmd/osbuild-rcm-tests/main_test.go
-	go test -c -tags=integration,travis -o osbuild-image-tests ./cmd/osbuild-image-tests/
+	go test -c -tags=integration -covermode atomic -o osbuild-tests ./cmd/osbuild-tests/main_test.go
+	go test -c -tags=integration -covermode atomic -o osbuild-weldr-tests ./internal/client/
+	go test -c -tags=integration -covermode atomic -o osbuild-dnf-json-tests ./cmd/osbuild-dnf-json-tests/main_test.go
+	go test -c -tags=integration -covermode atomic -o osbuild-rcm-tests ./cmd/osbuild-rcm-tests/main_test.go
+	go test -c -tags=integration,travis -covermode atomic -o osbuild-image-tests ./cmd/osbuild-image-tests/
 
 .PHONY: install
 install:

--- a/jenkins/test_runner_base.yml
+++ b/jenkins/test_runner_base.yml
@@ -3,7 +3,7 @@
 - block:
 
     - name: "Run {{ test.name }} test"
-      command: "{{ tests_path }}/{{ test.name }} -test.v"
+      command: "{{ tests_path }}/{{ test.name }} -test.v -test.coverprofile=coverage.txt"
       args:
         chdir: "{{ tests_working_directory }}"
       register: async_test
@@ -14,6 +14,11 @@
     - name: "Mark {{ test.name }} as passed"
       set_fact:
         passed_tests: "{{ passed_tests + [test.name] }}"
+
+    - name: "Send coverage to codecov.io"
+      shell: curl -s https://codecov.io/bash | bash
+      args:
+        warn: no
 
   rescue:
 

--- a/jenkins/test_runner_base.yml
+++ b/jenkins/test_runner_base.yml
@@ -16,9 +16,14 @@
         passed_tests: "{{ passed_tests + [test.name] }}"
 
     - name: "Send coverage to codecov.io"
-      shell: curl -s https://codecov.io/bash | bash
+      shell: |
+        curl -s https://codecov.io/bash > codecov.sh
+        chmod a+x codecov.sh
+        ./codecov.sh -v
       args:
         warn: no
+      register: codecov
+    - debug: var=codecov.stdout_lines
 
   rescue:
 

--- a/jenkins/test_runner_image.yml
+++ b/jenkins/test_runner_image.yml
@@ -24,7 +24,7 @@
     # upset and nobody likes it when that happens.
     - name: "Run image tests"
       command: |
-        {{ image_test_executable }} -test.v \
+        {{ image_test_executable }} -test.v -test.coverprofile=coverage.txt \
           {% for test_case in osbuild_composer_image_test_cases %}
             {% if loop.last %}
           {{ image_test_case_path }}/{{ test_case_prefix }}-{{ test_case }}
@@ -42,6 +42,11 @@
     - name: "Mark image tests as passed"
       set_fact:
         passed_tests: "{{ passed_tests + ['image_tests'] }}"
+
+    - name: "Send coverage to codecov.io"
+      shell: curl -s https://codecov.io/bash | bash
+      args:
+        warn: no
 
   rescue:
 

--- a/osbuild-composer.spec
+++ b/osbuild-composer.spec
@@ -93,11 +93,11 @@ export GOPATH=%{gobuilddir}:%{gopath}
 
 TEST_LDFLAGS="${LDFLAGS:-} -B 0x$(od -N 20 -An -tx1 -w100 /dev/urandom | tr -d ' ')"
 
-go test -c -tags=integration -ldflags="${TEST_LDFLAGS}" -o _bin/osbuild-tests %{goipath}/cmd/osbuild-tests
-go test -c -tags=integration -ldflags="${TEST_LDFLAGS}" -o _bin/osbuild-dnf-json-tests %{goipath}/cmd/osbuild-dnf-json-tests
-go test -c -tags=integration -ldflags="${TEST_LDFLAGS}" -o _bin/osbuild-weldr-tests %{goipath}/internal/client/
-go test -c -tags=integration -ldflags="${TEST_LDFLAGS}" -o _bin/osbuild-rcm-tests %{goipath}/cmd/osbuild-rcm-tests
-go test -c -tags=integration -ldflags="${TEST_LDFLAGS}" -o _bin/osbuild-image-tests %{goipath}/cmd/osbuild-image-tests
+go test -c -tags=integration -ldflags="${TEST_LDFLAGS}" -covermode atomic -o _bin/osbuild-tests %{goipath}/cmd/osbuild-tests
+go test -c -tags=integration -ldflags="${TEST_LDFLAGS}" -covermode atomic -o _bin/osbuild-dnf-json-tests %{goipath}/cmd/osbuild-dnf-json-tests
+go test -c -tags=integration -ldflags="${TEST_LDFLAGS}" -covermode atomic -o _bin/osbuild-weldr-tests %{goipath}/internal/client/
+go test -c -tags=integration -ldflags="${TEST_LDFLAGS}" -covermode atomic -o _bin/osbuild-rcm-tests %{goipath}/cmd/osbuild-rcm-tests
+go test -c -tags=integration -ldflags="${TEST_LDFLAGS}" -covermode atomic -o _bin/osbuild-image-tests %{goipath}/cmd/osbuild-image-tests
 
 %endif
 


### PR DESCRIPTION
- first we need to compile the binaries to collect this data
- then when executing them specify where results will be written
- when done report to codecov.io