### PR TITLE
Fixing the logs once again with some refactorings

### DIFF
--- a/internal/rcm/api.go
+++ b/internal/rcm/api.go
@@ -252,7 +252,7 @@ func (api *API) status(writer http.ResponseWriter, request *http.Request, params
 	}
 
 	// Check that the compose exists
-	status, _, err := api.workers.JobResult(id)
+	status, err := api.workers.JobStatus(id)
 	if err != nil {
 		writer.WriteHeader(http.StatusBadRequest)
 		errorReason.Error = err.Error()
@@ -267,5 +267,5 @@ func (api *API) status(writer http.ResponseWriter, request *http.Request, params
 	}
 
 	// TODO: handle error
-	_ = json.NewEncoder(writer).Encode(reply{Status: status.ToString()})
+	_ = json.NewEncoder(writer).Encode(reply{Status: status.State.ToString()})
 }

--- a/internal/weldr/api.go
+++ b/internal/weldr/api.go
@@ -168,8 +168,9 @@ func (api *API) getComposeState(compose store.Compose) (state common.ComposeStat
 		return
 	}
 
-	state, queued, started, finished, _ = api.workers.JobStatus(jobId)
-	return
+	// is it ok to ignore this error?
+	jobStatus, _ := api.workers.JobStatus(jobId)
+	return jobStatus.State, jobStatus.Queued, jobStatus.Started, jobStatus.Finished
 }
 
 func verifyRequestVersion(writer http.ResponseWriter, params httprouter.Params, minVersion uint) bool {

--- a/internal/weldr/api.go
+++ b/internal/weldr/api.go
@@ -1752,9 +1752,9 @@ func (api *API) composeQueueHandler(writer http.ResponseWriter, request *http.Re
 		composeStatus := api.getComposeStatus(compose)
 		switch composeStatus.State {
 		case common.CWaiting:
-			reply.New = append(reply.New, composeToComposeEntry(id, compose, common.CWaiting, composeStatus.Queued, composeStatus.Started, composeStatus.Finished, includeUploads))
+			reply.New = append(reply.New, composeToComposeEntry(id, compose, composeStatus, includeUploads))
 		case common.CRunning:
-			reply.Run = append(reply.Run, composeToComposeEntry(id, compose, common.CRunning, composeStatus.Queued, composeStatus.Started, composeStatus.Finished, includeUploads))
+			reply.Run = append(reply.Run, composeToComposeEntry(id, compose, composeStatus, includeUploads))
 		}
 	}
 
@@ -1836,7 +1836,7 @@ func (api *API) composeStatusHandler(writer http.ResponseWriter, request *http.R
 	for _, id := range filteredUUIDs {
 		if compose, exists := composes[id]; exists {
 			composeStatus := api.getComposeStatus(compose)
-			reply.UUIDs = append(reply.UUIDs, composeToComposeEntry(id, compose, composeStatus.State, composeStatus.Queued, composeStatus.Started, composeStatus.Finished, includeUploads))
+			reply.UUIDs = append(reply.UUIDs, composeToComposeEntry(id, compose, composeStatus, includeUploads))
 		}
 	}
 	sortComposeEntries(reply.UUIDs)
@@ -2140,7 +2140,7 @@ func (api *API) composeFinishedHandler(writer http.ResponseWriter, request *http
 		if composeStatus.State != common.CFinished {
 			continue
 		}
-		reply.Finished = append(reply.Finished, composeToComposeEntry(id, compose, common.CFinished, composeStatus.Queued, composeStatus.Started, composeStatus.Finished, includeUploads))
+		reply.Finished = append(reply.Finished, composeToComposeEntry(id, compose, composeStatus, includeUploads))
 	}
 	sortComposeEntries(reply.Finished)
 
@@ -2163,7 +2163,7 @@ func (api *API) composeFailedHandler(writer http.ResponseWriter, request *http.R
 		if composeStatus.State != common.CFailed {
 			continue
 		}
-		reply.Failed = append(reply.Failed, composeToComposeEntry(id, compose, common.CFailed, composeStatus.Queued, composeStatus.Started, composeStatus.Finished, includeUploads))
+		reply.Failed = append(reply.Failed, composeToComposeEntry(id, compose, composeStatus, includeUploads))
 	}
 	sortComposeEntries(reply.Failed)
 

--- a/internal/weldr/api.go
+++ b/internal/weldr/api.go
@@ -147,6 +147,7 @@ type composeStatus struct {
 	Queued   time.Time
 	Started  time.Time
 	Finished time.Time
+	Result   *common.ComposeResult
 }
 
 // Returns the state of the image in `compose` and the times the job was
@@ -175,6 +176,7 @@ func (api *API) getComposeStatus(compose store.Compose) *composeStatus {
 			Queued:   compose.ImageBuild.JobCreated,
 			Started:  compose.ImageBuild.JobStarted,
 			Finished: compose.ImageBuild.JobFinished,
+			Result:   &common.ComposeResult{},
 		}
 	}
 
@@ -185,6 +187,7 @@ func (api *API) getComposeStatus(compose store.Compose) *composeStatus {
 		Queued:   jobStatus.Queued,
 		Started:  jobStatus.Started,
 		Finished: jobStatus.Finished,
+		Result:   jobStatus.Result.OSBuildOutput,
 	}
 }
 

