### PR TITLE
Remove most of the image tests from Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,4 +25,4 @@ script:
   - sudo sh -c 'mkdir /etc/rpm; echo "%_dbpath /var/lib/rpm" > /etc/rpm/macros'
   - export GO111MODULE=on
   - go test -c -tags 'travis integration' -o osbuild-image-tests ./cmd/osbuild-image-tests
-  - sudo ./osbuild-image-tests -test.v test/cases/${TRAVIS_JOB_NAME}*-x86_64-ami-boot.json test/cases/${TRAVIS_JOB_NAME}*-x86_64-vhd-boot.json
+  - travis_wait 30 sudo ./osbuild-image-tests -test.v test/cases/${TRAVIS_JOB_NAME}*-x86_64-ami-boot.json test/cases/${TRAVIS_JOB_NAME}*-x86_64-vhd-boot.json

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,4 +25,4 @@ script:
   - sudo sh -c 'mkdir /etc/rpm; echo "%_dbpath /var/lib/rpm" > /etc/rpm/macros'
   - export GO111MODULE=on
   - go test -c -tags 'travis integration' -o osbuild-image-tests ./cmd/osbuild-image-tests
-  - sudo ./osbuild-image-tests -test.v test/cases/$TRAVIS_JOB_NAME*
+  - sudo ./osbuild-image-tests -test.v test/cases/${TRAVIS_JOB_NAME}*-x86_64-ami-boot.json test/cases/${TRAVIS_JOB_NAME}*-x86_64-vhd-boot.json

--- a/schutzbot/vars.yml
+++ b/schutzbot/vars.yml
@@ -33,7 +33,9 @@ image_test_case_path: /usr/share/tests/osbuild-composer/cases
 
 # List of image tests and their timeouts (in minutes).
 osbuild_composer_image_test_cases:
+  - ami-boot.json
   - ext4_filesystem-boot.json
+  - openstack-boot.json
   - partitioned_disk-boot.json
   - qcow2-boot.json
   - tar-boot.json


### PR DESCRIPTION
This PR does 2 things:

1) Schutzbot didn't build ami and openstack images, so I added them.
2) Travis is now used to do only image tests with uploading, because that's not currently supported by Schutzbot.