### PR TITLE
↔ Parallel testing on internal Jenkins

### DIFF
--- a/schutzbot/Jenkinsfile
+++ b/schutzbot/Jenkinsfile
@@ -1,0 +1,84 @@
+pipeline {
+    agent none
+
+    options {
+        timestamps()
+        ansiColor('xterm')
+    }
+
+    stages {
+        stage("Functional Testing") {
+            parallel {
+                stage('Fedora 31 base') {
+                    agent {
+                        label "fedora31"
+                    }
+                    environment {
+                        TEST_TYPE = "base"
+                    }
+                    steps {
+                        sh "jenkins/run_tests.sh"
+                    }
+                }
+                stage('Fedora 31 image') {
+                    agent {
+                        label "fedora31"
+                    }
+                    environment {
+                        TEST_TYPE = "image"
+                    }
+                    steps {
+                        sh "jenkins/run_tests.sh"
+                    }
+                }
+                stage('Fedora 32 base') {
+                    agent {
+                        label "fedora32"
+                    }
+                    environment {
+                        TEST_TYPE = "base"
+                    }
+                    steps {
+                        sh "jenkins/run_tests.sh"
+                    }
+                }
+                stage('Fedora 32 image') {
+                    agent {
+                        label "fedora32"
+                    }
+                    environment {
+                        TEST_TYPE = "image"
+                    }
+                    steps {
+                        sh "jenkins/run_tests.sh"
+                    }
+                }
+                //stage('RHEL 8.2 base') {
+                //    agent {
+                //        label "rhel82"
+                //    }
+                //    environment {
+                //        TEST_TYPE = "base"
+                //    }
+                //    steps {
+                //        sh "jenkins/run_tests.sh"
+                //    }
+                //}
+                // Disable RHEL 8.3 image testing for now until we work out the
+                // QEMU issues there.
+                //
+                // stage('RHEL 8.2 image') {
+                //     agent {
+                //         label "rhel82"
+                //     }
+                //     environment {
+                //         TEST_TYPE = "image"
+                //     }
+                //     steps {
+                //         sh "jenkins/run_tests.sh"
+                //     }
+                // }
+            }
+        }
+    }
+}

--- a/schutzbot/run_tests.sh
+++ b/schutzbot/run_tests.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+set -euxo pipefail
+
+# Create temporary directories for Ansible.
+sudo mkdir -vp /opt/ansible_{local,remote}
+sudo chmod -R 777 /opt/ansible_{local,remote}
+
+# Restart systemd to work around some Fedora issues in cloud images.
+sudo systemctl restart systemd-journald
+
+# Get the current journald cursor.
+export JOURNALD_CURSOR=$(sudo journalctl --quiet -n 1 --show-cursor | tail -n 1 | grep -oP 's\=.*$')
+
+# Add a function to preserve the system journal if something goes wrong.
+preserve_journal() {
+  sudo journalctl --after-cursor=${JOURNALD_CURSOR} > systemd-journald.log
+  exit 1
+}
+trap "preserve_journal" ERR
+
+# Ensure Ansible is installed.
+if ! rpm -q ansible; then
+  sudo dnf -y install ansible
+fi
+
+# Write a simple hosts file for Ansible.
+echo -e "[test_instances]\nlocalhost ansible_connection=local" > hosts.ini
+
+# Set Ansible's config file location.
+export ANSIBLE_CONFIG=ansible-osbuild/ansible.cfg
+
+# Deploy the software.
+git clone https://github.com/osbuild/ansible-osbuild.git ansible-osbuild
+ansible-playbook \
+  -i hosts.ini \
+  -e osbuild_composer_repo=${WORKSPACE} \
+  -e osbuild_composer_version=$(git rev-parse HEAD) \
+  ansible-osbuild/playbook.yml
+
+# Run the tests.
+ansible-playbook \
+  -e workspace=${WORKSPACE} \
+  -e journald_cursor="${JOURNALD_CURSOR}" \
+  -e test_type=${TEST_TYPE:-base} \
+  -i hosts.ini \
+  jenkins/test.yml
+
+# Collect the systemd journal anyway if we made it all the way to the end.
+sudo journalctl --after-cursor=${JOURNALD_CURSOR} > systemd-journald.log

--- a/schutzbot/test.yml
+++ b/schutzbot/test.yml
@@ -1,0 +1,40 @@
+---
+
+- hosts: localhost
+  become: yes
+  vars:
+    passed_tests: []
+    failed_tests: []
+  vars_files:
+    - vars.yml
+  tasks:
+
+    - name: Run osbuild-composer base tests
+      include_tasks: test_runner_base.yml
+      loop: "{{ osbuild_composer_base_tests }}"
+      loop_control:
+        loop_var: test
+      when:
+        - test_type == 'base'
+
+    - name: Run osbuild-composer image tests
+      include_tasks: test_runner_image.yml
+      when:
+        - test_type == 'image'
+
+    - name: Show failed and passed tests
+      debug:
+        msg: |
+          Passed tests: {{ 'None' if not passed_tests else '' }}
+          {% for test_name in passed_tests %}
+            - {{ test_name }}
+          {% endfor %}
+          Failed tests: {{ 'None' if not failed_tests else '' }}
+          {% for test_name in failed_tests %}
+            - {{ test_name }}
+          {% endfor %}
+
+    - name: Fail the test run if a test failed
+      fail:
+        msg: One or more tests failed.
+      when: failed_tests

