### PR TITLE
Use osbuild's cache for image tests

### DIFF
--- a/schutzbot/test_runner_image.yml
+++ b/schutzbot/test_runner_image.yml
@@ -9,6 +9,12 @@
       rhel_{{ ansible_distribution_version }}-{{ ansible_machine }}
       {%- endif -%}
 
+- name: Create the output directory
+  file:
+    path: "{{ osbuild_composer_image_output_directory }}"
+    state: directory
+  when: "{{ osbuild_composer_image_output_directory | default(false) }}"
+
 - block:
 
     - name: "Run image test case: {{ test_case_prefix }}-{{ test_case }}"

--- a/schutzbot/vars.yml
+++ b/schutzbot/vars.yml
@@ -22,6 +22,9 @@ osbuild_composer_base_tests:
     timeout: 30
 
 ## Image test variables.
+# Image test output directory.
+osbuild_composer_image_output_directory: /var/tmp/image-tests-jenkins
+
 # Executable that runs image tests.
 image_test_executable: "{{ tests_path }}/osbuild-image-tests"
 
@@ -41,7 +44,8 @@ osbuild_composer_image_test_cases:
   - vmdk-boot.json
 
 # Environment variables for image tests.
-osbuild_composer_image_env_vars: {}
+osbuild_composer_image_env_vars:
+  IMAGE_TEST_OUTPUT_DIRECTORY: "{{ osbuild_composer_image_output_directory }}"
 
 # List of AWS test cases and their timeout (in minutes).
 osbuild_composer_aws_timeout: 60


### PR DESCRIPTION
There are two changes here:

1. Update osbuild-composer's image tests to allow an output directory to be specified for tests.
2. When testing, use the same output directory for each image test so that osbuild's cache is used.