### PR TITLE
worker: fix passing the result from osbuild when it fails

### DIFF
--- a/cmd/osbuild-worker/main.go
+++ b/cmd/osbuild-worker/main.go
@@ -71,7 +71,7 @@ func RunJob(job *worker.Job, uploadFunc func(*worker.Job, io.Reader) error) (*co
 
 	result, err := RunOSBuild(job.Manifest, tmpStore, os.Stderr)
 	if err != nil {
-		return result, fmt.Errorf("osbuild error: %v", err)
+		return nil, err
 	}
 
 	var r []error


### PR DESCRIPTION
I tried fixing this in 181128c5 and forgot to pass the right error at one place. This PR fixes it. I think I tested this properly now, sorry.