### PR TITLE
Pretty print osbuild JSON on failure

### DIFF
--- a/cmd/osbuild-image-tests/main_test.go
+++ b/cmd/osbuild-image-tests/main_test.go
@@ -63,7 +63,11 @@ func runOsbuild(manifest []byte, store, outputDirectory string) error {
 
 	err := cmd.Run()
 	if err != nil {
-		fmt.Println(outBuffer.String())
+		// Pretty print the osbuild error output.
+		buf := new(bytes.Buffer)
+		_ = json.Indent(buf, outBuffer.Bytes(), "", "    ")
+		fmt.Println(buf)
+
 		return fmt.Errorf("running osbuild failed: %v", err)
 	}
 


### PR DESCRIPTION
When osbuild fails, osbuild-composer's image tests print the output as
ugly JSON and that makes it difficult to determine why osbuild failed.

Instead, print the json in pretty format. 🌟

Fixes #782.

Signed-off-by: Major Hayden <major@redhat.com>