### PR TITLE
test/image: fix qemu args on qemu>=4.2

### DIFF
--- a/cmd/osbuild-image-tests/context-managers.go
+++ b/cmd/osbuild-image-tests/context-managers.go
@@ -136,7 +136,7 @@ func withBootedQemuImage(image string, ns netNS, f func() error) error {
 			"-smp", strconv.Itoa(runtime.NumCPU()),
 			"-m", "1024",
 			"-snapshot",
-			"-M", "accel=kvm:hvf:tcg",
+			"-M", "accel=kvm",
 			"-cdrom", cloudInitFile.Name(),
 			"-net", "nic,model=rtl8139", "-net", "user,hostfwd=tcp::22-:22",
 			"-nographic",

--- a/cmd/osbuild-image-tests/context-managers.go
+++ b/cmd/osbuild-image-tests/context-managers.go
@@ -122,7 +122,7 @@ func withBootedQemuImage(image string, ns netNS, f func() error) error {
 			// As opposed to x86_64, aarch64 uses UEFI, this one comes from edk2-aarch64 package on Fedora
 			"-bios", "/usr/share/edk2/aarch64/QEMU_EFI.fd",
 			"-boot", "efi",
-			"-accel", "accel=kvm",
+			"-M", "accel=kvm",
 			"-snapshot",
 			"-cdrom", cloudInitFile.Name(),
 			"-net", "nic,model=rtl8139", "-net", "user,hostfwd=tcp::22-:22",
@@ -136,7 +136,7 @@ func withBootedQemuImage(image string, ns netNS, f func() error) error {
 			"-smp", strconv.Itoa(runtime.NumCPU()),
 			"-m", "1024",
 			"-snapshot",
-			"-accel", "accel=kvm:hvf:tcg",
+			"-M", "accel=kvm:hvf:tcg",
 			"-cdrom", cloudInitFile.Name(),
 			"-net", "nic,model=rtl8139", "-net", "user,hostfwd=tcp::22-:22",
 			"-nographic",


### PR DESCRIPTION
Running qemu with -accel accel= results in the following error:

qemu-system-x86_64: -accel accel=kvm:hvf:tcg: Don't use ':' with -accel,
use -M accel=... for now instead

Qemu 4.2 deprecated the -accel accel= argument. When the arg is passed in,
qemu exists status code of 1.

This commit changes the qemu command to use the recommended way of specifying
the acceleration options.

See:
https://github.com/qemu/qemu/commit/3d5e90a50bd4ffa199166e01a365f5c5995534ae