### PR TITLE
osbuild: introduce zipl stage

### DIFF
--- a/internal/osbuild/zipl_stage.go
+++ b/internal/osbuild/zipl_stage.go
@@ -1,0 +1,25 @@
+package osbuild
+
+// The ZiplStageOptions describe how to create zipl stage
+//
+// The only configuration option available is a boot timeout and it is optional
+type ZiplStageOptions struct {
+	Timeout int `json:"timeout,omitempty"`
+}
+
+func (ZiplStageOptions) isStageOptions() {}
+
+// NewZiplStageOptions creates a new ZiplStageOptions object with no timeout
+func NewZiplStageOptions() *ZiplStageOptions {
+	return &ZiplStageOptions{
+		Timeout: 0,
+	}
+}
+
+// NewZiplStage creates a new zipl Stage object.
+func NewZiplStage(options *ZiplStageOptions) *Stage {
+	return &Stage{
+		Name:    "org.osbuild.zipl",
+		Options: options,
+	}
+}

--- a/internal/osbuild/zipl_stage_test.go
+++ b/internal/osbuild/zipl_stage_test.go
@@ -1,0 +1,24 @@
+package osbuild
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewZiplStageOptions(t *testing.T) {
+	expectedOptions := &ZiplStageOptions{
+		Timeout: 0,
+	}
+	actualOptions := NewZiplStageOptions()
+	assert.Equal(t, expectedOptions, actualOptions)
+}
+
+func TestNewZiplStage(t *testing.T) {
+	expectedStage := &Stage{
+		Name:    "org.osbuild.zipl",
+		Options: &ZiplStageOptions{},
+	}
+	actualStage := NewZiplStage(&ZiplStageOptions{})
+	assert.Equal(t, expectedStage, actualStage)
+}


### PR DESCRIPTION
zipl is a z initial program loader used with IBM Z systems. This stage
is required to get support for the s390x architecture.