### PR TITLE
osbuild: change legacy type from bool to string

### DIFF
--- a/internal/distro/fedora31/distro.go
+++ b/internal/distro/fedora31/distro.go
@@ -44,6 +44,7 @@ type arch struct {
 	name               string
 	bootloaderPackages []string
 	buildPackages      []string
+	legacy             string
 	uefi               bool
 	imageTypes         map[string]imageType
 }
@@ -356,6 +357,7 @@ func New() *Fedora31 {
 		buildPackages: []string{
 			"grub2-pc",
 		},
+		legacy: "i386-pc",
 	}
 	x8664.setImageTypes(
 		amiImgType,
@@ -611,10 +613,15 @@ func (r *imageType) grub2StageOptions(kernelOptions string, kernel *blueprint.Ke
 		}
 	}
 
+	var legacy string
+	if !uefi {
+		legacy = r.arch.legacy
+	}
+
 	return &osbuild.GRUB2StageOptions{
 		RootFilesystemUUID: id,
 		KernelOptions:      kernelOptions,
-		Legacy:             !uefi,
+		Legacy:             legacy,
 		UEFI:               uefiOptions,
 	}
 }

--- a/internal/distro/fedora32/distro.go
+++ b/internal/distro/fedora32/distro.go
@@ -31,6 +31,7 @@ type architecture struct {
 	name               string
 	bootloaderPackages []string
 	buildPackages      []string
+	legacy             string
 	uefi               bool
 	imageTypes         map[string]imageType
 }
@@ -458,10 +459,15 @@ func (t *imageType) grub2StageOptions(kernelOptions string, kernel *blueprint.Ke
 		}
 	}
 
+	var legacy string
+	if !uefi {
+		legacy = t.arch.legacy
+	}
+
 	return &osbuild.GRUB2StageOptions{
 		RootFilesystemUUID: id,
 		KernelOptions:      kernelOptions,
-		Legacy:             !uefi,
+		Legacy:             legacy,
 		UEFI:               uefiOptions,
 	}
 }
@@ -777,6 +783,7 @@ func New() distro.Distro {
 		buildPackages: []string{
 			"grub2-pc",
 		},
+		legacy: "i386-pc",
 	}
 	x8664.setImageTypes(
 		iotImgType,

--- a/internal/distro/rhel8/distro.go
+++ b/internal/distro/rhel8/distro.go
@@ -30,6 +30,7 @@ type architecture struct {
 	name               string
 	bootloaderPackages []string
 	buildPackages      []string
+	legacy             string
 	uefi               bool
 	imageTypes         map[string]imageType
 }
@@ -465,10 +466,15 @@ func (t *imageType) grub2StageOptions(kernelOptions string, kernel *blueprint.Ke
 		}
 	}
 
+	var legacy string
+	if !uefi {
+		legacy = t.arch.legacy
+	}
+
 	return &osbuild.GRUB2StageOptions{
 		RootFilesystemUUID: id,
 		KernelOptions:      kernelOptions,
-		Legacy:             !uefi,
+		Legacy:             legacy,
 		UEFI:               uefiOptions,
 	}
 }
