### PR TITLE
worker: dont cache just yet

### DIFF
--- a/cmd/osbuild-worker/main.go
+++ b/cmd/osbuild-worker/main.go
@@ -68,8 +68,12 @@ func RunJob(job *worker.Job, uploadFunc func(uuid.UUID, string, io.Reader) error
 	if err != nil {
 		return nil, fmt.Errorf("error setting up osbuild output directory: %v", err)
 	}
-	// FIXME: how to handle errors in defer?
-	defer os.RemoveAll(tmpOutput)
+	defer func() {
+		err := os.RemoveAll(tmpOutput)
+		if err != nil {
+			log.Printf("Error removing temporary directory %s for job %s: %v", tmpOutput, job.Id, err)
+		}
+	}()
 
 	result, err := RunOSBuild(job.Manifest, tmpOutput, os.Stderr)
 	if err != nil {

--- a/cmd/osbuild-worker/osbuild.go
+++ b/cmd/osbuild-worker/osbuild.go
@@ -19,9 +19,10 @@ func (e *OSBuildError) Error() string {
 	return e.Message
 }
 
-func RunOSBuild(manifest *osbuild.Manifest, outputDirectory string, errorWriter io.Writer) (*common.ComposeResult, error) {
+func RunOSBuild(manifest *osbuild.Manifest, store, outputDirectory string, errorWriter io.Writer) (*common.ComposeResult, error) {
 	cmd := exec.Command(
 		"osbuild",
+		"--store", store,
 		"--output-directory", outputDirectory,
 		"--json", "-",
 	)


### PR DESCRIPTION
When fdd7536 added `--output-directory` to the invocation of osbuild,
it also removed `--store`.

This was a mistake: osbuild's default store is `.osbuild`, which is not
what we want. Restore the old behavior of passing a temporary directory.