--- a/schutzbot/test_runner_base.yml
+++ b/schutzbot/test_runner_base.yml
@@ -1,0 +1,36 @@
+---
+
+- block:
+
+    - name: "Run {{ test.name }} test"
+      command: "{{ tests_path }}/{{ test.name }} -test.v"
+      args:
+        chdir: "{{ tests_working_directory }}"
+      register: async_test
+      async: "{{ test.timeout * 60 }}"
+      poll: "{{ polling_interval }}"
+
+    - name: "Mark {{ test.name }} as passed"
+      set_fact:
+        passed_tests: "{{ passed_tests + [test.name] }}"
+
+  rescue:
+
+    - name: "Mark {{ test.name }} as failed"
+      set_fact:
+        failed_tests: "{{ failed_tests + [test.name] }}"
+
+  always:
+
+    - name: "Write log for {{ test.name }}"
+      copy:
+        dest: "{{ workspace }}/{{ test.name }}.log"
+        content: |
+          Logs from {{ test.name }}
+          ----------------------------------------------------------------------
+          stderr:
+          {{ async_test.stderr }}
+          ----------------------------------------------------------------------
+          stdout:
+          {{ async_test.stdout }}
+

--- a/schutzbot/test_runner_image.yml
+++ b/schutzbot/test_runner_image.yml
@@ -1,0 +1,64 @@
+---
+
+- name: Setup test case prefix based on distro and release
+  set_fact:
+    test_case_prefix: >-
+      {%- if ansible_distribution == "Fedora" -%}
+      fedora_{{ ansible_distribution_version }}-{{ ansible_machine }}
+      {%- else -%}
+      rhel_{{ ansible_distribution_version }}-{{ ansible_machine }}
+      {%- endif -%}
+
+- name: Show which tests will be run
+  debug:
+    msg: |
+      Running the following image test cases:
+      {% for test_case in osbuild_composer_image_test_cases %}
+        - {{ test_case | splitext | first }}
+      {% endfor %}
+
+- block:
+
+    # NOTE(mhayden): The fancy jinja2 here ensures that the last test case
+    # in the list does not have a backslash added. That would make the shell
+    # upset and nobody likes it when that happens.
+    - name: "Run image tests"
+      command: |
+        {{ image_test_executable }} -test.v \
+          {% for test_case in osbuild_composer_image_test_cases %}
+            {% if loop.last %}
+          {{ image_test_case_path }}/{{ test_case_prefix }}-{{ test_case }}
+            {% else %}
+          {{ image_test_case_path }}/{{ test_case_prefix }}-{{ test_case }} \
+            {% endif %}
+          {% endfor %}
+      args:
+        chdir: "{{ tests_working_directory }}"
+      register: async_test
+      async: "{{ image_test_timeout * 60 }}"
+      poll: "{{ polling_interval }}"
+
+    - name: "Mark image tests as passed"
+      set_fact:
+        passed_tests: "{{ passed_tests + ['image_tests'] }}"
+
+  rescue:
+
+    - name: "Mark image tests as failed"
+      set_fact:
+        failed_tests: "{{ failed_tests + ['image_tests'] }}"
+
+  always:
+
+    - name: "Write log for image tests"
+      copy:
+        dest: "{{ workspace }}/image_test.log"
+        content: |
+          Logs from image test
+          ----------------------------------------------------------------------
+          stderr:
+          {{ async_test.stderr }}
+          ----------------------------------------------------------------------
+          stdout:
+          {{ async_test.stdout }}
+

--- a/schutzbot/vars.yml
+++ b/schutzbot/vars.yml
@@ -1,0 +1,41 @@
+## Global test variables
+# Tests should use this as their working directory. This part is critical
+# since dnf-json must be in $PATH.
+tests_working_directory: /usr/libexec/osbuild-composer
+
+# The test executables are here.
+tests_path: /usr/libexec/tests/osbuild-composer
+
+# Frequency to check for completed tests.
+polling_interval: 15
+
+## Non-image test variables.
+# List of base tests and their timeouts (in minutes)
+osbuild_composer_base_tests:
+  - name: osbuild-rcm-tests
+    timeout: 5
+  - name: osbuild-weldr-tests
+    timeout: 5
+  - name: osbuild-dnf-json-tests
+    timeout: 15
+  - name: osbuild-tests
+    timeout: 30
+
+## Image test variables.
+# Executable that runs image tests.
+image_test_executable: "{{ tests_path }}/osbuild-image-tests"
+
+# Timeout for image tests (in minutes).
+image_test_timeout: 45
+
+# Location of image test case files.
+image_test_case_path: /usr/share/tests/osbuild-composer/cases
+
+# List of image tests and their timeouts (in minutes).
+osbuild_composer_image_test_cases:
+  - ext4_filesystem-boot.json
+  - partitioned_disk-boot.json
+  - qcow2-boot.json
+  - tar-boot.json
+  - vhd-boot.json
+  - vmdk-boot.json


### PR DESCRIPTION
Attempt osbuild-composer testing on the internal Jenkins deployment with
nodes that are destroyed after each use. The internal Jenkins looks for
a Jenkinsfile inside the `schutzbot` directory.

Let's not remove the `jenkins` directory (used by jenkins.osbuild.org)
yet until we know the internal Jenkins is stable and performs well.

Signed-off-by: Major Hayden <major@redhat.com>