### PR TITLE
image-types: link the Azure requirements

### DIFF
--- a/image-types/rhel8/microsoft-azure.md
+++ b/image-types/rhel8/microsoft-azure.md
@@ -1,7 +1,14 @@
 # Microsoft Azure Image
 
 This image is meant to be used in [Microsoft Azure][azure], a popular cloud
-computing platform. It conforms to Azure's requirements for images.
+computing platform. It conforms to Azure's [requirements for images][rhelrequirements].
+
+
+## Implementation Choices
+
+This image is only availble for `x86_64`, because it is the only architecture available
+in Azure.
 
 
 [azure]: https://azure.microsoft.com
+[rhelrequirements]: https://docs.microsoft.com/en-us/azure/virtual-machines/linux/create-upload-generic


### PR DESCRIPTION
This patch makes it easier to find the right document describing image
requirements for Linux VM images. It does not link the RHEL page
specifically because it is mainly for RHEL 6 and 7 whereas we build RHEL
8. It instead links documentation for generic Linux distribution.