### PR TITLE
Add Fedora IoT support

### DIFF
--- a/internal/distro/distro.go
+++ b/internal/distro/distro.go
@@ -84,7 +84,14 @@ type ImageType interface {
 
 // The ImageOptions specify options for a specific image build
 type ImageOptions struct {
-	Size uint64
+	OSTree OSTreeImageOptions
+	Size   uint64
+}
+
+// The OSTreeImageOptions specify ostree-specific image options
+type OSTreeImageOptions struct {
+	Ref    string
+	Parent string
 }
 
 type Registry struct {

--- a/internal/distro/distro.go
+++ b/internal/distro/distro.go
@@ -79,7 +79,12 @@ type ImageType interface {
 	// Returns an osbuild manifest, containing the sources and pipeline necessary
 	// to build an image, given output format with all packages and customizations
 	// specified in the given blueprint.
-	Manifest(b *blueprint.Customizations, repos []rpmmd.RepoConfig, packageSpecs, buildPackageSpecs []rpmmd.PackageSpec, size uint64) (*osbuild.Manifest, error)
+	Manifest(b *blueprint.Customizations, options ImageOptions, repos []rpmmd.RepoConfig, packageSpecs, buildPackageSpecs []rpmmd.PackageSpec) (*osbuild.Manifest, error)
+}
+
+// The ImageOptions specify options for a specific image build
+type ImageOptions struct {
+	Size uint64
 }
 
 type Registry struct {

--- a/internal/distro/distro_test_common/distro_test_common.go
+++ b/internal/distro/distro_test_common/distro_test_common.go
@@ -82,10 +82,12 @@ func TestDistro_Manifest(t *testing.T, pipelinePath string, prefix string, distr
 				return
 			}
 			got, err := imageType.Manifest(tt.ComposeRequest.Blueprint.Customizations,
+				distro.ImageOptions{
+					Size: imageType.Size(0),
+				},
 				repos,
 				tt.RpmMD.Packages,
-				tt.RpmMD.BuildPackages,
-				imageType.Size(0))
+				tt.RpmMD.BuildPackages)
 
 			if (err == nil && tt.Manifest == nil) || (err != nil && tt.Manifest != nil) {
 				t.Errorf("distro.Manifest() error = %v", err)

--- a/internal/distro/fedora30/distro.go
+++ b/internal/distro/fedora30/distro.go
@@ -168,11 +168,11 @@ func (t *imageType) BuildPackages() []string {
 }
 
 func (t *imageType) Manifest(c *blueprint.Customizations,
+	options distro.ImageOptions,
 	repos []rpmmd.RepoConfig,
 	packageSpecs,
-	buildPackageSpecs []rpmmd.PackageSpec,
-	size uint64) (*osbuild.Manifest, error) {
-	pipeline, err := t.pipeline(c, repos, packageSpecs, buildPackageSpecs, size)
+	buildPackageSpecs []rpmmd.PackageSpec) (*osbuild.Manifest, error) {
+	pipeline, err := t.pipeline(c, repos, packageSpecs, buildPackageSpecs, options.Size)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/distro/fedora31/distro.go
+++ b/internal/distro/fedora31/distro.go
@@ -167,11 +167,11 @@ func (t *imageType) BuildPackages() []string {
 }
 
 func (t *imageType) Manifest(c *blueprint.Customizations,
+	options distro.ImageOptions,
 	repos []rpmmd.RepoConfig,
 	packageSpecs,
-	buildPackageSpecs []rpmmd.PackageSpec,
-	size uint64) (*osbuild.Manifest, error) {
-	pipeline, err := t.pipeline(c, repos, packageSpecs, buildPackageSpecs, size)
+	buildPackageSpecs []rpmmd.PackageSpec) (*osbuild.Manifest, error) {
+	pipeline, err := t.pipeline(c, repos, packageSpecs, buildPackageSpecs, options.Size)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/distro/fedora32/distro.go
+++ b/internal/distro/fedora32/distro.go
@@ -168,11 +168,11 @@ func (t *imageType) BuildPackages() []string {
 }
 
 func (t *imageType) Manifest(c *blueprint.Customizations,
+	options distro.ImageOptions,
 	repos []rpmmd.RepoConfig,
 	packageSpecs,
-	buildPackageSpecs []rpmmd.PackageSpec,
-	size uint64) (*osbuild.Manifest, error) {
-	pipeline, err := t.pipeline(c, repos, packageSpecs, buildPackageSpecs, size)
+	buildPackageSpecs []rpmmd.PackageSpec) (*osbuild.Manifest, error) {
+	pipeline, err := t.pipeline(c, repos, packageSpecs, buildPackageSpecs, options.Size)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/distro/fedora32/distro_test.go
+++ b/internal/distro/fedora32/distro_test.go
@@ -135,7 +135,14 @@ func TestImageType_BuildPackages(t *testing.T) {
 				t.Errorf("d.GetArch(%v) returned err = %v; expected nil", archLabel, err)
 				continue
 			}
-			assert.ElementsMatch(t, buildPackages[archLabel], itStruct.BuildPackages())
+			if itLabel == "fedora-iot-commit" {
+				// For now we only include rpm-ostree when building fedora-iot-commit image types, this we may want
+				// to reconsider. The only reason to specia-case it is that it might pull in a lot of dependencies
+				// for a niche usecase.
+				assert.ElementsMatch(t, append(buildPackages[archLabel], "rpm-ostree"), itStruct.BuildPackages())
+			} else {
+				assert.ElementsMatch(t, buildPackages[archLabel], itStruct.BuildPackages())
+			}
 		}
 	}
 }

--- a/internal/distro/fedoratest/distro.go
+++ b/internal/distro/fedoratest/distro.go
@@ -91,10 +91,10 @@ func (t *imageType) BuildPackages() []string {
 }
 
 func (t *imageType) Manifest(c *blueprint.Customizations,
+	options distro.ImageOptions,
 	repos []rpmmd.RepoConfig,
 	packageSpecs,
-	buildPackageSpecs []rpmmd.PackageSpec,
-	size uint64) (*osbuild.Manifest, error) {
+	buildPackageSpecs []rpmmd.PackageSpec) (*osbuild.Manifest, error) {
 	return &osbuild.Manifest{
 		Pipeline: osbuild.Pipeline{},
 		Sources:  osbuild.Sources{},

--- a/internal/distro/rhel8/distro.go
+++ b/internal/distro/rhel8/distro.go
@@ -150,11 +150,11 @@ func (t *rhel8ImageType) BuildPackages() []string {
 }
 
 func (t *rhel8ImageType) Manifest(c *blueprint.Customizations,
+	options distro.ImageOptions,
 	repos []rpmmd.RepoConfig,
 	packageSpecs,
-	buildPackageSpecs []rpmmd.PackageSpec,
-	size uint64) (*osbuild.Manifest, error) {
-	pipeline, err := t.pipeline(c, repos, packageSpecs, buildPackageSpecs, size)
+	buildPackageSpecs []rpmmd.PackageSpec) (*osbuild.Manifest, error) {
+	pipeline, err := t.pipeline(c, repos, packageSpecs, buildPackageSpecs, options.Size)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/distro/test_distro/distro.go
+++ b/internal/distro/test_distro/distro.go
@@ -74,7 +74,7 @@ func (t *TestImageType) BuildPackages() []string {
 	return nil
 }
 
-func (t *TestImageType) Manifest(b *blueprint.Customizations, repos []rpmmd.RepoConfig, packageSpecs, buildPackageSpecs []rpmmd.PackageSpec, size uint64) (*osbuild.Manifest, error) {
+func (t *TestImageType) Manifest(b *blueprint.Customizations, options distro.ImageOptions, repos []rpmmd.RepoConfig, packageSpecs, buildPackageSpecs []rpmmd.PackageSpec) (*osbuild.Manifest, error) {
 	return &osbuild.Manifest{
 		Sources:  osbuild.Sources{},
 		Pipeline: osbuild.Pipeline{},

--- a/internal/osbuild/assembler.go
+++ b/internal/osbuild/assembler.go
@@ -32,12 +32,14 @@ func (assembler *Assembler) UnmarshalJSON(data []byte) error {
 	}
 	var options AssemblerOptions
 	switch rawAssembler.Name {
-	case "org.osbuild.tar":
-		options = new(TarAssemblerOptions)
+	case "org.osbuild.ostree.commit":
+		options = new(OSTreeCommitAssemblerOptions)
 	case "org.osbuild.qemu":
 		options = new(QEMUAssemblerOptions)
 	case "org.osbuild.rawfs":
 		options = new(RawFSAssemblerOptions)
+	case "org.osbuild.tar":
+		options = new(TarAssemblerOptions)
 	default:
 		return errors.New("unexpected assembler name")
 	}

--- a/internal/osbuild/assembler_test.go
+++ b/internal/osbuild/assembler_test.go
@@ -108,6 +108,19 @@ func TestAssembler_UnmarshalJSON(t *testing.T) {
 			},
 			data: []byte(`{"name":"org.osbuild.rawfs","options":{"filename":"filesystem.img","root_fs_uuid":"76a22bf4-f153-4541-b6c7-0332c0dfaeac","size":2147483648}}`),
 		},
+		{
+			name: "ostree commit assembler",
+			assembler: Assembler{
+				Name: "org.osbuild.ostree.commit",
+				Options: &OSTreeCommitAssemblerOptions{
+					Ref: "foo",
+					Tar: OSTreeCommitAssemblerTarOptions{
+						Filename: "foo.tar",
+					},
+				},
+			},
+			data: []byte(`{"name":"org.osbuild.ostree.commit","options":{"ref":"foo","tar":{"filename":"foo.tar"}}}`),
+		},
 	}
 
 	assert := assert.New(t)

--- a/internal/osbuild/fstab_stage.go
+++ b/internal/osbuild/fstab_stage.go
@@ -22,7 +22,8 @@ func NewFSTabStage(options *FSTabStageOptions) *Stage {
 // An FSTabEntry represents one line in /etc/fstab. With the one exception
 // that the the spec field must be represented as an UUID.
 type FSTabEntry struct {
-	UUID    string `json:"uuid"`
+	UUID    string `json:"uuid,omitempty"`
+	Label   string `json:"label,omitempty"`
 	VFSType string `json:"vfs_type"`
 	Path    string `json:"path,omitempty"`
 	Options string `json:"options,omitempty"`

--- a/internal/osbuild/ostree_commit_assembler.go
+++ b/internal/osbuild/ostree_commit_assembler.go
@@ -1,0 +1,23 @@
+package osbuild
+
+// OSTreeCommitAssemblerOptions desrcibe how to assemble a tree into an OSTree commit.
+type OSTreeCommitAssemblerOptions struct {
+	Ref    string                          `json:"ref"`
+	Parent string                          `json:"parent,omitempty"`
+	Tar    OSTreeCommitAssemblerTarOptions `json:"tar"`
+}
+
+// OSTreeCommitAssemblerTarOptions desrcibes the output tarball
+type OSTreeCommitAssemblerTarOptions struct {
+	Filename string `json:"filename"`
+}
+
+func (OSTreeCommitAssemblerOptions) isAssemblerOptions() {}
+
+// NewOSTreeCommitAssembler creates a new OSTree Commit Assembler object.
+func NewOSTreeCommitAssembler(options *OSTreeCommitAssemblerOptions) *Assembler {
+	return &Assembler{
+		Name:    "org.osbuild.ostree.commit",
+		Options: options,
+	}
+}

--- a/internal/osbuild/rpm_ostree_stage.go
+++ b/internal/osbuild/rpm_ostree_stage.go
@@ -1,0 +1,16 @@
+package osbuild
+
+// The RPM-OSTree stage describes how to transform the imgae into an OSTree.
+type RPMOSTreeStageOptions struct {
+	EtcGroupMembers []string `json:"etc_group_members,omitempty"`
+}
+
+func (RPMOSTreeStageOptions) isStageOptions() {}
+
+// NewLocaleStage creates a new Locale Stage object.
+func NewRPMOSTreeStage(options *RPMOSTreeStageOptions) *Stage {
+	return &Stage{
+		Name:    "org.osbuild.rpm-ostree",
+		Options: options,
+	}
+}

--- a/internal/osbuild/stage.go
+++ b/internal/osbuild/stage.go
@@ -62,6 +62,8 @@ func (stage *Stage) UnmarshalJSON(data []byte) error {
 		options = new(FirewallStageOptions)
 	case "org.osbuild.rpm":
 		options = new(RPMStageOptions)
+	case "org.osbuild.rpm-ostree":
+		options = new(RPMOSTreeStageOptions)
 	case "org.osbuild.systemd":
 		options = new(SystemdStageOptions)
 	case "org.osbuild.script":

--- a/internal/osbuild/stage_test.go
+++ b/internal/osbuild/stage_test.go
@@ -196,6 +196,20 @@ func TestStage_UnmarshalJSON(t *testing.T) {
 			},
 		},
 		{
+			name: "rpm-ostree",
+			fields: fields{
+				Name: "org.osbuild.rpm-ostree",
+				Options: &RPMOSTreeStageOptions{
+					EtcGroupMembers: []string{
+						"wheel",
+					},
+				},
+			},
+			args: args{
+				data: []byte(`{"name":"org.osbuild.rpm-ostree","options":{"etc_group_members":["wheel"]}}`),
+			},
+		},
+		{
 			name: "script",
 			fields: fields{
 				Name:    "org.osbuild.script",

--- a/internal/store/json.go
+++ b/internal/store/json.go
@@ -336,6 +336,7 @@ var imageTypeCompatMapping = map[string]string{
 	"ext4-filesystem":   "Raw-filesystem",
 	"partitioned-disk":  "Partitioned-disk",
 	"tar":               "Tar",
+	"fedora-iot-commit": "fedora-iot-commit",
 	"test_type":         "test_type",         // used only in json_test.go
 	"test_type_invalid": "test_type_invalid", // used only in json_test.go
 }

--- a/internal/weldr/api.go
+++ b/internal/weldr/api.go
@@ -1603,7 +1603,13 @@ func (api *API) composeHandler(writer http.ResponseWriter, request *http.Request
 	}
 
 	size := imageType.Size(cr.Size)
-	manifest, err := imageType.Manifest(bp.Customizations, api.allRepositories(), packages, buildPackages, size)
+	manifest, err := imageType.Manifest(bp.Customizations,
+		distro.ImageOptions{
+			Size: size,
+		},
+		api.allRepositories(),
+		packages,
+		buildPackages)
 	if err != nil {
 		errors := responseError{
 			ID:  "ManifestCreationFailed",

--- a/internal/weldr/api.go
+++ b/internal/weldr/api.go
@@ -1506,11 +1506,17 @@ func (api *API) composeHandler(writer http.ResponseWriter, request *http.Request
 		return
 	}
 
+	type OSTreeRequest struct {
+		Ref    string `json:"ref"`
+		Parent string `json:"parent"`
+	}
+
 	// https://weldr.io/lorax/pylorax.api.html#pylorax.api.v0.v0_compose_start
 	type ComposeRequest struct {
 		BlueprintName string         `json:"blueprint_name"`
 		ComposeType   string         `json:"compose_type"`
 		Size          uint64         `json:"size"`
+		OSTree        OSTreeRequest  `json:"ostree"`
 		Branch        string         `json:"branch"`
 		Upload        *uploadRequest `json:"upload"`
 	}
@@ -1606,6 +1612,10 @@ func (api *API) composeHandler(writer http.ResponseWriter, request *http.Request
 	manifest, err := imageType.Manifest(bp.Customizations,
 		distro.ImageOptions{
 			Size: size,
+			OSTree: distro.OSTreeImageOptions{
+				Ref:    cr.OSTree.Ref,
+				Parent: cr.OSTree.Parent,
+			},
 		},
 		api.allRepositories(),
 		packages,

--- a/internal/worker/server_test.go
+++ b/internal/worker/server_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 
+	"github.com/osbuild/osbuild-composer/internal/distro"
 	"github.com/osbuild/osbuild-composer/internal/distro/fedoratest"
 	"github.com/osbuild/osbuild-composer/internal/jobqueue/testjobqueue"
 	"github.com/osbuild/osbuild-composer/internal/test"
@@ -52,7 +53,7 @@ func TestCreate(t *testing.T) {
 	}
 	server := worker.NewServer(nil, testjobqueue.New(), nil)
 
-	manifest, err := imageType.Manifest(nil, nil, nil, nil, imageType.Size(0))
+	manifest, err := imageType.Manifest(nil, distro.ImageOptions{Size: imageType.Size(0)}, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("error creating osbuild manifest")
 	}
@@ -78,7 +79,7 @@ func testUpdateTransition(t *testing.T, from, to string, expectedStatus int) {
 
 	id := uuid.Nil
 	if from != "VOID" {
-		manifest, err := imageType.Manifest(nil, nil, nil, nil, imageType.Size(0))
+		manifest, err := imageType.Manifest(nil, distro.ImageOptions{Size: imageType.Size(0)}, nil, nil, nil)
 		if err != nil {
 			t.Fatalf("error creating osbuild manifest")
 		}


### PR DESCRIPTION
This adds support for generating Fedora IoT commit tarballs for Fedora 32. See individual commits for details.

I had a short discussion with @jgiardino about this, and she suggested that we could handle the required ostree-specific options in the same way as we handle image size, for now. That is, in the cockpit-composer UI, the user would can specify the parent commit and the ostree ref in the same place they select the image type (where the image size is currently configured).

Does that make sense to you @jkozol?