### PR TITLE
test/cases: remove tar size

### DIFF
--- a/test/cases/fedora_30-aarch64-tar-boot.json
+++ b/test/cases/fedora_30-aarch64-tar-boot.json
@@ -773,7 +773,6 @@
         "name": "org.osbuild.tar",
         "options": {
           "filename": "root.tar.xz",
-          "size": 0,
           "compression": "xz"
         }
       }

--- a/test/cases/fedora_30-x86_64-tar-boot.json
+++ b/test/cases/fedora_30-x86_64-tar-boot.json
@@ -781,7 +781,6 @@
         "name": "org.osbuild.tar",
         "options": {
           "filename": "root.tar.xz",
-          "size": 0,
           "compression": "xz"
         }
       }

--- a/test/cases/fedora_31-aarch64-tar-boot.json
+++ b/test/cases/fedora_31-aarch64-tar-boot.json
@@ -850,7 +850,6 @@
         "name": "org.osbuild.tar",
         "options": {
           "filename": "root.tar.xz",
-          "size": 0,
           "compression": "xz"
         }
       }

--- a/test/cases/fedora_31-x86_64-tar-boot.json
+++ b/test/cases/fedora_31-x86_64-tar-boot.json
@@ -893,7 +893,6 @@
         "name": "org.osbuild.tar",
         "options": {
           "filename": "root.tar.xz",
-          "size": 0,
           "compression": "xz"
         }
       }

--- a/test/cases/fedora_32-x86_64-tar-boot.json
+++ b/test/cases/fedora_32-x86_64-tar-boot.json
@@ -772,7 +772,6 @@
         "name": "org.osbuild.tar",
         "options": {
           "filename": "root.tar.xz",
-          "size": 0,
           "compression": "xz"
         }
       }

--- a/test/cases/rhel_8.2-x86_64-tar-boot.json
+++ b/test/cases/rhel_8.2-x86_64-tar-boot.json
@@ -774,7 +774,6 @@
         "name": "org.osbuild.tar",
         "options": {
           "filename": "root.tar.xz",
-          "size": 0,
           "compression": "xz"
         }
       }


### PR DESCRIPTION
When building a tar image the image size should not be specified. All image size fields are removed from the assembler options in the tar test cases. This is a follow up to #557 