### PR TITLE
CI: Store RPMs by SHA

### DIFF
--- a/schutzbot/Jenkinsfile
+++ b/schutzbot/Jenkinsfile
@@ -33,6 +33,10 @@ pipeline {
                     }
                     steps {
                         sh "schutzbot/mockbuild.sh"
+                        stash (
+                            includes: 'osbuild-mock.repo',
+                            name: 'fedora31'
+                        )
                     }
                 }
                 stage('Fedora 32') {
@@ -42,6 +46,10 @@ pipeline {
                     }
                     steps {
                         sh "schutzbot/mockbuild.sh"
+                        stash (
+                            includes: 'osbuild-mock.repo',
+                            name: 'fedora32'
+                        )
                     }
                 }
                 stage('RHEL 8 CDN') {
@@ -51,17 +59,25 @@ pipeline {
                     }
                     steps {
                         sh "schutzbot/mockbuild.sh"
+                        stash (
+                            includes: 'osbuild-mock.repo',
+                            name: 'rhel8cdn'
+                        )
                     }
                 }
-                // stage('RHEL 8.3 Nightly') {
-                //     agent { label "rhel83" }
-                //     environment {
-                //         OPENSTACK_CREDS = credentials('psi-openstack-clouds-yaml')
-                //     }
-                //     steps {
-                //         sh "schutzbot/mockbuild.sh"
-                //     }
-                // }
+                stage('RHEL 8.3 Nightly') {
+                    agent { label "rhel83" }
+                    environment {
+                        OPENSTACK_CREDS = credentials('psi-openstack-clouds-yaml')
+                    }
+                    steps {
+                        sh "schutzbot/mockbuild.sh"
+                        stash (
+                            includes: 'osbuild-mock.repo',
+                            name: 'rhel83'
+                        )
+                    }
+                }
             }
         }
         stage("Functional Testing") {
@@ -73,6 +89,7 @@ pipeline {
                     agent { label "fedora31" }
                     environment { TEST_TYPE = "base" }
                     steps {
+                        unstash 'fedora31'
                         run_tests()
                     }
                     post {
@@ -90,6 +107,7 @@ pipeline {
                         AWS_BUCKET = "imagebuilder-jenkins-testing-use2"
                     }
                     steps {
+                        unstash 'fedora31'
                         run_tests()
                     }
                     post {
@@ -102,6 +120,7 @@ pipeline {
                     agent { label "fedora32" }
                     environment { TEST_TYPE = "base" }
                     steps {
+                        unstash 'fedora32'
                         run_tests()
                     }
                     post {
@@ -119,6 +138,7 @@ pipeline {
                         AWS_BUCKET = "imagebuilder-jenkins-testing-use2"
                     }
                     steps {
+                        unstash 'fedora32'
                         run_tests()
                     }
                     post {
@@ -131,6 +151,7 @@ pipeline {
                     agent { label "rhel8" }
                     environment { TEST_TYPE = "base" }
                     steps {
+                        unstash 'rhel8cdn'
                         run_tests()
                     }
                     post {
@@ -148,6 +169,7 @@ pipeline {
                         AWS_BUCKET = "imagebuilder-jenkins-testing-use2"
                     }
                     steps {
+                        unstash 'rhel8cdn'
                         run_tests()
                     }
                     post {

--- a/schutzbot/mockbuild.sh
+++ b/schutzbot/mockbuild.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
-set -euxo pipefail
+set -euo pipefail
+
+# Colorful output.
+function greenprint {
+  echo -e "\033[1;32m${1}\033[0m"
+}
 
 # Get OS details.
 source /etc/os-release
@@ -8,36 +13,62 @@ source /etc/os-release
 CONTAINER=osbuildci-artifacts
 WORKSPACE=${WORKSPACE:-$(pwd)}
 MOCK_CONFIG="${ID}-${VERSION_ID%.*}-$(uname -m)"
-REPO_DIR=repo/${BUILD_TAG}/${ID}${VERSION_ID//./}
+POST_MERGE_SHA=$(git rev-parse --short HEAD)
+REPO_DIR=repo/${JOB_NAME}/${POST_MERGE_SHA}/${ID}${VERSION_ID//./}
+REPO_URL=${MOCK_REPO_BASE_URL}/${JOB_NAME}/${POST_MERGE_SHA}/${ID}${VERSION_ID//./}
+
+# Print some data.
+greenprint "🧬 Using mock config: ${MOCK_CONFIG}"
+greenprint "📦 Post merge SHA: ${POST_MERGE_SHA}"
+greenprint "📤 RPMS will be uploaded to: ${REPO_URL}"
 
 # Build source RPMs.
+greenprint "🔧 Building source RPMs."
 make srpm
 make -C osbuild srpm
 
 # Fix RHEL 8 mock template for non-subscribed images.
-if [[ $NODE_NAME == "rhel82*" ]] || [[ $NODE_NAME == "rhel83*" ]]; then
+if [[ $NODE_NAME == *rhel8[23]* ]]; then
+    greenprint "📋 Updating RHEL 8 mock template for unsubscribed image"
     sudo curl --retry 5 -Lsko /etc/mock/templates/rhel-8.tpl \
         https://gitlab.cee.redhat.com/snippets/2208/raw
 fi
 
 # Compile RPMs in a mock chroot
+greenprint "🎁 Building RPMs with mock"
 sudo mock -r $MOCK_CONFIG --no-bootstrap-chroot \
     --resultdir $REPO_DIR --with=tests \
     rpmbuild/SRPMS/*.src.rpm osbuild/rpmbuild/SRPMS/*.src.rpm
 sudo chown -R $USER ${REPO_DIR}
 
 # Move the logs out of the way.
+greenprint "🧹 Retaining logs from mock build"
 mv ${REPO_DIR}/*.log $WORKSPACE
 
 # Create a repo of the built RPMs.
+greenprint "⛓️ Creating dnf repository"
 createrepo_c ${REPO_DIR}
 
 # Prepare to upload to swift.
+greenprint "🛂 Setting up OpenStack authentication credentials"
 mkdir -p ~/.config/openstack
 cp $OPENSTACK_CREDS ~/.config/openstack/clouds.yml
 export OS_CLOUD=psi
 
 # Upload repository to swift.
+greenprint "☁ Uploading RPMs to OpenStack object storage"
 pushd repo
     find * -type f -print | xargs openstack object create -f value $CONTAINER
 popd
+
+# Create a repository file.
+greenprint "📜 Generating dnf repository file"
+tee osbuild-mock.repo << EOF
+[osbuild-mock]
+name=osbuild mock ${JOB_NAME}-${POST_MERGE_SHA} ${ID}${VERSION_ID//./}
+baseurl=${REPO_URL}
+enabled=1
+gpgcheck=0
+# Default dnf repo priority is 99. Lower number means higher priority.
+priority=5
+EOF

--- a/schutzbot/run_tests.sh
+++ b/schutzbot/run_tests.sh
@@ -5,18 +5,8 @@ set -euxo pipefail
 source /etc/os-release
 
 # Set up a dnf repository for the RPMs we built via mock.
-sudo tee /etc/yum.repos.d/osbuild-mock.repo > /dev/null << EOF
-[osbuild-mock]
-name=osbuild mock ${BUILD_TAG} ${ID}${VERSION_ID//./}
-baseurl=${MOCK_REPO_BASE_URL}/${BUILD_TAG}/${ID}${VERSION_ID//./}
-enabled=1
-gpgcheck=0
-# Default dnf repo priority is 99. Lower number means higher priority.
-priority=5
-EOF
-
-# Verify that the repository we added is working properly.
-sudo dnf list all | grep osbuild-mock
+sudo cp osbuild-mock.repo /etc/yum.repos.d/osbuild-mock.repo
+dnf repository-packages osbuild-mock list
 
 # Create temporary directories for Ansible.
 sudo mkdir -vp /opt/ansible_{local,remote}


### PR DESCRIPTION
Store RPMs in object storage based on their SHA rather than the Jenkins
build ID. This allows tests to be re-run without repeating the mock
build step.

Signed-off-by: Major Hayden <major@redhat.com>