### PR TITLE
worker: add JobArtifact() and DeleteJobArtifacts()

### DIFF
--- a/cmd/osbuild-composer/main.go
+++ b/cmd/osbuild-composer/main.go
@@ -137,7 +137,7 @@ func main() {
 	compatOutputDir := path.Join(stateDir, "outputs")
 
 	workers := worker.NewServer(logger, jobs, artifactsDir)
-	weldrAPI := weldr.New(rpm, arch, distribution, repoMap[common.CurrentArch()], logger, store, workers, artifactsDir, compatOutputDir)
+	weldrAPI := weldr.New(rpm, arch, distribution, repoMap[common.CurrentArch()], logger, store, workers, compatOutputDir)
 
 	go func() {
 		err := workers.Serve(jobListener)

--- a/internal/client/unit_test.go
+++ b/internal/client/unit_test.go
@@ -11,7 +11,6 @@ import (
 	"net"
 	"net/http"
 	"os"
-	"path"
 	"testing"
 
 	"github.com/osbuild/osbuild-composer/internal/distro/fedoratest"
@@ -37,12 +36,6 @@ func executeTests(m *testing.M) int {
 		panic(err)
 	}
 
-	artifactsDir := path.Join(tmpdir, "artifacts")
-	err = os.Mkdir(artifactsDir, 0755)
-	if err != nil {
-		panic(err)
-	}
-
 	// Create a mock API server listening on the temporary socket
 	fixture := rpmmd_mock.BaseFixture()
 	rpm := rpmmd_mock.NewRPMMDMock(fixture)
@@ -53,7 +46,7 @@ func executeTests(m *testing.M) int {
 	}
 	repos := []rpmmd.RepoConfig{{Id: "test-system-repo", BaseURL: "http://example.com/test/os/test_arch"}}
 	logger := log.New(os.Stdout, "", 0)
-	api := weldr.New(rpm, arch, distro, repos, logger, fixture.Store, fixture.Workers, artifactsDir, "")
+	api := weldr.New(rpm, arch, distro, repos, logger, fixture.Store, fixture.Workers, "")
 	server := http.Server{Handler: api}
 	defer server.Close()
 

--- a/internal/weldr/api_test.go
+++ b/internal/weldr/api_test.go
@@ -4,7 +4,6 @@ import (
 	"archive/tar"
 	"bytes"
 	"io"
-	"io/ioutil"
 	"math/rand"
 	"net/http"
 	"net/http/httptest"
@@ -38,13 +37,7 @@ func createWeldrAPI(fixtureGenerator rpmmd_mock.FixtureGenerator) (*API, *store.
 		panic(err)
 	}
 
-	artifactsDir, err := ioutil.TempDir("", "client_test-")
-	if err != nil {
-		panic(err)
-	}
-	defer os.RemoveAll(artifactsDir)
-
-	return New(rpm, arch, d, repos, nil, fixture.Store, fixture.Workers, artifactsDir, ""), fixture.Store
+	return New(rpm, arch, d, repos, nil, fixture.Store, fixture.Workers, ""), fixture.Store
 }
 
 func TestBasic(t *testing.T) {


### PR DESCRIPTION
This allows removing the `artifactsDir` from `weldr.API`. It makes more
sense to deal with that directory in one place only.

This is a follow-up to @teg's [comment](https://github.com/osbuild/osbuild-composer/pull/666#discussion_r430248077) on the job artifact PR.