### PR TITLE
[tests] Fix distro manifest tests pipeline paths

### DIFF
--- a/internal/distro/distro_test.go
+++ b/internal/distro/distro_test.go
@@ -18,7 +18,7 @@ import (
 func TestDistro_Manifest(t *testing.T) {
 	distro_test_common.TestDistro_Manifest(
 		t,
-		"../../../test/cases/",
+		"../../test/cases/",
 		"*",
 		fedora30.New(), fedora31.New(), fedora32.New(), rhel81.New(), rhel82.New(), rhel83.New(),
 	)

--- a/internal/distro/distro_test_common/distro_test_common.go
+++ b/internal/distro/distro_test_common/distro_test_common.go
@@ -20,6 +20,7 @@ func TestDistro_Manifest(t *testing.T, pipelinePath string, prefix string, distr
 	assert := assert.New(t)
 	fileNames, err := filepath.Glob(filepath.Join(pipelinePath, prefix))
 	assert.NoErrorf(err, "Could not read pipelines directory '%s': %v", pipelinePath, err)
+	require.Greaterf(t, len(fileNames), 0, "No pipelines found in %s for %s", pipelinePath, prefix)
 	for _, fileName := range fileNames {
 		type repository struct {
 			BaseURL    string `json:"baseurl,omitempty"`

--- a/internal/distro/fedora30/distro_test.go
+++ b/internal/distro/fedora30/distro_test.go
@@ -318,7 +318,7 @@ func TestImageType_BasePackages(t *testing.T) {
 }
 
 func TestDistro_Manifest(t *testing.T) {
-	distro_test_common.TestDistro_Manifest(t, "../../../../test/cases/", "f30*", fedora30.New())
+	distro_test_common.TestDistro_Manifest(t, "../../../test/cases/", "fedora_30*", fedora30.New())
 }
 
 func TestFedora30_ListArches(t *testing.T) {

--- a/internal/distro/fedora31/distro_test.go
+++ b/internal/distro/fedora31/distro_test.go
@@ -274,7 +274,7 @@ func TestImageType_BasePackages(t *testing.T) {
 }
 
 func TestDistro_Manifest(t *testing.T) {
-	distro_test_common.TestDistro_Manifest(t, "../../../../test/cases/", "f31*", fedora31.New())
+	distro_test_common.TestDistro_Manifest(t, "../../../test/cases/", "fedora_31*", fedora31.New())
 }
 
 func TestFedora31_ListArches(t *testing.T) {

--- a/internal/distro/fedora32/distro_test.go
+++ b/internal/distro/fedora32/distro_test.go
@@ -318,7 +318,7 @@ func TestImageType_BasePackages(t *testing.T) {
 }
 
 func TestDistro_Manifest(t *testing.T) {
-	distro_test_common.TestDistro_Manifest(t, "../../../../test/cases/", "f30*", fedora32.New())
+	distro_test_common.TestDistro_Manifest(t, "../../../test/cases/", "fedora_32*", fedora32.New())
 }
 
 func TestFedora32_ListArches(t *testing.T) {


### PR DESCRIPTION
It turned out the paths leading to pipeline JSONs used in TestDistro_Manifest were wrong. This was not obvious before, because this didn't lead to FAILs, so I fixed this problem as well by adding an assert to make sure at least some pipeline files are matched for the test.