### PR TITLE
worker: Check OSBuildOutput for nil before using it

### DIFF
--- a/internal/worker/server.go
+++ b/internal/worker/server.go
@@ -101,7 +101,7 @@ func (s *Server) JobStatus(id uuid.UUID) (*JobStatus, error) {
 	if canceled {
 		state = common.CFailed
 	} else if !finished.IsZero() {
-		if result.OSBuildOutput.Success {
+		if result.OSBuildOutput != nil && result.OSBuildOutput.Success {
 			state = common.CFinished
 		} else {
 			state = common.CFailed


### PR DESCRIPTION
It is possible for it to end up as nil so it needs to be checked
everywhere it is used.