### PR TITLE
Add three hour timeout to test pipelines

### DIFF
--- a/schutzbot/Jenkinsfile
+++ b/schutzbot/Jenkinsfile
@@ -4,6 +4,11 @@ pipeline {
     options {
         timestamps()
         ansiColor('xterm')
+        // Cancel the pipeline if it runs for more than three hours.
+        timeout(
+            time: 3,
+            unit: "HOURS"
+        )
     }
 
     stages {


### PR DESCRIPTION
If a pipeline runs for three hours, stop the pipeline. This can happen
if a network connection breaks down or if jenkins loses control of one
of its agents due to infrastructure issues.

Signed-off-by: Major Hayden <major@redhat.com>