### PR TITLE
📔 Remove the no_log for image tests

### DIFF
--- a/jenkins/test_runner_base.yml
+++ b/jenkins/test_runner_base.yml
@@ -9,7 +9,6 @@
       register: async_test
       async: "{{ test.timeout * 60 }}"
       poll: "{{ polling_interval }}"
-      no_log: yes
 
     - name: "Mark {{ test.name }} as passed"
       set_fact:

--- a/jenkins/test_runner_image.yml
+++ b/jenkins/test_runner_image.yml
@@ -37,7 +37,6 @@
       register: async_test
       async: "{{ image_test_timeout * 60 }}"
       poll: "{{ polling_interval }}"
-      no_log: yes
 
     - name: "Mark image tests as passed"
       set_fact:


### PR DESCRIPTION
Hiding logs makes the output prettier, but it is sometimes easier to see
the problem right there in the Ansible output.

Signed-off-by: Major Hayden <major@redhat.com>