### PR TITLE
github: Fix go test coverage report

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -44,7 +44,7 @@ jobs:
         run: $(go env GOPATH)/bin/golangci-lint run
 
       - name: Run unit tests
-        run: go test -v -race -covermode atomic -coverprofile=coverage.txt ./...
+        run: go test -v -race -covermode=atomic -coverprofile=coverage.txt -coverpkg=./... ./...
 
       - name: Send coverage to codecov.io
         run: bash <(curl -s https://codecov.io/bash)


### PR DESCRIPTION
The go test coverage report does not cover other packages unless you
list them with the -coverpkg= argument. This results in an incomplete
coverage report with oddly missing lines.

This commit lists all of the packages so that they will all be included
when running the tests and gathering the results.