### PR TITLE
🐞 Fix worker https logic

### DIFF
--- a/internal/worker/client.go
+++ b/internal/worker/client.go
@@ -39,10 +39,11 @@ func NewClient(address string, conf *tls.Config) *Client {
 	}
 
 	var scheme string
+	// Use https if the TLS configuration is present, otherwise use http.
 	if conf != nil {
-		scheme = "http"
-	} else {
 		scheme = "https"
+	} else {
+		scheme = "http"
 	}
 
 	return &Client{client, scheme, address}


### PR DESCRIPTION
Use https scheme for workers with TLS configuration set.

Fixes #568.

Signed-off-by: Major Hayden <major@redhat.com>