### PR TITLE
store: don't log if no logger was passed

### DIFF
--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -75,7 +75,7 @@ func New(stateDir *string, arch distro.Arch, log *log.Logger) *Store {
 	if stateDir != nil {
 		db = jsondb.New(*stateDir, 0600)
 		_, err := db.Read(StoreDBName, &storeStruct)
-		if err != nil {
+		if err != nil && log != nil {
 			log.Fatalf("cannot read state: %v", err)
 		}
 	}


### PR DESCRIPTION
`log` is `nil`, unless we are in verbose mode. Skip logging if no logger
was passed.

Long-term I think we should reconsider how we do our logging, and always
log these type of unexpected errors, and hence always have the logger be
non-nil. For now, fix the immediate problem.

The fact that loading the store from disk fails on upgrade is
unexpected, and should be fixed separately.

Fixes #685.

Signed-off-by: Tom Gundersen <teg@jklm.no>