### PR TITLE
Fix the AWS_BUCKET check

### DIFF
--- a/schutzbot/run_tests.sh
+++ b/schutzbot/run_tests.sh
@@ -37,6 +37,7 @@ ansible-playbook \
   ansible-osbuild/playbook.yml
 
 # Run the tests.
+echo "The AWS_BUCKET env var is set to: ${AWS_BUCKET:-}"
 ansible-playbook \
   -e workspace=${WORKSPACE} \
   -e test_type=${TEST_TYPE:-base} \

--- a/schutzbot/test.yml
+++ b/schutzbot/test.yml
@@ -43,7 +43,7 @@
       when:
         - test_type == 'image'
         # Don't run the AWS test if the bucket env var is not set.
-        - (lookup('env', 'AWS_BUCKET') | default(false)) | bool
+        - lookup('env', 'AWS_BUCKET') | length > 0
 
     - name: Show failed and passed tests
       debug:


### PR DESCRIPTION
Ensure that AWS tests are run if the AWS_BUCKET environment variable is
set.

Signed-off-by: Major Hayden <major@redhat.com>