### PR TITLE
Remove 8.2 test case symlinks

### DIFF
--- a/test/cases/rhel_8.2-aarch64-tar-boot.json
+++ b/test/cases/rhel_8.2-aarch64-tar-boot.json
@@ -1,1 +1,0 @@
-rhel_8-aarch64-tar-boot.json

--- a/test/cases/rhel_8.2-ppc64le-tar-boot.json
+++ b/test/cases/rhel_8.2-ppc64le-tar-boot.json
@@ -1,1 +1,0 @@
-rhel_8-ppc64le-tar-boot.json

--- a/test/cases/rhel_8.2-s390x-tar-boot.json
+++ b/test/cases/rhel_8.2-s390x-tar-boot.json
@@ -1,1 +1,0 @@
-rhel_8-s390x-tar-boot.json

--- a/test/cases/rhel_8.2-x86_64-ami-boot.json
+++ b/test/cases/rhel_8.2-x86_64-ami-boot.json
@@ -1,1 +1,0 @@
-rhel_8-x86_64-ami-boot.json

--- a/test/cases/rhel_8.2-x86_64-openstack-boot.json
+++ b/test/cases/rhel_8.2-x86_64-openstack-boot.json
@@ -1,1 +1,0 @@
-rhel_8-x86_64-openstack-boot.json

--- a/test/cases/rhel_8.2-x86_64-qcow2-boot.json
+++ b/test/cases/rhel_8.2-x86_64-qcow2-boot.json
@@ -1,1 +1,0 @@
-rhel_8-x86_64-qcow2-boot.json

--- a/test/cases/rhel_8.2-x86_64-tar-boot.json
+++ b/test/cases/rhel_8.2-x86_64-tar-boot.json
@@ -1,1 +1,0 @@
-rhel_8-x86_64-tar-boot.json

--- a/test/cases/rhel_8.2-x86_64-vhd-boot.json
+++ b/test/cases/rhel_8.2-x86_64-vhd-boot.json
@@ -1,1 +1,0 @@
-rhel_8-x86_64-vhd-boot.json

--- a/test/cases/rhel_8.2-x86_64-vmdk-boot.json
+++ b/test/cases/rhel_8.2-x86_64-vmdk-boot.json
@@ -1,1 +1,0 @@
-rhel_8-x86_64-vmdk-boot.json


### PR DESCRIPTION
These symlinks are no longer needed now that the testing scripts have
been adjusted.

Signed-off-by: Major Hayden <major@redhat.com>