### PR TITLE
osbuild: add support for marshalling Fedora IoT manifests

### DIFF
--- a/internal/osbuild/assembler.go
+++ b/internal/osbuild/assembler.go
@@ -32,12 +32,14 @@ func (assembler *Assembler) UnmarshalJSON(data []byte) error {
 	}
 	var options AssemblerOptions
 	switch rawAssembler.Name {
-	case "org.osbuild.tar":
-		options = new(TarAssemblerOptions)
+	case "org.osbuild.ostree.commit":
+		options = new(OSTreeCommitAssemblerOptions)
 	case "org.osbuild.qemu":
 		options = new(QEMUAssemblerOptions)
 	case "org.osbuild.rawfs":
 		options = new(RawFSAssemblerOptions)
+	case "org.osbuild.tar":
+		options = new(TarAssemblerOptions)
 	default:
 		return errors.New("unexpected assembler name")
 	}

--- a/internal/osbuild/assembler_test.go
+++ b/internal/osbuild/assembler_test.go
@@ -108,6 +108,19 @@ func TestAssembler_UnmarshalJSON(t *testing.T) {
 			},
 			data: []byte(`{"name":"org.osbuild.rawfs","options":{"filename":"filesystem.img","root_fs_uuid":"76a22bf4-f153-4541-b6c7-0332c0dfaeac","size":2147483648}}`),
 		},
+		{
+			name: "ostree commit assembler",
+			assembler: Assembler{
+				Name: "org.osbuild.ostree.commit",
+				Options: &OSTreeCommitAssemblerOptions{
+					Ref: "foo",
+					Tar: OSTreeCommitAssemblerTarOptions{
+						Filename: "foo.tar",
+					},
+				},
+			},
+			data: []byte(`{"name":"org.osbuild.ostree.commit","options":{"ref":"foo","tar":{"filename":"foo.tar"}}}`),
+		},
 	}
 
 	assert := assert.New(t)

--- a/internal/osbuild/ostree_commit_assembler.go
+++ b/internal/osbuild/ostree_commit_assembler.go
@@ -1,0 +1,22 @@
+package osbuild
+
+// OSTreeCommitAssemblerOptions desrcibe how to assemble a tree into an OSTree commit.
+type OSTreeCommitAssemblerOptions struct {
+	Ref string                          `json:"ref"`
+	Tar OSTreeCommitAssemblerTarOptions `json:"tar"`
+}
+
+// OSTreeCommitAssemblerTarOptions desrcibes the output tarball
+type OSTreeCommitAssemblerTarOptions struct {
+	Filename string `json:"filename"`
+}
+
+func (OSTreeCommitAssemblerOptions) isAssemblerOptions() {}
+
+// NewOSTreeCommitAssembler creates a new OSTree Commit Assembler object.
+func NewOSTreeCommitAssembler(options *OSTreeCommitAssemblerOptions) *Assembler {
+	return &Assembler{
+		Name:    "org.osbuild.ostree.commit",
+		Options: options,
+	}
+}

--- a/internal/osbuild/rpm_ostree_stage.go
+++ b/internal/osbuild/rpm_ostree_stage.go
@@ -1,0 +1,16 @@
+package osbuild
+
+// The RPM-OSTree stage describes how to transform the imgae into an OSTree.
+type RPMOSTreeStageOptions struct {
+	EtcGroupMembers []string `json:"etc_group_members"`
+}
+
+func (RPMOSTreeStageOptions) isStageOptions() {}
+
+// NewLocaleStage creates a new Locale Stage object.
+func NewRPMOSTreeStage(options *RPMOSTreeStageOptions) *Stage {
+	return &Stage{
+		Name:    "org.osbuild.rpm-ostree",
+		Options: options,
+	}
+}

--- a/internal/osbuild/stage.go
+++ b/internal/osbuild/stage.go
@@ -62,6 +62,8 @@ func (stage *Stage) UnmarshalJSON(data []byte) error {
 		options = new(FirewallStageOptions)
 	case "org.osbuild.rpm":
 		options = new(RPMStageOptions)
+	case "org.osbuild.rpm-ostree":
+		options = new(RPMOSTreeStageOptions)
 	case "org.osbuild.systemd":
 		options = new(SystemdStageOptions)
 	case "org.osbuild.script":

--- a/internal/osbuild/stage_test.go
+++ b/internal/osbuild/stage_test.go
@@ -196,6 +196,20 @@ func TestStage_UnmarshalJSON(t *testing.T) {
 			},
 		},
 		{
+			name: "rpm-ostree",
+			fields: fields{
+				Name: "org.osbuild.rpm-ostree",
+				Options: &RPMOSTreeStageOptions{
+					EtcGroupMembers: []string{
+						"wheel",
+					},
+				},
+			},
+			args: args{
+				data: []byte(`{"name":"org.osbuild.rpm-ostree","options":{"etc_group_members":["wheel"]}}`),
+			},
+		},
+		{
 			name: "script",
 			fields: fields{
 				Name:    "org.osbuild.script",


### PR DESCRIPTION
This has not yet been hooked up from the distro package, so is still unused.