### PR TITLE
client: drop client timeout in tests

### DIFF
--- a/internal/client/integration_test.go
+++ b/internal/client/integration_test.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"os"
 	"testing"
-	"time"
 
 	"github.com/osbuild/osbuild-composer/internal/test"
 )
@@ -21,7 +20,7 @@ var testState *TestState
 // Also makes sure there is a running server to test against
 func executeTests(m *testing.M) int {
 	var err error
-	testState, err = setUpTestState("/run/weldr/api.socket", 60*time.Second, false)
+	testState, err = setUpTestState("/run/weldr/api.socket", false)
 	if err != nil {
 		fmt.Printf("ERROR: Test setup failed: %s\n", err)
 		panic(err)

--- a/internal/client/unit_test.go
+++ b/internal/client/unit_test.go
@@ -12,7 +12,6 @@ import (
 	"net/http"
 	"os"
 	"testing"
-	"time"
 
 	"github.com/osbuild/osbuild-composer/internal/distro/fedoratest"
 	rpmmd_mock "github.com/osbuild/osbuild-composer/internal/mocks/rpmmd"
@@ -58,7 +57,7 @@ func executeTests(m *testing.M) int {
 		}
 	}()
 
-	testState, err = setUpTestState(socketPath, 60*time.Second, true)
+	testState, err = setUpTestState(socketPath, true)
 	if err != nil {
 		log.Fatalf("ERROR: Test setup failed: %s\n", err)
 	}

--- a/internal/client/utils.go
+++ b/internal/client/utils.go
@@ -11,7 +11,6 @@ import (
 	"net/http"
 	"sort"
 	"strconv"
-	"time"
 )
 
 type TestState struct {
@@ -32,12 +31,10 @@ func isStringInSlice(slice []string, s string) bool {
 	return false
 }
 
-func setUpTestState(socketPath string, timeout time.Duration, unitTest bool) (*TestState, error) {
+func setUpTestState(socketPath string, unitTest bool) (*TestState, error) {
 	state := TestState{unitTest: unitTest}
 
 	state.socket = &http.Client{
-		// TODO This may be too short/simple for downloading images
-		Timeout: timeout,
 		Transport: &http.Transport{
 			DialContext: func(_ context.Context, _, _ string) (net.Conn, error) {
 				return net.Dial("unix", socketPath)


### PR DESCRIPTION
A timeout doesn't make sense on this level, because it is very difficult
to estimate how long downloading rpm metadata takes. Drop it completely
in favor of higher-level timeouts in the test runner.

Fixes #601