### PR TITLE
Re-enable RHEL 8.3 mock build

### DIFF
--- a/schutzbot/Jenkinsfile
+++ b/schutzbot/Jenkinsfile
@@ -65,21 +65,20 @@ pipeline {
                         )
                     }
                 }
-                // NOTE(mhayden): Disabling this for now since we don't have
-                // access to these repositories in AWS.
-                // stage('RHEL 8.3 Nightly') {
-                //     agent { label "rhel83 && psi" }
-                //     environment {
-                //         AWS_CREDS = credentials('aws-credentials-osbuildci')
-                //     }
-                //     steps {
-                //         sh "schutzbot/mockbuild.sh"
-                //         stash (
-                //             includes: 'osbuild-mock.repo',
-                //             name: 'rhel83'
-                //         )
-                //     }
-                // }
+                // NOTE(mhayden): RHEL 8.3 is only available in PSI for now.
+                stage('RHEL 8.3 Nightly') {
+                    agent { label "rhel83 && psi" }
+                    environment {
+                        AWS_CREDS = credentials('aws-credentials-osbuildci')
+                    }
+                    steps {
+                        sh "schutzbot/mockbuild.sh"
+                        stash (
+                            includes: 'osbuild-mock.repo',
+                            name: 'rhel83'
+                        )
+                    }
+                }
             }
         }
         stage("Functional Testing") {


### PR DESCRIPTION
Enabling the RHEL 8.3 mock build. More steps/tests can be added after this is merged.