### PR TITLE
Fix image test VERSION_ID

### DIFF
--- a/schutzbot/run_image_tests.sh
+++ b/schutzbot/run_image_tests.sh
@@ -26,7 +26,7 @@ test_divider () {
 
 # Get the full test case name based on distro and architecture.
 get_full_test_case () {
-    echo "${IMAGE_TEST_CASES_PATH}/${ID}_${VERSION_ID}-$(uname -m)-${1}"
+    echo "${IMAGE_TEST_CASES_PATH}/${ID}_${VERSION_ID%.*}-$(uname -m)-${1}"
 }
 
 # Run a test case and store the result as passed or failed.


### PR DESCRIPTION
On RHEL, `VERSION_ID` shows up as `8.2` or `8.3`, but we need it to be
just `8`.

Remove the period and everything after it in `$VERSION_ID`.

Signed-off-by: Major Hayden <major@redhat.com>