### PR TITLE
Image info: support for analyzing ostree commits

### DIFF
--- a/tools/image-info
+++ b/tools/image-info
@@ -248,6 +248,13 @@ def append_filesystem(report, tree, *, is_ostree=False):
         with open(f"{tree}/etc/group") as f:
             report["groups"] = sorted(f.read().strip().split("\n"))
 
+        if is_ostree:
+            with open(f"{tree}/usr/lib/passwd") as f:
+                report["passwd-system"] = sorted(f.read().strip().split("\n"))
+
+            with open(f"{tree}/usr/lib/group") as f:
+                report["groups-system"] = sorted(f.read().strip().split("\n"))
+
         if os.path.exists(f"{tree}/boot") and len(os.listdir(f"{tree}/boot")) > 0:
             assert "bootmenu" not in report
             try:

--- a/tools/image-info
+++ b/tools/image-info
@@ -164,6 +164,11 @@ def rpm_verify(tree):
     }
 
 
+def rpm_packages(tree):
+    pkgs = subprocess_check_output(["rpm", "--root", tree, "-qa"], str.split)
+    return list(sorted(pkgs))
+
+
 def read_services(tree, state):
     return subprocess_check_output(["systemctl", f"--root={tree}", "list-unit-files"], (lambda s: parse_unit_files(s, state)))
 
@@ -190,7 +195,7 @@ def read_firewall_zone(tree):
 
 def append_filesystem(report, tree):
     if os.path.exists(f"{tree}/etc/os-release"):
-        report["packages"] = sorted(subprocess_check_output(["rpm", "--root", tree, "-qa"], str.split))
+        report["packages"] = rpm_packages(tree)
         report["rpm-verify"] = rpm_verify(tree)
 
         with open(f"{tree}/etc/os-release") as f:

--- a/tools/image-info
+++ b/tools/image-info
@@ -4,6 +4,7 @@ import argparse
 import contextlib
 import functools
 import glob
+import mimetypes
 import json
 import os
 import subprocess
@@ -361,6 +362,28 @@ def analyse_directory(path):
     return report
 
 
+def is_tarball(path):
+    mtype, encoding = mimetypes.guess_type(path)
+    return mtype == "application/x-tar"
+
+
+def analyse_tarball(path):
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tree = os.path.join(tmpdir, "root")
+        os.makedirs(tree)
+        command = [
+            "tar",
+            "-x",
+            "--auto-compress",
+            "-f", path,
+            "-C", tree
+        ]
+        subprocess.run(command,
+                       stdout=sys.stderr,
+                       check=True)
+        return analyse_directory(tree)
+
+
 def main():
     parser = argparse.ArgumentParser(description="Inspect an image")
     parser.add_argument("target",  help="The file or directory to analyse")
@@ -370,6 +393,8 @@ def main():
 
     if os.path.isdir(target):
         report = analyse_directory(target)
+    elif is_tarball(target):
+        report = analyse_tarball(target)
     else:
         report = analyse_image(target)
 

--- a/tools/image-info
+++ b/tools/image-info
@@ -1,5 +1,6 @@
 #!/usr/bin/python3
 
+import argparse
 import contextlib
 import glob
 import json
@@ -255,7 +256,9 @@ def find_esp(partitions):
     return None, 0
 
 
-def main(image):
+def analyse_image(image):
+    subprocess.run(["modprobe", "nbd"], check=True)
+
     report = {}
     with nbd_connect(image) as device:
         report["image-format"] = read_image_format(image)
@@ -279,8 +282,17 @@ def main(image):
 
     return report
 
-if __name__ == "__main__":
-    subprocess.run(["modprobe", "nbd"], check=True)
 
-    report = main(sys.argv[1])
+def main():
+    parser = argparse.ArgumentParser(description="Inspect an image")
+    parser.add_argument("target",  help="The file or directory to analyse")
+
+    args = parser.parse_args()
+    report = analyse_image(args.target)
+
     json.dump(report, sys.stdout, sort_keys=True, indent=2)
+
+
+if __name__ == "__main__":
+    main()
+

--- a/tools/image-info
+++ b/tools/image-info
@@ -2,6 +2,7 @@
 
 import argparse
 import contextlib
+import functools
 import glob
 import json
 import os
@@ -9,6 +10,17 @@ import subprocess
 import sys
 import tempfile
 import xml.etree.ElementTree
+
+
+def run_ostree(*args, _input=None, _check=True, **kwargs):
+    args = list(args) + [f'--{k}={v}' for k, v in kwargs.items()]
+    print("ostree " + " ".join(args), file=sys.stderr)
+    res = subprocess.run(["ostree"] + args,
+                         encoding="utf-8",
+                         stdout=subprocess.PIPE,
+                         input=_input,
+                         check=_check)
+    return res
 
 
 @contextlib.contextmanager
