### PR TITLE
worker: fix missing logs when osbuild fails

### DIFF
--- a/cmd/osbuild-worker/main.go
+++ b/cmd/osbuild-worker/main.go
@@ -71,7 +71,7 @@ func RunJob(job *worker.Job, uploadFunc func(*worker.Job, io.Reader) error) (*co
 
 	result, err := RunOSBuild(job.Manifest, tmpStore, os.Stderr)
 	if err != nil {
-		return nil, fmt.Errorf("osbuild error: %v", err)
+		return result, fmt.Errorf("osbuild error: %v", err)
 	}
 
 	var r []error
@@ -175,6 +175,11 @@ func main() {
 		if err != nil {
 			log.Printf("  Job failed: %v", err)
 			status = common.IBFailed
+
+			// If the error comes from osbuild, retrieve the result
+			if osbuildError, ok := err.(*OSBuildError); ok {
+				result = osbuildError.Result
+			}
 		} else {
 			status = common.IBFinished
 		}

--- a/cmd/osbuild-worker/osbuild.go
+++ b/cmd/osbuild-worker/osbuild.go
@@ -10,6 +10,15 @@ import (
 	"github.com/osbuild/osbuild-composer/internal/osbuild"
 )
 
+type OSBuildError struct {
+	Message string
+	Result  *common.ComposeResult
+}
+
+func (e *OSBuildError) Error() string {
+	return e.Message
+}
+
 func RunOSBuild(manifest *osbuild.Manifest, store string, errorWriter io.Writer) (*common.ComposeResult, error) {
 	cmd := exec.Command(
 		"osbuild",
@@ -48,7 +57,10 @@ func RunOSBuild(manifest *osbuild.Manifest, store string, errorWriter io.Writer)
 
 	err = cmd.Wait()
 	if err != nil {
-		return &result, err
+		return nil, &OSBuildError{
+			Message: fmt.Sprintf("running osbuild failed: %v", err),
+			Result:  &result,
+		}
 	}
 
 	return &result, nil


### PR DESCRIPTION
The commit 2435163f broke sending the logs to osbuild-composer. This was
partly because of unusual error handling in the RunOSBuild function.

This commit fixes that by creating a custom error and properly propagating
the result from it.