### PR TITLE
worker: introduce job artifact directory

### DIFF
--- a/cmd/osbuild-composer/main.go
+++ b/cmd/osbuild-composer/main.go
@@ -128,14 +128,16 @@ func main() {
 		log.Fatalf("cannot create jobqueue: %v", err)
 	}
 
-	outputDir := path.Join(stateDir, "outputs")
-	err = os.Mkdir(outputDir, 0755)
+	artifactsDir := path.Join(stateDir, "artifacts")
+	err = os.Mkdir(artifactsDir, 0755)
 	if err != nil && !os.IsExist(err) {
-		log.Fatalf("cannot create output directory: %v", err)
+		log.Fatalf("cannot create artifacts directory: %v", err)
 	}
 
-	workers := worker.NewServer(logger, jobs, store.AddImageToImageUpload)
-	weldrAPI := weldr.New(rpm, arch, distribution, repoMap[common.CurrentArch()], logger, store, workers)
+	compatOutputDir := path.Join(stateDir, "outputs")
+
+	workers := worker.NewServer(logger, jobs, artifactsDir)
+	weldrAPI := weldr.New(rpm, arch, distribution, repoMap[common.CurrentArch()], logger, store, workers, artifactsDir, compatOutputDir)
 
 	go func() {
 		err := workers.Serve(jobListener)

--- a/cmd/osbuild-worker/main.go
+++ b/cmd/osbuild-worker/main.go
@@ -63,7 +63,7 @@ func (e *TargetsError) Error() string {
 	return errString
 }
 
-func RunJob(job *worker.Job, uploadFunc func(uuid.UUID, int, io.Reader) error) (*common.ComposeResult, error) {
+func RunJob(job *worker.Job, uploadFunc func(uuid.UUID, string, io.Reader) error) (*common.ComposeResult, error) {
 	tmpOutput, err := ioutil.TempDir("/var/tmp", "osbuild-output-*")
 	if err != nil {
 		return nil, fmt.Errorf("error setting up osbuild output directory: %v", err)
@@ -87,7 +87,7 @@ func RunJob(job *worker.Job, uploadFunc func(uuid.UUID, int, io.Reader) error) (
 				continue
 			}
 
-			err = uploadFunc(options.ComposeId, options.ImageBuildId, f)
+			err = uploadFunc(job.Id, options.Filename, f)
 			if err != nil {
 				r = append(r, err)
 				continue

--- a/internal/client/unit_test.go
+++ b/internal/client/unit_test.go
@@ -11,6 +11,7 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"path"
 	"testing"
 
 	"github.com/osbuild/osbuild-composer/internal/distro/fedoratest"
@@ -36,6 +37,12 @@ func executeTests(m *testing.M) int {
 		panic(err)
 	}
 
+	artifactsDir := path.Join(tmpdir, "artifacts")
+	err = os.Mkdir(artifactsDir, 0755)
+	if err != nil {
+		panic(err)
+	}
+
 	// Create a mock API server listening on the temporary socket
 	fixture := rpmmd_mock.BaseFixture()
 	rpm := rpmmd_mock.NewRPMMDMock(fixture)
@@ -46,7 +53,7 @@ func executeTests(m *testing.M) int {
 	}
 	repos := []rpmmd.RepoConfig{{Id: "test-system-repo", BaseURL: "http://example.com/test/os/test_arch"}}
 	logger := log.New(os.Stdout, "", 0)
-	api := weldr.New(rpm, arch, distro, repos, logger, fixture.Store, fixture.Workers)
+	api := weldr.New(rpm, arch, distro, repos, logger, fixture.Store, fixture.Workers, artifactsDir, "")
 	server := http.Server{Handler: api}
 	defer server.Close()
 

--- a/internal/mocks/rpmmd/fixtures.go
+++ b/internal/mocks/rpmmd/fixtures.go
@@ -53,7 +53,7 @@ func generatePackageList() rpmmd.PackageList {
 }
 
 func createBaseWorkersFixture() *worker.Server {
-	return worker.NewServer(nil, testjobqueue.New(), nil)
+	return worker.NewServer(nil, testjobqueue.New(), "")
 }
 
 func createBaseDepsolveFixture() []rpmmd.PackageSpec {

--- a/internal/rcm/api_test.go
+++ b/internal/rcm/api_test.go
@@ -37,7 +37,7 @@ func newTestWorkerServer(t *testing.T) (*worker.Server, string) {
 	dir, err := ioutil.TempDir("", "rcm-test-")
 	require.NoError(t, err)
 
-	w := worker.NewServer(nil, testjobqueue.New(), nil)
+	w := worker.NewServer(nil, testjobqueue.New(), "")
 	require.NotNil(t, w)
 
 	return w, dir

--- a/internal/weldr/api_test.go
+++ b/internal/weldr/api_test.go
@@ -4,6 +4,7 @@ import (
 	"archive/tar"
 	"bytes"
 	"io"
+	"io/ioutil"
 	"math/rand"
 	"net/http"
 	"net/http/httptest"
@@ -37,7 +38,13 @@ func createWeldrAPI(fixtureGenerator rpmmd_mock.FixtureGenerator) (*API, *store.
 		panic(err)
 	}
 
-	return New(rpm, arch, d, repos, nil, fixture.Store, fixture.Workers), fixture.Store
+	artifactsDir, err := ioutil.TempDir("", "client_test-")
+	if err != nil {
+		panic(err)
+	}
+	defer os.RemoveAll(artifactsDir)
+
+	return New(rpm, arch, d, repos, nil, fixture.Store, fixture.Workers, artifactsDir, ""), fixture.Store
 }
 
 func TestBasic(t *testing.T) {

--- a/internal/worker/client.go
+++ b/internal/worker/client.go
@@ -118,9 +118,8 @@ func (c *Client) UpdateJob(job *Job, status common.ImageBuildState, result *comm
 	return nil
 }
 
-func (c *Client) UploadImage(composeId uuid.UUID, imageBuildId int, reader io.Reader) error {
-	// content type doesn't really matter
-	url := c.createURL(fmt.Sprintf("/job-queue/v1/jobs/%s/builds/%d/image", composeId, imageBuildId))
+func (c *Client) UploadImage(job uuid.UUID, name string, reader io.Reader) error {
+	url := c.createURL(fmt.Sprintf("/job-queue/v1/jobs/%s/artifacts/%s", job, name))
 	_, err := c.client.Post(url, "application/octet-stream", reader)
 
 	return err

--- a/internal/worker/server_test.go
+++ b/internal/worker/server_test.go
@@ -35,7 +35,7 @@ func TestErrors(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		server := worker.NewServer(nil, testjobqueue.New(), nil)
+		server := worker.NewServer(nil, testjobqueue.New(), "")
 		test.TestRoute(t, server, false, c.Method, c.Path, c.Body, c.ExpectedStatus, "{}", "message")
 	}
 }
@@ -50,7 +50,7 @@ func TestCreate(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error getting image type from arch")
 	}
-	server := worker.NewServer(nil, testjobqueue.New(), nil)
+	server := worker.NewServer(nil, testjobqueue.New(), "")
 
 	manifest, err := imageType.Manifest(nil, nil, nil, nil, imageType.Size(0))
 	if err != nil {
@@ -74,7 +74,7 @@ func testUpdateTransition(t *testing.T, from, to string, expectedStatus int) {
 	if err != nil {
 		t.Fatalf("error getting image type from arch")
 	}
-	server := worker.NewServer(nil, testjobqueue.New(), nil)
+	server := worker.NewServer(nil, testjobqueue.New(), "")
 
 	id := uuid.Nil
 	if from != "VOID" {


### PR DESCRIPTION
The `jobs/:job_id/builds/:build_id/image` route was awkward: the
`:jobid` was actually weldr's compose id and `:build_id` was always `0`.

Change it to `jobs/:job_id/artifacts/:name`, where `:job_id` is now a
job id, and `:name` is the name of the artifact to upload. In the
future, it could support uploading more than one artifact.

This allows removing outputs from `store`, which is now back to being a
pure JSON-store. Take care that `weldr` returns (and deletes) images
from the new (or for backwards compatibility, the old) location.

The `org.osbuild.local` target continues to exist as a marker for the
worker to know whether it should upload artifacts.