### PR TITLE
CI: Skip AWS test if bucket missing

### DIFF
--- a/schutzbot/test.yml
+++ b/schutzbot/test.yml
@@ -36,6 +36,8 @@
         loop_var: test_case
       when:
         - test_type == 'image'
+        # Don't run the AWS test if the bucket env var is not set.
+        - (lookup('env', 'AWS_BUCKET') | default(false)) | bool
 
     - name: Show failed and passed tests
       debug:


### PR DESCRIPTION
The osbuild CI uses the osbuild-composer CI testing playbooks but
there's no need to run the EC2 import for osbuild's CI. Add a check in
the Ansible playbook to look for the AWS_BUCKET environment variable and
skip the EC2 import if the bucker variable is missing.

Signed-off-by: Major Hayden <major@redhat.com>