### PR TITLE
Use sudo/become for tests

### DIFF
--- a/jenkins/run_tests.sh
+++ b/jenkins/run_tests.sh
@@ -2,14 +2,14 @@
 set -euxo pipefail
 
 # Restart systemd to work around some Fedora issues in cloud images.
-systemctl restart systemd-journald
+sudo systemctl restart systemd-journald
 
 # Get the current journald cursor.
-export JOURNALD_CURSOR=$(journalctl --quiet -n 1 --show-cursor | tail -n 1 | grep -oP 's\=.*$')
+export JOURNALD_CURSOR=$(sudo journalctl --quiet -n 1 --show-cursor | tail -n 1 | grep -oP 's\=.*$')
 
 # Add a function to preserve the system journal if something goes wrong.
 preserve_journal() {
-  journalctl --after-cursor=${JOURNALD_CURSOR} > systemd-journald.log
+  sudo journalctl --after-cursor=${JOURNALD_CURSOR} > systemd-journald.log
   exit 1
 }
 trap "preserve_journal" ERR
@@ -42,4 +42,4 @@ ansible-playbook \
   jenkins/test.yml
 
 # Collect the systemd journal anyway if we made it all the way to the end.
-journalctl --after-cursor=${JOURNALD_CURSOR} > systemd-journald.log
+sudo journalctl --after-cursor=${JOURNALD_CURSOR} > systemd-journald.log

--- a/jenkins/test.yml
+++ b/jenkins/test.yml
@@ -1,10 +1,10 @@
 ---
 
 - hosts: localhost
+  become: yes
   vars:
     passed_tests: []
     failed_tests: []
-    journald_cursor: "{{ ansible_env.JOURNALD_CURSOR"
   vars_files:
     - vars.yml
   tasks:


### PR DESCRIPTION
Jenkins now uses a non-root user for its agent, so we will need to use
sudo for some commands and `become` within the Ansible playbooks.

Signed-off-by: Major Hayden <major@redhat.com>