### PR TITLE
osbuild: introduce bootloader struct into qemu assembler

### DIFF
--- a/internal/osbuild/qemu_assembler.go
+++ b/internal/osbuild/qemu_assembler.go
@@ -9,6 +9,7 @@ import "github.com/google/uuid"
 // containing the indicated partitions. Finally, the image is converted into
 // the target format and stored with the given filename.
 type QEMUAssemblerOptions struct {
+	Bootloader *QEMUBootloader `json:"bootloader,omitempty"`
 	Format     string          `json:"format"`
 	Filename   string          `json:"filename"`
 	Size       uint64          `json:"size"`
@@ -31,6 +32,11 @@ type QEMUFilesystem struct {
 	UUID       string `json:"uuid"`
 	Label      string `json:"label,omitempty"`
 	Mountpoint string `json:"mountpoint"`
+}
+
+type QEMUBootloader struct {
+	Type     string `json:"type"`
+	Platform string `json:"platform"`
 }
 
 func (QEMUAssemblerOptions) isAssemblerOptions() {}


### PR DESCRIPTION
osbuild takes a "bootloader" object as an option to the qemu assembler:
https://github.com/osbuild/osbuild/blob/3f14ace5c1ac876555aab6e05aa6f0f8dbbe278b/assemblers/org.osbuild.qemu#L43
we don't use it because for x86_64 with enabled legacy support it
defaults to the right value:
https://github.com/osbuild/osbuild/blob/3f14ace5c1ac876555aab6e05aa6f0f8dbbe278b/assemblers/org.osbuild.qemu#L482
but in order to gain support for ppc64le we need to introduce this.
Example usage can be found in samples directory:
https://github.com/osbuild/osbuild/blob/3f14ace5c1ac876555aab6e05aa6f0f8dbbe278b/samples/f30-ppc64le.json#L819

This change itself does not alter osbuild-composer output.