### PR TITLE
internal: Fix golang panic on startup

### DIFF
--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -75,7 +75,7 @@ func New(stateDir *string, arch distro.Arch, log *log.Logger) *Store {
 	if stateDir != nil {
 		db = jsondb.New(*stateDir, 0600)
 		_, err := db.Read(StoreDBName, &storeStruct)
-		if err != nil {
+		if err != nil && log != nil {
 			log.Fatalf("cannot read state: %v", err)
 		}
 	}


### PR DESCRIPTION
This is due to a regression introduced in #594 and in commit
a22cd78eb35bde21aad2c682a7edd0fa3562b832

Fixes #685