@@ -26,9 +38,9 @@ def nbd_connect(image):
 
 
 @contextlib.contextmanager
-def mount_at(device, mountpoint, options=[]):
+def mount_at(device, mountpoint, options=[], extra=[]):
     opts = ",".join(["ro"] + options)
-    subprocess.run(["mount", "-o", opts, device, mountpoint], check=True)
+    subprocess.run(["mount", "-o", opts] + extra + [device, mountpoint], check=True)
     try:
         yield mountpoint
     finally:
@@ -164,8 +176,11 @@ def rpm_verify(tree):
     }
 
 
-def rpm_packages(tree):
-    pkgs = subprocess_check_output(["rpm", "--root", tree, "-qa"], str.split)
+def rpm_packages(tree, is_ostree):
+    cmd = ["rpm", "--root", tree, "-qa"]
+    if is_ostree:
+        cmd += ["--dbpath", "/usr/share/rpm"]
+    pkgs = subprocess_check_output(cmd, str.split)
     return list(sorted(pkgs))
 
 
@@ -193,10 +208,11 @@ def read_firewall_zone(tree):
     return r
 
 
-def append_filesystem(report, tree):
+def append_filesystem(report, tree, *, is_ostree=False):
     if os.path.exists(f"{tree}/etc/os-release"):
-        report["packages"] = rpm_packages(tree)
-        report["rpm-verify"] = rpm_verify(tree)
+        report["packages"] = rpm_packages(tree, is_ostree)
+        if not is_ostree:
+            report["rpm-verify"] = rpm_verify(tree)
 
         with open(f"{tree}/etc/os-release") as f:
             report["os-release"] = parse_environment_vars(f.read())
@@ -288,12 +304,67 @@ def analyse_image(image):
     return report
 
 
+def append_directory(report, tree):
+    if os.path.lexists(f"{tree}/ostree"):
+        os.makedirs(f"{tree}/etc", exist_ok=True)
+        with mount_at(f"{tree}/usr/etc", f"{tree}/etc", extra=["--bind"]):
+            append_filesystem(report, tree, is_ostree=True)
+    else:
+        append_filesystem(report, tree)
+
+
+def append_ostree_repo(report, repo):
+    ostree = functools.partial(run_ostree, repo=repo)
+
+    r = ostree("config", "get", "core.mode")
+    report["ostree"] = {
+        "repo": {
+            "core.mode": r.stdout.strip()
+        }
+    }
+
+    r = ostree("refs")
+    refs = r.stdout.strip().split("\n")
+    resolved = {r: ostree("rev-parse", r).stdout.strip() for r in refs}
+    print(resolved)
+
+    commit = resolved[refs[0]]
+    report["ostree"]["refs"] = resolved
+    report["ostree"]["commit"] = commit
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tree = os.path.join(tmpdir, "tree")
+        ostree("checkout", "--force-copy", commit, tree)
+        append_directory(report, tree)
+
+
+def analyse_directory(path):
+    report = {}
+
+    if os.path.exists(os.path.join(path, "compose.json")):
+        report["type"] = "ostree/commit"
+        repo = os.path.join(path, "repo")
+        append_ostree_repo(report, repo)
+    elif os.path.isdir(os.path.join(path, "refs")):
+        report["type"] = "ostree/repo"
+        append_ostree_repo(report, repo)
+    else:
+        append_directory(report, path)
+
+    return report
+
+
 def main():
     parser = argparse.ArgumentParser(description="Inspect an image")
     parser.add_argument("target",  help="The file or directory to analyse")
 
     args = parser.parse_args()
-    report = analyse_image(args.target)
+    target = args.target
+
+    if os.path.isdir(target):
+        report = analyse_directory(target)
+    else:
+        report = analyse_image(target)
 
     json.dump(report, sys.stdout, sort_keys=True, indent=2)
 


### PR DESCRIPTION
See the individual commits for details, here an excerpt from the main one:

Support analyzing ostree repositories or directory that contain an ostree commit as created by osbuild. Will return the mode of the repository along with the references and their commits. For the first references, the commit is resolved and checked-out to a temp directory. This directory in turn is then analyzed via the existing append_filesystem function. The latter has gained some small ostree specific tweaks.
NB: for the ostree checkout /usr/etc/ is bind mounted to /etc in order to make append_filesystem happy. The rpm verification step is NOT run, because that is not really compatible with ostree.
