### PR TITLE
worker: ensure that the reported result is always non-nil

### DIFF
--- a/cmd/osbuild-worker/main.go
+++ b/cmd/osbuild-worker/main.go
@@ -250,6 +250,15 @@ func main() {
 		// signal to WatchJob() that it can stop watching
 		cancel()
 
+		// Ensure we always have a non-nil result, composer doesn't like nils.
+		// This can happen in cases when OSBuild crashes and doesn't produce
+		// a meaningful output. E.g. when the machine runs of disk space.
+		if result == nil {
+			result = &common.ComposeResult{
+				Success: false,
+			}
+		}
+
 		err = client.UpdateJob(job, status, result)
 		if err != nil {
 			log.Fatalf("Error reporting job result: %v", err)


### PR DESCRIPTION
When osbuild crashes (e.g. when cp fails because of the machine running
out of disk space), it doesn't produce a machine-readable result. Due to
our suboptimal handling of the result struct (this is my fault), this can
lead to result == nil. However, composer expects that result != nil in all
cases because it uses the Success flag to assess the compose state. If
result == nil, it just crashes terribly.