### PR TITLE
[tests] use assert.Equal instead of reflect.DeepEqual in distro_test

### DIFF
--- a/internal/distro/fedora30/distro_test.go
+++ b/internal/distro/fedora30/distro_test.go
@@ -1,7 +1,6 @@
 package fedora30_test
 
 import (
-	"reflect"
 	"testing"
 
 	"github.com/osbuild/osbuild-composer/internal/distro/distro_test_common"
@@ -136,7 +135,7 @@ func TestImageType_BuildPackages(t *testing.T) {
 				t.Errorf("d.GetArch(%v) returned err = %v; expected nil", archLabel, err)
 				continue
 			}
-			reflect.DeepEqual(itStruct.BuildPackages(), buildPackages[archLabel])
+			assert.ElementsMatch(t, buildPackages[archLabel], itStruct.BuildPackages())
 		}
 	}
 }

--- a/internal/distro/fedora31/distro_test.go
+++ b/internal/distro/fedora31/distro_test.go
@@ -1,7 +1,6 @@
 package fedora31_test
 
 import (
-	"reflect"
 	"testing"
 
 	"github.com/osbuild/osbuild-composer/internal/distro/distro_test_common"
@@ -136,7 +135,7 @@ func TestImageType_BuildPackages(t *testing.T) {
 				t.Errorf("d.GetArch(%v) returned err = %v; expected nil", archLabel, err)
 				continue
 			}
-			reflect.DeepEqual(itStruct.BuildPackages(), buildPackages[archLabel])
+			assert.ElementsMatch(t, buildPackages[archLabel], itStruct.BuildPackages())
 		}
 	}
 }

--- a/internal/distro/fedora32/distro_test.go
+++ b/internal/distro/fedora32/distro_test.go
@@ -1,7 +1,6 @@
 package fedora32_test
 
 import (
-	"reflect"
 	"testing"
 
 	"github.com/osbuild/osbuild-composer/internal/distro/distro_test_common"
@@ -136,7 +135,7 @@ func TestImageType_BuildPackages(t *testing.T) {
 				t.Errorf("d.GetArch(%v) returned err = %v; expected nil", archLabel, err)
 				continue
 			}
-			reflect.DeepEqual(itStruct.BuildPackages(), buildPackages[archLabel])
+			assert.ElementsMatch(t, buildPackages[archLabel], itStruct.BuildPackages())
 		}
 	}
 }


### PR DESCRIPTION
The asserts should do the same job and also at the same time make sure that the two compared lists are equal. In the original state, the comparison was performed, but the result was thrown away - and actually the result was false, as the two lists were different due to non-equal order of items.

This change originates from a suggestion by @atodorov in #591.

EDIT: I just found out that I could possibly use `assert.ElementsMatch` instead of `assert.Equal` and leave the items order in the list as it was before. What would be the better option?