--- a/internal/worker/server.go
+++ b/internal/worker/server.go
@@ -32,6 +32,7 @@ type JobStatus struct {
 	Queued   time.Time
 	Started  time.Time
 	Finished time.Time
+	Result   OSBuildJobResult
 }
 
 type WriteImageFunc func(composeID uuid.UUID, imageBuildID int, reader io.Reader) error
@@ -111,6 +112,7 @@ func (s *Server) JobStatus(id uuid.UUID) (*JobStatus, error) {
 		Queued:   queued,
 		Started:  started,
 		Finished: finished,
+		Result:   result,
 	}, nil
 }
 

--- a/internal/worker/server.go
+++ b/internal/worker/server.go
@@ -116,31 +116,6 @@ func (s *Server) JobStatus(id uuid.UUID) (*JobStatus, error) {
 	}, nil
 }
 
-func (s *Server) JobResult(id uuid.UUID) (common.ComposeState, *common.ComposeResult, error) {
-	var canceled bool
-	var result OSBuildJobResult
-
-	_, started, finished, canceled, err := s.jobs.JobStatus(id, &result)
-	if err != nil {
-		return common.CWaiting, nil, err
-	}
-
-	state := common.CWaiting
-	if canceled {
-		state = common.CFailed
-	} else if !finished.IsZero() {
-		if result.OSBuildOutput.Success {
-			state = common.CFinished
-		} else {
-			state = common.CFailed
-		}
-	} else if !started.IsZero() {
-		state = common.CRunning
-	}
-
-	return state, result.OSBuildOutput, nil
-}
-
 // jsonErrorf() is similar to http.Error(), but returns the message in a json
 // object with a "message" field.
 func jsonErrorf(writer http.ResponseWriter, code int, message string, args ...interface{}) {


### PR DESCRIPTION
The fix for the logs is here! This grew larger than I thought...

First 11 commits are just a minor refactoring. Basically, the `worker.JobStatus()` method got renamed to `worker.GetJobStatus()` and it now returns also the `JobResult`. In `weldr`, `getComposeState()` is now called `getComposeStatus()` and returns also `JobResult`. `worker.JobResult()` method was dropped because `GetJobStatus()` can be used instead.

Let's explain more in detail why I merged `JobResult()` and `GetJobStatus()` together:

Both methods actually called `jobqueue.GetJobStatus()`, so performance-wise there's no real difference and it feels to me that it makes the code simpler: You don't have to decide which method to call, you just get all the data about a job in one call. We could split those again when we see some perf issues with retrieving logs on each status check but I don't think we should optimize prematurely. Let's leave some work for the future us.

After this was done, the fix was rather simple - make the logs routes use the updated `getComposeStatus()` method which returns logs in both `compose has a job` and `compose doesn't have a job` situations. In the latter case, this means returning empty log, but hey, we don't have that many users and if someone really wants them, they are still in `/var`.

The second to last commit adds a quick smoke test to see that logs are created.

Finally, the last commit drops all the code managing the `result.json` file because no one is actually using that code now.