### PR TITLE
spec: make the subpackages require a matching version of composer

### DIFF
--- a/golang-github-osbuild-composer.spec
+++ b/golang-github-osbuild-composer.spec
@@ -42,7 +42,7 @@ BuildRequires:  golang(github.com/google/go-cmp/cmp)
 BuildRequires:  golang(github.com/stretchr/testify)
 %endif
 
-Requires: golang-github-osbuild-composer-worker
+Requires: %{name}-worker = %{version}-%{release}
 Requires: systemd
 Requires: osbuild >= 17
 Requires: osbuild-ostree >= 17
@@ -161,7 +161,7 @@ export GOPATH=$PWD/_build:%{gopath}
 
 %package rcm
 Summary:    RCM-specific version of osbuild-composer
-Requires:   osbuild-composer
+Requires:   %{name} = %{version}-%{release}
 
 %description rcm
 RCM-specific version of osbuild-composer not intended for public usage.
@@ -209,7 +209,7 @@ systemctl stop "osbuild-worker@*.service" "osbuild-remote-worker@*.service"
 
 %package tests
 Summary:    Integration tests
-Requires:   osbuild-composer
+Requires:   %{name} = %{version}-%{release}
 Requires:   composer-cli
 Requires:   createrepo_c
 Requires:   genisoimage

--- a/osbuild-composer.spec
+++ b/osbuild-composer.spec
@@ -46,7 +46,7 @@ BuildRequires:  golang(github.com/google/go-cmp/cmp)
 BuildRequires:  golang(github.com/stretchr/testify/assert)
 %endif
 
-Requires: osbuild-composer-worker
+Requires: %{name}-worker = %{version}-%{release}
 Requires: systemd
 Requires: osbuild >= 17
 Requires: osbuild-ostree >= 17
@@ -177,7 +177,7 @@ export GOPATH=$PWD/_build:%{gopath}
 
 %package rcm
 Summary:    RCM-specific version of osbuild-composer
-Requires:   osbuild-composer
+Requires:   %{name} = %{version}-%{release}
 
 # remove in F34
 Obsoletes: golang-github-osbuild-composer-rcm < %{version}-%{release}
@@ -235,7 +235,7 @@ systemctl stop "osbuild-worker@*.service" "osbuild-remote-worker@*.service"
 
 %package tests
 Summary:    Integration tests
-Requires:   osbuild-composer
+Requires:   %{name} = %{version}-%{release}
 Requires:   composer-cli
 Requires:   createrepo_c
 Requires:   genisoimage


### PR DESCRIPTION
The subpackages are not really meant to be used with a different version of
the osbuild-composer package. This commit enforces.the usage of a matching
version in the spec file.