### PR TITLE
Add health check at /status

### DIFF
--- a/internal/worker/json.go
+++ b/internal/worker/json.go
@@ -25,6 +25,10 @@ type OSBuildJobResult struct {
 // JSON-serializable types for the HTTP API
 //
 
+type statusResponse struct {
+	Status string `json:"status"`
+}
+
 type errorResponse struct {
 	Message string `json:"message"`
 }

--- a/internal/worker/server.go
+++ b/internal/worker/server.go
@@ -49,6 +49,10 @@ func NewServer(logger *log.Logger, jobs jobqueue.JobQueue, artifactsDir string) 
 	s.router.MethodNotAllowed = http.HandlerFunc(methodNotAllowedHandler)
 	s.router.NotFound = http.HandlerFunc(notFoundHandler)
 
+	// Add a basic status handler for checking if osbuild-composer is alive.
+	s.router.GET("/status", s.statusHandler)
+
+	// Add handlers for managing jobs.
 	s.router.POST("/job-queue/v1/jobs", s.addJobHandler)
 	s.router.PATCH("/job-queue/v1/jobs/:job_id", s.updateJobHandler)
 	s.router.POST("/job-queue/v1/jobs/:job_id/artifacts/:name", s.addJobImageHandler)
@@ -132,6 +136,15 @@ func methodNotAllowedHandler(writer http.ResponseWriter, request *http.Request) 
 
 func notFoundHandler(writer http.ResponseWriter, request *http.Request) {
 	jsonErrorf(writer, http.StatusNotFound, "not found")
+}
+
+func (s *Server) statusHandler(writer http.ResponseWriter, request *http.Request, _ httprouter.Params) {
+	writer.WriteHeader(http.StatusOK)
+
+	// Send back a status message.
+	_ = json.NewEncoder(writer).Encode(&statusResponse{
+		Status: "OK",
+	})
 }
 
 func (s *Server) addJobHandler(writer http.ResponseWriter, request *http.Request, _ httprouter.Params) {

--- a/internal/worker/server_test.go
+++ b/internal/worker/server_test.go
@@ -14,6 +14,12 @@ import (
 	"github.com/osbuild/osbuild-composer/internal/worker"
 )
 
+// Ensure that the status request returns OK.
+func TestStatus(t *testing.T) {
+	server := worker.NewServer(nil, testjobqueue.New(), "")
+	test.TestRoute(t, server, false, "GET", "/status", ``, http.StatusOK, `{"status":"OK"}`, "message")
+}
+
 func TestErrors(t *testing.T) {
 	var cases = []struct {
 		Method         string


### PR DESCRIPTION
There are times where it would be good to monitor that osbuild-composer
is up and running. Add a very simple status check that always returns
`200 OK`. This can be expanded later to verify that other parts of
osbuild-composer are working properly.

Signed-off-by: Major Hayden <major@redhat.com>