### PR TITLE
distribution: split weldr and job sockets

### DIFF
--- a/distribution/osbuild-composer.conf
+++ b/distribution/osbuild-composer.conf
@@ -1,1 +1,2 @@
 u   _osbuild-composer   -   "OSBuild Composer user"
+g   weldr               -

--- a/distribution/osbuild-composer.socket
+++ b/distribution/osbuild-composer.socket
@@ -4,6 +4,8 @@ Description=OSBuild Composer API sockets
 [Socket]
 ListenStream=/run/weldr/api.socket
 ListenStream=/run/osbuild-composer/job.socket
+SocketGroup=weldr
+SocketMode=660
 
 [Install]
 WantedBy=sockets.target


### PR DESCRIPTION
This fixes permission for the weldr socket: allow users in group `weldr`
to access it, but nobody else. Also add this group to the sysusers file.

Keep the job socket accessible by everyone, as it was before. It will
probably be dropped at some point in favor of remote workers.

Fixes #646