### PR TITLE
Use internal download mirror for Fedora images

### DIFF
--- a/schutzbot/test_runner_image.yml
+++ b/schutzbot/test_runner_image.yml
@@ -11,6 +11,11 @@
 
 - block:
 
+    - name: Adjust test case to use the internal mirror
+      command: |
+        sed -i "s#http://download.fedoraproject.org/pub/fedora/#{{ image_test_internal_fedora_mirror }}#" \
+          {{ image_test_case_path }}/{{ test_case_prefix }}-{{ test_case }}
+
     - name: "Run image test case: {{ test_case_prefix }}-{{ test_case }}"
       command: |
         {{ image_test_executable }} -test.v \

--- a/schutzbot/vars.yml
+++ b/schutzbot/vars.yml
@@ -31,6 +31,9 @@ image_test_timeout: 45
 # Location of image test case files.
 image_test_case_path: /usr/share/tests/osbuild-composer/cases
 
+# Location of internal mirror for downloading Fedora RPMs.
+image_test_internal_fedora_mirror: http://download.eng.rdu.redhat.com/fedora/
+
 # List of image tests and their timeouts (in minutes).
 osbuild_composer_image_test_cases:
   - ext4_filesystem-boot.json


### PR DESCRIPTION
Reduce stress on upstream mirrors and speed up builds by using an
internal mirror to download packages in CI.

Signed-off-by: Major Hayden <major@redhat.com>