### PR TITLE
CI: Test EC2 import and boot

### DIFF
--- a/internal/upload/awsupload/awsupload.go
+++ b/internal/upload/awsupload/awsupload.go
@@ -71,10 +71,14 @@ func WaitUntilImportSnapshotTaskCompleted(c *ec2.EC2, input *ec2.DescribeImportS
 // the context is nil a panic will occur. In the future the SDK may create
 // sub-contexts for http.Requests. See https://golang.org/pkg/context/
 // for more information on using Contexts.
+//
+// NOTE(mhayden): Wait for 45 minutes for the snapshot to import.
+// Some AWS regions are fairly busy with image imports and they can
+// sometimes take a long time.
 func WaitUntilImportSnapshotTaskCompletedWithContext(c *ec2.EC2, ctx aws.Context, input *ec2.DescribeImportSnapshotTasksInput, opts ...request.WaiterOption) error {
 	w := request.Waiter{
 		Name:        "WaitUntilImportSnapshotTaskCompleted",
-		MaxAttempts: 80, // this can take up to 15 minutes, therefore set the timeout to 20 minutes
+		MaxAttempts: 180,
 		Delay:       request.ConstantWaiterDelay(15 * time.Second),
 		Acceptors: []request.WaiterAcceptor{
 			{

--- a/schutzbot/Jenkinsfile
+++ b/schutzbot/Jenkinsfile
@@ -62,6 +62,23 @@ pipeline {
                         }
                     }
                 }
+                stage('Fedora 32 AWS') {
+                    agent { label "fedora32" }
+                    environment {
+                        TEST_TYPE = "aws"
+                        AWS_CREDS = credentials('aws-credentials-osbuildci')
+                        AWS_REGION = "us-east-2"
+                        AWS_BUCKET = "imagebuilder-jenkins-testing-use2"
+                    }
+                    steps {
+                        run_tests()
+                    }
+                    post {
+                        always {
+                            preserve_logs('fedora32-image')
+                        }
+                    }
+                }
                 stage('RHEL 8.2 base') {
                     agent { label "rhel82" }
                     environment { TEST_TYPE = "base" }

--- a/schutzbot/test.yml
+++ b/schutzbot/test.yml
@@ -22,8 +22,22 @@
       loop: "{{ osbuild_composer_image_test_cases }}"
       loop_control:
         loop_var: test_case
+      vars:
+        test_timeout: "{{ osbuild_composer_image_timeout }}"
+        env_vars: "{{ osbuild_composer_image_env_vars }}"
       when:
         - test_type == 'image'
+
+    - name: Run osbuild-composer AWS tests
+      include_tasks: test_runner_image.yml
+      loop: "{{ osbuild_composer_aws_test_cases }}"
+      vars:
+        test_timeout: "{{ osbuild_composer_aws_timeout }}"
+        env_vars: "{{ osbuild_composer_aws_env_vars }}"
+      loop_control:
+        loop_var: test_case
+      when:
+        - test_type == 'aws'
 
     - name: Show failed and passed tests
       debug:

--- a/schutzbot/test_runner_image.yml
+++ b/schutzbot/test_runner_image.yml
@@ -14,10 +14,11 @@
     - name: "Run image test case: {{ test_case_prefix }}-{{ test_case }}"
       command: |
         {{ image_test_executable }} -test.v \
-          -test.timeout {{image_test_timeout * 60}}s \
+          -test.timeout {{ test_timeout * 60 }}s \
           {{ image_test_case_path }}/{{ test_case_prefix }}-{{ test_case }}
       args:
         chdir: "{{ tests_working_directory }}"
+      environment: "{{ env_vars }}"
       register: test_cmd
 
     - name: "Mark test case as passed: {{ test_case_prefix }}-{{ test_case }}"

--- a/schutzbot/vars.yml
+++ b/schutzbot/vars.yml
@@ -25,13 +25,11 @@ osbuild_composer_base_tests:
 # Executable that runs image tests.
 image_test_executable: "{{ tests_path }}/osbuild-image-tests"
 
-# Timeout for image tests (in minutes).
-image_test_timeout: 45
-
 # Location of image test case files.
 image_test_case_path: /usr/share/tests/osbuild-composer/cases
 
-# List of image tests and their timeouts (in minutes).
+# List of image tests and their timeout (in minutes).
+osbuild_composer_image_timeout: 15
 osbuild_composer_image_test_cases:
   - ami-boot.json
   - ext4_filesystem-boot.json
@@ -41,3 +39,18 @@ osbuild_composer_image_test_cases:
   - tar-boot.json
   - vhd-boot.json
   - vmdk-boot.json
+
+# Environment variables for image tests.
+osbuild_composer_image_env_vars: {}
+
+# List of AWS test cases and their timeout (in minutes).
+osbuild_composer_aws_timeout: 60
+osbuild_composer_aws_test_cases:
+  - ami-boot.json
+
+# Environment variables for AWS tests.
+osbuild_composer_aws_env_vars:
+  AWS_BUCKET: "{{ lookup('env', 'AWS_BUCKET') }}"
+  AWS_REGION: "{{ lookup('env', 'AWS_REGION') }}"
+  AWS_ACCESS_KEY_ID: "{{ lookup('env', 'AWS_ACCESS_KEY_ID') }}"
+  AWS_SECRET_ACCESS_KEY: "{{ lookup('env', 'AWS_SECRET_ACCESS_KEY') }}"


### PR DESCRIPTION
Build an AWS AMI image, upload it to S3, import it into EC2, and boot it.

![https://i.kym-cdn.com/entries/icons/facebook/000/019/304/old.jpg](https://i.kym-cdn.com/entries/icons/facebook/000/019/304/old.jpg)

Signed-off-by: Major Hayden <major@redhat.com>