### PR TITLE
tests/compose: use qcow2 rather than ami for tests

### DIFF
--- a/cmd/osbuild-tests/main_test.go
+++ b/cmd/osbuild-tests/main_test.go
@@ -46,7 +46,7 @@ func TestComposeCommands(t *testing.T) {
 	runComposer(t, "compose", "list", "failed")
 
 	// Full integration tests
-	uuid := buildCompose(t, "empty", "ami")
+	uuid := buildCompose(t, "empty", "qcow2")
 	defer deleteCompose(t, uuid)
 
 	runComposer(t, "compose", "info", uuid.String())
@@ -73,9 +73,13 @@ func TestComposeCommands(t *testing.T) {
 	defer os.Remove(uuid.String() + "-logs.tar")
 
 	runComposer(t, "compose", "image", uuid.String())
-	_, err = os.Stat(uuid.String() + "-image.vhdx")
-	require.NoError(t, err, "'%s-image.vhdx' not found", uuid.String())
-	defer os.Remove(uuid.String() + "-image.vhdx")
+	_, err = os.Stat(uuid.String() + "-disk.qcow2")
+	require.NoError(t, err, "'%s-disk.qcow2' not found", uuid.String())
+	defer os.Remove(uuid.String() + "-disk.qcow2")
+
+	// Check that reusing the cache works ok
+	uuid = buildCompose(t, "empty", "qcow2")
+	defer deleteCompose(t, uuid)
 
 	// https://github.com/osbuild/osbuild-composer/pull/180
 	// uuid = startCompose(t, "empty", "tar")


### PR DESCRIPTION
qcow2, unlike ami, is guaranteed to exist on all the architectures we
support.

Also, now that we preserve the cache, make two composes, rather than
just one. This verifies that nothing breaks horribly just because the
cache not being cold. The fact that we have a cache at all should make
this tolerably fast.

This should fix #693.

Signed-off-by: Tom Gundersen <teg@jklm.no>