### PR TITLE
test/dnf-json: use the fullpath to dnf-json

### DIFF
--- a/cmd/osbuild-composer/main.go
+++ b/cmd/osbuild-composer/main.go
@@ -87,7 +87,9 @@ func main() {
 		log.Fatal("CACHE_DIRECTORY is not set. Is the service file missing CacheDirectory=?")
 	}
 
-	rpm := rpmmd.NewRPMMD(path.Join(cacheDirectory, "rpmmd"))
+	// osbuild-composer must be run in /usr/libexec/osbuild-composer directory,
+	// therefore use ./dnf-json as the path to dnf-json.
+	rpm := rpmmd.NewRPMMD(path.Join(cacheDirectory, "rpmmd"), "./dnf-json")
 
 	distros, err := distro.NewRegistry(fedora31.New(), fedora32.New(), rhel8.New())
 	if err != nil {

--- a/cmd/osbuild-composer/main.go
+++ b/cmd/osbuild-composer/main.go
@@ -89,7 +89,7 @@ func main() {
 
 	// osbuild-composer must be run in /usr/libexec/osbuild-composer directory,
 	// therefore use ./dnf-json as the path to dnf-json.
-	rpm := rpmmd.NewRPMMD(path.Join(cacheDirectory, "rpmmd"), "./dnf-json")
+	rpm := rpmmd.NewRPMMD(path.Join(cacheDirectory, "rpmmd"), "/usr/libexec/osbuild-composer/dnf-json")
 
 	distros, err := distro.NewRegistry(fedora31.New(), fedora32.New(), rhel8.New())
 	if err != nil {

--- a/cmd/osbuild-dnf-json-tests/main_test.go
+++ b/cmd/osbuild-dnf-json-tests/main_test.go
@@ -35,7 +35,9 @@ func TestFetchChecksum(t *testing.T) {
 		IgnoreSSL: true,
 	}
 
-	rpmMetadata := rpmmd.NewRPMMD(path.Join(dir, "rpmmd"), "./dnf-json")
+	// use a fullpath to dnf-json, this allows this test to have an arbitrary
+	// working directory
+	rpmMetadata := rpmmd.NewRPMMD(path.Join(dir, "rpmmd"), "/usr/libexec/osbuild-composer/dnf-json")
 	_, c, err := rpmMetadata.FetchMetadata([]rpmmd.RepoConfig{repoCfg}, "platform:f31", "x86_64")
 	assert.Nilf(t, err, "Failed to fetch checksum: %v", err)
 	assert.NotEqual(t, "", c["repo"], "The checksum is empty")
@@ -60,7 +62,9 @@ func TestCrossArchDepsolve(t *testing.T) {
 			require.Nilf(t, err, "Failed to create tmp dir for depsolve test: %v", err)
 			defer os.RemoveAll(dir)
 
-			rpm := rpmmd.NewRPMMD(dir, "./dnf-json")
+			// use a fullpath to dnf-json, this allows this test to have an arbitrary
+			// working directory
+			rpm := rpmmd.NewRPMMD(dir, "/usr/libexec/osbuild-composer/dnf-json")
 
 			repos, err := rpmmd.LoadRepositories([]string{repoDir}, distroStruct.Name())
 			require.NoErrorf(t, err, "Failed to LoadRepositories %v", distroStruct.Name())

--- a/cmd/osbuild-dnf-json-tests/main_test.go
+++ b/cmd/osbuild-dnf-json-tests/main_test.go
@@ -34,7 +34,8 @@ func TestFetchChecksum(t *testing.T) {
 		BaseURL:   fmt.Sprintf("file://%s", dir),
 		IgnoreSSL: true,
 	}
-	rpmMetadata := rpmmd.NewRPMMD(path.Join(dir, "rpmmd"))
+
+	rpmMetadata := rpmmd.NewRPMMD(path.Join(dir, "rpmmd"), "./dnf-json")
 	_, c, err := rpmMetadata.FetchMetadata([]rpmmd.RepoConfig{repoCfg}, "platform:f31", "x86_64")
 	assert.Nilf(t, err, "Failed to fetch checksum: %v", err)
 	assert.NotEqual(t, "", c["repo"], "The checksum is empty")
@@ -58,7 +59,8 @@ func TestCrossArchDepsolve(t *testing.T) {
 			dir, err := ioutil.TempDir("/tmp", "rpmmd-test-")
 			require.Nilf(t, err, "Failed to create tmp dir for depsolve test: %v", err)
 			defer os.RemoveAll(dir)
-			rpm := rpmmd.NewRPMMD(dir)
+
+			rpm := rpmmd.NewRPMMD(dir, "./dnf-json")
 
 			repos, err := rpmmd.LoadRepositories([]string{repoDir}, distroStruct.Name())
 			require.NoErrorf(t, err, "Failed to LoadRepositories %v", distroStruct.Name())

--- a/cmd/osbuild-pipeline/main.go
+++ b/cmd/osbuild-pipeline/main.go
@@ -132,7 +132,7 @@ func main() {
 		panic("os.UserHomeDir(): " + err.Error())
 	}
 
-	rpmmd := rpmmd.NewRPMMD(path.Join(home, ".cache/osbuild-composer/rpmmd"))
+	rpmmd := rpmmd.NewRPMMD(path.Join(home, ".cache/osbuild-composer/rpmmd"), "./dnf-json")
 	packageSpecs, checksums, err := rpmmd.Depsolve(packages, excludePkgs, repos, d.ModulePlatformID(), arch.Name())
 	if err != nil {
 		panic("Could not depsolve: " + err.Error())

--- a/cmd/osbuild-pipeline/main.go
+++ b/cmd/osbuild-pipeline/main.go
@@ -132,7 +132,7 @@ func main() {
 		panic("os.UserHomeDir(): " + err.Error())
 	}
 
-	rpmmd := rpmmd.NewRPMMD(path.Join(home, ".cache/osbuild-composer/rpmmd"), "./dnf-json")
+	rpmmd := rpmmd.NewRPMMD(path.Join(home, ".cache/osbuild-composer/rpmmd"), "/usr/libexec/osbuild-composer/dnf-json")
 	packageSpecs, checksums, err := rpmmd.Depsolve(packages, excludePkgs, repos, d.ModulePlatformID(), arch.Name())
 	if err != nil {
 		panic("Could not depsolve: " + err.Error())

--- a/cmd/osbuild-store-dump/main.go
+++ b/cmd/osbuild-store-dump/main.go
@@ -137,7 +137,7 @@ func main() {
 	if err != nil {
 		panic("os.UserHomeDir(): " + err.Error())
 	}
-	rpmmd := rpmmd.NewRPMMD(path.Join(homeDir, ".cache/osbuild-composer/rpmmd"), "./dnf-json")
+	rpmmd := rpmmd.NewRPMMD(path.Join(homeDir, ".cache/osbuild-composer/rpmmd"), "/usr/libexec/osbuild-composer/dnf-json")
 
 	s := store.New(&cwd, a, nil)
 	if s == nil {

--- a/cmd/osbuild-store-dump/main.go
+++ b/cmd/osbuild-store-dump/main.go
@@ -137,7 +137,7 @@ func main() {
 	if err != nil {
 		panic("os.UserHomeDir(): " + err.Error())
 	}
-	rpmmd := rpmmd.NewRPMMD(path.Join(homeDir, ".cache/osbuild-composer/rpmmd"))
+	rpmmd := rpmmd.NewRPMMD(path.Join(homeDir, ".cache/osbuild-composer/rpmmd"), "./dnf-json")
 
 	s := store.New(&cwd, a, nil)
 	if s == nil {

--- a/internal/rpmmd/repository.go
+++ b/internal/rpmmd/repository.go
@@ -241,7 +241,7 @@ func runDNF(dnfJsonPath string, command string, arguments interface{}, result in
 		arguments,
 	}
 
-	cmd := exec.Command("python3", dnfJsonPath)
+	cmd := exec.Command(dnfJsonPath)
 
 	stdin, err := cmd.StdinPipe()
 	if err != nil {


### PR DESCRIPTION
osbuild-dnf-json-tests requires dnf-json to be available in the current directory. This confused many people in the past. This commit adds a check if dnf-json is present in the current directory. If not, it prints a helpful message and fails the test immediately.

Another solution is to change the cwd in the test but that would make running the test locally a bit harder, so I chose a more conservative approach. Happy to dicuss though.