### PR TITLE
CI: Use RHEL 8 CDN subscribed instance

### DIFF
--- a/schutzbot/Jenkinsfile
+++ b/schutzbot/Jenkinsfile
@@ -44,8 +44,8 @@ pipeline {
                         sh "schutzbot/mockbuild.sh"
                     }
                 }
-                stage('RHEL 8.2') {
-                    agent { label "rhel82" }
+                stage('RHEL 8 CDN') {
+                    agent { label "rhel8" }
                     environment {
                         OPENSTACK_CREDS = credentials('psi-openstack-clouds-yaml')
                     }
@@ -53,15 +53,15 @@ pipeline {
                         sh "schutzbot/mockbuild.sh"
                     }
                 }
-                stage('RHEL 8.3') {
-                    agent { label "rhel83" }
-                    environment {
-                        OPENSTACK_CREDS = credentials('psi-openstack-clouds-yaml')
-                    }
-                    steps {
-                        sh "schutzbot/mockbuild.sh"
-                    }
-                }
+                // stage('RHEL 8.3 Nightly') {
+                //     agent { label "rhel83" }
+                //     environment {
+                //         OPENSTACK_CREDS = credentials('psi-openstack-clouds-yaml')
+                //     }
+                //     steps {
+                //         sh "schutzbot/mockbuild.sh"
+                //     }
+                // }
             }
         }
         stage("Functional Testing") {
@@ -127,20 +127,20 @@ pipeline {
                         }
                     }
                 }
-                stage('RHEL 8.2 base') {
-                    agent { label "rhel82" }
+                stage('RHEL 8 CDN Base') {
+                    agent { label "rhel8" }
                     environment { TEST_TYPE = "base" }
                     steps {
                         run_tests()
                     }
                     post {
                         always {
-                            preserve_logs('rhel82-base')
+                            preserve_logs('rhel8-base')
                         }
                     }
                 }
-                stage('RHEL 8.2 image') {
-                    agent { label "rhel82" }
+                stage('RHEL 8 CDN Image') {
+                    agent { label "rhel8" }
                     environment {
                         TEST_TYPE = "image"
                         AWS_CREDS = credentials('aws-credentials-osbuildci')
@@ -152,7 +152,7 @@ pipeline {
                     }
                     post {
                         always {
-                            preserve_logs('rhel82-image')
+                            preserve_logs('rhel8-image')
                         }
                     }
                 }

--- a/schutzbot/run_tests.sh
+++ b/schutzbot/run_tests.sh
@@ -38,9 +38,6 @@ trap "preserve_journal" ERR
 # Write a simple hosts file for Ansible.
 echo -e "[test_instances]\nlocalhost ansible_connection=local" > hosts.ini
 
-# Get the SHA of osbuild-composer which Jenkins checked out for us.
-OSBUILD_COMPOSER_VERSION=$(git rev-parse HEAD)
-
 # Deploy osbuild/osbuild-composer via the repository we created.
 export ANSIBLE_CONFIG=ansible-osbuild/ansible.cfg
 git clone https://github.com/osbuild/ansible-osbuild.git ansible-osbuild
@@ -48,9 +45,6 @@ ansible-playbook \
   -i hosts.ini \
   -e install_source=os \
   ansible-osbuild/playbook.yml
-
-# Ensure the testing package is installed.
-sudo dnf -y install osbuild-composer-tests
 
 # Run the tests.
 ansible-playbook \

--- a/schutzbot/test.yml
+++ b/schutzbot/test.yml
@@ -1,6 +1,7 @@
 ---
 
-- hosts: localhost
+- name: Run osbuild-composer tests
+  hosts: localhost
   become: yes
   vars:
     passed_tests: []
@@ -8,6 +9,11 @@
   vars_files:
     - vars.yml
   tasks:
+
+    - name: Install osbuild-composer-tests
+      dnf:
+        name: osbuild-composer-tests
+        state: present
 
     - name: Run osbuild-composer base tests
       include_tasks: test_runner_base.yml


### PR DESCRIPTION
Replace RHEL 8.2 nightly images with a RHEL 8 CDN subscribed instance so
we can test with the exact content a customer would have.

Signed-off-by: Major Hayden <major@redhat.com>