### PR TITLE
Disable automatic local worker startup

### DIFF
--- a/distribution/osbuild-worker@.service
+++ b/distribution/osbuild-worker@.service
@@ -11,6 +11,3 @@ Restart=on-failure
 RestartSec=10s
 CPUSchedulingPolicy=batch
 IOSchedulingClass=idle
-
-[Install]
-WantedBy=osbuild-composer.service


### PR DESCRIPTION
Now that we deploy remote workers by default, there's no need for an
automatically-started local worker that listens on a socket. This also
alleviates the need to mask the `osbuild-worker@.service` unit when you
deploy remote workers.

Signed-off-by: Major Hayden <major@redhat.com>