### PR TITLE
spec: exclude i686 architecture

### DIFF
--- a/golang-github-osbuild-composer.spec
+++ b/golang-github-osbuild-composer.spec
@@ -14,6 +14,10 @@ Name:           %{goname}
 Release:        1%{?dist}
 Summary:        An image building service based on osbuild
 
+# osbuild-composer doesn't have support for building i686 images
+# and also RHEL and Fedora has now only limited support for this arch.
+ExcludeArch:    i686
+
 # Upstream license specification: Apache-2.0
 License:        ASL 2.0
 URL:            %{gourl}

--- a/osbuild-composer.spec
+++ b/osbuild-composer.spec
@@ -18,6 +18,10 @@ Name:           osbuild-composer
 Release:        1%{?dist}
 Summary:        An image building service based on osbuild
 
+# osbuild-composer doesn't have support for building i686 images
+# and also RHEL and Fedora has now only limited support for this arch.
+ExcludeArch:    i686
+
 # Upstream license specification: Apache-2.0
 License:        ASL 2.0
 URL:            %{gourl}


### PR DESCRIPTION
RHEL 8 doesn't have golang in the i686 buildroot anymore. Fedora doesn't have
i686 images and kernel anymore. Also, osbuild-composer doesn't have support
for building i686.

Let's exclude i686 for these reasons, it's dead.

See rhbz#1752991