### PR TITLE
test/cases: fix expected values for the image info sub-test

### DIFF
--- a/test/cases/fedora_30-aarch64-ami-boot.json
+++ b/test/cases/fedora_30-aarch64-ami-boot.json
@@ -7233,7 +7233,6 @@
   },
   "image-info": {
     "boot-environment": {
-      "GRUB2_ROOT_FS_UUID": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
       "kernelopts": "root=UUID=76a22bf4-f153-4541-b6c7-0332c0dfaeac ro no_timer_check console=ttyS0,115200n8 console=tty1 biosdevname=0 net.ifnames=0 console=ttyS0,115200"
     },
     "bootloader": "unknown",

--- a/test/cases/fedora_30-aarch64-openstack-boot.json
+++ b/test/cases/fedora_30-aarch64-openstack-boot.json
@@ -7479,7 +7479,6 @@
   },
   "image-info": {
     "boot-environment": {
-      "GRUB2_ROOT_FS_UUID": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
       "kernelopts": "root=UUID=76a22bf4-f153-4541-b6c7-0332c0dfaeac ro biosdevname=0 net.ifnames=0"
     },
     "bootloader": "unknown",

--- a/test/cases/fedora_30-aarch64-partitioned_disk-boot.json
+++ b/test/cases/fedora_30-aarch64-partitioned_disk-boot.json
@@ -6794,7 +6794,6 @@
   },
   "image-info": {
     "boot-environment": {
-      "GRUB2_ROOT_FS_UUID": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
       "kernelopts": "root=UUID=76a22bf4-f153-4541-b6c7-0332c0dfaeac ro biosdevname=0 net.ifnames=0"
     },
     "bootloader": "unknown",

--- a/test/cases/fedora_30-aarch64-qcow2-boot.json
+++ b/test/cases/fedora_30-aarch64-qcow2-boot.json
@@ -7106,7 +7106,6 @@
   },
   "image-info": {
     "boot-environment": {
-      "GRUB2_ROOT_FS_UUID": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
       "kernelopts": "root=UUID=76a22bf4-f153-4541-b6c7-0332c0dfaeac ro biosdevname=0 net.ifnames=0"
     },
     "bootloader": "unknown",

--- a/test/cases/fedora_30-x86_64-ami-boot.json
+++ b/test/cases/fedora_30-x86_64-ami-boot.json
@@ -7193,7 +7193,6 @@
   },
   "image-info": {
     "boot-environment": {
-      "GRUB2_ROOT_FS_UUID": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
       "kernelopts": "root=UUID=76a22bf4-f153-4541-b6c7-0332c0dfaeac ro no_timer_check console=ttyS0,115200n8 console=tty1 biosdevname=0 net.ifnames=0 console=ttyS0,115200"
     },
     "bootloader": "grub",

--- a/test/cases/fedora_30-x86_64-openstack-boot.json
+++ b/test/cases/fedora_30-x86_64-openstack-boot.json
@@ -7427,7 +7427,6 @@
   },
   "image-info": {
     "boot-environment": {
-      "GRUB2_ROOT_FS_UUID": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
       "kernelopts": "root=UUID=76a22bf4-f153-4541-b6c7-0332c0dfaeac ro biosdevname=0 net.ifnames=0"
     },
     "bootloader": "grub",

--- a/test/cases/fedora_30-x86_64-partitioned_disk-boot.json
+++ b/test/cases/fedora_30-x86_64-partitioned_disk-boot.json
@@ -6754,7 +6754,6 @@
   },
   "image-info": {
     "boot-environment": {
-      "GRUB2_ROOT_FS_UUID": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
       "kernelopts": "root=UUID=76a22bf4-f153-4541-b6c7-0332c0dfaeac ro biosdevname=0 net.ifnames=0"
     },
     "bootloader": "grub",

--- a/test/cases/fedora_30-x86_64-qcow2-boot.json
+++ b/test/cases/fedora_30-x86_64-qcow2-boot.json
@@ -7131,7 +7131,6 @@
   },
   "image-info": {
     "boot-environment": {
-      "GRUB2_ROOT_FS_UUID": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
       "kernelopts": "root=UUID=76a22bf4-f153-4541-b6c7-0332c0dfaeac ro biosdevname=0 net.ifnames=0"
     },
     "bootloader": "grub",

--- a/test/cases/fedora_30-x86_64-vhd-boot.json
+++ b/test/cases/fedora_30-x86_64-vhd-boot.json
@@ -6883,7 +6883,6 @@
   },
   "image-info": {
     "boot-environment": {
-      "GRUB2_ROOT_FS_UUID": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
       "kernelopts": "root=UUID=76a22bf4-f153-4541-b6c7-0332c0dfaeac ro biosdevname=0 rootdelay=300 console=ttyS0 earlyprintk=ttyS0 net.ifnames=0"
     },
     "bootloader": "grub",

--- a/test/cases/fedora_30-x86_64-vmdk-boot.json
+++ b/test/cases/fedora_30-x86_64-vmdk-boot.json
@@ -6961,7 +6961,6 @@
   },
   "image-info": {
     "boot-environment": {
-      "GRUB2_ROOT_FS_UUID": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
       "kernelopts": "root=UUID=76a22bf4-f153-4541-b6c7-0332c0dfaeac ro biosdevname=0 net.ifnames=0"
     },
     "bootloader": "grub",

--- a/test/cases/fedora_31-aarch64-ami-boot.json
+++ b/test/cases/fedora_31-aarch64-ami-boot.json
@@ -8513,7 +8513,6 @@
   },
   "image-info": {
     "boot-environment": {
-      "GRUB2_ROOT_FS_UUID": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
       "kernelopts": "root=UUID=76a22bf4-f153-4541-b6c7-0332c0dfaeac ro no_timer_check console=ttyS0,115200n8 console=tty1 biosdevname=0 net.ifnames=0 console=ttyS0,115200"
     },
     "bootloader": "unknown",

--- a/test/cases/fedora_31-aarch64-openstack-boot.json
+++ b/test/cases/fedora_31-aarch64-openstack-boot.json
@@ -8646,7 +8646,6 @@
   },
   "image-info": {
     "boot-environment": {
-      "GRUB2_ROOT_FS_UUID": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
       "kernelopts": "root=UUID=76a22bf4-f153-4541-b6c7-0332c0dfaeac ro biosdevname=0 net.ifnames=0"
     },
     "bootloader": "unknown",

--- a/test/cases/fedora_31-aarch64-partitioned_disk-boot.json
+++ b/test/cases/fedora_31-aarch64-partitioned_disk-boot.json
@@ -8087,7 +8087,6 @@
   },
   "image-info": {
     "boot-environment": {
-      "GRUB2_ROOT_FS_UUID": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
       "kernelopts": "root=UUID=76a22bf4-f153-4541-b6c7-0332c0dfaeac ro biosdevname=0 net.ifnames=0"
     },
     "bootloader": "unknown",

--- a/test/cases/fedora_31-aarch64-qcow2-boot.json
+++ b/test/cases/fedora_31-aarch64-qcow2-boot.json
@@ -8438,7 +8438,6 @@
   },
   "image-info": {
     "boot-environment": {
-      "GRUB2_ROOT_FS_UUID": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
       "kernelopts": "root=UUID=76a22bf4-f153-4541-b6c7-0332c0dfaeac ro biosdevname=0 net.ifnames=0"
     },
     "bootloader": "unknown",

--- a/test/cases/fedora_31-x86_64-ami-boot.json
+++ b/test/cases/fedora_31-x86_64-ami-boot.json
@@ -8762,7 +8762,6 @@
   },
   "image-info": {
     "boot-environment": {
-      "GRUB2_ROOT_FS_UUID": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
       "kernelopts": "root=UUID=76a22bf4-f153-4541-b6c7-0332c0dfaeac ro no_timer_check console=ttyS0,115200n8 console=tty1 biosdevname=0 net.ifnames=0 console=ttyS0,115200"
     },
     "bootloader": "grub",

--- a/test/cases/fedora_31-x86_64-openstack-boot.json
+++ b/test/cases/fedora_31-x86_64-openstack-boot.json
@@ -8895,7 +8895,6 @@
   },
   "image-info": {
     "boot-environment": {
-      "GRUB2_ROOT_FS_UUID": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
       "kernelopts": "root=UUID=76a22bf4-f153-4541-b6c7-0332c0dfaeac ro biosdevname=0 net.ifnames=0"
     },
     "bootloader": "grub",

--- a/test/cases/fedora_31-x86_64-partitioned_disk-boot.json
+++ b/test/cases/fedora_31-x86_64-partitioned_disk-boot.json
@@ -8349,7 +8349,6 @@
   },
   "image-info": {
     "boot-environment": {
-      "GRUB2_ROOT_FS_UUID": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
       "kernelopts": "root=UUID=76a22bf4-f153-4541-b6c7-0332c0dfaeac ro biosdevname=0 net.ifnames=0"
     },
     "bootloader": "grub",

--- a/test/cases/fedora_31-x86_64-qcow2-boot.json
+++ b/test/cases/fedora_31-x86_64-qcow2-boot.json
@@ -8765,7 +8765,6 @@
   },
   "image-info": {
     "boot-environment": {
-      "GRUB2_ROOT_FS_UUID": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
       "kernelopts": "root=UUID=76a22bf4-f153-4541-b6c7-0332c0dfaeac ro biosdevname=0 net.ifnames=0"
     },
     "bootloader": "grub",

--- a/test/cases/fedora_31-x86_64-vhd-boot.json
+++ b/test/cases/fedora_31-x86_64-vhd-boot.json
@@ -8452,7 +8452,6 @@
   },
   "image-info": {
     "boot-environment": {
-      "GRUB2_ROOT_FS_UUID": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
       "kernelopts": "root=UUID=76a22bf4-f153-4541-b6c7-0332c0dfaeac ro biosdevname=0 rootdelay=300 console=ttyS0 earlyprintk=ttyS0 net.ifnames=0"
     },
     "bootloader": "grub",

--- a/test/cases/fedora_31-x86_64-vmdk-boot.json
+++ b/test/cases/fedora_31-x86_64-vmdk-boot.json
@@ -8556,7 +8556,6 @@
   },
   "image-info": {
     "boot-environment": {
-      "GRUB2_ROOT_FS_UUID": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
       "kernelopts": "root=UUID=76a22bf4-f153-4541-b6c7-0332c0dfaeac ro biosdevname=0 net.ifnames=0"
     },
     "bootloader": "grub",

--- a/test/cases/fedora_32-x86_64-ami-boot.json
+++ b/test/cases/fedora_32-x86_64-ami-boot.json
@@ -7254,7 +7254,6 @@
   },
   "image-info": {
     "boot-environment": {
-      "GRUB2_ROOT_FS_UUID": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
       "kernelopts": "root=UUID=76a22bf4-f153-4541-b6c7-0332c0dfaeac ro no_timer_check console=ttyS0,115200n8 console=tty1 biosdevname=0 net.ifnames=0 console=ttyS0,115200"
     },
     "bootloader": "grub",

--- a/test/cases/fedora_32-x86_64-openstack-boot.json
+++ b/test/cases/fedora_32-x86_64-openstack-boot.json
@@ -7517,7 +7517,6 @@
   },
   "image-info": {
     "boot-environment": {
-      "GRUB2_ROOT_FS_UUID": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
       "kernelopts": "root=UUID=76a22bf4-f153-4541-b6c7-0332c0dfaeac ro biosdevname=0 net.ifnames=0"
     },
     "bootloader": "grub",

--- a/test/cases/fedora_32-x86_64-partitioned_disk-boot.json
+++ b/test/cases/fedora_32-x86_64-partitioned_disk-boot.json
@@ -6854,7 +6854,6 @@
   },
   "image-info": {
     "boot-environment": {
-      "GRUB2_ROOT_FS_UUID": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
       "kernelopts": "root=UUID=76a22bf4-f153-4541-b6c7-0332c0dfaeac ro biosdevname=0 net.ifnames=0"
     },
     "bootloader": "grub",

--- a/test/cases/fedora_32-x86_64-qcow2-boot.json
+++ b/test/cases/fedora_32-x86_64-qcow2-boot.json
@@ -7218,7 +7218,6 @@
   },
   "image-info": {
     "boot-environment": {
-      "GRUB2_ROOT_FS_UUID": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
       "kernelopts": "root=UUID=76a22bf4-f153-4541-b6c7-0332c0dfaeac ro biosdevname=0 net.ifnames=0"
     },
     "bootloader": "grub",

--- a/test/cases/fedora_32-x86_64-vhd-boot.json
+++ b/test/cases/fedora_32-x86_64-vhd-boot.json
@@ -6957,7 +6957,6 @@
   },
   "image-info": {
     "boot-environment": {
-      "GRUB2_ROOT_FS_UUID": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
       "kernelopts": "root=UUID=76a22bf4-f153-4541-b6c7-0332c0dfaeac ro biosdevname=0 rootdelay=300 console=ttyS0 earlyprintk=ttyS0 net.ifnames=0"
     },
     "bootloader": "grub",

--- a/test/cases/fedora_32-x86_64-vmdk-boot.json
+++ b/test/cases/fedora_32-x86_64-vmdk-boot.json
@@ -7035,7 +7035,6 @@
   },
   "image-info": {
     "boot-environment": {
-      "GRUB2_ROOT_FS_UUID": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
       "kernelopts": "root=UUID=76a22bf4-f153-4541-b6c7-0332c0dfaeac ro biosdevname=0 net.ifnames=0"
     },
     "bootloader": "grub",

--- a/test/cases/rhel_8.2-x86_64-ami-boot.json
+++ b/test/cases/rhel_8.2-x86_64-ami-boot.json
@@ -7830,7 +7830,6 @@
   },
   "image-info": {
     "boot-environment": {
-      "GRUB2_ROOT_FS_UUID": "0bd700f8-090f-4556-b797-b340297ea1bd",
       "kernelopts": "root=UUID=0bd700f8-090f-4556-b797-b340297ea1bd ro console=ttyS0,115200n8 console=tty0 net.ifnames=0 rd.blacklist=nouveau nvme_core.io_timeout=4294967295 crashkernel=auto"
     },
     "bootloader": "grub",

--- a/test/cases/rhel_8.2-x86_64-ext4_filesystem-boot.json
+++ b/test/cases/rhel_8.2-x86_64-ext4_filesystem-boot.json
@@ -5303,7 +5303,6 @@
   },
   "image-info": {
     "boot-environment": {
-      "GRUB2_ROOT_FS_UUID": "0bd700f8-090f-4556-b797-b340297ea1bd",
       "kernelopts": "root=UUID=0bd700f8-090f-4556-b797-b340297ea1bd ro net.ifnames=0"
     },
     "bootloader": "unknown",

--- a/test/cases/rhel_8.2-x86_64-openstack-boot.json
+++ b/test/cases/rhel_8.2-x86_64-openstack-boot.json
@@ -8362,7 +8362,6 @@
   },
   "image-info": {
     "boot-environment": {
-      "GRUB2_ROOT_FS_UUID": "0bd700f8-090f-4556-b797-b340297ea1bd",
       "kernelopts": "root=UUID=0bd700f8-090f-4556-b797-b340297ea1bd ro net.ifnames=0"
     },
     "bootloader": "grub",

--- a/test/cases/rhel_8.2-x86_64-partitioned_disk-boot.json
+++ b/test/cases/rhel_8.2-x86_64-partitioned_disk-boot.json
@@ -7894,7 +7894,6 @@
   },
   "image-info": {
     "boot-environment": {
-      "GRUB2_ROOT_FS_UUID": "0bd700f8-090f-4556-b797-b340297ea1bd",
       "kernelopts": "root=UUID=0bd700f8-090f-4556-b797-b340297ea1bd ro net.ifnames=0"
     },
     "bootloader": "grub",

--- a/test/cases/rhel_8.2-x86_64-qcow2-boot.json
+++ b/test/cases/rhel_8.2-x86_64-qcow2-boot.json
@@ -8425,7 +8425,6 @@
   },
   "image-info": {
     "boot-environment": {
-      "GRUB2_ROOT_FS_UUID": "0bd700f8-090f-4556-b797-b340297ea1bd",
       "kernelopts": "root=UUID=0bd700f8-090f-4556-b797-b340297ea1bd console=ttyS0 console=ttyS0,115200n8 no_timer_check crashkernel=auto net.ifnames=0"
     },
     "bootloader": "grub",

--- a/test/cases/rhel_8.2-x86_64-vhd-boot.json
+++ b/test/cases/rhel_8.2-x86_64-vhd-boot.json
@@ -8291,7 +8291,6 @@
   },
   "image-info": {
     "boot-environment": {
-      "GRUB2_ROOT_FS_UUID": "0bd700f8-090f-4556-b797-b340297ea1bd",
       "kernelopts": "root=UUID=0bd700f8-090f-4556-b797-b340297ea1bd ro biosdevname=0 rootdelay=300 console=ttyS0 earlyprintk=ttyS0 net.ifnames=0"
     },
     "bootloader": "grub",

--- a/test/cases/rhel_8.2-x86_64-vmdk-boot.json
+++ b/test/cases/rhel_8.2-x86_64-vmdk-boot.json
@@ -8049,7 +8049,6 @@
   },
   "image-info": {
     "boot-environment": {
-      "GRUB2_ROOT_FS_UUID": "0bd700f8-090f-4556-b797-b340297ea1bd",
       "kernelopts": "root=UUID=0bd700f8-090f-4556-b797-b340297ea1bd ro net.ifnames=0"
     },
     "bootloader": "grub",


### PR DESCRIPTION
osbuild removed GRUB2_ROOT_FS_UUID from grubenv in 22d131a5. This broke the Jenkins CI because it runs against osbuild master.

This commit fixes all the testcases and bumps the osbuild submodule to version 13 that changed the GRUB2_ROOT_FS_UUID behaviour.