### PR TITLE
codevoc: fix threshold

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,9 +1,9 @@
 coverage:
-  project:
-    default:
-      treshold: 5%
   status:
     patch: no
+    project:
+      default:
+        threshold: 5%
 codecov:
   require_ci_to_pass: no
 comment: no


### PR DESCRIPTION
d49f0fef4 added a 5% threshold to codecov.yml, so that small fixes don't
turn the CI red.

However, it contained a typo and put the setting in the wrong place in
the file. codecov.io ignores unknown keys instead of throwing an error.

Fix this and validate with:

    cat codecov.yml | curl --data-binary @- https://codecov.io/validate