### PR TITLE
Enable Travis for Fedora 32

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,8 @@ matrix:
       arch: amd64
     - name: fedora_31
       arch: amd64
+    - name: fedora_32
+      arch: amd64
 
 language: generic
 script:

--- a/test/cases/fedora_32-x86_64-vhd-boot.json
+++ b/test/cases/fedora_32-x86_64-vhd-boot.json
@@ -1,6 +1,6 @@
 {
   "boot": {
-    "type": "qemu"
+    "type": "azure"
   },
   "compose-request": {
     "distro": "fedora-32",

--- a/test/cases/rhel_8.2-x86_64-vhd-boot.json
+++ b/test/cases/rhel_8.2-x86_64-vhd-boot.json
@@ -1,6 +1,6 @@
 {
   "boot": {
-    "type": "qemu"
+    "type": "azure"
   },
   "compose-request": {
     "distro": "rhel-8.2",


### PR DESCRIPTION
Jenkins still doesn't run all the image tests as Travis does, so let's add Fedora 32 for now, so we know it's working.

Also, I changed the boot type for f32 and rhel 8.2 to azure, I think they were still set to qemu because of " a merge race condition".