### PR TITLE
schutzbot: remove all timeouts except the global one

### DIFF
--- a/schutzbot/test.yml
+++ b/schutzbot/test.yml
@@ -23,7 +23,6 @@
       loop_control:
         loop_var: test_case
       vars:
-        test_timeout: "{{ osbuild_composer_image_timeout }}"
         env_vars: "{{ osbuild_composer_image_env_vars }}"
       when:
         - test_type == 'image'
@@ -32,7 +31,6 @@
       include_tasks: test_runner_image.yml
       loop: "{{ osbuild_composer_aws_test_cases }}"
       vars:
-        test_timeout: "{{ osbuild_composer_aws_timeout }}"
         env_vars: "{{ osbuild_composer_aws_env_vars }}"
       loop_control:
         loop_var: test_case

--- a/schutzbot/test_runner_base.yml
+++ b/schutzbot/test_runner_base.yml
@@ -2,29 +2,29 @@
 
 - block:
 
-    - name: "Run {{ test.name }} test"
-      command: "{{ tests_path }}/{{ test.name }} -test.v -test.timeout {{ test.timeout * 60 }}s"
+    - name: "Run {{ test }} test"
+      command: "{{ tests_path }}/{{ test }} -test.v"
       args:
         chdir: "{{ tests_working_directory }}"
       register: test_cmd
 
-    - name: "Mark {{ test.name }} as passed"
+    - name: "Mark {{ test }} as passed"
       set_fact:
-        passed_tests: "{{ passed_tests + [test.name] }}"
+        passed_tests: "{{ passed_tests + [test] }}"
 
   rescue:
 
-    - name: "Mark {{ test.name }} as failed"
+    - name: "Mark {{ test }} as failed"
       set_fact:
-        failed_tests: "{{ failed_tests + [test.name] }}"
+        failed_tests: "{{ failed_tests + [test] }}"
 
   always:
 
-    - name: "Write log for {{ test.name }}"
+    - name: "Write log for {{ test }}"
       copy:
-        dest: "{{ workspace }}/{{ test.name }}.log"
+        dest: "{{ workspace }}/{{ test }}.log"
         content: |
-          Logs from {{ test.name }}
+          Logs from {{ test }}
           ----------------------------------------------------------------------
           stderr:
           {{ test_cmd.stderr }}

--- a/schutzbot/test_runner_image.yml
+++ b/schutzbot/test_runner_image.yml
@@ -14,7 +14,6 @@
     - name: "Run image test case: {{ test_case_prefix }}-{{ test_case }}"
       command: |
         {{ image_test_executable }} -test.v \
-          -test.timeout {{ test_timeout * 60 }}s \
           {{ image_test_case_path }}/{{ test_case_prefix }}-{{ test_case }}
       args:
         chdir: "{{ tests_working_directory }}"

--- a/schutzbot/vars.yml
+++ b/schutzbot/vars.yml
@@ -10,16 +10,12 @@ tests_path: /usr/libexec/tests/osbuild-composer
 polling_interval: 15
 
 ## Non-image test variables.
-# List of base tests and their timeouts (in minutes)
+# List of base tests
 osbuild_composer_base_tests:
-  - name: osbuild-rcm-tests
-    timeout: 5
-  - name: osbuild-weldr-tests
-    timeout: 5
-  - name: osbuild-dnf-json-tests
-    timeout: 15
-  - name: osbuild-tests
-    timeout: 30
+  - osbuild-rcm-tests
+  - osbuild-weldr-tests
+  - osbuild-dnf-json-tests
+  - osbuild-tests
 
 ## Image test variables.
 # Executable that runs image tests.
@@ -28,8 +24,7 @@ image_test_executable: "{{ tests_path }}/osbuild-image-tests"
 # Location of image test case files.
 image_test_case_path: /usr/share/tests/osbuild-composer/cases
 
-# List of image tests and their timeout (in minutes).
-osbuild_composer_image_timeout: 15
+# List of image tests
 osbuild_composer_image_test_cases:
   - ami-boot.json
   - ext4_filesystem-boot.json
@@ -43,8 +38,7 @@ osbuild_composer_image_test_cases:
 # Environment variables for image tests.
 osbuild_composer_image_env_vars: {}
 
-# List of AWS test cases and their timeout (in minutes).
-osbuild_composer_aws_timeout: 60
+# List of AWS test cases
 osbuild_composer_aws_test_cases:
   - ami-boot.json
 


### PR DESCRIPTION
When we ran into these timeouts, they were always false negatives. It is
hard to find right values for them.

If someone does introduce a bug that hangs one of the tests, we still
have the global timeout.

Fixes #648