### PR TITLE
🤗 Image tests for Fedora 32 + RHEL 8.2

### DIFF
--- a/jenkins/test_runner_image.yml
+++ b/jenkins/test_runner_image.yml
@@ -1,5 +1,14 @@
 ---
 
+- name: Setup test case prefix based on distro and release
+  set_fact:
+    test_case_prefix: >-
+      {%- if ansible_distribution == "Fedora" -%}
+      fedora_{{ ansible_distribution_version }}-{{ ansible_machine }}
+      {%- else -%}
+      rhel_{{ ansible_distribution_version }}-{{ ansible_machine }}
+      {%- endif -%}
+
 - name: Show which tests will be run
   debug:
     msg: |
@@ -18,9 +27,9 @@
         {{ image_test_executable }} -test.v \
           {% for test_case in osbuild_composer_image_test_cases %}
             {% if loop.last %}
-          {{ image_test_case_path }}/{{ test_case }}
+          {{ image_test_case_path }}/{{ test_case_prefix }}-{{ test_case }}
             {% else %}
-          {{ image_test_case_path }}/{{ test_case }} \
+          {{ image_test_case_path }}/{{ test_case_prefix }}-{{ test_case }} \
             {% endif %}
           {% endfor %}
       args:

--- a/jenkins/vars.yml
+++ b/jenkins/vars.yml
@@ -33,5 +33,5 @@ image_test_case_path: /usr/share/tests/osbuild-composer/cases
 
 # List of image tests and their timeouts (in minutes).
 osbuild_composer_image_test_cases:
-  - fedora_31-x86_64-ext4_filesystem-boot.json
-  - fedora_31-x86_64-tar-boot.json
+  - ext4_filesystem-boot.json
+  - tar-boot.json


### PR DESCRIPTION
Enable image tests for Fedora 31 and RHEL 8.2 since we now have the JSON
test case files for all distributions.

Signed-off-by: Major Hayden <major@redhat.com>