### PR TITLE
Add support for /compose/metadata, /compose/results, as well as tests

### DIFF
--- a/internal/client/compose.go
+++ b/internal/client/compose.go
@@ -186,3 +186,27 @@ func WriteComposeLogV0(socket *http.Client, w io.Writer, uuid string) (*APIRespo
 
 	return nil, err
 }
+
+// WriteComposeMetadataV0 requests the metadata for a compose and writes it to an io.Writer
+func WriteComposeMetadataV0(socket *http.Client, w io.Writer, uuid string) (*APIResponse, error) {
+	body, resp, err := GetRawBody(socket, "GET", "/api/v0/compose/metadata/"+uuid)
+	if resp != nil || err != nil {
+		return resp, err
+	}
+	_, err = io.Copy(w, body)
+	body.Close()
+
+	return nil, err
+}
+
+// WriteComposeResultsV0 requests the results for a compose and writes it to an io.Writer
+func WriteComposeResultsV0(socket *http.Client, w io.Writer, uuid string) (*APIResponse, error) {
+	body, resp, err := GetRawBody(socket, "GET", "/api/v0/compose/metadata/"+uuid)
+	if resp != nil || err != nil {
+		return resp, err
+	}
+	_, err = io.Copy(w, body)
+	body.Close()
+
+	return nil, err
+}

--- a/internal/client/compose_test.go
+++ b/internal/client/compose_test.go
@@ -184,6 +184,28 @@ func TestComposeInvalidLogV0(t *testing.T) {
 	require.Contains(t, resp.Errors[0].Msg, "c91818f9-8025-47af-89d2-f030d7000c2c")
 }
 