@@ -820,6 +826,7 @@ func New() distro.Distro {
 		buildPackages: []string{
 			"grub2-pc",
 		},
+		legacy: "i386-pc",
 	}
 	x8664.setImageTypes(
 		amiImgType,

--- a/internal/osbuild/grub2_stage.go
+++ b/internal/osbuild/grub2_stage.go
@@ -14,7 +14,7 @@ type GRUB2StageOptions struct {
 	RootFilesystemUUID uuid.UUID  `json:"root_fs_uuid"`
 	BootFilesystemUUID *uuid.UUID `json:"boot_fs_uuid,omitempty"`
 	KernelOptions      string     `json:"kernel_opts,omitempty"`
-	Legacy             bool       `json:"legacy"`
+	Legacy             string     `json:"legacy,omitempty"`
 	UEFI               *GRUB2UEFI `json:"uefi,omitempty"`
 }
 

--- a/internal/osbuild/stage_test.go
+++ b/internal/osbuild/stage_test.go
@@ -111,7 +111,7 @@ func TestStage_UnmarshalJSON(t *testing.T) {
 				},
 			},
 			args: args{
-				data: []byte(`{"name":"org.osbuild.grub2","options":{"root_fs_uuid":"00000000-0000-0000-0000-000000000000","legacy":false}}`),
+				data: []byte(`{"name":"org.osbuild.grub2","options":{"root_fs_uuid":"00000000-0000-0000-0000-000000000000"}}`),
 			},
 		},
 		{
@@ -126,7 +126,7 @@ func TestStage_UnmarshalJSON(t *testing.T) {
 				},
 			},
 			args: args{
-				data: []byte(`{"name":"org.osbuild.grub2","options":{"root_fs_uuid":"00000000-0000-0000-0000-000000000000","legacy":false,"uefi":{"vendor":"vendor"}}}`),
+				data: []byte(`{"name":"org.osbuild.grub2","options":{"root_fs_uuid":"00000000-0000-0000-0000-000000000000","uefi":{"vendor":"vendor"}}}`),
 			},
 		},
 		{
@@ -139,7 +139,7 @@ func TestStage_UnmarshalJSON(t *testing.T) {
 				},
 			},
 			args: args{
-				data: []byte(`{"name":"org.osbuild.grub2","options":{"root_fs_uuid":"00000000-0000-0000-0000-000000000000","boot_fs_uuid":"00000000-0000-0000-0000-000000000000","legacy":false}}`),
+				data: []byte(`{"name":"org.osbuild.grub2","options":{"root_fs_uuid":"00000000-0000-0000-0000-000000000000","boot_fs_uuid":"00000000-0000-0000-0000-000000000000"}}`),
 			},
 		},
 		{

--- a/test/cases/fedora_31-aarch64-ami-boot.json
+++ b/test/cases/fedora_31-aarch64-ami-boot.json
@@ -1992,7 +1992,6 @@
           "options": {
             "root_fs_uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
             "kernel_opts": "ro no_timer_check console=ttyS0,115200n8 console=tty1 biosdevname=0 net.ifnames=0 console=ttyS0,115200",
-            "legacy": false,
             "uefi": {
               "vendor": "fedora"
             }

--- a/test/cases/fedora_31-aarch64-openstack-boot.json
+++ b/test/cases/fedora_31-aarch64-openstack-boot.json
@@ -2052,7 +2052,6 @@
           "options": {
             "root_fs_uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
             "kernel_opts": "ro biosdevname=0 net.ifnames=0",
-            "legacy": false,
             "uefi": {
               "vendor": "fedora"
             }

--- a/test/cases/fedora_31-aarch64-qcow2-boot.json
+++ b/test/cases/fedora_31-aarch64-qcow2-boot.json
@@ -1988,7 +1988,6 @@
           "options": {
             "root_fs_uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
             "kernel_opts": "ro biosdevname=0 net.ifnames=0",
-            "legacy": false,
             "uefi": {
               "vendor": "fedora"
             }

--- a/test/cases/fedora_31-x86_64-ami-boot.json
+++ b/test/cases/fedora_31-x86_64-ami-boot.json
@@ -1993,7 +1993,7 @@
           "options": {
             "root_fs_uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
             "kernel_opts": "ro no_timer_check console=ttyS0,115200n8 console=tty1 biosdevname=0 net.ifnames=0 console=ttyS0,115200",
-            "legacy": true
+            "legacy": "i386-pc"
           }
         },
         {

--- a/test/cases/fedora_31-x86_64-openstack-boot.json
+++ b/test/cases/fedora_31-x86_64-openstack-boot.json
@@ -2053,7 +2053,7 @@
           "options": {
             "root_fs_uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
             "kernel_opts": "ro biosdevname=0 net.ifnames=0",
-            "legacy": true
+            "legacy": "i386-pc"
           }
         },
         {

--- a/test/cases/fedora_31-x86_64-qcow2-boot.json
+++ b/test/cases/fedora_31-x86_64-qcow2-boot.json
@@ -2013,7 +2013,7 @@
           "options": {
             "root_fs_uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
             "kernel_opts": "ro biosdevname=0 net.ifnames=0",
-            "legacy": true
+            "legacy": "i386-pc"
           }
         },
         {

--- a/test/cases/fedora_31-x86_64-vhd-boot.json
+++ b/test/cases/fedora_31-x86_64-vhd-boot.json
@@ -1910,7 +1910,7 @@
           "options": {
             "root_fs_uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
             "kernel_opts": "ro biosdevname=0 rootdelay=300 console=ttyS0 earlyprintk=ttyS0 net.ifnames=0",
-            "legacy": true
+            "legacy": "i386-pc"
           }
         },
         {

--- a/test/cases/fedora_31-x86_64-vmdk-boot.json
+++ b/test/cases/fedora_31-x86_64-vmdk-boot.json
@@ -1946,7 +1946,7 @@
           "options": {
             "root_fs_uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
             "kernel_opts": "ro biosdevname=0 net.ifnames=0",
-            "legacy": true
+            "legacy": "i386-pc"
           }
         },
         {

--- a/test/cases/fedora_32-x86_64-ami-boot.json
+++ b/test/cases/fedora_32-x86_64-ami-boot.json
@@ -1704,7 +1704,7 @@
           "options": {
             "root_fs_uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
             "kernel_opts": "ro no_timer_check console=ttyS0,115200n8 console=tty1 biosdevname=0 net.ifnames=0 console=ttyS0,115200",
-            "legacy": true
+            "legacy": "i386-pc"
           }
         },
         {

--- a/test/cases/fedora_32-x86_64-openstack-boot.json
+++ b/test/cases/fedora_32-x86_64-openstack-boot.json
@@ -1804,7 +1804,7 @@
           "options": {
             "root_fs_uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
             "kernel_opts": "ro biosdevname=0 net.ifnames=0",
-            "legacy": true
+            "legacy": "i386-pc"
           }
         },
         {

--- a/test/cases/fedora_32-x86_64-qcow2-boot.json
+++ b/test/cases/fedora_32-x86_64-qcow2-boot.json
@@ -1712,7 +1712,7 @@
           "options": {
             "root_fs_uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
             "kernel_opts": "ro biosdevname=0 net.ifnames=0",
-            "legacy": true
+            "legacy": "i386-pc"
           }
         },
         {

--- a/test/cases/fedora_32-x86_64-vhd-boot.json
+++ b/test/cases/fedora_32-x86_64-vhd-boot.json
@@ -1625,7 +1625,7 @@
           "options": {
             "root_fs_uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
             "kernel_opts": "ro biosdevname=0 rootdelay=300 console=ttyS0 earlyprintk=ttyS0 net.ifnames=0",
-            "legacy": true
+            "legacy": "i386-pc"
           }
         },
         {

--- a/test/cases/fedora_32-x86_64-vmdk-boot.json
+++ b/test/cases/fedora_32-x86_64-vmdk-boot.json
@@ -1653,7 +1653,7 @@
           "options": {
             "root_fs_uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
             "kernel_opts": "ro biosdevname=0 net.ifnames=0",
-            "legacy": true
+            "legacy": "i386-pc"
           }
         },
         {

--- a/test/cases/rhel_8-x86_64-ami-boot.json
+++ b/test/cases/rhel_8-x86_64-ami-boot.json
@@ -1899,7 +1899,7 @@
           "options": {
             "root_fs_uuid": "0bd700f8-090f-4556-b797-b340297ea1bd",
             "kernel_opts": "ro console=ttyS0,115200n8 console=tty0 net.ifnames=0 rd.blacklist=nouveau nvme_core.io_timeout=4294967295 crashkernel=auto",
-            "legacy": true
+            "legacy": "i386-pc"
           }
         },
         {

--- a/test/cases/rhel_8-x86_64-openstack-boot.json
+++ b/test/cases/rhel_8-x86_64-openstack-boot.json
@@ -2072,7 +2072,7 @@
           "options": {
             "root_fs_uuid": "0bd700f8-090f-4556-b797-b340297ea1bd",
             "kernel_opts": "ro net.ifnames=0",
-            "legacy": true
+            "legacy": "i386-pc"
           }
         },
         {

--- a/test/cases/rhel_8-x86_64-qcow2-boot.json
+++ b/test/cases/rhel_8-x86_64-qcow2-boot.json
@@ -2086,7 +2086,7 @@
           "options": {
             "root_fs_uuid": "0bd700f8-090f-4556-b797-b340297ea1bd",
             "kernel_opts": "console=ttyS0 console=ttyS0,115200n8 no_timer_check crashkernel=auto net.ifnames=0",
-            "legacy": true
+            "legacy": "i386-pc"
           }
         },
         {

--- a/test/cases/rhel_8-x86_64-vhd-boot.json
+++ b/test/cases/rhel_8-x86_64-vhd-boot.json
@@ -2039,7 +2039,7 @@
           "options": {
             "root_fs_uuid": "0bd700f8-090f-4556-b797-b340297ea1bd",
             "kernel_opts": "ro biosdevname=0 rootdelay=300 console=ttyS0 earlyprintk=ttyS0 net.ifnames=0",
-            "legacy": true
+            "legacy": "i386-pc"
           }
         },
         {

--- a/test/cases/rhel_8-x86_64-vmdk-boot.json
+++ b/test/cases/rhel_8-x86_64-vmdk-boot.json
@@ -1973,7 +1973,7 @@
           "options": {
             "root_fs_uuid": "0bd700f8-090f-4556-b797-b340297ea1bd",
             "kernel_opts": "ro net.ifnames=0",
-            "legacy": true
+            "legacy": "i386-pc"
           }
         },
         {


### PR DESCRIPTION
This work is based on previous PRs, namely:
https://github.com/osbuild/osbuild-composer/pull/501
and
https://github.com/osbuild/osbuild/pull/327

The problem here is that we used to treat legacy as a boolean before we
started introducing support for alternative architectures, but now we
need to specify exact strings for the grub2 stage, for example for
ppc64le the legacy parameter looks like this:

```
"legacy": "powerpc-ieee1275"
```

This patch will allow us to introduce support for ppc64le and fix
associated issues:
https://github.com/osbuild/osbuild-composer/issues/693