### PR TITLE
osbuild-composer.spec: Add a dependency on osbuild-ostree

### DIFF
--- a/osbuild-composer.spec
+++ b/osbuild-composer.spec
@@ -49,6 +49,7 @@ BuildRequires:  golang(github.com/stretchr/testify/assert)
 Requires: osbuild-composer-worker
 Requires: systemd
 Requires: osbuild >= 15
+Requires: osbuild-ostree >= 15
 
 Provides: weldr
 


### PR DESCRIPTION
The new functionality that landed in b0cfec767ab3aba7a411e8ae3097f2af59c7a02d
needs this dependency in order to function.

Fixes #689