### PR TITLE
Run image tests separately

### DIFF
--- a/jenkins/test.yml
+++ b/jenkins/test.yml
@@ -19,6 +19,9 @@
 
     - name: Run osbuild-composer image tests
       include_tasks: test_runner_image.yml
+      loop: "{{ osbuild_composer_image_test_cases }}"
+      loop_control:
+        loop_var: test_case
       when:
         - test_type == 'image'
 

--- a/jenkins/test_runner_image.yml
+++ b/jenkins/test_runner_image.yml
@@ -9,52 +9,35 @@
       rhel_{{ ansible_distribution_version }}-{{ ansible_machine }}
       {%- endif -%}
 
-- name: Show which tests will be run
-  debug:
-    msg: |
-      Running the following image test cases:
-      {% for test_case in osbuild_composer_image_test_cases %}
-        - {{ test_case | splitext | first }}
-      {% endfor %}
-
 - block:
 
-    # NOTE(mhayden): The fancy jinja2 here ensures that the last test case
-    # in the list does not have a backslash added. That would make the shell
-    # upset and nobody likes it when that happens.
-    - name: "Run image tests"
+    - name: "Run image test: {{ test_case }}"
       command: |
         {{ image_test_executable }} -test.v \
-          {% for test_case in osbuild_composer_image_test_cases %}
-            {% if loop.last %}
           {{ image_test_case_path }}/{{ test_case_prefix }}-{{ test_case }}
-            {% else %}
-          {{ image_test_case_path }}/{{ test_case_prefix }}-{{ test_case }} \
-            {% endif %}
-          {% endfor %}
       args:
         chdir: "{{ tests_working_directory }}"
       register: async_test
       async: "{{ image_test_timeout * 60 }}"
       poll: "{{ polling_interval }}"
 
-    - name: "Mark image tests as passed"
+    - name: "Mark test passed: {{ test_case }}"
       set_fact:
-        passed_tests: "{{ passed_tests + ['image_tests'] }}"
+        passed_tests: "{{ passed_tests + [test_case] }}"
 
   rescue:
 
-    - name: "Mark image tests as failed"
+    - name: "Mark test failed: {{ test_case }}"
       set_fact:
-        failed_tests: "{{ failed_tests + ['image_tests'] }}"
+        failed_tests: "{{ failed_tests + [test_case] }}"
 
   always:
 
-    - name: "Write log for image tests"
+    - name: "Write log for image test: {{ test_case }}"
       copy:
         dest: "{{ workspace }}/image_test.log"
         content: |
-          Logs from image test
+          Logs from {{ test_case }} test
           ----------------------------------------------------------------------
           stderr:
           {{ async_test.stderr }}


### PR DESCRIPTION
The image tests have been less stable lately since merging the code that
runs them in parallel. Let's run them separately and verify that they
are more stable.

Signed-off-by: Major Hayden <major@redhat.com>