### PR TITLE
CI: Add mock builds for RHEL 8.3

### DIFF
--- a/schutzbot/Jenkinsfile
+++ b/schutzbot/Jenkinsfile
@@ -53,6 +53,15 @@ pipeline {
                         sh "schutzbot/mockbuild.sh"
                     }
                 }
+                stage('RHEL 8.3') {
+                    agent { label "rhel83" }
+                    environment {
+                        OPENSTACK_CREDS = credentials('psi-openstack-clouds-yaml')
+                    }
+                    steps {
+                        sh "schutzbot/mockbuild.sh"
+                    }
+                }
             }
         }
         stage("Functional Testing") {


### PR DESCRIPTION
Now that mock building seems to be stable, let's start building RPMs for
RHEL 8.3 so we can onboard it for base/image testing soon.

Signed-off-by: Major Hayden <major@redhat.com>