### PR TITLE
schutzbot: use -test.timeout argument

### DIFF
--- a/schutzbot/test_runner_base.yml
+++ b/schutzbot/test_runner_base.yml
@@ -3,12 +3,10 @@
 - block:
 
     - name: "Run {{ test.name }} test"
-      command: "{{ tests_path }}/{{ test.name }} -test.v"
+      command: "{{ tests_path }}/{{ test.name }} -test.v -test.timeout {{ test.timeout * 60 }}s"
       args:
         chdir: "{{ tests_working_directory }}"
-      register: async_test
-      async: "{{ test.timeout * 60 }}"
-      poll: "{{ polling_interval }}"
+      register: test_cmd
 
     - name: "Mark {{ test.name }} as passed"
       set_fact:
@@ -29,8 +27,8 @@
           Logs from {{ test.name }}
           ----------------------------------------------------------------------
           stderr:
-          {{ async_test.stderr }}
+          {{ test_cmd.stderr }}
           ----------------------------------------------------------------------
           stdout:
-          {{ async_test.stdout }}
+          {{ test_cmd.stdout }}
 

--- a/schutzbot/test_runner_image.yml
+++ b/schutzbot/test_runner_image.yml
@@ -24,7 +24,7 @@
     # upset and nobody likes it when that happens.
     - name: "Run image tests"
       command: |
-        {{ image_test_executable }} -test.v \
+        {{ image_test_executable }} -test.v -test.timeout {{image_test_timeout * 60}}s \
           {% for test_case in osbuild_composer_image_test_cases %}
             {% if loop.last %}
           {{ image_test_case_path }}/{{ test_case_prefix }}-{{ test_case }}
@@ -34,9 +34,7 @@
           {% endfor %}
       args:
         chdir: "{{ tests_working_directory }}"
-      register: async_test
-      async: "{{ image_test_timeout * 60 }}"
-      poll: "{{ polling_interval }}"
+      register: test_cmd
 
     - name: "Mark image tests as passed"
       set_fact:
@@ -57,8 +55,8 @@
           Logs from image test
           ----------------------------------------------------------------------
           stderr:
-          {{ async_test.stderr }}
+          {{ test_cmd.stderr }}
           ----------------------------------------------------------------------
           stdout:
-          {{ async_test.stdout }}
+          {{ test_cmd.stdout }}
 


### PR DESCRIPTION
Use golang's `test.timeout` to set the timeout instead of using
ansible's `async` property. The latter doesn't respect `register` when
running into a timeout, which means there are no logs in that case.

Simplify these playbooks by setting `ignore_errors: true` on the
`command` module, so that it's easier to collect logs.