### PR TITLE
weldr: messages → msgs in status route

### DIFF
--- a/internal/weldr/api.go
+++ b/internal/weldr/api.go
@@ -286,7 +286,7 @@ func (api *API) statusHandler(writer http.ResponseWriter, request *http.Request,
 		SchemaVersion string   `json:"schema_version"`
 		Backend       string   `json:"backend"`
 		Build         string   `json:"build"`
-		Messages      []string `json:"messages"`
+		Messages      []string `json:"msgs"`
 	}
 
 	err := json.NewEncoder(writer).Encode(reply{

--- a/internal/weldr/api_test.go
+++ b/internal/weldr/api_test.go
@@ -46,7 +46,7 @@ func TestBasic(t *testing.T) {
 		ExpectedStatus int
 		ExpectedJSON   string
 	}{
-		{"/api/status", http.StatusOK, `{"api":"1","db_supported":true,"db_version":"0","schema_version":"0","backend":"osbuild-composer","build":"devel","messages":[]}`},
+		{"/api/status", http.StatusOK, `{"api":"1","db_supported":true,"db_version":"0","schema_version":"0","backend":"osbuild-composer","build":"devel","msgs":[]}`},
 
 		{"/api/v0/projects/source/list", http.StatusOK, `{"sources":["test-id"]}`},
 


### PR DESCRIPTION
composer-cli expects `msgs`, not `messages`, and throws an exception if
it doesn't exist:

    https://github.com/weldr/lorax/blob/master/src/composer/cli/status.py#L52

It is not used anywhere else, so this is a safe change.