### PR TITLE
tools: fix generate-test-case script

### DIFF
--- a/tools/test-case-generators/generate-test-case
+++ b/tools/test-case-generators/generate-test-case
@@ -41,9 +41,10 @@ def run_osbuild(manifest, store, output):
                     "--store", store,
                     "--output-directory", output,
                     "--json", "-"],
-                   check=True,
-                   encoding="utf-8",
-                   input=json.dumps(manifest))
+                    stdout=subprocess.DEVNULL,
+                    check=True,
+                    encoding="utf-8",
+                    input=json.dumps(manifest))
 
 
 def main(test_case, store):


### PR DESCRIPTION
Commit 8dd45544919961bf6d5d285a7fb6724ec0404e0f introduced a bug because
the output from osbuild is not captured. The problem is that osbuild
itself writes JSON document to STDOUT so two different JSON documents
are written to STDOUT: osbuild output and generated test case. The
generate-test-cases script then fails because it cannot json.loads() the
test case.

This patch simply supresses the output which fixes the issue.