### PR TITLE
Document additional RHEL image types

### DIFF
--- a/image-types/rhel8/README.md
+++ b/image-types/rhel8/README.md
@@ -2,18 +2,9 @@
 
 *osbuild-composer* can create [Red Hat Enterprise Linux 8][rhel] images.
 
-## Architectures
+A RHEL installation consists of the `@Core` group and the `kernel` package from
+RHEL repositories. The default file system is `xfs`.
 
-RHEL supports `x86_64`, `aarch64`, `ppc64le`, and `s390x`.
-
-## Partitioning and Booting
-
-The default file system is `xfs` on one bootable partition.
-
-## Packages
-
-By default, these images are created by installing the `@Core` group and the
-`kernel` package.
-
+RHEL supports `x86_64`, `aarch64`, `ppc64le`, and `s390x` architectures.
 
 [rhel]: https://access.redhat.com/products/red-hat-enterprise-linux

--- a/image-types/rhel8/README.md
+++ b/image-types/rhel8/README.md
@@ -1,7 +1,5 @@
 # Red Hat Enterprise Linux 8
 
-Owner: *None*
-
 *osbuild-composer* can create [Red Hat Enterprise Linux 8][rhel] images.
 
 ## Architectures

--- a/image-types/rhel8/amazon-ec2.md
+++ b/image-types/rhel8/amazon-ec2.md
@@ -1,10 +1,11 @@
 # Amazon EC2 Image
 
 This image is meant to be used in [Amazon Elastic Compute Cloud (EC2)][ec2], a
-popular cloud computing platform. It has to follow Amazon’s
+popular cloud computing platform. It conforms to Amazon’s
 [guidelines][guidelines] and [requirements][requirements] for shared AMIs.
 
-## File Format
+
+## Implementation Choices
 
 EC2 uses Amazon Machine Images (AMIs) internally, which can only be created
 inside EC2. An image in a standard format (ova, vmdk, vhd/x, or raw) must be
@@ -12,21 +13,8 @@ imported from S3 storage. *osbuild-composer* generates this image type in the
 VHDX format, because it is fairly modern, widely used, and uses less space than
 RAW images.
 
-The default image size is 6 GB.
-
-## Architectures
-
-Limited to `x86_64` and `aarch64`, because those are available on EC2.
-
-## Partitioning and Booting
-
-The image specifies partitions with a MBR partition table, because that is
-required by EC2. It contains one bootable partition formatted with RHEL's
-default file system `xfs`.
-
-## Packages
-
-`cloud-init` is included in this image, because it is required by EC2.
+This image is availble for `x86_64` and `aarch64`, because those are the only
+architectures available in EC2.
 
 EC2 doesn't require any specialized firmware. Thus, in order to keep the
 resulting image size small, all `-firmware` packages are excluded. An exception
@@ -35,10 +23,6 @@ package depends on it.
 
 `dracut-config-rescue` is excluded from the image, because the boot loader
 entry it provides is broken.
-
-## Kernel Command Line
-
-`ro console=ttyS0,115200n8 console=tty0 net.ifnames=0 rd.blacklist=nouveau nvme_core.io_timeout=4294967295 crashkernel=auto`
 
 
 [ec2]: https://aws.amazon.com/ec2

--- a/image-types/rhel8/amazon-ec2.md
+++ b/image-types/rhel8/amazon-ec2.md
@@ -1,7 +1,5 @@
 # Amazon EC2 Image
 
-Owner: *None*
-
 This image is meant to be used in [Amazon Elastic Compute Cloud (EC2)][ec2], a
 popular cloud computing platform. It has to follow Amazon’s
 [guidelines][guidelines] and [requirements][requirements] for shared AMIs.

--- a/image-types/rhel8/kvm-guest-image.md
+++ b/image-types/rhel8/kvm-guest-image.md
@@ -1,0 +1,18 @@
+# KVM Guest Image
+
+This is an image meant to be used as a generic base image for various
+virtualization environments.
+
+To be usable in common environments, it is provided in the *qcow2* format and
+has *cloud-init* installed and enabled.
+
+
+## Implementation Choices
+
+`dracut-config-rescue` is excluded from the image, because the boot loader
+entry it provides is broken.
+
+The environments this image is meant to be used in usually don't require any
+specialized firmware. Thus, in order to keep the resulting image size small,
+all `-firmware` packages are excluded. An exception is the `linux-firmware`
+package, which cannot be excluded because the `kernel` package depends on it.

--- a/image-types/rhel8/microsoft-azure.md
+++ b/image-types/rhel8/microsoft-azure.md
@@ -1,0 +1,7 @@
+# Microsoft Azure Image
+
+This image is meant to be used in [Microsoft Azure][azure], a popular cloud
+computing platform. It conforms to Azure's requirements for images.
+
+
+[azure]: https://azure.microsoft.com

--- a/image-types/rhel8/openstack.md
+++ b/image-types/rhel8/openstack.md
@@ -3,27 +3,19 @@
 This image is meant to be run in an OpenStack environment. It has to conform to
 OpenStack’s [image requirements][requirements].
 
-## File Format
 
-This image is OpenStack's native file format is qcow2.
+## Implementation Choices
 
-The default image size is 2 GB.
-
-## Partitioning and Booting
-
-The generated images contain one bootable partition formatted with RHEL's
-default file system `xfs`.
-
-## Software
-
-`cloud-init` is included in this image, because it is required by OpenStack.
+To be usable in OpenStack, it is provided in the *qcow2* format and has
+*cloud-init* installed and enabled.
 
 `dracut-config-rescue` is excluded from the image, because the boot loader
 entry it provides is broken.
 
-## Kernel Command Line
-
-`ro net.ifnames=0`
+The environments this image is meant to be used in usually don't require any
+specialized firmware. Thus, in order to keep the resulting image size small,
+all `-firmware` packages are excluded. An exception is the `linux-firmware`
+package, which cannot be excluded because the `kernel` package depends on it.
 
 
 [requirements]: https://docs.openstack.org/image-guide/openstack-images.html

--- a/image-types/rhel8/openstack.md
+++ b/image-types/rhel8/openstack.md
@@ -1,7 +1,5 @@
 # OpenStack Image
 
-Owner: *None*
-
 This image is meant to be run in an OpenStack environment. It has to conform to
 OpenStack’s [image requirements][requirements].
 

--- a/image-types/rhel8/vmware.md
+++ b/image-types/rhel8/vmware.md
@@ -1,0 +1,7 @@
+# VMWare Image
+
+This image is meant to be used in various VMWare environments, such as
+[vSphere][vsphere].
+
+
+[vsphere]: https://www.vmware.com/products/vsphere.html


### PR DESCRIPTION
Together with https://github.com/osbuild/osbuild-composer/pull/671, all RHEL image types have a documented purpose.