### PR TITLE
osbuild: introduce kernel-cmdline stage

### DIFF
--- a/internal/osbuild/kernel_cmdline_stage.go
+++ b/internal/osbuild/kernel_cmdline_stage.go
@@ -1,0 +1,19 @@
+package osbuild
+
+// KernelCmdlineStageOptions describe how to create kernel-cmdline stage
+//
+// Configures the kernel boot parameters, also known as the kernel command line.
+type KernelCmdlineStageOptions struct {
+	RootFsUUID int `json:"root_fs_uuid,omitempty"`
+	KernelOpts int `json:"kernel_opts,omitempty"`
+}
+
+func (KernelCmdlineStageOptions) isStageOptions() {}
+
+// NewKernelCmdlineStage creates a new kernel-cmdline Stage object.
+func NewKernelCmdlineStage(options *KernelCmdlineStageOptions) *Stage {
+	return &Stage{
+		Name:    "org.osbuild.kernel-cmdline",
+		Options: options,
+	}
+}

--- a/internal/osbuild/kernel_cmdline_stage_test.go
+++ b/internal/osbuild/kernel_cmdline_stage_test.go
@@ -1,0 +1,16 @@
+package osbuild
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewKernelCmdlineStage(t *testing.T) {
+	expectedStage := &Stage{
+		Name:    "org.osbuild.kernel-cmdline",
+		Options: &KernelCmdlineStageOptions{},
+	}
+	actualStage := NewKernelCmdlineStage(&KernelCmdlineStageOptions{})
+	assert.Equal(t, expectedStage, actualStage)
+}


### PR DESCRIPTION
This stage can be used to set kernel boot parameters.