### PR TITLE
Print success log line after job is done

### DIFF
--- a/cmd/osbuild-worker/main.go
+++ b/cmd/osbuild-worker/main.go
@@ -244,6 +244,7 @@ func main() {
 				result = osbuildError.Result
 			}
 		} else {
+			log.Printf("  🎉 Job completed successfully: %s", job.Id)
 			status = common.IBFinished
 		}
 


### PR DESCRIPTION
We print messages to the log when the build fails, but we don't print
one when the build is successful.

I really want to celebrate our successes more often, so let's print a
success message when osbuild completes successfully. Since success
doesn't feel like success without an emoji, let's add one of those, too. 🎉

Signed-off-by: Major Hayden <major@redhat.com>