### PR TITLE
CI: Gather log artifacts

### DIFF
--- a/schutzbot/Jenkinsfile
+++ b/schutzbot/Jenkinsfile
@@ -13,31 +13,75 @@ pipeline {
                     agent { label "fedora31" }
                     environment { TEST_TYPE = "base" }
                     steps {
-                        sh "schutzbot/run_tests.sh"
+                        run_tests()
+                    }
+                    post {
+                        always {
+                            preserve_logs('fedora31-base')
+                        }
                     }
                 }
                 stage('Fedora 31 image') {
                     agent { label "fedora31" }
                     environment { TEST_TYPE = "image" }
                     steps {
-                        sh "schutzbot/run_tests.sh"
+                        run_tests()
+                    }
+                    post {
+                        always {
+                            preserve_logs('fedora31-image')
+                        }
                     }
                 }
                 stage('Fedora 32 base') {
                     agent { label "fedora32" }
                     environment { TEST_TYPE = "base" }
                     steps {
-                        sh "schutzbot/run_tests.sh"
+                        run_tests()
+                    }
+                    post {
+                        always {
+                            preserve_logs('fedora32-base')
+                        }
                     }
                 }
                 stage('Fedora 32 image') {
                     agent { label "fedora32" }
                     environment { TEST_TYPE = "image" }
                     steps {
-                        sh "schutzbot/run_tests.sh"
+                        run_tests()
+                    }
+                    post {
+                        always {
+                            preserve_logs('fedora32-image')
+                        }
                     }
                 }
             }
         }
     }
+}
+
+// Set up a function to hold the steps needed to run the tests so we don't
+// need to copy/paste the same lines over and over above.
+void run_tests() {
+
+    // Run the tests from the repository.
+    sh "schutzbot/run_tests.sh"
+
+}
+
+// Move logs to a unique location and tell Jenkins to capture them on success
+// or failure.
+void preserve_logs(test_slug) {
+
+    // Make a directory for the log files and move the logs there.
+    sh "mkdir ${test_slug} && mv *.log ${test_slug}/"
+
+    // Artifact the logs.
+    archiveArtifacts (
+        allowEmptyArchive: true,
+        artifacts: "${test_slug}/*.log"
+    )
+
 }


### PR DESCRIPTION
Ensure that logs are artifacted after a test run. Also, ensure that
these logs are in unique directories so that they are not overwritten by
Jenkins as it builds the final artifact archive.

For example, if two jobs have a `test.log`, Jenkis will only keep one of
those logs. Each log must be named differently or placed in a unique
directory.

Signed-off-by: Major Hayden <major@redhat.com>