### PR TITLE
codecov: add 5% threshold

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,4 +1,7 @@
 coverage:
+  project:
+    default:
+      treshold: 5%
   status:
     patch: no
 codecov:


### PR DESCRIPTION
We're using code coverage as additional information, but don't want to
gate pull requests on it.