### PR TITLE
Let AWS figure out the image format during import

### DIFF
--- a/internal/upload/awsupload/awsupload.go
+++ b/internal/upload/awsupload/awsupload.go
@@ -114,7 +114,6 @@ func (a *AWS) Register(name, bucket, key string) (*string, error) {
 					S3Bucket: aws.String(bucket),
 					S3Key:    aws.String(key),
 				},
-				Format: aws.String("vhdx"),
 			},
 		},
 	)


### PR DESCRIPTION
Specifying the image format in the `DiskContainers` part of the snapshot
import process sometimes causes AWS to fail the import due to formatting
issues. However, AWS seems to do a decent job at determining the image
format on its own without specifying the format explicitly.

Signed-off-by: Major Hayden <major@redhat.com>