### PR TITLE
CI: Remove journald_cursor play variable

### DIFF
--- a/schutzbot/run_tests.sh
+++ b/schutzbot/run_tests.sh
@@ -49,7 +49,6 @@ ansible-playbook \
 # Run the tests.
 ansible-playbook \
   -e workspace=${WORKSPACE} \
-  -e journald_cursor="${JOURNALD_CURSOR}" \
   -e test_type=${TEST_TYPE:-base} \
   -i hosts.ini \
   schutzbot/test.yml


### PR DESCRIPTION
This variable is no longer needed since the bash script handles the
cursor.

Signed-off-by: Major Hayden <major@redhat.com>