### PR TITLE
Remove CacheDirectory for remote worker

### DIFF
--- a/distribution/osbuild-remote-worker@.service
+++ b/distribution/osbuild-remote-worker@.service
@@ -6,7 +6,6 @@ After=multi-user.target
 Type=simple
 PrivateTmp=true
 ExecStart=/usr/libexec/osbuild-composer/osbuild-worker %i
-CacheDirectory=osbuild-composer
 Restart=on-failure
 RestartSec=10s
 CPUSchedulingPolicy=batch


### PR DESCRIPTION
Setting the cache directory to `/var/cache` causes problems on the
remote worker startup and it needs to be removed.

Signed-off-by: Major Hayden <major@redhat.com>