+// Test compose metadata for unknown uuid
+func TestComposeInvalidMetadataV0(t *testing.T) {
+	resp, err := WriteComposeMetadataV0(testState.socket, ioutil.Discard, "c91818f9-8025-47af-89d2-f030d7000c2c")
+	require.NoError(t, err, "failed with a client error")
+	require.NotNil(t, resp)
+	require.False(t, resp.Status)
+	require.Equal(t, 1, len(resp.Errors))
+	require.Equal(t, "UnknownUUID", resp.Errors[0].ID)
+	require.Contains(t, resp.Errors[0].Msg, "c91818f9-8025-47af-89d2-f030d7000c2c")
+}
+
+// Test compose results for unknown uuid
+func TestComposeInvalidResultsV0(t *testing.T) {
+	resp, err := WriteComposeResultsV0(testState.socket, ioutil.Discard, "c91818f9-8025-47af-89d2-f030d7000c2c")
+	require.NoError(t, err, "failed with a client error")
+	require.NotNil(t, resp)
+	require.False(t, resp.Status)
+	require.Equal(t, 1, len(resp.Errors))
+	require.Equal(t, "UnknownUUID", resp.Errors[0].ID)
+	require.Contains(t, resp.Errors[0].Msg, "c91818f9-8025-47af-89d2-f030d7000c2c")
+}
+
 // Test status filter for unknown uuid
 func TestComposeInvalidStatusV0(t *testing.T) {
 	status, resp, err := GetComposeStatusV0(testState.socket, "c91818f9-8025-47af-89d2-f030d7000c2c", "", "", "")
@@ -317,6 +339,21 @@ func TestFailedComposeV0(t *testing.T) {
 	require.Nil(t, resp)
 	require.Equal(t, "FAILED", info.QueueStatus)
 	require.Equal(t, buildID, info.ID)
+
+	// Test requesting the compose logs for the failed build
+	resp, err = WriteComposeLogsV0(testState.socket, ioutil.Discard, buildID.String())
+	require.NoError(t, err, "failed with a client error")
+	require.Nil(t, resp)
+
+	// Test requesting the compose metadata for the failed build
+	resp, err = WriteComposeMetadataV0(testState.socket, ioutil.Discard, buildID.String())
+	require.NoError(t, err, "failed with a client error")
+	require.Nil(t, resp)
+
+	// Test requesting the compose results for the failed build
+	resp, err = WriteComposeResultsV0(testState.socket, ioutil.Discard, buildID.String())
+	require.NoError(t, err, "failed with a client error")
+	require.Nil(t, resp)
 }
 
 // Setup and run the finished compose tests
@@ -397,4 +434,19 @@ func TestFinishedComposeV0(t *testing.T) {
 	require.Nil(t, resp)
 	require.Equal(t, "FINISHED", info.QueueStatus)
 	require.Equal(t, buildID, info.ID)
+
+	// Test requesting the compose logs for the finished build
+	resp, err = WriteComposeLogsV0(testState.socket, ioutil.Discard, buildID.String())
+	require.NoError(t, err, "failed with a client error")
+	require.Nil(t, resp)
+
+	// Test requesting the compose metadata for the finished build
+	resp, err = WriteComposeMetadataV0(testState.socket, ioutil.Discard, buildID.String())
+	require.NoError(t, err, "failed with a client error")
+	require.Nil(t, resp)
+
+	// Test requesting the compose results for the finished build
+	resp, err = WriteComposeResultsV0(testState.socket, ioutil.Discard, buildID.String())
+	require.NoError(t, err, "failed with a client error")
+	require.Nil(t, resp)
 }

--- a/internal/store/fixtures.go
+++ b/internal/store/fixtures.go
@@ -7,6 +7,7 @@ import (
 	"github.com/osbuild/osbuild-composer/internal/blueprint"
 	"github.com/osbuild/osbuild-composer/internal/common"
 	"github.com/osbuild/osbuild-composer/internal/distro/fedoratest"
+	"github.com/osbuild/osbuild-composer/internal/osbuild"
 	"github.com/osbuild/osbuild-composer/internal/target"
 )
 
@@ -65,6 +66,7 @@ func FixtureBase() *Store {
 			ImageBuild: ImageBuild{
 				QueueStatus: common.IBWaiting,
 				ImageType:   imgType,
+				Manifest:    &osbuild.Manifest{},
 				Targets:     []*target.Target{localTarget, awsTarget},
 				JobCreated:  date,
 			},
@@ -74,6 +76,7 @@ func FixtureBase() *Store {
 			ImageBuild: ImageBuild{
 				QueueStatus: common.IBRunning,
 				ImageType:   imgType,
+				Manifest:    &osbuild.Manifest{},
 				Targets:     []*target.Target{localTarget},
 				JobCreated:  date,
 				JobStarted:  date,
@@ -84,6 +87,7 @@ func FixtureBase() *Store {
 			ImageBuild: ImageBuild{
 				QueueStatus: common.IBFinished,
 				ImageType:   imgType,
+				Manifest:    &osbuild.Manifest{},
 				Targets:     []*target.Target{localTarget, awsTarget},
 				JobCreated:  date,
 				JobStarted:  date,
@@ -95,6 +99,7 @@ func FixtureBase() *Store {
 			ImageBuild: ImageBuild{
 				QueueStatus: common.IBFailed,
 				ImageType:   imgType,
+				Manifest:    &osbuild.Manifest{},
 				Targets:     []*target.Target{localTarget, awsTarget},
 				JobCreated:  date,
 				JobStarted:  date,

--- a/internal/weldr/api_test.go
+++ b/internal/weldr/api_test.go
@@ -646,6 +646,10 @@ func TestComposeLogs(t *testing.T) {
 	}{
 		{"/api/v0/compose/logs/30000000-0000-0000-0000-000000000002", "attachment; filename=30000000-0000-0000-0000-000000000002-logs.tar", "application/x-tar", "logs/osbuild.log", "The compose result is empty.\n"},
 		{"/api/v1/compose/logs/30000000-0000-0000-0000-000000000002", "attachment; filename=30000000-0000-0000-0000-000000000002-logs.tar", "application/x-tar", "logs/osbuild.log", "The compose result is empty.\n"},
+		{"/api/v0/compose/metadata/30000000-0000-0000-0000-000000000002", "attachment; filename=30000000-0000-0000-0000-000000000002-metadata.tar", "application/x-tar", "30000000-0000-0000-0000-000000000002.json", "{\"sources\":null,\"pipeline\":{}}"},
+		{"/api/v1/compose/metadata/30000000-0000-0000-0000-000000000002", "attachment; filename=30000000-0000-0000-0000-000000000002-metadata.tar", "application/x-tar", "30000000-0000-0000-0000-000000000002.json", "{\"sources\":null,\"pipeline\":{}}"},
+		{"/api/v0/compose/results/30000000-0000-0000-0000-000000000002", "attachment; filename=30000000-0000-0000-0000-000000000002.tar", "application/x-tar", "30000000-0000-0000-0000-000000000002.json", "{\"sources\":null,\"pipeline\":{}}"},
+		{"/api/v1/compose/results/30000000-0000-0000-0000-000000000002", "attachment; filename=30000000-0000-0000-0000-000000000002.tar", "application/x-tar", "30000000-0000-0000-0000-000000000002.json", "{\"sources\":null,\"pipeline\":{}}"},
 	}
 
 	for _, c := range successCases {
@@ -676,6 +680,10 @@ func TestComposeLogs(t *testing.T) {
 		{"/api/v1/compose/logs/30000000-0000-0000-0000", `{"status":false,"errors":[{"id":"UnknownUUID","msg":"30000000-0000-0000-0000 is not a valid build uuid"}]}`},
 		{"/api/v1/compose/logs/42000000-0000-0000-0000-000000000000", `{"status":false,"errors":[{"id":"UnknownUUID","msg":"Compose 42000000-0000-0000-0000-000000000000 doesn't exist"}]}`},
 		{"/api/v1/compose/logs/30000000-0000-0000-0000-000000000000", `{"status":false,"errors":[{"id":"BuildInWrongState","msg":"Build 30000000-0000-0000-0000-000000000000 not in FINISHED or FAILED state."}]}`},
+		{"/api/v1/compose/metadata/30000000-0000-0000-0000-000000000000", `{"status":false,"errors":[{"id":"BuildInWrongState","msg":"Build 30000000-0000-0000-0000-000000000000 is in wrong state: WAITING"}]}`},
+		{"/api/v1/compose/results/30000000-0000-0000-0000-000000000000", `{"status":false,"errors":[{"id":"BuildInWrongState","msg":"Build 30000000-0000-0000-0000-000000000000 is in wrong state: WAITING"}]}`},
+		{"/api/v1/compose/metadata/30000000-0000-0000-0000-000000000001", `{"status":false,"errors":[{"id":"BuildInWrongState","msg":"Build 30000000-0000-0000-0000-000000000001 is in wrong state: RUNNING"}]}`},
+		{"/api/v1/compose/results/30000000-0000-0000-0000-000000000001", `{"status":false,"errors":[{"id":"BuildInWrongState","msg":"Build 30000000-0000-0000-0000-000000000001 is in wrong state: RUNNING"}]}`},
 	}
 
 	if len(os.Getenv("OSBUILD_COMPOSER_TEST_EXTERNAL")) > 0 {


### PR DESCRIPTION
This fixes #643 and #644