### PR TITLE
🦑 Cache RPMs with squid

### DIFF
--- a/jenkins/squid.conf
+++ b/jenkins/squid.conf
@@ -1,0 +1,53 @@
+# Squid configuration for caching RPM packages from yum/dnf mirrors.
+# Adapted from the one available here:
+#   https://github.com/spacewalkproject/spacewalk/blob/master/proxy/installer/squid.conf
+#
+http_port 8080
+
+cache_mem 400 MB
+maximum_object_size 200 MB
+maximum_object_size_in_memory 1024 KB
+
+access_log /var/log/squid/access.log squid
+
+# Size should be about 60% of your free space
+cache_dir ufs /var/spool/squid 15000 16 256
+
+# Average object size, used to estimate number of objects your
+# cache can hold.  The default is 13 KB.
+store_avg_object_size 817 KB
+
+# We want to keep the largest objects around longer, and just download the smaller objects if we can.
+cache_replacement_policy heap LFUDA
+
+memory_replacement_policy heap GDSF
+
+# cache repodata only few minutes and then query parent whether it is fresh
+refresh_pattern /XMLRPC/GET-REQ/.*/repodata/.*$ 0 1% 1440 ignore-no-cache reload-into-ims refresh-ims
+# rpm will hardly ever change, force to chache it for very long time
+refresh_pattern  \.rpm$  10080 100% 525960 override-expire override-lastmod ignore-reload reload-into-ims
+refresh_pattern 	.		0	100%	525960
+
+# secure squid
+# allow request only from localhost and to http and https ports
+acl all src 0.0.0.0/0.0.0.0
+acl localhost src 127.0.0.1/32
+acl SSL_ports port 443
+acl Safe_ports port 80          # http
+acl Safe_ports port 443         # https
+acl CONNECT method CONNECT
+
+http_access deny !Safe_ports
+http_access deny CONNECT !SSL_ports
+http_access allow localhost
+http_access deny all
+icp_access allow all
+miss_access allow all
+
+# if transport is canceled, finish downloading anyway
+quick_abort_pct -1
+quick_abort_min -1 KB
+
+# we download only from 1 server, default is 1024
+# which is too much for us
+fqdncache_size 4

--- a/jenkins/squid_package_cache.yml
+++ b/jenkins/squid_package_cache.yml
@@ -1,0 +1,33 @@
+---
+
+- name: Install squid
+  dnf:
+    name: squid
+    state: latest
+
+- name: Deploy squid configuration file
+  copy:
+    src: squid.conf
+    dest: /etc/squid/squid.conf
+  register: squid_conf
+
+- name: Ensure squid is running
+  systemd:
+    name: squid
+    state: "{{ squid_conf is changed | ternary('restarted', 'started') }}"
+    enabled: yes
+
+- name: Verify that squid is listening
+  wait_for:
+    host: 127.0.0.1
+    port: 8080
+    state: started
+
+# osbuild uses curl to download packages.
+- name: Set curl configuration file to use the proxy
+  copy:
+    dest: /root/.curlrc
+    content: |
+      # Managed by Ansible for osbuild-composer CI.
+      proxy = 127.0.0.1:8080
+

--- a/jenkins/test.yml
+++ b/jenkins/test.yml
@@ -9,6 +9,9 @@
     - vars.yml
   tasks:
 
+    - name: Prepare squid cache for image tests
+      include_tasks: squid_package_cache.yml
+
     - name: Run osbuild-composer base tests
       include_tasks: test_runner_base.yml
       loop: "{{ osbuild_composer_base_tests }}"


### PR DESCRIPTION
Various osbuild-composer tests require downloads from various dnf
mirrors and these can take time on slow network links. Also, it puts
undue strain on mirrors when we run a lot of tests.

Use a small squid proxy on the CI machine to cache these packages, speed
up image tests, reduce mirror strain, and potentially save a little
money in some clouds.

Signed-off-by: Major Hayden <major@redhat.com>