### PR TITLE
CI: Run EC2 tests for all instances

### DIFF
--- a/schutzbot/Jenkinsfile
+++ b/schutzbot/Jenkinsfile
@@ -28,7 +28,12 @@ pipeline {
                 }
                 stage('Fedora 31 image') {
                     agent { label "fedora31" }
-                    environment { TEST_TYPE = "image" }
+                    environment {
+                        TEST_TYPE = "image"
+                        AWS_CREDS = credentials('aws-credentials-osbuildci')
+                        AWS_REGION = "us-east-2"
+                        AWS_BUCKET = "imagebuilder-jenkins-testing-use2"
+                    }
                     steps {
                         run_tests()
                     }
@@ -52,20 +57,8 @@ pipeline {
                 }
                 stage('Fedora 32 image') {
                     agent { label "fedora32" }
-                    environment { TEST_TYPE = "image" }
-                    steps {
-                        run_tests()
-                    }
-                    post {
-                        always {
-                            preserve_logs('fedora32-image')
-                        }
-                    }
-                }
-                stage('Fedora 32 AWS') {
-                    agent { label "fedora32" }
                     environment {
-                        TEST_TYPE = "aws"
+                        TEST_TYPE = "image"
                         AWS_CREDS = credentials('aws-credentials-osbuildci')
                         AWS_REGION = "us-east-2"
                         AWS_BUCKET = "imagebuilder-jenkins-testing-use2"
@@ -93,7 +86,12 @@ pipeline {
                 }
                 stage('RHEL 8.2 image') {
                     agent { label "rhel82" }
-                    environment { TEST_TYPE = "image" }
+                    environment {
+                        TEST_TYPE = "image"
+                        AWS_CREDS = credentials('aws-credentials-osbuildci')
+                        AWS_REGION = "us-east-2"
+                        AWS_BUCKET = "imagebuilder-jenkins-testing-use2"
+                    }
                     steps {
                         run_tests()
                     }

--- a/schutzbot/test.yml
+++ b/schutzbot/test.yml
@@ -37,7 +37,7 @@
       loop_control:
         loop_var: test_case
       when:
-        - test_type == 'aws'
+        - test_type == 'image'
 
     - name: Show failed and passed tests
       debug:

--- a/schutzbot/vars.yml
+++ b/schutzbot/vars.yml
@@ -31,7 +31,6 @@ image_test_case_path: /usr/share/tests/osbuild-composer/cases
 # List of image tests and their timeout (in minutes).
 osbuild_composer_image_timeout: 15
 osbuild_composer_image_test_cases:
-  - ami-boot.json
   - ext4_filesystem-boot.json
   - openstack-boot.json
   - partitioned_disk-boot.json


### PR DESCRIPTION
Now that EC2 image testing is working well for Fedora 32, enable it for
all of the distros. Also, make it less special and allow it to run with
the other image tests.

Remove the `ami-boot` test from the list of regular image test cases
since it will be thoroughly tested via an import into AWS.

Signed-off-by: Major Hayden <major@redhat.com>