### PR TITLE
Remove image size from tar assembler options

### DIFF
--- a/internal/osbuild/assembler_test.go
+++ b/internal/osbuild/assembler_test.go
@@ -18,7 +18,7 @@ func TestAssembler_UnmarshalJSON(t *testing.T) {
 		{
 			// invalid JSON - note the missing brace at the end of the string
 			name:          "invalid json",
-			data:          []byte(`{"name":"org.osbuild.tar","options":{"filename":"",size:0}`),
+			data:          []byte(`{"name":"org.osbuild.tar","options":{"filename":""}`),
 			errorExpected: true,
 		},
 		{
@@ -75,7 +75,7 @@ func TestAssembler_UnmarshalJSON(t *testing.T) {
 				Name:    "org.osbuild.tar",
 				Options: &TarAssemblerOptions{},
 			},
-			data: []byte(`{"name":"org.osbuild.tar","options":{"filename":"","size":0}}`),
+			data: []byte(`{"name":"org.osbuild.tar","options":{"filename":""}}`),
 		},
 		{
 			name: "tar assembler full",
@@ -83,11 +83,10 @@ func TestAssembler_UnmarshalJSON(t *testing.T) {
 				Name: "org.osbuild.tar",
 				Options: &TarAssemblerOptions{
 					Filename:    "root.tar.xz",
-					Size:        0,
 					Compression: "xz",
 				},
 			},
-			data: []byte(`{"name":"org.osbuild.tar","options":{"filename":"root.tar.xz","size":0,"compression":"xz"}}`),
+			data: []byte(`{"name":"org.osbuild.tar","options":{"filename":"root.tar.xz","compression":"xz"}}`),
 		},
 		{
 			name: "rawfs assembler empty",

--- a/internal/osbuild/tar_assembler.go
+++ b/internal/osbuild/tar_assembler.go
@@ -6,7 +6,6 @@ package osbuild
 // compression type, and stores the output with the given filename.
 type TarAssemblerOptions struct {
 	Filename    string `json:"filename"`
-	Size        uint64 `json:"size"`
 	Compression string `json:"compression,omitempty"`
 }
 


### PR DESCRIPTION
@gicmo mentioned that  when using the https://github.com/osbuild/osbuild/pull/219 PR against the tar test cases an invalid size argument was passed in the assembler options. 

Image size should not be specified for a tar image. When the tar assembler was being created image size was not passed to it. However, the TarAssemblerOptions contained a Size field which would default to 0. This field is removed so that the tar assembler options no longer specify a size. The assembler tests are also updated to reflect this change.

I believe the tar test cases will need to be updated to remove the image size. Can I do this manually or is there a benefit to regenerating the test cases?