### PR TITLE
worker: switch to `--output-diectory=DIR`

### DIFF
--- a/cmd/osbuild-image-tests/constants/constants-travis.go
+++ b/cmd/osbuild-image-tests/constants/constants-travis.go
@@ -4,12 +4,12 @@ package constants
 
 import "os/exec"
 
-func GetOsbuildCommand(store string) *exec.Cmd {
+func GetOsbuildCommand(outputDirectory string) *exec.Cmd {
 	cmd := exec.Command(
 		"python3",
 		"-m", "osbuild",
 		"--libdir", ".",
-		"--store", store,
+		"--output-directory", outputDirectory,
 		"--json",
 		"-",
 	)

--- a/cmd/osbuild-image-tests/constants/constants.go
+++ b/cmd/osbuild-image-tests/constants/constants.go
@@ -4,10 +4,10 @@ package constants
 
 import "os/exec"
 
-func GetOsbuildCommand(store string) *exec.Cmd {
+func GetOsbuildCommand(outputDirectory string) *exec.Cmd {
 	return exec.Command(
 		"osbuild",
-		"--store", store,
+		"--output-directory", outputDirectory,
 		"--json",
 		"-",
 	)

--- a/cmd/osbuild-image-tests/context-managers.go
+++ b/cmd/osbuild-image-tests/context-managers.go
@@ -169,11 +169,10 @@ func withBootedQemuImage(image string, ns netNS, f func() error) error {
 
 // withBootedNspawnImage boots the specified image in the specified namespace
 // using nspawn. The VM is killed immediately after function returns.
-func withBootedNspawnImage(image, name string, ns netNS, f func() error) error {
+func withBootedNspawnImage(image string, ns netNS, f func() error) error {
 	cmd := exec.Command(
 		"systemd-nspawn",
 		"--boot", "--register=no",
-		"-M", name,
 		"--image", image,
 		"--network-namespace-path", ns.Path(),
 	)
@@ -195,11 +194,10 @@ func withBootedNspawnImage(image, name string, ns netNS, f func() error) error {
 
 // withBootedNspawnImage boots the specified directory in the specified namespace
 // using nspawn. The VM is killed immediately after function returns.
-func withBootedNspawnDirectory(dir, name string, ns netNS, f func() error) error {
+func withBootedNspawnDirectory(dir string, ns netNS, f func() error) error {
 	cmd := exec.Command(
 		"systemd-nspawn",
 		"--boot", "--register=no",
-		"-M", name,
 		"--directory", dir,
 		"--network-namespace-path", ns.Path(),
 	)

--- a/cmd/osbuild-worker/osbuild.go
+++ b/cmd/osbuild-worker/osbuild.go
@@ -19,10 +19,10 @@ func (e *OSBuildError) Error() string {
 	return e.Message
 }
 
-func RunOSBuild(manifest *osbuild.Manifest, store string, errorWriter io.Writer) (*common.ComposeResult, error) {
+func RunOSBuild(manifest *osbuild.Manifest, outputDirectory string, errorWriter io.Writer) (*common.ComposeResult, error) {
 	cmd := exec.Command(
 		"osbuild",
-		"--store", store,
+		"--output-directory", outputDirectory,
 		"--json", "-",
 	)
 	cmd.Stderr = errorWriter

--- a/tools/test-case-generators/generate-test-case
+++ b/tools/test-case-generators/generate-test-case
@@ -5,6 +5,7 @@ import subprocess
 import json
 import os
 import sys
+import tempfile
 
 '''
 This script generates a json test case. It accepts a test_case_request as input through standard input.
@@ -35,10 +36,14 @@ def get_subprocess_stdout(*args, **kwargs):
     return sp.stdout
 
 
-def run_osbuild(manifest, store):
-    osbuild_cmd = ["osbuild", "--store", store, "--json", "-"]
-    result = json.loads(get_subprocess_stdout(osbuild_cmd, encoding="utf-8", input=json.dumps(manifest)))
-    return result.get("output_id")
+def run_osbuild(manifest, store, output):
+    subprocess.run(["osbuild",
+                    "--store", store,
+                    "--output-directory", output,
+                    "--json", "-"],
+                   check=True,
+                   encoding="utf-8",
+                   input=json.dumps(manifest))
 
 
 def main(test_case, store):
@@ -52,9 +57,10 @@ def main(test_case, store):
     test_case["rpmmd"] = json.loads(get_subprocess_stdout(pipeline_command, input=compose_request, encoding="utf-8"))
 
     if boot_type != "nspawn-extract":
-        output_id = run_osbuild(test_case["manifest"], store)
-        image_file = os.path.join(store, "refs", output_id, test_case["compose-request"]["filename"])
-        test_case["image-info"] = json.loads(get_subprocess_stdout(["tools/image-info", image_file], encoding="utf-8"))
+        with tempfile.TemporaryDirectory(dir=store, prefix="test-case-output-") as output:
+            run_osbuild(test_case["manifest"], store, output)
+            image_file = os.path.join(output, test_case["compose-request"]["filename"])
+            test_case["image-info"] = json.loads(get_subprocess_stdout(["tools/image-info", image_file], encoding="utf-8"))
 
     return test_case
 


### PR DESCRIPTION
Since 2 releases `osbuild` accepts an `--output-directory=DIR` argument
which lets us decide where to place generated artifacts. Switch over to
it, rather than digging into the store, to make sure we will not access
the osbuild store when parallel cleanups are ongoing (which are not yet
a thing, though).