### PR TITLE
distro/{rhel8, fedora32}: no fstab for OSTree

### DIFF
--- a/internal/distro/fedora32/distro.go
+++ b/internal/distro/fedora32/distro.go
@@ -267,8 +267,6 @@ func (t *imageType) pipeline(c *blueprint.Customizations, options distro.ImageOp
 	if t.bootable {
 		p.AddStage(osbuild.NewFSTabStage(t.fsTabStageOptions(t.arch.uefi)))
 		p.AddStage(osbuild.NewGRUB2Stage(t.grub2StageOptions(t.kernelOptions, c.GetKernel(), t.arch.uefi)))
-	} else if t.rpmOstree {
-		p.AddStage(osbuild.NewFSTabStage(t.fsOstreeTabStageOptions()))
 	}
 
 	if services := c.GetServices(); services != nil || t.enabledServices != nil {
@@ -416,37 +414,6 @@ func (t *imageType) fsTabStageOptions(uefi bool) *osbuild.FSTabStageOptions {
 		options.AddFilesystem("46BB-8120", "vfat", "/boot/efi", "umask=0077,shortname=winnt", 0, 2)
 	}
 	return &options
-}
-
-func (t *imageType) fsOstreeTabStageOptions() *osbuild.FSTabStageOptions {
-	return &osbuild.FSTabStageOptions{
-		FileSystems: []*osbuild.FSTabEntry{
-			{
-				Label:   "root",
-				VFSType: "ext4",
-				Path:    "/",
-				Options: "defaults",
-				Freq:    1,
-				PassNo:  1,
-			},
-			{
-				Label:   "boot",
-				VFSType: "ext4",
-				Path:    "/boot",
-				Options: "defaults",
-				Freq:    1,
-				PassNo:  1,
-			},
-			{
-				Label:   "EFI-SYSTEM",
-				VFSType: "vfat",
-				Path:    "/boot/efi",
-				Options: "umask=0077,shortname=winnt",
-				Freq:    0,
-				PassNo:  2,
-			},
-		},
-	}
 }
 
 func (t *imageType) grub2StageOptions(kernelOptions string, kernel *blueprint.KernelCustomization, uefi bool) *osbuild.GRUB2StageOptions {

--- a/internal/distro/rhel8/distro.go
+++ b/internal/distro/rhel8/distro.go
@@ -243,8 +243,6 @@ func (t *imageType) pipeline(c *blueprint.Customizations, options distro.ImageOp
 		if t.arch.Name() != "s390x" {
 			p.AddStage(osbuild.NewGRUB2Stage(t.grub2StageOptions(t.kernelOptions, c.GetKernel(), t.arch.uefi)))
 		}
-	} else if t.rpmOstree {
-		p.AddStage(osbuild.NewFSTabStage(t.fsOstreeTabStageOptions()))
 	}
 
 	// TODO support setting all languages and install corresponding langpack-* package
@@ -438,37 +436,6 @@ func (t *imageType) fsTabStageOptions(uefi bool) *osbuild.FSTabStageOptions {
 		options.AddFilesystem("46BB-8120", "vfat", "/boot/efi", "umask=0077,shortname=winnt", 0, 2)
 	}
 	return &options
-}
-
-func (t *imageType) fsOstreeTabStageOptions() *osbuild.FSTabStageOptions {
-	return &osbuild.FSTabStageOptions{
-		FileSystems: []*osbuild.FSTabEntry{
-			{
-				Label:   "root",
-				VFSType: "ext4",
-				Path:    "/",
-				Options: "defaults",
-				Freq:    1,
-				PassNo:  1,
-			},
-			{
-				Label:   "boot",
-				VFSType: "ext4",
-				Path:    "/boot",
-				Options: "defaults",
-				Freq:    1,
-				PassNo:  1,
-			},
-			{
-				Label:   "EFI-SYSTEM",
-				VFSType: "vfat",
-				Path:    "/boot/efi",
-				Options: "umask=0077,shortname=winnt",
-				Freq:    0,
-				PassNo:  2,
-			},
-		},
-	}
 }
 
 func (t *imageType) grub2StageOptions(kernelOptions string, kernel *blueprint.KernelCustomization, uefi bool) *osbuild.GRUB2StageOptions {

--- a/test/cases/fedora_32-x86_64-fedora_iot_commit-boot.json
+++ b/test/cases/fedora_32-x86_64-fedora_iot_commit-boot.json
@@ -1,0 +1,10693 @@
+{
+  "compose-request": {
+    "distro": "fedora-32",
+    "arch": "x86_64",
+    "image-type": "fedora-iot-commit",
+    "repositories": [
+      {
+        "baseurl": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/",
+        "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBF1RVqsBEADWMBqYv/G1r4PwyiPQCfg5fXFGXV1FCZ32qMi9gLUTv1CX7rYy\nH4Inj93oic+lt1kQ0kQCkINOwQczOkm6XDkEekmMrHknJpFLwrTK4AS28bYF2RjL\nM+QJ/dGXDMPYsP0tkLvoxaHr9WTRq89A+AmONcUAQIMJg3JxXAAafBi2UszUUEPI\nU35MyufFt2ePd1k/6hVAO8S2VT72TxXSY7Ha4X2J0pGzbqQ6Dq3AVzogsnoIi09A\n7fYutYZPVVAEGRUqavl0th8LyuZShASZ38CdAHBMvWV4bVZghd/wDV5ev3LXUE0o\nitLAqNSeiDJ3grKWN6v0qdU0l3Ya60sugABd3xaE+ROe8kDCy3WmAaO51Q880ZA2\niXOTJFObqkBTP9j9+ZeQ+KNE8SBoiH1EybKtBU8HmygZvu8ZC1TKUyL5gwGUJt8v\nergy5Bw3Q7av520sNGD3cIWr4fBAVYwdBoZT8RcsnU1PP67NmOGFcwSFJ/LpiOMC\npZ1IBvjOC7KyKEZY2/63kjW73mB7OHOd18BHtGVkA3QAdVlcSule/z68VOAy6bih\nE6mdxP28D4INsts8w6yr4G+3aEIN8u0qRQq66Ri5mOXTyle+ONudtfGg3U9lgicg\nz6oVk17RT0jV9uL6K41sGZ1sH/6yTXQKagdAYr3w1ix2L46JgzC+/+6SSwARAQAB\ntDFGZWRvcmEgKDMyKSA8ZmVkb3JhLTMyLXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQI4BBMBAgAiBQJdUVarAhsPBgsJCAcDAgYVCAIJCgsEFgIDAQIeAQIXgAAK\nCRBsEwJtEslE0LdAD/wKdAMtfzr7O2y06/sOPnrb3D39Y2DXbB8y0iEmRdBL29Bq\n5btxwmAka7JZRJVFxPsOVqZ6KARjS0/oCBmJc0jCRANFCtM4UjVHTSsxrJfuPkel\nvrlNE9tcR6OCRpuj/PZgUa39iifF/FTUfDgh4Q91xiQoLqfBxOJzravQHoK9VzrM\nNTOu6J6l4zeGzY/ocj6DpT+5fdUO/3HgGFNiNYPC6GVzeiA3AAVR0sCyGENuqqdg\nwUxV3BIht05M5Wcdvxg1U9x5I3yjkLQw+idvX4pevTiCh9/0u+4g80cT/21Cxsdx\n7+DVHaewXbF87QQIcOAing0S5QE67r2uPVxmWy/56TKUqDoyP8SNsV62lT2jutsj\nLevNxUky011g5w3bc61UeaeKrrurFdRs+RwBVkXmtqm/i6g0ZTWZyWGO6gJd+HWA\nqY1NYiq4+cMvNLatmA2sOoCsRNmE9q6jM/ESVgaH8hSp8GcLuzt9/r4PZZGl5CvU\neldOiD221u8rzuHmLs4dsgwJJ9pgLT0cUAsOpbMPI0JpGIPQ2SG6yK7LmO6HFOxb\nAkz7IGUt0gy1MzPTyBvnB+WgD1I+IQXXsJbhP5+d+d3mOnqsd6oDM/grKBzrhoUe\noNadc9uzjqKlOrmrdIR3Bz38SSiWlde5fu6xPqJdmGZRNjXtcyJlbSPVDIloxw==\n=QWRO\n-----END PGP PUBLIC KEY BLOCK-----\n",
+        "check_gpg": true
+      }
+    ],
+    "filename": "commit.tar",
+    "blueprint": {}
+  },
+  "manifest": {
+    "sources": {
+      "org.osbuild.files": {
+        "urls": {
+          "sha256:0065bc128a5c8b08b57f92651bfa62895221a9f001f1169447a56a8a6671bbae": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/c/clevis-systemd-12-2.fc32.x86_64.rpm"
+          },
+          "sha256:00d0bb6a08f20bea2b6bd0d2c4de99b51c770b2dab266d1d3da85891efeded01": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/a/attr-2.4.48-8.fc32.x86_64.rpm"
+          },
+          "sha256:01173d218dccdf88c1159bba4af332ce703fc0dcd7171cd279cb3e16f12b30a9": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/g/grub2-common-2.04-12.fc32.noarch.rpm"
+          },
+          "sha256:024dd8a75eb5472692d0291292d25939b97a0295e5ab0958dcd22600d392eaae": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/r/rsync-3.1.3-11.fc32.x86_64.rpm"
+          },
+          "sha256:02654432f3853c9ae39c7601b5b0606c9d5eb5eef1d95e3e6f0074501842941f": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/p/python3-six-1.14.0-2.fc32.noarch.rpm"
+          },
+          "sha256:032e4944fe53dc7a11ae62d746579177a5c52b00a4ad5540da8221aa287fdf18": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/i/iwl1000-firmware-39.31.5.1-106.fc32.noarch.rpm"
+          },
+          "sha256:04152a3a608d022a58830c0e3dac0818e2c060469b0f41d8d731f659981a4464": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/n/ncurses-libs-6.1-15.20191109.fc32.x86_64.rpm"
+          },
+          "sha256:052d04c9a6697c6e5aa546546ae5058d547fc4a4f474d2805a3e45dbf69193c6": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libtasn1-4.16.0-1.fc32.x86_64.rpm"
+          },
+          "sha256:052ddc487a29acce1b5d44532f79f8ab594d0ac6565504071f4c7706d97fc552": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/g/gobject-introspection-1.64.1-1.fc32.x86_64.rpm"
+          },
+          "sha256:05efccb06aa336d2547eb8fd5b7e0935c883f89084688f32ce0b09954149b796": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/e/efivar-libs-37-7.fc32.x86_64.rpm"
+          },
+          "sha256:0608e0a9922e6748b39bd1719e2dabd6fe283b22cf590f1a3350327ae6c13561": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/c/containernetworking-plugins-0.8.5-1.1.gitf5c3d1b.fc32.x86_64.rpm"
+          },
+          "sha256:08c41c10745c172c34880e384cf5cff014a9627f4895e59fa482948b27e2ce9e": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/i/iptables-nft-1.8.4-7.fc32.x86_64.rpm"
+          },
+          "sha256:09fea9af8b695af862b19c1a8fbe1b1e8854257825ee4f663f67b3782a75d58a": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/f/fedora-gpg-keys-32-1.noarch.rpm"
+          },
+          "sha256:0b290954bc2868b3dfc976b2b7a13ea8aeade76eeafc17674ff8e721049a5bf7": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/p/python-unversioned-command-3.8.2-2.fc32.noarch.rpm"
+          },
+          "sha256:0b7cd6f6cb3b7cd9e0704dd6c62b65254b04cb870ab638b9bed4951564436e24": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/f/findutils-4.7.0-3.fc32.x86_64.rpm"
+          },
+          "sha256:0b7d24759aac33303ff4b101c111dea03ff2529efc95661140e22f629cc1ab7a": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/n/nftables-0.9.3-2.fc32.x86_64.rpm"
+          },
+          "sha256:0bace0cf41921db39247c99bfccb228818b83b68c7b8be7c8c4a92ea298a9a29": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/p/pkgconf-m4-1.6.3-3.fc32.noarch.rpm"
+          },
+          "sha256:0c6f4c1fbbdaf02014bf81726264e3301cbfe0ecda610765be11dbbfe99e34ae": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/i/iproute-tc-5.5.0-1.fc32.x86_64.rpm"
+          },
+          "sha256:0d51c1319ee78978e6ea5a49b815c2078b4ffd4d575e98c70e54ca01c3390eb8": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/o/openssh-8.2p1-2.fc32.x86_64.rpm"
+          },
+          "sha256:0d9d80adb91ccc8eed62bea68b23da5edb77675b1ec93227e2179d028449a2f7": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/p/python3-libcomps-0.1.14-4.fc32.x86_64.rpm"
+          },
+          "sha256:0e59b422e35eee975ba68e6e4de022c8f145feec7e169e86e0244d2fdad2f590": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libselinux-3.0-3.fc32.x86_64.rpm"
+          },
+          "sha256:0fc0193d95d69c780b6feb1cb74759ca2d4804701b3de936dac8429cfbe0f2e9": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/p/python3-nftables-0.9.3-2.fc32.x86_64.rpm"
+          },
+          "sha256:10883ce95852cc9ae9b4e0d435b100a25f8fe5c0ea4677eb4a0b39f4f8def886": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/lua-libs-5.3.5-7.fc32.x86_64.rpm"
+          },
+          "sha256:110f538d82f15f009d95e89d8c1e3669dc7358feb9aa7724301fef037f8b67fe": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/g/grub2-pc-2.04-12.fc32.x86_64.rpm"
+          },
+          "sha256:1110261787146443e089955912255d99daf7ba042c3743e13648a9eb3d80ceb4": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/f/filesystem-3.14-2.fc32.x86_64.rpm"
+          },
+          "sha256:116b9d121fad9886f245cd5e1ef678fdba889cd23a39e91447e75649214a6a8d": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/c/cpio-2.13-4.fc32.x86_64.rpm"
+          },
+          "sha256:11d6aa88c7e5bbaad38353bbb557ad8370452cd258f2a0d16bfd490116138d67": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/d/dracut-network-050-26.git20200316.fc32.x86_64.rpm"
+          },
+          "sha256:129adf9147d5d120546ca8e0fb5f165761106d386d366fe82591e372754d0b4a": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/p/python3-decorator-4.4.0-6.fc32.noarch.rpm"
+          },
+          "sha256:129d919e55c09edecaa8edd0fd4058dbf7460aaae5d1c5625ca11f6df7defefe": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/g/glibc-all-langpacks-2.31-2.fc32.x86_64.rpm"
+          },
+          "sha256:136a9cbae9c225be60718fdc8cc8988a55235d6502e451df77d1c5c765143850": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/r/rpm-4.15.1-2.fc32.1.x86_64.rpm"
+          },
+          "sha256:13a0c9c767f71164cc678ee36d89b7fddcdd6fb8243e3daf8b47cca0d1d14c4f": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/g/gpgme-1.13.1-6.fc32.x86_64.rpm"
+          },
+          "sha256:140708561a2ec1c7709fd38d8b1b115d02da710b80eeecd65c2b8387d9d78ef9": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/z/zchunk-libs-1.1.5-2.fc32.x86_64.rpm"
+          },
+          "sha256:1446032720fb8e0090190828fcea294a86fc7f83edd70f6089e3446770ba0438": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libselinux-utils-3.0-3.fc32.x86_64.rpm"
+          },
+          "sha256:14bd7e305e13795e0d37c613dfa3ead3a3219d28c32b27ad6527d3592361923d": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libftdi-1.4-2.fc32.x86_64.rpm"
+          },
+          "sha256:14cf772225c04c005add71372fce866e90f7144c27bbb8e846ce7887e0d286e0": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/s/slirp4netns-0.4.3-6.0.dev.gita8414d1.fc32.x86_64.rpm"
+          },
+          "sha256:150815dd62da40fee60ad5ceb988938c3be01e03aa54a025772b33a7a2c11311": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/k/kernel-tools-libs-5.6.6-300.fc32.x86_64.rpm"
+          },
+          "sha256:156709efeaa1dfac72cc189d7e99de12d7c4b2069445da5d34fa807582e85719": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/p/passwd-0.80-8.fc32.x86_64.rpm"
+          },
+          "sha256:15f08ce979e48fd25be5e16d63d1c95c57f9abff7704005137ea00b958442939": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/p/pigz-2.4-6.fc32.x86_64.rpm"
+          },
+          "sha256:15f2fc89b7bd39dcd3f6f8db30f56b76b65df311d7ad9852d498fbbc5c7d2aa2": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/p/python3-policycoreutils-3.0-2.fc32.noarch.rpm"
+          },
+          "sha256:15f70393f706ea0ac6c622563268d9c00509ef376e3e087c1c05007b49894ee9": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/linux-firmware-whence-20200316-106.fc32.noarch.rpm"
+          },
+          "sha256:178e4470a6dfca84ec133932606737bfe167094560bf473940504c511354ddc9": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/g/gmp-6.1.2-13.fc32.x86_64.rpm"
+          },
+          "sha256:1830b4aa42ef492c13b62f63fe941970869ba19bd9abde4dea5c97f9e38ffd68": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libblkid-2.35.1-7.fc32.x86_64.rpm"
+          },
+          "sha256:187dd61be71efcca6adf9819a523d432217abb335afcb2b95ef27b72928aff4b": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/d/diffutils-3.7-4.fc32.x86_64.rpm"
+          },
+          "sha256:1a2f22eed83ef568021c464cce841ef98725b614093f2c518307e85d5b6e759b": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/i/iwd-1.6-1.fc32.x86_64.rpm"
+          },
+          "sha256:1aee865249b031e591a5e94d62d05b69ad1a6118a26adccf2dfd46b0002716e5": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/c/cracklib-dicts-2.9.6-22.fc32.x86_64.rpm"
+          },
+          "sha256:1b05dd5abad5a31380c859bc33e7851158c24333fda837ca9facf869005f81fe": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libksba-1.3.5-11.fc32.x86_64.rpm"
+          },
+          "sha256:1bc0542cf8a3746d0fe25c397a93c8206963f1f287246c6fb864eedfc9ffa4a7": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libcap-2.26-7.fc32.x86_64.rpm"
+          },
+          "sha256:1bdde5dc99a5588a8983f70b7b3e45e7006215d529c72adfec118c3bcbf7b01c": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/x/xz-5.2.5-1.fc32.x86_64.rpm"
+          },
+          "sha256:1c68255945533ed4e3368125bc46e19f3fe348d7ec507a85a35038dbb976003f": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libmnl-1.0.4-11.fc32.x86_64.rpm"
+          },
+          "sha256:1de2be4fe5280ec3097305d9e671f5f2c768267f90d255edf2075eecb0c0afe9": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/s/systemd-245.4-1.fc32.x86_64.rpm"
+          },
+          "sha256:1ec84749250a0095d645f11fa0dcdf8c4500e0bbc303af696762a12616375757": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/g/greenboot-reboot-0.9-1.fc32.noarch.rpm"
+          },
+          "sha256:1f2ba0fc562864ad1bea31a42da124030fc188d23a84d144be616c2d066e1531": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/f/fedora-release-32-1.noarch.rpm"
+          },
+          "sha256:20787251df57a108bbf9c40e30f041b71ac36c8a10900fb699e574ee7e259bf2": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libidn2-2.3.0-2.fc32.x86_64.rpm"
+          },
+          "sha256:213c17fb822ffa50fad16989ed363aa023de106c6262ccc3f16e52a154b7133f": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/d/dbus-broker-22-1.fc32.x86_64.rpm"
+          },
+          "sha256:2141f1dec8fe7a442c061f603bf4ee6203e10a290990789af0f4ef9db5523679": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/b/bluez-mesh-5.54-1.fc32.x86_64.rpm"
+          },
+          "sha256:21e3fd914a3bcc65b79de022782967903c55a4aed9a3c7d3464bc2fef32d02b3": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/f/fedora-repos-32-1.noarch.rpm"
+          },
+          "sha256:22d311f22902d592f72bd0fb4010a682f796e5a4698d5ea209848468a2d5aa96": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/a/audit-libs-3.0-0.19.20191104git1c2f876.fc32.x86_64.rpm"
+          },
+          "sha256:2434cd04a437c06f59d67ee2580443c0ba676c39440cd0f74cca768ec57577f9": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libluksmeta-9-7.fc32.x86_64.rpm"
+          },
+          "sha256:251fd875421da4708b76c15c7f5ba478d50b74d7e4242071a621625eac51a767": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libsecret-0.20.2-2.fc32.x86_64.rpm"
+          },
+          "sha256:25fc5d288536e1973436da38357690575ed58e03e17ca48d2b3840364f830659": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/n/ncurses-base-6.1-15.20191109.fc32.noarch.rpm"
+          },
+          "sha256:26db62c2bc52c3eee5f3039cdbdf19498f675d0f45aec0c2a1c61c635f01479e": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/e/e2fsprogs-libs-1.45.5-3.fc32.x86_64.rpm"
+          },
+          "sha256:27701cda24f5f6386e0173745aabc4f6df28052975e73529854432c35399cfc8": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libss-1.45.5-3.fc32.x86_64.rpm"
+          },
+          "sha256:27dd9c78e41c04b5151a2b9ac150d3ebb89f2ca7a23e4896dfc718f19a000be3": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/r/rpm-plugin-selinux-4.15.1-2.fc32.1.x86_64.rpm"
+          },
+          "sha256:28656826cb0dfbae9b6e8d1e5c5691773d84000493c4be47f727092fec6dc6f4": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/f/file-5.38-2.fc32.x86_64.rpm"
+          },
+          "sha256:28d1118b3debda3daee76fc89f250576627a28b3ec39069256ddc212d993ddbc": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/c/container-selinux-2.130.0-1.fc32.noarch.rpm"
+          },
+          "sha256:28f4bcbf53258114ebbf0a167351d67e204ff6f717b49b3893c2372845e6bd0a": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/i/iptables-1.8.4-7.fc32.x86_64.rpm"
+          },
+          "sha256:29d7df69d66f51f6dddd637d3f599e70bdaa9bd476669002250bc038735a318c": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/u/unbound-libs-1.9.6-2.fc32.x86_64.rpm"
+          },
+          "sha256:29e2b62e9e63f25139a6863c863c3b534660440d7dec0c985807302a6895dbaf": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libsepol-3.0-3.fc32.x86_64.rpm"
+          },
+          "sha256:2b098bc6f8004270ee9eac9f63980b364b5fe19394dc73a230b3c846cf488b1b": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/m/mpfr-4.0.2-3.fc32.x86_64.rpm"
+          },
+          "sha256:2b783576612dcf10ab151fee03084f8ae1667c044a9e2e9404a2a139e7c6c884": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/less-551-3.fc32.x86_64.rpm"
+          },
+          "sha256:2cee64e12b295b74d2f4b008c7628ef3a01ef4149905fc4a7ae14b304da5f53b": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/t/tar-1.32-4.fc32.x86_64.rpm"
+          },
+          "sha256:2db6d80760ab0e99f4e9c9816615e4f06b967bbb23a8c8c941b3f2d4b5f176c2": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/t/tzdata-2019c-3.fc32.noarch.rpm"
+          },
+          "sha256:2fa5e252441852dae918b522a2ff3f46a5bbee4ce8936e06702bf65f57d7ff99": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/e/e2fsprogs-1.45.5-3.fc32.x86_64.rpm"
+          },
+          "sha256:30c5f02ed28d59a4d72e020097602091bb8e34d65a6f3be69f4b1dd63a46f892": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/c/containers-common-0.1.41-1.fc32.x86_64.rpm"
+          },
+          "sha256:3151132084577032b4c827eb577a1509950601888c6ff13a0a30b24252ee26d2": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/r/rpm-build-libs-4.15.1-2.fc32.1.x86_64.rpm"
+          },
+          "sha256:317654c97a9dc11fe498b61d4189ff31cd1277250993d826e9bc5815d0485f29": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/f/flashrom-1.2-2.fc32.x86_64.rpm"
+          },
+          "sha256:32f8cbb3be91f589d569a2e737130f29c752f78eebc61e287af17f207e1b8c58": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libssh-0.9.3-2.fc32.x86_64.rpm"
+          },
+          "sha256:3343d9e7c90bd58e1e44ee07e7c59bb570ffc74da50f0607c5f5681a00b70e76": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/o/ostree-libs-2020.3-2.fc32.x86_64.rpm"
+          },
+          "sha256:334d63914e7ff6fe8cfce0c8f80006c6cf2ab0615cd044a6ee588809395499e5": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/s/systemd-udev-245.4-1.fc32.x86_64.rpm"
+          },
+          "sha256:342bdf0143d9145f8846e1b5c3401685e0d1274b66df39ac8cbfb78013313861": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/n/NetworkManager-1.22.10-1.fc32.x86_64.rpm"
+          },
+          "sha256:34411604a91c301dc8489285065c68f3a2f50910717097fedcaade6481c7469e": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/p/python3-gobject-base-3.36.0-2.fc32.x86_64.rpm"
+          },
+          "sha256:349af433b2f6d45ff2e1ea5a38f847ec692fef0a8dd656a9a07d423a981946d0": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/g/gettext-0.20.1-4.fc32.x86_64.rpm"
+          },
+          "sha256:355a095bb3c6d58f927277ff53267f88eb0729adbcafd8082b8d97e4815ee206": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/p/python3-rpm-4.15.1-2.fc32.1.x86_64.rpm"
+          },
+          "sha256:3589b982ac0c2f5f6b47cde5cb7ec33c2c01d756dabf8c4ca64f6d9d0d78b35e": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/p/p11-kit-trust-0.23.20-1.fc32.x86_64.rpm"
+          },
+          "sha256:397f0b024d3c58ca6e174c6de5abcb19304d7c58903199e1e6fe02e84d5bcb3a": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/g/gdisk-1.0.5-1.fc32.x86_64.rpm"
+          },
+          "sha256:398ce75ffc673f048ffd47d417b17ef086abc43f318b2b77d2869095ec764d57": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/c/chrony-3.5-8.fc32.x86_64.rpm"
+          },
+          "sha256:39961756e07f6f49ddf2ff277dc04a63fa4d5b4fb035480945bd2f665ba1dd4d": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libell-0.30-1.fc32.x86_64.rpm"
+          },
+          "sha256:3ab2173d9d4016febcdaf283408f9939d0a7b2fdba3e46a2d45fbef88a1463a0": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/g/greenboot-status-0.9-1.fc32.noarch.rpm"
+          },
+          "sha256:3afab9512fd4d56a13c95b530c805ac8b2bc872572ec5bb435eccdd59fbbc8b6": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libnftnl-1.1.5-2.fc32.x86_64.rpm"
+          },
+          "sha256:3b4ce7fc4e2778758881feedf6ea19b65e99aa3672e19a7dd62977efe3b910b9": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libnsl2-1.2.0-6.20180605git4a062cf.fc32.x86_64.rpm"
+          },
+          "sha256:3b76bc46dd279404408d34946cfdb0c3899359a1c6b48e614e63d1259a94262a": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/lvm2-2.03.09-1.fc32.x86_64.rpm"
+          },
+          "sha256:3be681b78e919bfd82eb186c7393718f1d37abd0b1bb8b1a8571aefa11e7a248": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/k/kbd-legacy-2.2.0-1.fc32.noarch.rpm"
+          },
+          "sha256:3c2a641f118ab2e8b08df6dd2da72a60121d02df8d932b4afa2920eb80392875": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/n/npth-1.6-4.fc32.x86_64.rpm"
+          },
+          "sha256:3cd56dea57c00e2c4a9d5aac69a1e843ebef581ba76dde9d9878082fa1215485": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/p/policycoreutils-python-utils-3.0-2.fc32.noarch.rpm"
+          },
+          "sha256:3d33c29bcc4a39be16d6647a70a0d7ae2f08baf26dcea5c802289df1128d5f21": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libreport-filesystem-2.12.0-3.fc32.noarch.rpm"
+          },
+          "sha256:3f2cb9092d6f55f84dd9eacd5359dfb354772e5f38308328027c7758f4a06fb6": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/o/openssl-pkcs11-0.4.10-5.fc32.x86_64.rpm"
+          },
+          "sha256:3f7861ea2d8b4380b567f629a86fa31951a55f46f6eee017cb84ed87baf2c19e": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/z/zram-0.4-1.fc32.noarch.rpm"
+          },
+          "sha256:3f8dcae27ad3609b7de298d0ca8d34a2790b9898f5f1b03f3f9f8784374e307b": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/c/crypto-policies-20191128-5.gitcd267a5.fc32.noarch.rpm"
+          },
+          "sha256:3f9c95f3827b785f49ac4a270d4c3a703dceba673c452838744ec5064cf43cbd": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/k/kmod-27-1.fc32.x86_64.rpm"
+          },
+          "sha256:42fcfac5037eab4099648e0f0ed3eb2aec6eb6a23a9e3808f9b69619ea7c44e3": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/n/nss-altfiles-2.18.1-16.fc32.x86_64.rpm"
+          },
+          "sha256:431d836b2be015212d8c15b4290d5ce5bb45282cbf3fc52696f632d84ce34dfe": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libdb-utils-5.3.28-40.fc32.x86_64.rpm"
+          },
+          "sha256:4375c398dff722a29bd1700bc8dc8b528345412d1e17d8d9d1176d9774962957": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/lzo-2.10-2.fc32.x86_64.rpm"
+          },
+          "sha256:4494013eac1ad337673f084242aa8ebffb4a149243475b448bee9266401f2896": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libcom_err-1.45.5-3.fc32.x86_64.rpm"
+          },
+          "sha256:449d2888d6b835d207a55a2d9b4478eff1b926581fcead6260b6508e4db1b782": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/c/compat-readline5-5.2-36.fc32.x86_64.rpm"
+          },
+          "sha256:44cfb58b368fba586981aa838a7f3974ac1d66d2b3b695f88d7b1d2e9c81a0b6": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/lz4-libs-1.9.1-2.fc32.x86_64.rpm"
+          },
+          "sha256:44fabecae31a5900fe10837863ed231303f6863bd9fa5efa40a93a0fc059344f": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/p/python3-libdnf-0.45.0-3.fc32.x86_64.rpm"
+          },
+          "sha256:45132e53c649def28d63c199d8c3a3b9fd16fa8bca7426ad4e9c202e52a233b4": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/f/fuse-common-3.9.1-1.fc32.x86_64.rpm"
+          },
+          "sha256:4546444c0647efaa8fa8bf604ace7f7dbd152e74761b8d7a11fa185bc72bece8": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/g/greenboot-rpm-ostree-grub2-0.9-1.fc32.noarch.rpm"
+          },
+          "sha256:45fc2608b746fd841dd25919e9e4d44834154758aec8fb8b529c014b11c7917d": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/o/os-prober-1.77-4.fc32.x86_64.rpm"
+          },
+          "sha256:4659e7b76850ce5dedbe80fb0a64947e83f15f907b35c5819d91be6ed0523653": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/i/iwl3160-firmware-25.30.13.0-106.fc32.noarch.rpm"
+          },
+          "sha256:474fd088c7e7234221d251153e9fda6081b0aa8979bf5ae25810c9862e1e9960": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/d/dbus-libs-1.12.16-4.fc32.x86_64.rpm"
+          },
+          "sha256:47538b1db9720be4699329a8da32d873187d0c6c22f45252614ac5b8a8312482": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/f/firewalld-filesystem-0.8.2-2.fc32.noarch.rpm"
+          },
+          "sha256:475b6de876914aec2187ac4858a13ae75585f5c4cb5d739c637f79a5ca6f05f9": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/q/qemu-img-4.2.0-7.fc32.x86_64.rpm"
+          },
+          "sha256:4819b3ce25b997d8d3e5e4e4be4ba270e8b66852576b474daf0e6d61b6e22d73": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/d/dracut-config-generic-050-26.git20200316.fc32.x86_64.rpm"
+          },
+          "sha256:48cf5ab32f6af8f2283d4d4834e8dd262aa412be7ea07c2292483e150d614bef": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libgcc-10.0.1-0.11.fc32.x86_64.rpm"
+          },
+          "sha256:49bac21d5cdf863fccfcc32bf070e582d204706e35ee9f60b3e69df694bff87d": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libssh-config-0.9.3-2.fc32.noarch.rpm"
+          },
+          "sha256:4a7b63b32f176b8861f6ac7363bc8010caea0c323eaa83167227118f05603022": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/p/pkgconf-pkg-config-1.6.3-3.fc32.x86_64.rpm"
+          },
+          "sha256:4c80ade4ac0889316930a8d181ea43fa2d1b2f1a6a5703c22f2b3ba191346eec": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/p/pam-1.3.1-24.fc32.x86_64.rpm"
+          },
+          "sha256:4cd01a3135b9e72906eaf4552e29929334dcccee2ed092a38bf60698522ecd5f": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/r/rng-tools-6.9-3.fc32.x86_64.rpm"
+          },
+          "sha256:4dd6100e477d88a4987b6eebfddecff168f38c7ff47cbb12f2fecba1e87c10d9": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/s/shadow-utils-4.8.1-2.fc32.x86_64.rpm"
+          },
+          "sha256:4eb6a2e34173a2b6ca7db031cecce56c0bed711691abf1c8d6bfe6cb7ca45dc0": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libmbim-utils-1.22.0-1.fc32.x86_64.rpm"
+          },
+          "sha256:4f318cec61cb69fc233ba5505b7e24f679afdfb0b5defbaef507f1b471e7dbb5": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/e/elfutils-debuginfod-client-0.179-1.fc32.x86_64.rpm"
+          },
+          "sha256:4f4ef59861c0566d22bd76369d22369d43130f5ccdb35a5fc2c8a236cf33651f": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libndp-1.7-5.fc32.x86_64.rpm"
+          },
+          "sha256:4fca21cfdcbed052e3e9e1eff74c22fb8ffb1fbbeb63e87e2aa540e43a8c0d09": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/v/vim-minimal-8.2.525-1.fc32.x86_64.rpm"
+          },
+          "sha256:517ff9662e5a1897b74f4ab4fbc8a88eccaad9880bc18be9cf4df6aba9824bd5": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/p/python3-unbound-1.9.6-2.fc32.x86_64.rpm"
+          },
+          "sha256:52fe378ffab317ec4d26ae5fc0389dec874002a8d70a9413cefb68c7b16b0612": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/p/protobuf-c-1.3.2-2.fc32.x86_64.rpm"
+          },
+          "sha256:5323eb8d89b2d0c905a633513e04ca7df633c21eec288ee8c50f3f5170534e37": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/c/coreutils-common-8.32-3.fc32.1.x86_64.rpm"
+          },
+          "sha256:536a157da5332c0bdacb3e5891e3012b79b18fcdedb63b393110d6eb8b04e428": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/p/podman-plugins-1.8.2-2.fc32.x86_64.rpm"
+          },
+          "sha256:53992752850779218421994f61f1589eda5d368e28d340dccaae3f67de06e7f2": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/f/fuse-libs-2.9.9-9.fc32.x86_64.rpm"
+          },
+          "sha256:53f1e8570b175e8b58895646df6d8068a7e1f3cb1bafdde714ddd038bcf91e85": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/g/gzip-1.10-2.fc32.x86_64.rpm"
+          },
+          "sha256:54b740cf7a75a7215168970378d9a1d6b9a5e4eb81159a874ce8ea5990436641": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/r/rpm-libs-4.15.1-2.fc32.1.x86_64.rpm"
+          },
+          "sha256:54cb827278ae474cbab1f05e0fbee0355bee2674d46a804f1c2b78ff80a48caa": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libsemanage-3.0-3.fc32.x86_64.rpm"
+          },
+          "sha256:55bafcdf9c31b1456af3bf584bfe7ac745a03f4decd17197ea97b498d68b3b82": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/p/python3-libsemanage-3.0-3.fc32.x86_64.rpm"
+          },
+          "sha256:56187c1c980cc0680f4dbc433ed2c8507e7dc9ab00000615b63ea08c086b7ab2": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/k/kmod-libs-27-1.fc32.x86_64.rpm"
+          },
+          "sha256:598a136b7027cb9b4fef6bfa34715979d41c2f62c9d8bec5d50b633a17790f7b": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libassuan-2.5.3-3.fc32.x86_64.rpm"
+          },
+          "sha256:599549d72d26b48c45156585a5698898c853e56469142e202d3749b781428465": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libsss_idmap-2.2.3-13.fc32.x86_64.rpm"
+          },
+          "sha256:59be778afcf464d79f7dc440d6b49de8a9527fd73e7b514573d389bf8a51b246": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/c/criu-3.13-5.fc32.x86_64.rpm"
+          },
+          "sha256:5a4c0187b96690e0088057f7656c67d399fad44b28b86644e3434c581377c229": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libproxy-0.4.15-17.fc32.x86_64.rpm"
+          },
+          "sha256:5ad0d1b4e641e5d2fe7f6385ace0f827a431c5a52c6dc3516d85e655caca880f": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libqmi-1.24.8-1.fc32.x86_64.rpm"
+          },
+          "sha256:5b8a205f3d4bde162e01a821fdacbc10ebfa01b88ec61b166b4b6317c45910c4": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/linux-firmware-20200316-106.fc32.noarch.rpm"
+          },
+          "sha256:5c91890bf33527b9fb422cbed17600e761750a4e596fad3f0d0fa419070e82b0": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/p/pkgconf-1.6.3-3.fc32.x86_64.rpm"
+          },
+          "sha256:5d520576b7ac63cb029c4b0b86398e2b71589df3bafa618018b3729d81036203": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/c/clevis-dracut-12-2.fc32.x86_64.rpm"
+          },
+          "sha256:5d5c8c7e9c78e3b8827ad38771efb44951d1c3c1692cf4e07b138c1c8c42bd5b": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libkcapi-hmaccalc-1.1.5-2.fc32.x86_64.rpm"
+          },
+          "sha256:5d933f9bf444d4c8732caa65e9227b27127c625840859a0453a32a5719916f48": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/i/iwl2030-firmware-18.168.6.1-106.fc32.noarch.rpm"
+          },
+          "sha256:5db7c0e949bd9172b9645237e72f6139d4ffcf14defad487262b8ad25b427daf": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/p/pcre2-syntax-10.34-9.fc32.noarch.rpm"
+          },
+          "sha256:5e7a16df5bdfab2acfd8ac061827ace0642f2e5521689d6b9f0812f2a6ece231": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/f/fedora-release-iot-32-1.noarch.rpm"
+          },
+          "sha256:5f0ae954b5955c86623e68cd81ccf8505a89f260003b8a3be6a93bd76f18452c": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libgcrypt-1.8.5-3.fc32.x86_64.rpm"
+          },
+          "sha256:5f156c2a950699d5cb9a21349cce049b3c8bfdcc4fcc780665fe2d3103f576c1": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/t/trousers-0.3.13-13.fc31.x86_64.rpm"
+          },
+          "sha256:5fc2fd0cb5b6fdce1203e43d6f2df6a3098ec9522b04815d896ecedbb1489063": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/g/glib-networking-2.64.1-1.fc32.x86_64.rpm"
+          },
+          "sha256:605c3cf38451c6b93f331b605ab03ca611e37aa11d14a4019de61278add04f74": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/m/ModemManager-glib-1.12.8-1.fc32.x86_64.rpm"
+          },
+          "sha256:60774007011889671c28158f599032f0db253c153ccae70f5e2f5840f2dc490b": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/k/kbd-misc-2.2.0-1.fc32.noarch.rpm"
+          },
+          "sha256:61cae80187ef2924857fdfc48a240646d23b331482cf181e7d8c661b02c15949": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/d/device-mapper-libs-1.02.171-1.fc32.x86_64.rpm"
+          },
+          "sha256:624b9079b4a571218adced203e19bdaca1d2cf57891f9653f409dd1db92fbf86": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/c/clevis-12-2.fc32.x86_64.rpm"
+          },
+          "sha256:630ad20496ff00f76764e01b9302ccbe94e3e91d76ececef88bd9e8a890b1ac3": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/r/rpm-sign-libs-4.15.1-2.fc32.1.x86_64.rpm"
+          },
+          "sha256:632aedc06003e319a1c3fa98876055fc3bd3b44c1188b44d3b7a455cef0d40e4": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/p/python3-dnf-4.2.19-1.fc32.noarch.rpm"
+          },
+          "sha256:63400fedea4a6ddb8fced58d33e60560791f29cd439169998f337d09fb50a7d4": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libcroco-0.6.13-3.fc32.x86_64.rpm"
+          },
+          "sha256:640afe5b9d499c9a7efc1d23cce8c54e3e3704d92eb7e7a93a048f97d1e983e1": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/m/mkpasswd-5.5.6-1.fc32.x86_64.rpm"
+          },
+          "sha256:64567be564634937bd918d33a3f04017808d29269a5b0891a0f4d4aecad6161b": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libsysfs-2.1.0-28.fc32.x86_64.rpm"
+          },
+          "sha256:64922311f45700f2f4f98d78efbdfa240987a6a2b1396ffe694d30e2b5f34ac3": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libqmi-utils-1.24.8-1.fc32.x86_64.rpm"
+          },
+          "sha256:65e0cfe367ae4d54cf8bf509cb05e063c9eb6f2fea8dadcf746cdd85adc31d88": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libattr-2.4.48-8.fc32.x86_64.rpm"
+          },
+          "sha256:65e5209398c6b2c196cb42f3bc3f82e00af1026f623026857a9b330ec92d0330": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/i/iwl100-firmware-39.31.5.1-106.fc32.noarch.rpm"
+          },
+          "sha256:66bb5b2e99d2c74b82943fe61fe9b9a3674350b0242f69a6854ec9718dcf5e07": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libsss_nss_idmap-2.2.3-13.fc32.x86_64.rpm"
+          },
+          "sha256:6749bd0b96339c32b57635b69b474583b50c94e4bbaa3eb8753fa604b9d1c521": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/i/ignition-2.2.1-3.git2d3ff58.fc32.x86_64.rpm"
+          },
+          "sha256:6794fe48004c0403c29fc779b49f0fbea436123b96783a2df225eef2f0858795": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/p/pcre2-10.34-9.fc32.x86_64.rpm"
+          },
+          "sha256:684aae86de55bd42215c136777613211f596788d3b6405d8fa645fb967904354": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/s/selinux-policy-targeted-3.14.5-32.fc32.noarch.rpm"
+          },
+          "sha256:688fcc0b7ef3c48cf7d602eefd7fefae7bcad4f0dc71c9fe9432c2ce5bbd9daa": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libdb-5.3.28-40.fc32.x86_64.rpm"
+          },
+          "sha256:6952dfc6a8f583c9aeafb16d5d34208d7e39fd7ec8628c5aa8ccde039acbe548": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libpkgconf-1.6.3-3.fc32.x86_64.rpm"
+          },
+          "sha256:699c1a3ff311bbaa2380c085fb4f516aa08be474bed02bcd1569d0bbf5b22d07": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/s/sssd-client-2.2.3-13.fc32.x86_64.rpm"
+          },
+          "sha256:6a2f4706a37bc5ad229f6fdddbd70fbcf82da85ec577a8deeb455513cbedc174": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/p/python3-hawkey-0.45.0-3.fc32.x86_64.rpm"
+          },
+          "sha256:6a3282927f525629bc0aaf4090e108d33b0709d3d5b35bc442000c2837e7b9b4": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/i/iputils-20190515-5.fc32.x86_64.rpm"
+          },
+          "sha256:6aa0c6420a03f20e18842da9de611d823580efb8f6da93a94dafb48d59c2a070": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/p/python3-dbus-1.2.16-1.fc32.x86_64.rpm"
+          },
+          "sha256:6eb95e39b9771c4dde5f9954a74cef6be90522c28c7c4aa767ebe7a9d55fcdf9": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libmetalink-0.1.3-10.fc32.x86_64.rpm"
+          },
+          "sha256:6eeebf21f245bf0d6f58962dc49b6dfb51f55acb6a595c6b9cbe9628806b80a4": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/c/curl-7.69.1-1.fc32.x86_64.rpm"
+          },
+          "sha256:6f5f53b66f7c3bf6958f6f163788583265ff0360188620c3b0f7ddedeac3d1f4": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/p/python3-setools-4.3.0-1.fc32.x86_64.rpm"
+          },
+          "sha256:6f669ae6f70cfa80917adf4ae9d5e86fbd9d31ee308a9a3408a19be3afc46f7b": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/t/tss2-1331-4.fc32.x86_64.rpm"
+          },
+          "sha256:6fc1b9a27eeb368a98f50dba5fc514f20a5eb23f8e0ee7dd92c4051ef8b4a940": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/d/dbus-common-1.12.16-4.fc32.noarch.rpm"
+          },
+          "sha256:6fe524feb38312f9c370b2190aeb42330acc9ce42f3a45e9cd05748b4aa00db2": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/g/glib2-2.64.1-1.fc32.x86_64.rpm"
+          },
+          "sha256:7023687eb65baa56a9b4c3ffde1e439b3d41b03ac4ad35a1a1fc3903464548f7": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/c/coreutils-8.32-3.fc32.1.x86_64.rpm"
+          },
+          "sha256:703fb5ca1651bb72d8ab58576ce3d78c9479cbb2e78ff8666ae3a3d1cd9bb0da": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/c/checkpolicy-3.0-3.fc32.x86_64.rpm"
+          },
+          "sha256:705bdb96aab3a0f9d9e2ff48ead1208e2dbc1927d713d8637632af936235217b": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/a/acl-2.2.53-5.fc32.x86_64.rpm"
+          },
+          "sha256:70794c8537fb3cf197f051cfce3b23956d587062daf114f8480770754804f339": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/g/greenboot-0.9-1.fc32.noarch.rpm"
+          },
+          "sha256:724cca9919bb7b0183b030aca216d4d51de70bf35c2cc5e8325a21a52ca15ceb": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/p/python3-setuptools-41.6.0-2.fc32.noarch.rpm"
+          },
+          "sha256:729fb595040f1e2e71ff0a8c1c22ebe4b7187f78b816af8e6a8d93c03fc5d844": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libusbx-1.0.23-1.fc32.x86_64.rpm"
+          },
+          "sha256:73f6a9108f7d5ec3cd89c31dbbaa874ae28cd5cb443ef69700a1218903ee2fc4": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/c/ca-certificates-2020.2.40-3.fc32.noarch.rpm"
+          },
+          "sha256:750da30da0289d5e2ad9ca297dda44e5ca18dbed0c3e0d4200379bc1818c22f3": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/s/systemd-pam-245.4-1.fc32.x86_64.rpm"
+          },
+          "sha256:759165656ac8141b0c0ada230c258ffcd4516c4c8d132d7fbaf762cd5a5e4095": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/g/grep-3.3-4.fc32.x86_64.rpm"
+          },
+          "sha256:769e34caae25f05786ae53e535c6e3c64f5c548f06c422325d68598b7abb99b7": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/c/conmon-2.0.14-1.fc32.x86_64.rpm"
+          },
+          "sha256:78db9007c08fa51f177210e47343b8e733ce0751826abb357ca96429836588db": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/s/systemd-libs-245.4-1.fc32.x86_64.rpm"
+          },
+          "sha256:78e1aa11379eec2906eedf843216f47bcbdfe4da4713d566fb44ca313c893f3f": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/d/dnf-4.2.19-1.fc32.noarch.rpm"
+          },
+          "sha256:79e22d23ba0a156b3d74ec4b0da8fd71bc632386366ade2c48006ba82074055d": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/i/iwl105-firmware-18.168.6.1-106.fc32.noarch.rpm"
+          },
+          "sha256:7a525abda7230bfbc87763dfe58bf7684e385b3c78ca242a1685a589300909e9": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/d/device-mapper-persistent-data-0.8.5-3.fc32.x86_64.rpm"
+          },
+          "sha256:7a97e71cd552285ead303d07dbb6417403edf45c0a531e02cf4ebfb0efda4975": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/b/bash-5.0.11-2.fc32.x86_64.rpm"
+          },
+          "sha256:7bf42ff57ce2a31db0da7d6c5926552f4e51e9f25cded77bd634eb5cd35eadab": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libevent-2.1.8-8.fc32.x86_64.rpm"
+          },
+          "sha256:7c1a229f4a36ac8b077e0514f68f311229652121528b0f8a2a7434c618276dcb": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libxcrypt-4.4.16-1.fc32.x86_64.rpm"
+          },
+          "sha256:7c21c21c3e3dbace06bee03fe4835ae6cb1e3ef86750ba2853f39d40dead2309": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/i/ipset-7.6-1.fc32.x86_64.rpm"
+          },
+          "sha256:7c7eff31251dedcc3285a8b08c1b18f7fd9ee2e07dff86ad090f45a81e19e85e": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/p/polkit-pkla-compat-0.1-16.fc32.x86_64.rpm"
+          },
+          "sha256:7d9bd2fe016ca8860e8fab4a430b3aae4c7b7bea55f8ccd7775ad470172e2886": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libargon2-20171227-4.fc32.x86_64.rpm"
+          },
+          "sha256:7dd93baaf69a8004ae2cd3b9e6660b862d0b6f399d53c05a27a48a2e276ef1ee": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/p/python-setuptools-wheel-41.6.0-2.fc32.noarch.rpm"
+          },
+          "sha256:7df4fa1a29772696d92866e890af6fbe006088f3407ed3e67b0e7867ef58d899": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/p/pinentry-1.1.0-7.fc32.x86_64.rpm"
+          },
+          "sha256:7dfe1e8dac6d759479ae3dfd415fdd2662bbed9ff0f4da6093279efd1bacae31": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libcurl-7.69.1-1.fc32.x86_64.rpm"
+          },
+          "sha256:7f555c600b35ba798d8c0a63e30a1a12e917231730e1a44f48161ba0fe4b5973": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/s/sqlite-libs-3.31.1-1.fc32.x86_64.rpm"
+          },
+          "sha256:7f6d2841ec9402ee5e57f1a46b9886935138c02005d860899f3c746c7885c7b9": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/g/grub2-tools-2.04-12.fc32.x86_64.rpm"
+          },
+          "sha256:80cf220a3314f965c088e03d2b750426767db0b36b6b7c5e8059b9217ff4de6d": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/m/mozjs60-60.9.0-5.fc32.x86_64.rpm"
+          },
+          "sha256:80d407bbc5f6bb8d95504cfdb51faaca937f6c4c08df4c4aadcd46fe703c8a57": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/d/dnf-data-4.2.19-1.fc32.noarch.rpm"
+          },
+          "sha256:824fe37d58cadac2f23678c9eb95c29b4acb1852df97cf799e77aa7e8034b54e": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libgudev-232-7.fc32.x86_64.rpm"
+          },
+          "sha256:82e0d8f1e0dccc6d18acd04b7806350343140d9c91da7a216f93167dcf650a61": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/w/which-2.21-19.fc32.x86_64.rpm"
+          },
+          "sha256:83a08b7066000ebbdf8a6c5706485a19b5dfe2d492b1faaac1922e8f0c42cd0c": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/i/iwl6050-firmware-41.28.5.1-106.fc32.noarch.rpm"
+          },
+          "sha256:8402d3aabfc02c16f3789f3f93338dbee2448db8a49956002b83aff5390922d9": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libuuid-2.35.1-7.fc32.x86_64.rpm"
+          },
+          "sha256:842f7a38be2e8dbb14eff3ede4091db214ebe241e1fde7a128e88c4e686b63b0": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/b/bzip2-libs-1.0.8-2.fc32.x86_64.rpm"
+          },
+          "sha256:84702d6395a9577c1a268184f123cfd4b15bc2287f01033625ba388a34ec2338": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/x/xz-libs-5.2.5-1.fc32.x86_64.rpm"
+          },
+          "sha256:84c338b327a3fb2f6edb79caa2242804fff8c83ffa3db0d9227f55eef4107b2a": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/s/setools-console-4.3.0-1.fc32.x86_64.rpm"
+          },
+          "sha256:862e75c10377098a9cc50407a0395e5f3a81d14b5b6fecfb3f223325c8867829": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/c/cracklib-2.9.6-22.fc32.x86_64.rpm"
+          },
+          "sha256:865c7677d2664287bb4ba2874c83bc805232e1b3a02cf6ba96e047266d9ef684": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/i/iproute-5.5.0-1.fc32.x86_64.rpm"
+          },
+          "sha256:8677b34fa73f258b1a599d18419f6fbbb8961bb1ca2ae5b0f9abdcc4f93b319e": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libkcapi-1.1.5-2.fc32.x86_64.rpm"
+          },
+          "sha256:86acbe8d77b05c1fe9bb0168443a579b1d4538f9733813db4e72e4a4a2be29e3": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libgusb-0.3.4-1.fc32.x86_64.rpm"
+          },
+          "sha256:86c87a4169bdf75c6d3a2f11d3a7e20b6364b2db97c74bc7eb62b1b22bc54401": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libffi-3.1-24.fc32.x86_64.rpm"
+          },
+          "sha256:872639e4ccb4f1c5de66d5eaa85ca673141b10e3d614b33c84ff887c228d465d": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/j/jitterentropy-2.2.0-2.fc32.x86_64.rpm"
+          },
+          "sha256:879ba2533610771dbf3fa103fdbde878edf255b771b53aa8a170009d01446012": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/f/fonts-filesystem-2.0.3-1.fc32.noarch.rpm"
+          },
+          "sha256:884357540f4be2a74e608e2c7a31f2371ee3b4d29be2fe39a371c0b131d84aa6": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libnetfilter_conntrack-1.0.7-4.fc32.x86_64.rpm"
+          },
+          "sha256:88d283c2d5aa96c2b0899f6bd6c0409a5d5c6fda2958e8eae19eb49c3ede58d6": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/i/iwl5150-firmware-8.24.2.2-106.fc32.noarch.rpm"
+          },
+          "sha256:88f4bd19a6cf6eba5e6f2b5bba80819b5ccddb0476aadc53c8df13f9c45b1e58": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libarchive-3.4.2-1.fc32.x86_64.rpm"
+          },
+          "sha256:89c972ec7d2ab305c91c23bc248562c76f0ae645a9ed9f94d312e2f57c4d38fe": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/k/kernel-5.6.6-300.fc32.x86_64.rpm"
+          },
+          "sha256:89f85f749bfee7d083c84845e908a3471297a3d8a75f7397903d15eb7f403297": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/i/iwl6000-firmware-9.221.4.1-106.fc32.noarch.rpm"
+          },
+          "sha256:8a03d482b5294f7452b2f9ce31ebb6aea9eefac002281c1b9152fbb1a0341987": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/j/json-glib-1.4.4-4.fc32.x86_64.rpm"
+          },
+          "sha256:8a0c00a69f9cb3a9ffacaf1cdc162c38a1faca76c9b976cb177bdc988902f2d4": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/p/popt-1.16-19.fc32.x86_64.rpm"
+          },
+          "sha256:8aa8258a1a13c1120d6c28321f618385111cb9363dae09eea2e4af481053e28b": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/d/device-mapper-event-libs-1.02.171-1.fc32.x86_64.rpm"
+          },
+          "sha256:8b148415fb6a583ef131d0ddff44f3209c30d0299fde7b20cd3ea385590927c1": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/o/openssh-clients-8.2p1-2.fc32.x86_64.rpm"
+          },
+          "sha256:8c560f3927e36e41657067e4bdc741fd8f3b55b497f0fc3c2331fb361ba8de8b": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/t/tpm2-tools-4.1-2.fc32.x86_64.rpm"
+          },
+          "sha256:8df8541abd806578e43fe28a7ea2c41efbbb813866bed35fabe779274790a538": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/f/fuse3-3.9.1-1.fc32.x86_64.rpm"
+          },
+          "sha256:8df97dcfb42c1667b5d2e4150012eaf96f58eeac4f7b879e0928c8c36e3a7604": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/p/policycoreutils-3.0-2.fc32.x86_64.rpm"
+          },
+          "sha256:8dfdbe51193bdcfc3db41b5b9f317f009bfab6373e6ed3c5475466b8772a85e1": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libnl3-3.5.0-2.fc32.x86_64.rpm"
+          },
+          "sha256:8ee8c4bbf024b998ffb77a6b4194a2306ac21c5a6fcf70c8c81a0fbf38f7c7fc": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/p/python3-firewall-0.8.2-2.fc32.noarch.rpm"
+          },
+          "sha256:8fc2ae85f242105987d8fa7f05e4fa19358a7c81dff5fa163cf021eb6b9905e9": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/e/expat-2.2.8-2.fc32.x86_64.rpm"
+          },
+          "sha256:907393755387a351806ec2afff376e7491f177116caadd12f07d0fcbed796750": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/f/fipscheck-1.5.0-8.fc32.x86_64.rpm"
+          },
+          "sha256:90bc2171f438ffa7488a9c69cd86bb1de175807be468f285c8ca16cf8dd4a83c": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/t/tpm2-tss-2.4.0-1.fc32.x86_64.rpm"
+          },
+          "sha256:9194788f87e4a1aa8835f1305d290cc2cd67cee6a5b1ab82643d3a068c0145b6": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/y/yajl-2.1.0-14.fc32.x86_64.rpm"
+          },
+          "sha256:929f1c5ce4775b28439a1b5726e98c38204930d5880dc6096fc56e8d3eab275f": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/f/fuse-overlayfs-0.7.8-1.fc32.x86_64.rpm"
+          },
+          "sha256:932a37ddd2a990a22a1ee7811d204552e8860e39a3e0c050ed618a535ae8c78c": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/s/selinux-policy-3.14.5-32.fc32.noarch.rpm"
+          },
+          "sha256:933bdb4cc6e14b2ebb1ca76c14ca176c13d271a2d1e88632f237392777d11808": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/p/pcre-8.44-1.fc32.x86_64.rpm"
+          },
+          "sha256:9369d4fed30402f45705b7a5cb51b6eeefb1dabbe0942c84514c6fdf1edac5e0": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/f/fuse-2.9.9-9.fc32.x86_64.rpm"
+          },
+          "sha256:942707884401498938fba6e2439dc923d4e2d81f4bac205f4e73d458e9879927": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libsigsegv-2.11-10.fc32.x86_64.rpm"
+          },
+          "sha256:942d06ec1f7033ea4c729b84ee09f5491481770efe10151ba581479ac7f3f9dc": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libfdisk-2.35.1-7.fc32.x86_64.rpm"
+          },
+          "sha256:9465f2f1103697207a52d15edd716ab72dc6c281823c60f424cd064d706c7a51": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libzstd-1.4.4-2.fc32.x86_64.rpm"
+          },
+          "sha256:95a89032291b05a0e483f336ea29897d951e8845b0f347a4117de90ef3ef3467": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/m/microcode_ctl-2.1-35.fc32.x86_64.rpm"
+          },
+          "sha256:966084f83e0fedb7a217aa102b484ac8a63082ccfe99517544ed2cb102191204": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/g/gnupg2-smime-2.2.19-1.fc32.x86_64.rpm"
+          },
+          "sha256:96e0c019cb91d8deefb7664cfe417807d23562d2a1bfd2cbfd1051e243136b57": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/s/screen-4.8.0-2.fc32.x86_64.rpm"
+          },
+          "sha256:97197411bca68cfba1ef6bab1fdd4b41c95ec71c36f1e67f525b963cf60598fd": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/s/systemd-rpm-macros-245.4-1.fc32.noarch.rpm"
+          },
+          "sha256:975719a0c73cf5cb5bcbc8ad11b816ed75923dccd9c091baa4a6c6000753dcd8": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/j/jansson-2.12-5.fc32.x86_64.rpm"
+          },
+          "sha256:9899cfd32ada2537693af30b60051da21c6264b0d0db51ba709fceb179d4c836": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/g/gdbm-libs-1.18.1-3.fc32.x86_64.rpm"
+          },
+          "sha256:993680d5cd133a0c21184be92b3df405d757613d0ca25c4abf08b203d8d26b79": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/d/dracut-050-26.git20200316.fc32.x86_64.rpm"
+          },
+          "sha256:9976e6228a10fa2761f1265a2a7666578d79ca57819837e5d1fbecc53324f1b9": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/u/util-linux-2.35.1-7.fc32.x86_64.rpm"
+          },
+          "sha256:99f87b4ec7c5852d45028f3eae65fc813f3ef107e128777f265b09a19ce262e0": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/e/elfutils-libs-0.179-1.fc32.x86_64.rpm"
+          },
+          "sha256:9a12db30090023c60e3d7bcd5b07142cdc6d84c77e25ddb1cf41a4c490e52f09": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libedit-3.1-32.20191231cvs.fc32.x86_64.rpm"
+          },
+          "sha256:9a2beeeede69d8910115608c2d98efa6a8dba73ab2df246df5b0f10e2fa37f54": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/d/device-mapper-event-1.02.171-1.fc32.x86_64.rpm"
+          },
+          "sha256:9ade87dbb32f27e7f38ec981002ddc5a2189cc6f5ad5f24bada3b71cfa9167fd": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/p/python3-pip-19.3.1-2.fc32.noarch.rpm"
+          },
+          "sha256:9bd5cb588664e8427bc8bebde0cdf5e14315916624ab6b1979dde60f6eae4278": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libgpg-error-1.36-3.fc32.x86_64.rpm"
+          },
+          "sha256:9c8a274158a6fe97598e33900cd51e171f7e7517ccfc8ad6351873e69b225986": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libyaml-0.2.2-3.fc32.x86_64.rpm"
+          },
+          "sha256:9cf9b01f2c727e3576a8aa71fd7fe1bf4ec9ed1c9f50b756657cf9aeae18418f": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/m/mokutil-0.3.0-15.fc32.x86_64.rpm"
+          },
+          "sha256:9d220d8ee28cd0adf28e8fef547af92c3ec66e238747165939cf8e1a413ddf83": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/r/rpm-ostree-libs-2020.1-1.fc32.x86_64.rpm"
+          },
+          "sha256:9d4f1290565b852e56f9e9babc14b141b0283998121f78b0eb83dec367cf0abb": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/g/gnutls-3.6.13-1.fc32.x86_64.rpm"
+          },
+          "sha256:9dcc75ac945924ce496c9280e7ac31b88886d94a6494d0710725a81dd9d42c9a": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/w/wpa_supplicant-2.9-3.fc32.x86_64.rpm"
+          },
+          "sha256:9de8eb13fbdf8b8c5c3e04c52a890ccc5b667351ff17152786d12ffc66210433": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/p/python3-gpg-1.13.1-6.fc32.x86_64.rpm"
+          },
+          "sha256:9ebc5843faeb852bbbe3d53f03182197f6595a928ffa3f5d7a530749ee1e4ec8": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libmodman-2.0.1-21.fc32.x86_64.rpm"
+          },
+          "sha256:9ecc8aa9af05ba704cec879618afeda5ff92d8233811e2d6080aa02e0b5ceddf": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libpwquality-1.4.2-2.fc32.x86_64.rpm"
+          },
+          "sha256:9ee276ed9d036a4483bb8d1bd6f6d697b161a04276c6ce5f1d3f40d48e04bccb": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/k/keyutils-1.6-4.fc32.x86_64.rpm"
+          },
+          "sha256:9fa1959637c902dfeb19a0f16c7f42f7da4aab293f7c025c66d39debad6dbc34": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/luksmeta-9-7.fc32.x86_64.rpm"
+          },
+          "sha256:a05178831a546e2001e52f065fc6969f36d2292efaee2971fe7a7e882cc8c813": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/k/kbd-2.2.0-1.fc32.x86_64.rpm"
+          },
+          "sha256:a1613e90865db93fb578b8ee1a4ee40bd396c6c9f2fb2a14757acacecb9f23e8": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/k/kernel-core-5.6.6-300.fc32.x86_64.rpm"
+          },
+          "sha256:a1835a7929d3c1613f3890caef878e9bdf857dcc0f63eb4d63a1140370b3f21b": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/f/fedora-release-common-32-1.noarch.rpm"
+          },
+          "sha256:a280c633b73517da167b91298fc97aeee2eb5fcc253c038ae0ce4b8478d3a103": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/s/shared-mime-info-1.15-3.fc32.x86_64.rpm"
+          },
+          "sha256:a336d2e77255df4783f52762e44efcc8d77b044a3e39c7f577d5535212848280": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/s/setup-2.13.6-2.fc32.noarch.rpm"
+          },
+          "sha256:a346990bb07adca8c323a15f31b093ef6e639bde6ca84adf1a3abebc4dc9adce": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/b/basesystem-11-9.fc32.noarch.rpm"
+          },
+          "sha256:a3f80bb7068618dff795b3e0a3d32fa3c640e492c8f175b16bb3c7ff64a88a8e": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/i/iwl7260-firmware-25.30.13.0-106.fc32.noarch.rpm"
+          },
+          "sha256:a410db5c56d4f39f6ea71e7d5bb6d4a2bd518015d1e34f38fbc0d7bbd4e872d4": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libaio-0.3.111-7.fc32.x86_64.rpm"
+          },
+          "sha256:a4706de7a0d59f2b1e9e73f48c4279429676410c77fb93f82abf1b7b34330f82": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/a/adobe-source-code-pro-fonts-2.030.1.050-8.fc32.noarch.rpm"
+          },
+          "sha256:a7452c18c2cffc266ec36c54105b884c4d63181f20cebd705e33730534cb9093": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libvarlink-util-18-3.fc32.x86_64.rpm"
+          },
+          "sha256:a7da5590635b9c19afafc7dd247604194a5ce7d8d863dc600b8cb86accb2e469": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/p/python-pip-wheel-19.3.1-2.fc32.noarch.rpm"
+          },
+          "sha256:a7deef0a324ccb272a25f5eb6b30c72d0a842bf2c602c31fe3b60f984b2e50af": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/e/efibootmgr-16-7.fc32.x86_64.rpm"
+          },
+          "sha256:a7f040de29d2414cc99fcffcd9ed3fa9d06ecc7aecd783ec3d2eef769e2389f1": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libxml2-2.9.10-3.fc32.x86_64.rpm"
+          },
+          "sha256:a8ce7406c87f64972f0b70f1823c2aad05516c71fe375c6c97737459c2448825": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libnghttp2-1.40.0-2.fc32.x86_64.rpm"
+          },
+          "sha256:a9d5719cf5d4fdc4ae28099d623a751b0470264e7d2280be2669a066348b4ce1": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/a/abattis-cantarell-fonts-0.201-2.fc32.noarch.rpm"
+          },
+          "sha256:aa353206ef29b7d908554ccb7cd6f4c01a1f6c3c1c6358abb7452f4a745939d0": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/g/grub2-efi-x64-2.04-12.fc32.x86_64.rpm"
+          },
+          "sha256:aa5b658fd4a95c724b61eddadecdbcbc1b2a813ae681318ab092a2ed03954825": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libmodulemd1-1.8.16-2.fc32.x86_64.rpm"
+          },
+          "sha256:aa783a91b1823b7b056575e6276df35910eb2e0d4b72121cf5649651c7d23a16": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/librepo-1.11.1-4.fc32.x86_64.rpm"
+          },
+          "sha256:aac9be36fc9c345245b4a0db66bfb9ff8df25e36ae0c1ae89eca9bcf88e052e4": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libgcab1-1.4-2.fc32.x86_64.rpm"
+          },
+          "sha256:ab4c27523d6b5a0df75febac43cafa2dd9897dc3c1bb2f0d6990ca603b6168fe": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/f/fuse3-libs-3.9.1-1.fc32.x86_64.rpm"
+          },
+          "sha256:ac8b1fea0b678d7630033a8900be5641b934306961b39a29c79c6d72f34f7d1c": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libbrotli-1.0.7-10.fc32.x86_64.rpm"
+          },
+          "sha256:ad50ed0c4f4c956e3b59ac9fc7bf5fba22068a661ea75a46eb81bc2209af4cc5": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libxmlb-0.1.14-2.fc32.x86_64.rpm"
+          },
+          "sha256:ad6d7d9767e05978b14a39c08dba59ddc4396584576df194f77ed310a0816ae0": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/o/openssl-libs-1.1.1d-7.fc32.x86_64.rpm"
+          },
+          "sha256:ade8105796f5c1201a3efc8bcc654788cfc88c3815297b346845062a8c29cd59": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/o/openldap-2.4.47-4.fc32.x86_64.rpm"
+          },
+          "sha256:ae219ad5ecc0233271c3fd61263f817c646eecece19a8f075e7aa4dd9ff8698e": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libxkbcommon-0.10.0-2.fc32.x86_64.rpm"
+          },
+          "sha256:af18c71bca1121ac3cdeace9f7249079ee0568fcbb15ca7e46131fa9b9b521f8": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/b/bluez-libs-5.54-1.fc32.x86_64.rpm"
+          },
+          "sha256:af62d0611b995b9f2b2c7b4d4852e03e521d66979534871ccb5a71275a15518d": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/e/elfutils-default-yama-scope-0.179-1.fc32.noarch.rpm"
+          },
+          "sha256:af66820023c984d8b981ecac715d0c2daec1f89dcb69bed76ddf58b0ee80c1b1": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libsss_sudo-2.2.3-13.fc32.x86_64.rpm"
+          },
+          "sha256:af992ad02594b68f17d2da41104a26aee41d02639edf22332d7dbb1fe9af58a5": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/p/publicsuffix-list-dafsa-20190417-3.fc32.noarch.rpm"
+          },
+          "sha256:b09015ae5fb5772b73bc7932991aaf6e1f6d509432af605a565ef53d2d50606a": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libsoup-2.70.0-1.fc32.x86_64.rpm"
+          },
+          "sha256:b1111e77a5fdbacaa04acc90d3844706158bc5892173862928705620b8910adb": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/p/python3-audit-3.0-0.19.20191104git1c2f876.fc32.x86_64.rpm"
+          },
+          "sha256:b13eed593b31a9cc0174774b97701c7da876f91ccdfc951b67a3134d59ccd8b5": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libcbor-0.5.0-7.fc32.x86_64.rpm"
+          },
+          "sha256:b286141f38cd88b8c632515677423f49c81365f2ae99c5a7906205f35a273fb2": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/i/iwl135-firmware-18.168.6.1-106.fc32.noarch.rpm"
+          },
+          "sha256:b2e862283ac97b1d8b1ede2034ead452ac7dc4ff308593306275b1b0ae5b4102": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/n/ncurses-6.1-15.20191109.fc32.x86_64.rpm"
+          },
+          "sha256:b3201777d78ee13ee45ddbd982af5999ce058907b5dc552669644931b79c5f51": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libgpiod-utils-1.5.1-1.fc32.x86_64.rpm"
+          },
+          "sha256:b3230630a471b806a9153669d187508350cdb2b368a68f8c439c82abad038c3f": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libpcap-1.9.1-3.fc32.x86_64.rpm"
+          },
+          "sha256:b35256e417fd94c7efb1212f2f36b5e6b224ff5b9e8733774d4fbdc652078099": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libtextstyle-0.20.1-4.fc32.x86_64.rpm"
+          },
+          "sha256:b359ca3cdc68b6e5031f65975df38a8b96c19ddc4c367e1e3463fc8484a0b3b7": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libnet-1.1.6-19.fc32.x86_64.rpm"
+          },
+          "sha256:b58828b2f1ce4f7778d3f511c61ee8925042b9752aea526c23d33fd7533aa975": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libuser-0.62-24.fc32.x86_64.rpm"
+          },
+          "sha256:b60670fdcf91b50d97720f601d92277efedbd690bd887000ccd9a46b3fa8b314": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libcap-ng-0.7.10-2.fc32.x86_64.rpm"
+          },
+          "sha256:b67f1634acc7b84b284bda8afeef546aed4a3388dc7df67417001704aa444af1": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/b/btrfs-progs-5.6-1.fc32.x86_64.rpm"
+          },
+          "sha256:b70d1c93e3448b1a0b5e3f50488290283a260ff46e22bff4fb704469e6017fa8": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/d/deltarpm-3.6.2-5.fc32.x86_64.rpm"
+          },
+          "sha256:b743aafa82f3326f8f2e6d5464ae7fa57fabab3ad791099eaf2d151b43208b42": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/e/efi-filesystem-4-4.fc32.noarch.rpm"
+          },
+          "sha256:b79bb6af3e1650ba812c8affe42772ea566b164222a7d4d8e2f7efa867dc6849": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/p/python3-3.8.2-2.fc32.x86_64.rpm"
+          },
+          "sha256:b821e9e8bf66abacaed4a386f9ed8ffa17f4f8be3db55e1ac31d52ba2d1faa1b": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/c/crypto-policies-scripts-20191128-5.gitcd267a5.fc32.noarch.rpm"
+          },
+          "sha256:b8ecd7fa0e7e072828e374dfb0d61bb8eecca7c190f3661050cee5e3fc8854b4": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/f/firewalld-0.8.2-2.fc32.noarch.rpm"
+          },
+          "sha256:b98687828b1d222ea73ebb8457450913dac58dd0be2e430a93bb7e98ba816505": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/k/kernel-modules-5.6.6-300.fc32.x86_64.rpm"
+          },
+          "sha256:bca13571cf1452f3e41c8e89b8c64aa33d3d0f4e414571f9dde32a556591b339": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/i/initscripts-10.02-3.fc32.x86_64.rpm"
+          },
+          "sha256:be7ba234b6c48717ac0f69fb5868b3caa6ef09fbfc76c42a47b367578cd19444": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/p/psmisc-23.3-3.fc32.x86_64.rpm"
+          },
+          "sha256:be899d3e806441b1c46811c0ffe9f4e01f4ea4e1544f9cc32630254853e3f3a5": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libsolv-0.7.11-2.fc32.x86_64.rpm"
+          },
+          "sha256:be998dfbcc9ca8e3021ac4f56ed723cfa3fa1517524e89ee0b636f623abe995f": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libstdc++-10.0.1-0.11.fc32.x86_64.rpm"
+          },
+          "sha256:bfeba60bfb137f270e3b28db96ecfe8b226ea05e1761f6cb5ccc64c48c73c748": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/b/bluez-5.54-1.fc32.x86_64.rpm"
+          },
+          "sha256:c019d23ed2cb3ceb0ac9757a72c3e8b1d31f2a524b889e18049cc7d923bc9466": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/n/nettle-3.5.1-5.fc32.x86_64.rpm"
+          },
+          "sha256:c07fd5357963f99610bc676b25f1dfcbf1bae0b63538b5e1cd82ce42b79fd819": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/b/bash-completion-2.8-8.fc32.noarch.rpm"
+          },
+          "sha256:c0fff40dc1092e18ed3e608bc6143c89a0d7775b9e0553319bb2caca7d324d80": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/z/zlib-1.2.11-21.fc32.x86_64.rpm"
+          },
+          "sha256:c132999a3f110029cd427f7578965ad558e91374637087d5230ee11c626ebcd4": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/d/device-mapper-1.02.171-1.fc32.x86_64.rpm"
+          },
+          "sha256:c1d754773972b5f4ca157c0afa45d6767901d965a91f381660c72740d682df63": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libtirpc-1.2.5-1.rc2.fc32.x86_64.rpm"
+          },
+          "sha256:c1f957511b5e011e6f7995ed7bca9196703cf1214068f209e86b1dc4fd0e98bf": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/i/ima-evm-utils-1.2.1-3.fc32.x86_64.rpm"
+          },
+          "sha256:c2197913bc8db9548b0a40ffddf840a31956b18e932ad4eec77a48d87d2289ce": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/g/grub2-pc-modules-2.04-12.fc32.noarch.rpm"
+          },
+          "sha256:c3e2a3c23288899456fb996f3074c10637bcd4886bc446698cb1efa2734c1e4d": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/t/traceroute-2.1.0-10.fc32.x86_64.rpm"
+          },
+          "sha256:c3f7089ae50f79cf4d2cb59e01091d33c70cab89ae08f95c547339a87404c3ec": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/d/dosfstools-4.1-10.fc32.x86_64.rpm"
+          },
+          "sha256:c50ff544430830086ce484b20a2b6eaa934c82b6277a6f4fb02fc8cbc9e25db7": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/r/runc-1.0.0-144.dev.gite6555cc.fc32.x86_64.rpm"
+          },
+          "sha256:c55b30a3a8c0d36a219953e20960185263ae63dada0f050446066be1e873ce08": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/c/clevis-luks-12-2.fc32.x86_64.rpm"
+          },
+          "sha256:c574c5432197acbe08ea15c7837be7577cd0b49902a3e65227792f051d73ce5c": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/a/alternatives-1.11-6.fc32.x86_64.rpm"
+          },
+          "sha256:c8daa43a4504f9a4b6c106baf8a56aa0d256fc3c71bd417ea75b9c7fd830a9b7": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libgpiod-1.5.1-1.fc32.x86_64.rpm"
+          },
+          "sha256:c9ba05cb46a9cb52e3325ca20c457a377361abcd0e5a7dda776ba19481770467": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/linux-atm-libs-2.5.1-26.fc32.x86_64.rpm"
+          },
+          "sha256:c9f3d536c1fa73de90836147d15db06dc2025e84a44034bda6c66b9c4b60be58": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/r/rootfiles-8.1-27.fc32.noarch.rpm"
+          },
+          "sha256:caa3625b22908cf4f91faf2c281b0e7ab7d981c35ed1d761deb53b7b78d13cf8": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/i/iwl2000-firmware-18.168.6.1-106.fc32.noarch.rpm"
+          },
+          "sha256:cb0c64cc81e0b384bbc9d27ffcb2a655b13c91a799aad8972264aed1767926a3": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/p/python3-slip-dbus-0.6.4-19.fc32.noarch.rpm"
+          },
+          "sha256:cb4fb9b3733440ea15b3309c88d9471c4165aa7b71b4dbc5d0fb5bfcd97b2f2e": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libxcrypt-compat-4.4.16-1.fc32.x86_64.rpm"
+          },
+          "sha256:cbfc109588fa0e34bdc408dbb37dadf7873fb5788dd3fd8cd04c17c75f26e6db": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libsmbios-2.4.2-7.fc32.x86_64.rpm"
+          },
+          "sha256:cc1be420582afb6360f380ff301c5e3d873f69fe1f7e00e4450bf2daa40ef9ff": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/t/trousers-lib-0.3.13-13.fc31.x86_64.rpm"
+          },
+          "sha256:cc3396df93ce0e8f439b83fb6b4d210903876846b0bd3a22c19c7770cf5a9050": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/g/gnupg2-2.2.19-1.fc32.x86_64.rpm"
+          },
+          "sha256:ccc3cb2dcb7a534361cc911f27ff4e869902a150b68e236cf6eb209a99d4ee22": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/k/keyutils-libs-1.6-4.fc32.x86_64.rpm"
+          },
+          "sha256:ccdfb24da56aa394a64cf2f0c6ac6d15d0ebd6054686bd2ab27641a5502329be": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/p/podman-1.8.2-2.fc32.x86_64.rpm"
+          },
+          "sha256:cd01ae91895e60f189106a159bb551f906a8b663110f421ad6ee83c9e008851e": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/b/bubblewrap-0.4.1-1.fc32.x86_64.rpm"
+          },
+          "sha256:cd5d539fd0c469f2ebae012a9a8f2ed280363c355f205edc8fc735678ac0adb8": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/n/NetworkManager-wwan-1.22.10-1.fc32.x86_64.rpm"
+          },
+          "sha256:ce8c1f1ce3cb2cc0166dcaad17f35e84278ec39ea9bf232e24130d3ff3271923": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libpsl-0.21.0-4.fc32.x86_64.rpm"
+          },
+          "sha256:d027a3ff0712e3e98d7d2358f8c526fb8d143b2386c353aadcc27199cffe125b": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/w/whois-nls-5.5.6-1.fc32.noarch.rpm"
+          },
+          "sha256:d0e5d0104cf20c8dd332053a5903aab9b7fdadb84b35a1bfb3a6456f3399eb32": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/g/gawk-5.0.1-7.fc32.x86_64.rpm"
+          },
+          "sha256:d1a369d501e3ce1c17d06418c9cd57c4ada551ecc3b45a581e162215e8bd77f5": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/g/gsettings-desktop-schemas-3.36.0-1.fc32.x86_64.rpm"
+          },
+          "sha256:d1c6f183b9deaf6127db4ad7040046bd7f1aa62de177961aac39501605d2c815": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/g/grub2-tools-minimal-2.04-12.fc32.x86_64.rpm"
+          },
+          "sha256:d1e244b8b5ce7404846e97d96c762c8c18ff6447301f6fc63f50e615029aa7cd": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/o/openssh-server-8.2p1-2.fc32.x86_64.rpm"
+          },
+          "sha256:d2abba1a0523bd9df5073900593ab13ec2ed2e391440be4d883314fa154370f8": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/p/python3-slip-0.6.4-19.fc32.noarch.rpm"
+          },
+          "sha256:d3a64fcef3de79a97541b21c71ddd00d4cca9039c930bc660d6c5479eabf5f26": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/j/json-c-0.13.1-9.fc32.x86_64.rpm"
+          },
+          "sha256:d439ffbe20c8c0e8244e31c0324d60cf959dc1cd6cecc575d7b34509a73e9386": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/p/polkit-libs-0.116-7.fc32.x86_64.rpm"
+          },
+          "sha256:d49f0b1c8ecf9bc808ae93e9298a40fbcc124fe67c3bbdd37705b6b5d8cfdd87": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/p/polkit-0.116-7.fc32.x86_64.rpm"
+          },
+          "sha256:d5acde111b4cafc918decc8b9c530c9a7dfd6cc77b75538d33b32478219ae5da": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/c/crun-0.13-1.fc32.x86_64.rpm"
+          },
+          "sha256:d61ea8b6299f00397f740b73de146ef4daa6d6bb5863d525459765fa0f23a991": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/w/wpan-tools-0.9-4.fc32.x86_64.rpm"
+          },
+          "sha256:d65b4bb6fa49198237f9b704ec471d71dfd94b87290f4d03c1c34d12f6efeb95": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libgomp-10.0.1-0.11.fc32.x86_64.rpm"
+          },
+          "sha256:d74b76ce8c2c7306cc3f012d1ec56b1d5c67788748f56ecd505f257d342f97ee": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libbsd-0.10.0-2.fc32.x86_64.rpm"
+          },
+          "sha256:d7b8b5815b72fb157de26579362383e357e026ae6ac2599c451fb336fe995555": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/o/openssl-1.1.1d-7.fc32.x86_64.rpm"
+          },
+          "sha256:d7f57b9190c9cf05c36fe9fb3229330cdb9f0a1af1214a47b0a38dcc8ce929ee": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/i/iwl5000-firmware-8.83.5.1_1-106.fc32.noarch.rpm"
+          },
+          "sha256:d7fec1fb54953f1901cc505c225af94cb61f2206d0503be12313169a4b915e18": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/j/jose-10-6.fc32.x86_64.rpm"
+          },
+          "sha256:dc9c0401522bcf73fe5a692184c141b214947ad83364be97de0413ab46b712e5": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/g/glibc-2.31-2.fc32.x86_64.rpm"
+          },
+          "sha256:ddad78d00b09c6c85d46c06dcba4c951f7f7dfc9b2dab195bf45aa3f5a1fdc41": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libsmartcols-2.35.1-7.fc32.x86_64.rpm"
+          },
+          "sha256:de74076fc5073ad07ffa78fed6e7cd8f10133d99c1c73149b4ac74428699a6d1": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libmbim-1.22.0-1.fc32.x86_64.rpm"
+          },
+          "sha256:dedd37a96262c35763ab2dcbc19838f5cc39a2a3a392a650a80bd6d5ae42ff8b": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/p/p11-kit-0.23.20-1.fc32.x86_64.rpm"
+          },
+          "sha256:def89a494acbfd6aae1fb70700dd18275ddd3050893bc962f1853499af9dd823": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/h/hostname-3.23-2.fc32.x86_64.rpm"
+          },
+          "sha256:df0a39eb6b91c4a8f481c22445cbbd88334bf5e0a6e1dd5fb240981eb031c4eb": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libseccomp-2.4.2-3.fc32.x86_64.rpm"
+          },
+          "sha256:df174a90fd6bd3f9fae3b75433ae7f1869ff2db7102667fb243c8aede5b858d3": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/n/NetworkManager-wifi-1.22.10-1.fc32.x86_64.rpm"
+          },
+          "sha256:e0b1da98020a740991dbb70b42c0ff1eece9e268a461e555a5ec763bda1645f5": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/f/file-libs-5.38-2.fc32.x86_64.rpm"
+          },
+          "sha256:e0f9c4327d62e35ee2a066c95dfa37f86021b405515d0f902b72a7437b7b98e9": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/c/cryptsetup-2.3.0-1.fc32.x86_64.rpm"
+          },
+          "sha256:e2566356943c1c7485d206b858dd6ae3be37c28bfec2a43f869193f3b5b9cd23": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/n/nmap-ncat-7.80-3.fc32.x86_64.rpm"
+          },
+          "sha256:e291d6c021eaa01cc3c446b76c94aafde444936b8ba3f08a7fe7cbe66a23366b": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/k/kernel-tools-5.6.6-300.fc32.x86_64.rpm"
+          },
+          "sha256:e2a04f4de125ff60a3cdc3d2b3718a4530a9c9240c9cf14f55938444c229539f": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/r/rpm-plugin-systemd-inhibit-4.15.1-2.fc32.1.x86_64.rpm"
+          },
+          "sha256:e2b2dddbce49fab5f01ba75fae8796ab7c9fd8280c652f78d06a2644246bd16d": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/k/krb5-libs-1.18-1.fc32.x86_64.rpm"
+          },
+          "sha256:e40be03bd5808e640bb5fb18196499680a7b7b1d3fce47617f987baee849c0e5": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/d/dmidecode-3.2-5.fc32.x86_64.rpm"
+          },
+          "sha256:e5bf9266edf112540ec662bd492ce4bda3ed8d5e33d763b9f2318c42963a1d1b": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/s/sudo-1.9.0-0.1.b4.fc32.x86_64.rpm"
+          },
+          "sha256:e5efc87172d7081559137feaa221047385a5e248ffafd9794c2bfc73b61f8f37": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/p/pciutils-libs-3.6.4-1.fc32.x86_64.rpm"
+          },
+          "sha256:e712179ba8b9b6e93d14c902a6d6a390ba142153384dab9291c808a447b7ed0c": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/d/dnsmasq-2.80-14.fc32.x86_64.rpm"
+          },
+          "sha256:e740cc0a580639b887bda0039a779e750a32835be1fd8c64aa01183b4cbb98bf": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libmount-2.35.1-7.fc32.x86_64.rpm"
+          },
+          "sha256:e80533822e2a892345b869395b2c17c0bcc98d3c3c47787da30123096835db00": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/g/glibc-common-2.31-2.fc32.x86_64.rpm"
+          },
+          "sha256:e851ba0019baa83e1bebbe92e1a1cf629694ccf3b42c5ff84e0ed7bea74931d3": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/lvm2-libs-2.03.09-1.fc32.x86_64.rpm"
+          },
+          "sha256:e9a3ace2c71c2388ed6402e92ba148acb8d19b5c3495a47148b9e88cc6d6d1eb": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libcomps-0.1.14-4.fc32.x86_64.rpm"
+          },
+          "sha256:ea5f929563fb9ca0cf08da250c62c93d4755f4a41c1aca23eeeaf3e58e90d766": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/t/tmux-3.0a-2.fc32.x86_64.rpm"
+          },
+          "sha256:eaffaa8de8fd28ad124da12524a2ca5db86252404d70d66c7c42921dad6b69c1": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/c/cryptsetup-libs-2.3.0-1.fc32.x86_64.rpm"
+          },
+          "sha256:ebbace15f986288bba7681f44a111b14bcc7cae00b7a1faadaa838bd51897357": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libfido2-1.3.1-1.fc32.x86_64.rpm"
+          },
+          "sha256:ec12fef82d73314e3e4cb6e962f8de27e78989fa104dde0599a4480a53817647": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/x/xkeyboard-config-2.29-1.fc32.noarch.rpm"
+          },
+          "sha256:ec58d03c60386bfb8aed2af3d2a49f8c6e5ccb4d3fd592cf75fef3342be137c3": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/p/python3-libs-3.8.2-2.fc32.x86_64.rpm"
+          },
+          "sha256:ec64add7d60a70fbaf14a083929f22bd2637c33d20d2a30b7e842caa6040f817": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/o/ostree-2020.3-2.fc32.x86_64.rpm"
+          },
+          "sha256:ec6abd65541b5bded814de19c9d064e6c21e3d8b424dba7cb25b2fdc52d45a2b": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libnfnetlink-1.0.1-17.fc32.x86_64.rpm"
+          },
+          "sha256:ed36d759746e75a2834866fbeaa783df397f8813cae2ed79fcc4d146656bf6a6": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/d/dbus-1.12.16-4.fc32.x86_64.rpm"
+          },
+          "sha256:ed84414c9b2190d3026f58db78dffd8bc3a9ad40311cb0adb8ff8e3c7c06ca60": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libverto-0.3.0-9.fc32.x86_64.rpm"
+          },
+          "sha256:ee1681ee1ae6a3f86a876562939fbfe415ba78b0a803059e1b6d6cd63b0fa1a3": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/s/shim-x64-15-8.x86_64.rpm"
+          },
+          "sha256:ee664c392a97cdd272f57980c6856b2c57567005fa0ad9cb16c388b645d014f1": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/r/rpm-ostree-2020.1-1.fc32.x86_64.rpm"
+          },
+          "sha256:f09047c09660bc998460f710b9ac0561b4f6028214168d4d40f2f4d99f61a94d": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/a/audit-3.0-0.19.20191104git1c2f876.fc32.x86_64.rpm"
+          },
+          "sha256:f1150f9e17beaef09aca0f291e10db8c3ee5566fbf4c929b7672334410fa74e9": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/q/qrencode-libs-4.0.2-5.fc32.x86_64.rpm"
+          },
+          "sha256:f14d3b113e2c3ba3f8ab7a8146439924f38487c20dd533062616f17f500ff46b": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/s/skopeo-0.1.41-1.fc32.x86_64.rpm"
+          },
+          "sha256:f1c79039f4c6ba0fad88590c2cb55a96489449c334a671cc18c0bf424a4548b8": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/r/readline-8.0-4.fc32.x86_64.rpm"
+          },
+          "sha256:f2715fc8a04d33716f40f5b34466e082140df7ff3b7b972c29655d4dfc6e3a72": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/f/fipscheck-lib-1.5.0-8.fc32.x86_64.rpm"
+          },
+          "sha256:f36550dfc144e4608da672616fa44b2f2341f99bb38972e66e4a8fef4b59172c": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/g/glibc-minimal-langpack-2.31-2.fc32.x86_64.rpm"
+          },
+          "sha256:f3908831ae53f43b07a4e196850d0e59cc89b50c97d838538c3185fd0eb0d569": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/p/procps-ng-3.3.15-7.fc32.x86_64.rpm"
+          },
+          "sha256:f3eb795f68c80ccf870f1d27f8fd019878db748c0c19275634c48cf5cea5bc46": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/e/elfutils-libelf-0.179-1.fc32.x86_64.rpm"
+          },
+          "sha256:f4eb6d332b9aea8d8ef0a6ea8dc2b073d6bf5f2599d64f24111d8da2ee82ad48": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/i/iptables-libs-1.8.4-7.fc32.x86_64.rpm"
+          },
+          "sha256:f60fc561675e41ffa2c48b229960291e2438441d5ed758c1f28cb06b5d4e4ea9": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/i/ipset-libs-7.6-1.fc32.x86_64.rpm"
+          },
+          "sha256:f729c554ed4ac6335a548380a6f6335a332a3a2aca5321a322415a208701607d": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/d/dbxtool-8-11.fc32.x86_64.rpm"
+          },
+          "sha256:f77cad4c497f11c5b5bd7c9a29fc1f5f5574f8443cc4496e3bd98e680b363124": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/p/python3-libselinux-3.0-3.fc32.x86_64.rpm"
+          },
+          "sha256:f826f984b23d0701a1b72de5882b9c0e7bae87ef49d9edfea156654f489f8b2b": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libacl-2.2.53-5.fc32.x86_64.rpm"
+          },
+          "sha256:f98f854a86c68b534f71e1f35852fabddbe2cbfe481b01bb15291b3363013b2a": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libmodulemd-2.9.1-1.fc32.x86_64.rpm"
+          },
+          "sha256:f9ccea65ecf98f4dfac65d25986d08efa62a1d1c0db9db0a061e7408d6805a1a": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libutempter-1.1.6-18.fc32.x86_64.rpm"
+          },
+          "sha256:fa08dccd7a2e38dfbab999613bdb41df2034b506d21964d0ef368af6e56c4cf9": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libdnf-0.45.0-3.fc32.x86_64.rpm"
+          },
+          "sha256:fb06aa3d8059406a23694ddafe0ef340ca627dd68bf3f351f094de58ef30fb2c": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libunistring-0.9.10-7.fc32.x86_64.rpm"
+          },
+          "sha256:fbaf44214a3e93d4bdccb1519768849db5ea204c886df851b49f107e0c443e4a": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/g/greenboot-grub2-0.9-1.fc32.noarch.rpm"
+          },
+          "sha256:fbb81a7811f7a11b1c95eec20c3df63beef9e007f0b3d2713f13ad80029d7249": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/k/kpartx-0.8.2-3.fc32.x86_64.rpm"
+          },
+          "sha256:fc8a8027325828861bae0c41d2582d61f8cb4b9ed42a50e49c57939eabcad1b7": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/m/ModemManager-1.12.8-1.fc32.x86_64.rpm"
+          },
+          "sha256:fd2a2dd726d855f877296227fb351883d647df28b1b0085f525d87df622d49e4": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/n/NetworkManager-libnm-1.22.10-1.fc32.x86_64.rpm"
+          },
+          "sha256:fdb9bc612957a16fc44b717605a5a26e16a33850c0ff74a80a299cc2bab740e4": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/g/gettext-libs-0.20.1-4.fc32.x86_64.rpm"
+          },
+          "sha256:fefa4162a563eba24714ac43874c508d1ba036afb5127c5d21bbcbeaf238a740": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/c/cyrus-sasl-lib-2.1.27-4.fc32.x86_64.rpm"
+          },
+          "sha256:ff44071d53a2ed543c2ddad99cca8fc25493cbefc5d7ad869f9b6dbda340a465": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libjose-10-6.fc32.x86_64.rpm"
+          },
+          "sha256:ff5dd4d0c157cf1be9c8dbddce06640c67b2d02ae5a48d6b108bd70fc5c96211": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/f/fwupd-1.3.9-2.fc32.x86_64.rpm"
+          },
+          "sha256:ffe5076b9018efdb1612c487f637af39ab6c3c79ec37311978935cfa357ecd61": {
+            "url": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/s/sed-4.5-5.fc32.x86_64.rpm"
+          }
+        }
+      }
+    },
+    "pipeline": {
+      "build": {
+        "pipeline": {
+          "stages": [
+            {
+              "name": "org.osbuild.rpm",
+              "options": {
+                "gpgkeys": [
+                  "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBF1RVqsBEADWMBqYv/G1r4PwyiPQCfg5fXFGXV1FCZ32qMi9gLUTv1CX7rYy\nH4Inj93oic+lt1kQ0kQCkINOwQczOkm6XDkEekmMrHknJpFLwrTK4AS28bYF2RjL\nM+QJ/dGXDMPYsP0tkLvoxaHr9WTRq89A+AmONcUAQIMJg3JxXAAafBi2UszUUEPI\nU35MyufFt2ePd1k/6hVAO8S2VT72TxXSY7Ha4X2J0pGzbqQ6Dq3AVzogsnoIi09A\n7fYutYZPVVAEGRUqavl0th8LyuZShASZ38CdAHBMvWV4bVZghd/wDV5ev3LXUE0o\nitLAqNSeiDJ3grKWN6v0qdU0l3Ya60sugABd3xaE+ROe8kDCy3WmAaO51Q880ZA2\niXOTJFObqkBTP9j9+ZeQ+KNE8SBoiH1EybKtBU8HmygZvu8ZC1TKUyL5gwGUJt8v\nergy5Bw3Q7av520sNGD3cIWr4fBAVYwdBoZT8RcsnU1PP67NmOGFcwSFJ/LpiOMC\npZ1IBvjOC7KyKEZY2/63kjW73mB7OHOd18BHtGVkA3QAdVlcSule/z68VOAy6bih\nE6mdxP28D4INsts8w6yr4G+3aEIN8u0qRQq66Ri5mOXTyle+ONudtfGg3U9lgicg\nz6oVk17RT0jV9uL6K41sGZ1sH/6yTXQKagdAYr3w1ix2L46JgzC+/+6SSwARAQAB\ntDFGZWRvcmEgKDMyKSA8ZmVkb3JhLTMyLXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQI4BBMBAgAiBQJdUVarAhsPBgsJCAcDAgYVCAIJCgsEFgIDAQIeAQIXgAAK\nCRBsEwJtEslE0LdAD/wKdAMtfzr7O2y06/sOPnrb3D39Y2DXbB8y0iEmRdBL29Bq\n5btxwmAka7JZRJVFxPsOVqZ6KARjS0/oCBmJc0jCRANFCtM4UjVHTSsxrJfuPkel\nvrlNE9tcR6OCRpuj/PZgUa39iifF/FTUfDgh4Q91xiQoLqfBxOJzravQHoK9VzrM\nNTOu6J6l4zeGzY/ocj6DpT+5fdUO/3HgGFNiNYPC6GVzeiA3AAVR0sCyGENuqqdg\nwUxV3BIht05M5Wcdvxg1U9x5I3yjkLQw+idvX4pevTiCh9/0u+4g80cT/21Cxsdx\n7+DVHaewXbF87QQIcOAing0S5QE67r2uPVxmWy/56TKUqDoyP8SNsV62lT2jutsj\nLevNxUky011g5w3bc61UeaeKrrurFdRs+RwBVkXmtqm/i6g0ZTWZyWGO6gJd+HWA\nqY1NYiq4+cMvNLatmA2sOoCsRNmE9q6jM/ESVgaH8hSp8GcLuzt9/r4PZZGl5CvU\neldOiD221u8rzuHmLs4dsgwJJ9pgLT0cUAsOpbMPI0JpGIPQ2SG6yK7LmO6HFOxb\nAkz7IGUt0gy1MzPTyBvnB+WgD1I+IQXXsJbhP5+d+d3mOnqsd6oDM/grKBzrhoUe\noNadc9uzjqKlOrmrdIR3Bz38SSiWlde5fu6xPqJdmGZRNjXtcyJlbSPVDIloxw==\n=QWRO\n-----END PGP PUBLIC KEY BLOCK-----\n"
+                ],
+                "packages": [
+                  {
+                    "checksum": "sha256:705bdb96aab3a0f9d9e2ff48ead1208e2dbc1927d713d8637632af936235217b",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:c574c5432197acbe08ea15c7837be7577cd0b49902a3e65227792f051d73ce5c",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:22d311f22902d592f72bd0fb4010a682f796e5a4698d5ea209848468a2d5aa96",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:a346990bb07adca8c323a15f31b093ef6e639bde6ca84adf1a3abebc4dc9adce",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:7a97e71cd552285ead303d07dbb6417403edf45c0a531e02cf4ebfb0efda4975",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:cd01ae91895e60f189106a159bb551f906a8b663110f421ad6ee83c9e008851e",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:842f7a38be2e8dbb14eff3ede4091db214ebe241e1fde7a128e88c4e686b63b0",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:73f6a9108f7d5ec3cd89c31dbbaa874ae28cd5cb443ef69700a1218903ee2fc4",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:7023687eb65baa56a9b4c3ffde1e439b3d41b03ac4ad35a1a1fc3903464548f7",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:5323eb8d89b2d0c905a633513e04ca7df633c21eec288ee8c50f3f5170534e37",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:116b9d121fad9886f245cd5e1ef678fdba889cd23a39e91447e75649214a6a8d",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:862e75c10377098a9cc50407a0395e5f3a81d14b5b6fecfb3f223325c8867829",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:1aee865249b031e591a5e94d62d05b69ad1a6118a26adccf2dfd46b0002716e5",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:3f8dcae27ad3609b7de298d0ca8d34a2790b9898f5f1b03f3f9f8784374e307b",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:b821e9e8bf66abacaed4a386f9ed8ffa17f4f8be3db55e1ac31d52ba2d1faa1b",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:eaffaa8de8fd28ad124da12524a2ca5db86252404d70d66c7c42921dad6b69c1",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:6eeebf21f245bf0d6f58962dc49b6dfb51f55acb6a595c6b9cbe9628806b80a4",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:fefa4162a563eba24714ac43874c508d1ba036afb5127c5d21bbcbeaf238a740",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:ed36d759746e75a2834866fbeaa783df397f8813cae2ed79fcc4d146656bf6a6",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:213c17fb822ffa50fad16989ed363aa023de106c6262ccc3f16e52a154b7133f",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:6fc1b9a27eeb368a98f50dba5fc514f20a5eb23f8e0ee7dd92c4051ef8b4a940",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:474fd088c7e7234221d251153e9fda6081b0aa8979bf5ae25810c9862e1e9960",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:b70d1c93e3448b1a0b5e3f50488290283a260ff46e22bff4fb704469e6017fa8",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:c132999a3f110029cd427f7578965ad558e91374637087d5230ee11c626ebcd4",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:61cae80187ef2924857fdfc48a240646d23b331482cf181e7d8c661b02c15949",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:187dd61be71efcca6adf9819a523d432217abb335afcb2b95ef27b72928aff4b",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:78e1aa11379eec2906eedf843216f47bcbdfe4da4713d566fb44ca313c893f3f",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:80d407bbc5f6bb8d95504cfdb51faaca937f6c4c08df4c4aadcd46fe703c8a57",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:c3f7089ae50f79cf4d2cb59e01091d33c70cab89ae08f95c547339a87404c3ec",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:993680d5cd133a0c21184be92b3df405d757613d0ca25c4abf08b203d8d26b79",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:2fa5e252441852dae918b522a2ff3f46a5bbee4ce8936e06702bf65f57d7ff99",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:26db62c2bc52c3eee5f3039cdbdf19498f675d0f45aec0c2a1c61c635f01479e",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:4f318cec61cb69fc233ba5505b7e24f679afdfb0b5defbaef507f1b471e7dbb5",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:af62d0611b995b9f2b2c7b4d4852e03e521d66979534871ccb5a71275a15518d",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:f3eb795f68c80ccf870f1d27f8fd019878db748c0c19275634c48cf5cea5bc46",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:99f87b4ec7c5852d45028f3eae65fc813f3ef107e128777f265b09a19ce262e0",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:8fc2ae85f242105987d8fa7f05e4fa19358a7c81dff5fa163cf021eb6b9905e9",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:09fea9af8b695af862b19c1a8fbe1b1e8854257825ee4f663f67b3782a75d58a",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:1f2ba0fc562864ad1bea31a42da124030fc188d23a84d144be616c2d066e1531",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:a1835a7929d3c1613f3890caef878e9bdf857dcc0f63eb4d63a1140370b3f21b",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:21e3fd914a3bcc65b79de022782967903c55a4aed9a3c7d3464bc2fef32d02b3",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:28656826cb0dfbae9b6e8d1e5c5691773d84000493c4be47f727092fec6dc6f4",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:e0b1da98020a740991dbb70b42c0ff1eece9e268a461e555a5ec763bda1645f5",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:1110261787146443e089955912255d99daf7ba042c3743e13648a9eb3d80ceb4",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:0b7cd6f6cb3b7cd9e0704dd6c62b65254b04cb870ab638b9bed4951564436e24",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:9369d4fed30402f45705b7a5cb51b6eeefb1dabbe0942c84514c6fdf1edac5e0",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:45132e53c649def28d63c199d8c3a3b9fd16fa8bca7426ad4e9c202e52a233b4",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:53992752850779218421994f61f1589eda5d368e28d340dccaae3f67de06e7f2",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:d0e5d0104cf20c8dd332053a5903aab9b7fdadb84b35a1bfb3a6456f3399eb32",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:9899cfd32ada2537693af30b60051da21c6264b0d0db51ba709fceb179d4c836",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:349af433b2f6d45ff2e1ea5a38f847ec692fef0a8dd656a9a07d423a981946d0",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:fdb9bc612957a16fc44b717605a5a26e16a33850c0ff74a80a299cc2bab740e4",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:6fe524feb38312f9c370b2190aeb42330acc9ce42f3a45e9cd05748b4aa00db2",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:dc9c0401522bcf73fe5a692184c141b214947ad83364be97de0413ab46b712e5",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:129d919e55c09edecaa8edd0fd4058dbf7460aaae5d1c5625ca11f6df7defefe",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:e80533822e2a892345b869395b2c17c0bcc98d3c3c47787da30123096835db00",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:178e4470a6dfca84ec133932606737bfe167094560bf473940504c511354ddc9",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:cc3396df93ce0e8f439b83fb6b4d210903876846b0bd3a22c19c7770cf5a9050",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:966084f83e0fedb7a217aa102b484ac8a63082ccfe99517544ed2cb102191204",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:9d4f1290565b852e56f9e9babc14b141b0283998121f78b0eb83dec367cf0abb",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:13a0c9c767f71164cc678ee36d89b7fddcdd6fb8243e3daf8b47cca0d1d14c4f",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:759165656ac8141b0c0ada230c258ffcd4516c4c8d132d7fbaf762cd5a5e4095",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:01173d218dccdf88c1159bba4af332ce703fc0dcd7171cd279cb3e16f12b30a9",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:110f538d82f15f009d95e89d8c1e3669dc7358feb9aa7724301fef037f8b67fe",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:c2197913bc8db9548b0a40ffddf840a31956b18e932ad4eec77a48d87d2289ce",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:7f6d2841ec9402ee5e57f1a46b9886935138c02005d860899f3c746c7885c7b9",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:d1c6f183b9deaf6127db4ad7040046bd7f1aa62de177961aac39501605d2c815",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:53f1e8570b175e8b58895646df6d8068a7e1f3cb1bafdde714ddd038bcf91e85",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:c1f957511b5e011e6f7995ed7bca9196703cf1214068f209e86b1dc4fd0e98bf",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:f4eb6d332b9aea8d8ef0a6ea8dc2b073d6bf5f2599d64f24111d8da2ee82ad48",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:d3a64fcef3de79a97541b21c71ddd00d4cca9039c930bc660d6c5479eabf5f26",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:8a03d482b5294f7452b2f9ce31ebb6aea9eefac002281c1b9152fbb1a0341987",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:a05178831a546e2001e52f065fc6969f36d2292efaee2971fe7a7e882cc8c813",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:3be681b78e919bfd82eb186c7393718f1d37abd0b1bb8b1a8571aefa11e7a248",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:60774007011889671c28158f599032f0db253c153ccae70f5e2f5840f2dc490b",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:ccc3cb2dcb7a534361cc911f27ff4e869902a150b68e236cf6eb209a99d4ee22",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:3f9c95f3827b785f49ac4a270d4c3a703dceba673c452838744ec5064cf43cbd",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:56187c1c980cc0680f4dbc433ed2c8507e7dc9ab00000615b63ea08c086b7ab2",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:fbb81a7811f7a11b1c95eec20c3df63beef9e007f0b3d2713f13ad80029d7249",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:e2b2dddbce49fab5f01ba75fae8796ab7c9fd8280c652f78d06a2644246bd16d",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:f826f984b23d0701a1b72de5882b9c0e7bae87ef49d9edfea156654f489f8b2b",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:a410db5c56d4f39f6ea71e7d5bb6d4a2bd518015d1e34f38fbc0d7bbd4e872d4",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:88f4bd19a6cf6eba5e6f2b5bba80819b5ccddb0476aadc53c8df13f9c45b1e58",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:7d9bd2fe016ca8860e8fab4a430b3aae4c7b7bea55f8ccd7775ad470172e2886",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:598a136b7027cb9b4fef6bfa34715979d41c2f62c9d8bec5d50b633a17790f7b",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:65e0cfe367ae4d54cf8bf509cb05e063c9eb6f2fea8dadcf746cdd85adc31d88",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:1830b4aa42ef492c13b62f63fe941970869ba19bd9abde4dea5c97f9e38ffd68",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:ac8b1fea0b678d7630033a8900be5641b934306961b39a29c79c6d72f34f7d1c",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:1bc0542cf8a3746d0fe25c397a93c8206963f1f287246c6fb864eedfc9ffa4a7",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:b60670fdcf91b50d97720f601d92277efedbd690bd887000ccd9a46b3fa8b314",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:4494013eac1ad337673f084242aa8ebffb4a149243475b448bee9266401f2896",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:e9a3ace2c71c2388ed6402e92ba148acb8d19b5c3495a47148b9e88cc6d6d1eb",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:63400fedea4a6ddb8fced58d33e60560791f29cd439169998f337d09fb50a7d4",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:7dfe1e8dac6d759479ae3dfd415fdd2662bbed9ff0f4da6093279efd1bacae31",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:688fcc0b7ef3c48cf7d602eefd7fefae7bcad4f0dc71c9fe9432c2ce5bbd9daa",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:431d836b2be015212d8c15b4290d5ce5bb45282cbf3fc52696f632d84ce34dfe",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:fa08dccd7a2e38dfbab999613bdb41df2034b506d21964d0ef368af6e56c4cf9",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:7bf42ff57ce2a31db0da7d6c5926552f4e51e9f25cded77bd634eb5cd35eadab",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:942d06ec1f7033ea4c729b84ee09f5491481770efe10151ba581479ac7f3f9dc",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:86c87a4169bdf75c6d3a2f11d3a7e20b6364b2db97c74bc7eb62b1b22bc54401",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:48cf5ab32f6af8f2283d4d4834e8dd262aa412be7ea07c2292483e150d614bef",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:5f0ae954b5955c86623e68cd81ccf8505a89f260003b8a3be6a93bd76f18452c",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:d65b4bb6fa49198237f9b704ec471d71dfd94b87290f4d03c1c34d12f6efeb95",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:9bd5cb588664e8427bc8bebde0cdf5e14315916624ab6b1979dde60f6eae4278",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:20787251df57a108bbf9c40e30f041b71ac36c8a10900fb699e574ee7e259bf2",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:8677b34fa73f258b1a599d18419f6fbbb8961bb1ca2ae5b0f9abdcc4f93b319e",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:5d5c8c7e9c78e3b8827ad38771efb44951d1c3c1692cf4e07b138c1c8c42bd5b",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:1b05dd5abad5a31380c859bc33e7851158c24333fda837ca9facf869005f81fe",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:6eb95e39b9771c4dde5f9954a74cef6be90522c28c7c4aa767ebe7a9d55fcdf9",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:1c68255945533ed4e3368125bc46e19f3fe348d7ec507a85a35038dbb976003f",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:f98f854a86c68b534f71e1f35852fabddbe2cbfe481b01bb15291b3363013b2a",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:aa5b658fd4a95c724b61eddadecdbcbc1b2a813ae681318ab092a2ed03954825",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:e740cc0a580639b887bda0039a779e750a32835be1fd8c64aa01183b4cbb98bf",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:884357540f4be2a74e608e2c7a31f2371ee3b4d29be2fe39a371c0b131d84aa6",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:ec6abd65541b5bded814de19c9d064e6c21e3d8b424dba7cb25b2fdc52d45a2b",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:a8ce7406c87f64972f0b70f1823c2aad05516c71fe375c6c97737459c2448825",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:3b4ce7fc4e2778758881feedf6ea19b65e99aa3672e19a7dd62977efe3b910b9",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:b3230630a471b806a9153669d187508350cdb2b368a68f8c439c82abad038c3f",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:ce8c1f1ce3cb2cc0166dcaad17f35e84278ec39ea9bf232e24130d3ff3271923",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:9ecc8aa9af05ba704cec879618afeda5ff92d8233811e2d6080aa02e0b5ceddf",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:aa783a91b1823b7b056575e6276df35910eb2e0d4b72121cf5649651c7d23a16",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:3d33c29bcc4a39be16d6647a70a0d7ae2f08baf26dcea5c802289df1128d5f21",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:df0a39eb6b91c4a8f481c22445cbbd88334bf5e0a6e1dd5fb240981eb031c4eb",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:251fd875421da4708b76c15c7f5ba478d50b74d7e4242071a621625eac51a767",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:0e59b422e35eee975ba68e6e4de022c8f145feec7e169e86e0244d2fdad2f590",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:1446032720fb8e0090190828fcea294a86fc7f83edd70f6089e3446770ba0438",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:54cb827278ae474cbab1f05e0fbee0355bee2674d46a804f1c2b78ff80a48caa",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:29e2b62e9e63f25139a6863c863c3b534660440d7dec0c985807302a6895dbaf",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:942707884401498938fba6e2439dc923d4e2d81f4bac205f4e73d458e9879927",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:ddad78d00b09c6c85d46c06dcba4c951f7f7dfc9b2dab195bf45aa3f5a1fdc41",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:be899d3e806441b1c46811c0ffe9f4e01f4ea4e1544f9cc32630254853e3f3a5",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:27701cda24f5f6386e0173745aabc4f6df28052975e73529854432c35399cfc8",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:32f8cbb3be91f589d569a2e737130f29c752f78eebc61e287af17f207e1b8c58",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:49bac21d5cdf863fccfcc32bf070e582d204706e35ee9f60b3e69df694bff87d",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:be998dfbcc9ca8e3021ac4f56ed723cfa3fa1517524e89ee0b636f623abe995f",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:052d04c9a6697c6e5aa546546ae5058d547fc4a4f474d2805a3e45dbf69193c6",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:b35256e417fd94c7efb1212f2f36b5e6b224ff5b9e8733774d4fbdc652078099",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:c1d754773972b5f4ca157c0afa45d6767901d965a91f381660c72740d682df63",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:fb06aa3d8059406a23694ddafe0ef340ca627dd68bf3f351f094de58ef30fb2c",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:729fb595040f1e2e71ff0a8c1c22ebe4b7187f78b816af8e6a8d93c03fc5d844",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:f9ccea65ecf98f4dfac65d25986d08efa62a1d1c0db9db0a061e7408d6805a1a",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:8402d3aabfc02c16f3789f3f93338dbee2448db8a49956002b83aff5390922d9",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:ed84414c9b2190d3026f58db78dffd8bc3a9ad40311cb0adb8ff8e3c7c06ca60",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:7c1a229f4a36ac8b077e0514f68f311229652121528b0f8a2a7434c618276dcb",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:cb4fb9b3733440ea15b3309c88d9471c4165aa7b71b4dbc5d0fb5bfcd97b2f2e",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:ae219ad5ecc0233271c3fd61263f817c646eecece19a8f075e7aa4dd9ff8698e",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:a7f040de29d2414cc99fcffcd9ed3fa9d06ecc7aecd783ec3d2eef769e2389f1",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:9c8a274158a6fe97598e33900cd51e171f7e7517ccfc8ad6351873e69b225986",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:9465f2f1103697207a52d15edd716ab72dc6c281823c60f424cd064d706c7a51",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:10883ce95852cc9ae9b4e0d435b100a25f8fe5c0ea4677eb4a0b39f4f8def886",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:44cfb58b368fba586981aa838a7f3974ac1d66d2b3b695f88d7b1d2e9c81a0b6",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:640afe5b9d499c9a7efc1d23cce8c54e3e3704d92eb7e7a93a048f97d1e983e1",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:2b098bc6f8004270ee9eac9f63980b364b5fe19394dc73a230b3c846cf488b1b",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:b2e862283ac97b1d8b1ede2034ead452ac7dc4ff308593306275b1b0ae5b4102",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:25fc5d288536e1973436da38357690575ed58e03e17ca48d2b3840364f830659",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:04152a3a608d022a58830c0e3dac0818e2c060469b0f41d8d731f659981a4464",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:c019d23ed2cb3ceb0ac9757a72c3e8b1d31f2a524b889e18049cc7d923bc9466",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:3c2a641f118ab2e8b08df6dd2da72a60121d02df8d932b4afa2920eb80392875",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:ade8105796f5c1201a3efc8bcc654788cfc88c3815297b346845062a8c29cd59",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:d7b8b5815b72fb157de26579362383e357e026ae6ac2599c451fb336fe995555",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:ad6d7d9767e05978b14a39c08dba59ddc4396584576df194f77ed310a0816ae0",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:3f2cb9092d6f55f84dd9eacd5359dfb354772e5f38308328027c7758f4a06fb6",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:45fc2608b746fd841dd25919e9e4d44834154758aec8fb8b529c014b11c7917d",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:ec64add7d60a70fbaf14a083929f22bd2637c33d20d2a30b7e842caa6040f817",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:3343d9e7c90bd58e1e44ee07e7c59bb570ffc74da50f0607c5f5681a00b70e76",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:dedd37a96262c35763ab2dcbc19838f5cc39a2a3a392a650a80bd6d5ae42ff8b",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:3589b982ac0c2f5f6b47cde5cb7ec33c2c01d756dabf8c4ca64f6d9d0d78b35e",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:4c80ade4ac0889316930a8d181ea43fa2d1b2f1a6a5703c22f2b3ba191346eec",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:933bdb4cc6e14b2ebb1ca76c14ca176c13d271a2d1e88632f237392777d11808",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:6794fe48004c0403c29fc779b49f0fbea436123b96783a2df225eef2f0858795",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:5db7c0e949bd9172b9645237e72f6139d4ffcf14defad487262b8ad25b427daf",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:15f08ce979e48fd25be5e16d63d1c95c57f9abff7704005137ea00b958442939",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:7df4fa1a29772696d92866e890af6fbe006088f3407ed3e67b0e7867ef58d899",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:8df97dcfb42c1667b5d2e4150012eaf96f58eeac4f7b879e0928c8c36e3a7604",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:d439ffbe20c8c0e8244e31c0324d60cf959dc1cd6cecc575d7b34509a73e9386",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:8a0c00a69f9cb3a9ffacaf1cdc162c38a1faca76c9b976cb177bdc988902f2d4",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:f3908831ae53f43b07a4e196850d0e59cc89b50c97d838538c3185fd0eb0d569",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:af992ad02594b68f17d2da41104a26aee41d02639edf22332d7dbb1fe9af58a5",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:a7da5590635b9c19afafc7dd247604194a5ce7d8d863dc600b8cb86accb2e469",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:7dd93baaf69a8004ae2cd3b9e6660b862d0b6f399d53c05a27a48a2e276ef1ee",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:0b290954bc2868b3dfc976b2b7a13ea8aeade76eeafc17674ff8e721049a5bf7",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:b79bb6af3e1650ba812c8affe42772ea566b164222a7d4d8e2f7efa867dc6849",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:632aedc06003e319a1c3fa98876055fc3bd3b44c1188b44d3b7a455cef0d40e4",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:9de8eb13fbdf8b8c5c3e04c52a890ccc5b667351ff17152786d12ffc66210433",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:6a2f4706a37bc5ad229f6fdddbd70fbcf82da85ec577a8deeb455513cbedc174",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:0d9d80adb91ccc8eed62bea68b23da5edb77675b1ec93227e2179d028449a2f7",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:44fabecae31a5900fe10837863ed231303f6863bd9fa5efa40a93a0fc059344f",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:ec58d03c60386bfb8aed2af3d2a49f8c6e5ccb4d3fd592cf75fef3342be137c3",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:9ade87dbb32f27e7f38ec981002ddc5a2189cc6f5ad5f24bada3b71cfa9167fd",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:355a095bb3c6d58f927277ff53267f88eb0729adbcafd8082b8d97e4815ee206",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:724cca9919bb7b0183b030aca216d4d51de70bf35c2cc5e8325a21a52ca15ceb",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:517ff9662e5a1897b74f4ab4fbc8a88eccaad9880bc18be9cf4df6aba9824bd5",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:475b6de876914aec2187ac4858a13ae75585f5c4cb5d739c637f79a5ca6f05f9",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:f1150f9e17beaef09aca0f291e10db8c3ee5566fbf4c929b7672334410fa74e9",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:f1c79039f4c6ba0fad88590c2cb55a96489449c334a671cc18c0bf424a4548b8",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:136a9cbae9c225be60718fdc8cc8988a55235d6502e451df77d1c5c765143850",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:3151132084577032b4c827eb577a1509950601888c6ff13a0a30b24252ee26d2",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:54b740cf7a75a7215168970378d9a1d6b9a5e4eb81159a874ce8ea5990436641",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:ee664c392a97cdd272f57980c6856b2c57567005fa0ad9cb16c388b645d014f1",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:9d220d8ee28cd0adf28e8fef547af92c3ec66e238747165939cf8e1a413ddf83",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:e2a04f4de125ff60a3cdc3d2b3718a4530a9c9240c9cf14f55938444c229539f",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:630ad20496ff00f76764e01b9302ccbe94e3e91d76ececef88bd9e8a890b1ac3",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:ffe5076b9018efdb1612c487f637af39ab6c3c79ec37311978935cfa357ecd61",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:a336d2e77255df4783f52762e44efcc8d77b044a3e39c7f577d5535212848280",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:4dd6100e477d88a4987b6eebfddecff168f38c7ff47cbb12f2fecba1e87c10d9",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:a280c633b73517da167b91298fc97aeee2eb5fcc253c038ae0ce4b8478d3a103",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:7f555c600b35ba798d8c0a63e30a1a12e917231730e1a44f48161ba0fe4b5973",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:1de2be4fe5280ec3097305d9e671f5f2c768267f90d255edf2075eecb0c0afe9",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:78db9007c08fa51f177210e47343b8e733ce0751826abb357ca96429836588db",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:750da30da0289d5e2ad9ca297dda44e5ca18dbed0c3e0d4200379bc1818c22f3",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:97197411bca68cfba1ef6bab1fdd4b41c95ec71c36f1e67f525b963cf60598fd",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:334d63914e7ff6fe8cfce0c8f80006c6cf2ab0615cd044a6ee588809395499e5",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:2cee64e12b295b74d2f4b008c7628ef3a01ef4149905fc4a7ae14b304da5f53b",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:5f156c2a950699d5cb9a21349cce049b3c8bfdcc4fcc780665fe2d3103f576c1",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:cc1be420582afb6360f380ff301c5e3d873f69fe1f7e00e4450bf2daa40ef9ff",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:6f669ae6f70cfa80917adf4ae9d5e86fbd9d31ee308a9a3408a19be3afc46f7b",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:2db6d80760ab0e99f4e9c9816615e4f06b967bbb23a8c8c941b3f2d4b5f176c2",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:29d7df69d66f51f6dddd637d3f599e70bdaa9bd476669002250bc038735a318c",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:9976e6228a10fa2761f1265a2a7666578d79ca57819837e5d1fbecc53324f1b9",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:82e0d8f1e0dccc6d18acd04b7806350343140d9c91da7a216f93167dcf650a61",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:d027a3ff0712e3e98d7d2358f8c526fb8d143b2386c353aadcc27199cffe125b",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:ec12fef82d73314e3e4cb6e962f8de27e78989fa104dde0599a4480a53817647",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:1bdde5dc99a5588a8983f70b7b3e45e7006215d529c72adfec118c3bcbf7b01c",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:84702d6395a9577c1a268184f123cfd4b15bc2287f01033625ba388a34ec2338",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:140708561a2ec1c7709fd38d8b1b115d02da710b80eeecd65c2b8387d9d78ef9",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:c0fff40dc1092e18ed3e608bc6143c89a0d7775b9e0553319bb2caca7d324d80",
+                    "check_gpg": true
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        "runner": "org.osbuild.fedora32"
+      },
+      "stages": [
+        {
+          "name": "org.osbuild.rpm",
+          "options": {
+            "gpgkeys": [
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBF1RVqsBEADWMBqYv/G1r4PwyiPQCfg5fXFGXV1FCZ32qMi9gLUTv1CX7rYy\nH4Inj93oic+lt1kQ0kQCkINOwQczOkm6XDkEekmMrHknJpFLwrTK4AS28bYF2RjL\nM+QJ/dGXDMPYsP0tkLvoxaHr9WTRq89A+AmONcUAQIMJg3JxXAAafBi2UszUUEPI\nU35MyufFt2ePd1k/6hVAO8S2VT72TxXSY7Ha4X2J0pGzbqQ6Dq3AVzogsnoIi09A\n7fYutYZPVVAEGRUqavl0th8LyuZShASZ38CdAHBMvWV4bVZghd/wDV5ev3LXUE0o\nitLAqNSeiDJ3grKWN6v0qdU0l3Ya60sugABd3xaE+ROe8kDCy3WmAaO51Q880ZA2\niXOTJFObqkBTP9j9+ZeQ+KNE8SBoiH1EybKtBU8HmygZvu8ZC1TKUyL5gwGUJt8v\nergy5Bw3Q7av520sNGD3cIWr4fBAVYwdBoZT8RcsnU1PP67NmOGFcwSFJ/LpiOMC\npZ1IBvjOC7KyKEZY2/63kjW73mB7OHOd18BHtGVkA3QAdVlcSule/z68VOAy6bih\nE6mdxP28D4INsts8w6yr4G+3aEIN8u0qRQq66Ri5mOXTyle+ONudtfGg3U9lgicg\nz6oVk17RT0jV9uL6K41sGZ1sH/6yTXQKagdAYr3w1ix2L46JgzC+/+6SSwARAQAB\ntDFGZWRvcmEgKDMyKSA8ZmVkb3JhLTMyLXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQI4BBMBAgAiBQJdUVarAhsPBgsJCAcDAgYVCAIJCgsEFgIDAQIeAQIXgAAK\nCRBsEwJtEslE0LdAD/wKdAMtfzr7O2y06/sOPnrb3D39Y2DXbB8y0iEmRdBL29Bq\n5btxwmAka7JZRJVFxPsOVqZ6KARjS0/oCBmJc0jCRANFCtM4UjVHTSsxrJfuPkel\nvrlNE9tcR6OCRpuj/PZgUa39iifF/FTUfDgh4Q91xiQoLqfBxOJzravQHoK9VzrM\nNTOu6J6l4zeGzY/ocj6DpT+5fdUO/3HgGFNiNYPC6GVzeiA3AAVR0sCyGENuqqdg\nwUxV3BIht05M5Wcdvxg1U9x5I3yjkLQw+idvX4pevTiCh9/0u+4g80cT/21Cxsdx\n7+DVHaewXbF87QQIcOAing0S5QE67r2uPVxmWy/56TKUqDoyP8SNsV62lT2jutsj\nLevNxUky011g5w3bc61UeaeKrrurFdRs+RwBVkXmtqm/i6g0ZTWZyWGO6gJd+HWA\nqY1NYiq4+cMvNLatmA2sOoCsRNmE9q6jM/ESVgaH8hSp8GcLuzt9/r4PZZGl5CvU\neldOiD221u8rzuHmLs4dsgwJJ9pgLT0cUAsOpbMPI0JpGIPQ2SG6yK7LmO6HFOxb\nAkz7IGUt0gy1MzPTyBvnB+WgD1I+IQXXsJbhP5+d+d3mOnqsd6oDM/grKBzrhoUe\noNadc9uzjqKlOrmrdIR3Bz38SSiWlde5fu6xPqJdmGZRNjXtcyJlbSPVDIloxw==\n=QWRO\n-----END PGP PUBLIC KEY BLOCK-----\n"
+            ],
+            "packages": [
+              {
+                "checksum": "sha256:fc8a8027325828861bae0c41d2582d61f8cb4b9ed42a50e49c57939eabcad1b7",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:605c3cf38451c6b93f331b605ab03ca611e37aa11d14a4019de61278add04f74",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:342bdf0143d9145f8846e1b5c3401685e0d1274b66df39ac8cbfb78013313861",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:fd2a2dd726d855f877296227fb351883d647df28b1b0085f525d87df622d49e4",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:df174a90fd6bd3f9fae3b75433ae7f1869ff2db7102667fb243c8aede5b858d3",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:cd5d539fd0c469f2ebae012a9a8f2ed280363c355f205edc8fc735678ac0adb8",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:a9d5719cf5d4fdc4ae28099d623a751b0470264e7d2280be2669a066348b4ce1",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:705bdb96aab3a0f9d9e2ff48ead1208e2dbc1927d713d8637632af936235217b",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:a4706de7a0d59f2b1e9e73f48c4279429676410c77fb93f82abf1b7b34330f82",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:c574c5432197acbe08ea15c7837be7577cd0b49902a3e65227792f051d73ce5c",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:00d0bb6a08f20bea2b6bd0d2c4de99b51c770b2dab266d1d3da85891efeded01",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:f09047c09660bc998460f710b9ac0561b4f6028214168d4d40f2f4d99f61a94d",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:22d311f22902d592f72bd0fb4010a682f796e5a4698d5ea209848468a2d5aa96",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:a346990bb07adca8c323a15f31b093ef6e639bde6ca84adf1a3abebc4dc9adce",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:7a97e71cd552285ead303d07dbb6417403edf45c0a531e02cf4ebfb0efda4975",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:c07fd5357963f99610bc676b25f1dfcbf1bae0b63538b5e1cd82ce42b79fd819",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:bfeba60bfb137f270e3b28db96ecfe8b226ea05e1761f6cb5ccc64c48c73c748",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:af18c71bca1121ac3cdeace9f7249079ee0568fcbb15ca7e46131fa9b9b521f8",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:2141f1dec8fe7a442c061f603bf4ee6203e10a290990789af0f4ef9db5523679",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:b67f1634acc7b84b284bda8afeef546aed4a3388dc7df67417001704aa444af1",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:cd01ae91895e60f189106a159bb551f906a8b663110f421ad6ee83c9e008851e",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:842f7a38be2e8dbb14eff3ede4091db214ebe241e1fde7a128e88c4e686b63b0",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:73f6a9108f7d5ec3cd89c31dbbaa874ae28cd5cb443ef69700a1218903ee2fc4",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:703fb5ca1651bb72d8ab58576ce3d78c9479cbb2e78ff8666ae3a3d1cd9bb0da",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:398ce75ffc673f048ffd47d417b17ef086abc43f318b2b77d2869095ec764d57",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:624b9079b4a571218adced203e19bdaca1d2cf57891f9653f409dd1db92fbf86",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:5d520576b7ac63cb029c4b0b86398e2b71589df3bafa618018b3729d81036203",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:c55b30a3a8c0d36a219953e20960185263ae63dada0f050446066be1e873ce08",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:0065bc128a5c8b08b57f92651bfa62895221a9f001f1169447a56a8a6671bbae",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:449d2888d6b835d207a55a2d9b4478eff1b926581fcead6260b6508e4db1b782",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:769e34caae25f05786ae53e535c6e3c64f5c548f06c422325d68598b7abb99b7",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:28d1118b3debda3daee76fc89f250576627a28b3ec39069256ddc212d993ddbc",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:0608e0a9922e6748b39bd1719e2dabd6fe283b22cf590f1a3350327ae6c13561",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:30c5f02ed28d59a4d72e020097602091bb8e34d65a6f3be69f4b1dd63a46f892",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:7023687eb65baa56a9b4c3ffde1e439b3d41b03ac4ad35a1a1fc3903464548f7",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:5323eb8d89b2d0c905a633513e04ca7df633c21eec288ee8c50f3f5170534e37",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:116b9d121fad9886f245cd5e1ef678fdba889cd23a39e91447e75649214a6a8d",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:862e75c10377098a9cc50407a0395e5f3a81d14b5b6fecfb3f223325c8867829",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:1aee865249b031e591a5e94d62d05b69ad1a6118a26adccf2dfd46b0002716e5",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:59be778afcf464d79f7dc440d6b49de8a9527fd73e7b514573d389bf8a51b246",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:d5acde111b4cafc918decc8b9c530c9a7dfd6cc77b75538d33b32478219ae5da",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:3f8dcae27ad3609b7de298d0ca8d34a2790b9898f5f1b03f3f9f8784374e307b",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:b821e9e8bf66abacaed4a386f9ed8ffa17f4f8be3db55e1ac31d52ba2d1faa1b",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:e0f9c4327d62e35ee2a066c95dfa37f86021b405515d0f902b72a7437b7b98e9",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:eaffaa8de8fd28ad124da12524a2ca5db86252404d70d66c7c42921dad6b69c1",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:6eeebf21f245bf0d6f58962dc49b6dfb51f55acb6a595c6b9cbe9628806b80a4",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:fefa4162a563eba24714ac43874c508d1ba036afb5127c5d21bbcbeaf238a740",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:ed36d759746e75a2834866fbeaa783df397f8813cae2ed79fcc4d146656bf6a6",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:213c17fb822ffa50fad16989ed363aa023de106c6262ccc3f16e52a154b7133f",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:6fc1b9a27eeb368a98f50dba5fc514f20a5eb23f8e0ee7dd92c4051ef8b4a940",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:474fd088c7e7234221d251153e9fda6081b0aa8979bf5ae25810c9862e1e9960",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:f729c554ed4ac6335a548380a6f6335a332a3a2aca5321a322415a208701607d",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:c132999a3f110029cd427f7578965ad558e91374637087d5230ee11c626ebcd4",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:9a2beeeede69d8910115608c2d98efa6a8dba73ab2df246df5b0f10e2fa37f54",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:8aa8258a1a13c1120d6c28321f618385111cb9363dae09eea2e4af481053e28b",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:61cae80187ef2924857fdfc48a240646d23b331482cf181e7d8c661b02c15949",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:7a525abda7230bfbc87763dfe58bf7684e385b3c78ca242a1685a589300909e9",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:187dd61be71efcca6adf9819a523d432217abb335afcb2b95ef27b72928aff4b",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:e40be03bd5808e640bb5fb18196499680a7b7b1d3fce47617f987baee849c0e5",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:e712179ba8b9b6e93d14c902a6d6a390ba142153384dab9291c808a447b7ed0c",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:c3f7089ae50f79cf4d2cb59e01091d33c70cab89ae08f95c547339a87404c3ec",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:993680d5cd133a0c21184be92b3df405d757613d0ca25c4abf08b203d8d26b79",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:4819b3ce25b997d8d3e5e4e4be4ba270e8b66852576b474daf0e6d61b6e22d73",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:11d6aa88c7e5bbaad38353bbb557ad8370452cd258f2a0d16bfd490116138d67",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:2fa5e252441852dae918b522a2ff3f46a5bbee4ce8936e06702bf65f57d7ff99",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:26db62c2bc52c3eee5f3039cdbdf19498f675d0f45aec0c2a1c61c635f01479e",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:b743aafa82f3326f8f2e6d5464ae7fa57fabab3ad791099eaf2d151b43208b42",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:a7deef0a324ccb272a25f5eb6b30c72d0a842bf2c602c31fe3b60f984b2e50af",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:05efccb06aa336d2547eb8fd5b7e0935c883f89084688f32ce0b09954149b796",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:4f318cec61cb69fc233ba5505b7e24f679afdfb0b5defbaef507f1b471e7dbb5",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:af62d0611b995b9f2b2c7b4d4852e03e521d66979534871ccb5a71275a15518d",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:f3eb795f68c80ccf870f1d27f8fd019878db748c0c19275634c48cf5cea5bc46",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:99f87b4ec7c5852d45028f3eae65fc813f3ef107e128777f265b09a19ce262e0",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:8fc2ae85f242105987d8fa7f05e4fa19358a7c81dff5fa163cf021eb6b9905e9",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:09fea9af8b695af862b19c1a8fbe1b1e8854257825ee4f663f67b3782a75d58a",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:a1835a7929d3c1613f3890caef878e9bdf857dcc0f63eb4d63a1140370b3f21b",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:5e7a16df5bdfab2acfd8ac061827ace0642f2e5521689d6b9f0812f2a6ece231",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:21e3fd914a3bcc65b79de022782967903c55a4aed9a3c7d3464bc2fef32d02b3",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:28656826cb0dfbae9b6e8d1e5c5691773d84000493c4be47f727092fec6dc6f4",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:e0b1da98020a740991dbb70b42c0ff1eece9e268a461e555a5ec763bda1645f5",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:1110261787146443e089955912255d99daf7ba042c3743e13648a9eb3d80ceb4",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:0b7cd6f6cb3b7cd9e0704dd6c62b65254b04cb870ab638b9bed4951564436e24",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:907393755387a351806ec2afff376e7491f177116caadd12f07d0fcbed796750",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:f2715fc8a04d33716f40f5b34466e082140df7ff3b7b972c29655d4dfc6e3a72",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:b8ecd7fa0e7e072828e374dfb0d61bb8eecca7c190f3661050cee5e3fc8854b4",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:47538b1db9720be4699329a8da32d873187d0c6c22f45252614ac5b8a8312482",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:317654c97a9dc11fe498b61d4189ff31cd1277250993d826e9bc5815d0485f29",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:879ba2533610771dbf3fa103fdbde878edf255b771b53aa8a170009d01446012",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:9369d4fed30402f45705b7a5cb51b6eeefb1dabbe0942c84514c6fdf1edac5e0",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:45132e53c649def28d63c199d8c3a3b9fd16fa8bca7426ad4e9c202e52a233b4",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:53992752850779218421994f61f1589eda5d368e28d340dccaae3f67de06e7f2",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:929f1c5ce4775b28439a1b5726e98c38204930d5880dc6096fc56e8d3eab275f",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:8df8541abd806578e43fe28a7ea2c41efbbb813866bed35fabe779274790a538",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:ab4c27523d6b5a0df75febac43cafa2dd9897dc3c1bb2f0d6990ca603b6168fe",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:ff5dd4d0c157cf1be9c8dbddce06640c67b2d02ae5a48d6b108bd70fc5c96211",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:d0e5d0104cf20c8dd332053a5903aab9b7fdadb84b35a1bfb3a6456f3399eb32",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:9899cfd32ada2537693af30b60051da21c6264b0d0db51ba709fceb179d4c836",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:397f0b024d3c58ca6e174c6de5abcb19304d7c58903199e1e6fe02e84d5bcb3a",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:349af433b2f6d45ff2e1ea5a38f847ec692fef0a8dd656a9a07d423a981946d0",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:fdb9bc612957a16fc44b717605a5a26e16a33850c0ff74a80a299cc2bab740e4",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:5fc2fd0cb5b6fdce1203e43d6f2df6a3098ec9522b04815d896ecedbb1489063",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:6fe524feb38312f9c370b2190aeb42330acc9ce42f3a45e9cd05748b4aa00db2",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:dc9c0401522bcf73fe5a692184c141b214947ad83364be97de0413ab46b712e5",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:e80533822e2a892345b869395b2c17c0bcc98d3c3c47787da30123096835db00",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:f36550dfc144e4608da672616fa44b2f2341f99bb38972e66e4a8fef4b59172c",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:178e4470a6dfca84ec133932606737bfe167094560bf473940504c511354ddc9",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:cc3396df93ce0e8f439b83fb6b4d210903876846b0bd3a22c19c7770cf5a9050",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:966084f83e0fedb7a217aa102b484ac8a63082ccfe99517544ed2cb102191204",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:9d4f1290565b852e56f9e9babc14b141b0283998121f78b0eb83dec367cf0abb",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:052ddc487a29acce1b5d44532f79f8ab594d0ac6565504071f4c7706d97fc552",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:13a0c9c767f71164cc678ee36d89b7fddcdd6fb8243e3daf8b47cca0d1d14c4f",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:70794c8537fb3cf197f051cfce3b23956d587062daf114f8480770754804f339",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:fbaf44214a3e93d4bdccb1519768849db5ea204c886df851b49f107e0c443e4a",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:1ec84749250a0095d645f11fa0dcdf8c4500e0bbc303af696762a12616375757",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:4546444c0647efaa8fa8bf604ace7f7dbd152e74761b8d7a11fa185bc72bece8",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:3ab2173d9d4016febcdaf283408f9939d0a7b2fdba3e46a2d45fbef88a1463a0",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:759165656ac8141b0c0ada230c258ffcd4516c4c8d132d7fbaf762cd5a5e4095",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:01173d218dccdf88c1159bba4af332ce703fc0dcd7171cd279cb3e16f12b30a9",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:aa353206ef29b7d908554ccb7cd6f4c01a1f6c3c1c6358abb7452f4a745939d0",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:110f538d82f15f009d95e89d8c1e3669dc7358feb9aa7724301fef037f8b67fe",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:c2197913bc8db9548b0a40ffddf840a31956b18e932ad4eec77a48d87d2289ce",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:7f6d2841ec9402ee5e57f1a46b9886935138c02005d860899f3c746c7885c7b9",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:d1c6f183b9deaf6127db4ad7040046bd7f1aa62de177961aac39501605d2c815",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:d1a369d501e3ce1c17d06418c9cd57c4ada551ecc3b45a581e162215e8bd77f5",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:53f1e8570b175e8b58895646df6d8068a7e1f3cb1bafdde714ddd038bcf91e85",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:def89a494acbfd6aae1fb70700dd18275ddd3050893bc962f1853499af9dd823",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:6749bd0b96339c32b57635b69b474583b50c94e4bbaa3eb8753fa604b9d1c521",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:c1f957511b5e011e6f7995ed7bca9196703cf1214068f209e86b1dc4fd0e98bf",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:bca13571cf1452f3e41c8e89b8c64aa33d3d0f4e414571f9dde32a556591b339",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:865c7677d2664287bb4ba2874c83bc805232e1b3a02cf6ba96e047266d9ef684",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:0c6f4c1fbbdaf02014bf81726264e3301cbfe0ecda610765be11dbbfe99e34ae",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:7c21c21c3e3dbace06bee03fe4835ae6cb1e3ef86750ba2853f39d40dead2309",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:f60fc561675e41ffa2c48b229960291e2438441d5ed758c1f28cb06b5d4e4ea9",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:28f4bcbf53258114ebbf0a167351d67e204ff6f717b49b3893c2372845e6bd0a",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:f4eb6d332b9aea8d8ef0a6ea8dc2b073d6bf5f2599d64f24111d8da2ee82ad48",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:08c41c10745c172c34880e384cf5cff014a9627f4895e59fa482948b27e2ce9e",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:6a3282927f525629bc0aaf4090e108d33b0709d3d5b35bc442000c2837e7b9b4",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:1a2f22eed83ef568021c464cce841ef98725b614093f2c518307e85d5b6e759b",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:65e5209398c6b2c196cb42f3bc3f82e00af1026f623026857a9b330ec92d0330",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:032e4944fe53dc7a11ae62d746579177a5c52b00a4ad5540da8221aa287fdf18",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:79e22d23ba0a156b3d74ec4b0da8fd71bc632386366ade2c48006ba82074055d",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:b286141f38cd88b8c632515677423f49c81365f2ae99c5a7906205f35a273fb2",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:caa3625b22908cf4f91faf2c281b0e7ab7d981c35ed1d761deb53b7b78d13cf8",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:5d933f9bf444d4c8732caa65e9227b27127c625840859a0453a32a5719916f48",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:4659e7b76850ce5dedbe80fb0a64947e83f15f907b35c5819d91be6ed0523653",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:d7f57b9190c9cf05c36fe9fb3229330cdb9f0a1af1214a47b0a38dcc8ce929ee",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:88d283c2d5aa96c2b0899f6bd6c0409a5d5c6fda2958e8eae19eb49c3ede58d6",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:89f85f749bfee7d083c84845e908a3471297a3d8a75f7397903d15eb7f403297",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:83a08b7066000ebbdf8a6c5706485a19b5dfe2d492b1faaac1922e8f0c42cd0c",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:a3f80bb7068618dff795b3e0a3d32fa3c640e492c8f175b16bb3c7ff64a88a8e",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:975719a0c73cf5cb5bcbc8ad11b816ed75923dccd9c091baa4a6c6000753dcd8",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:872639e4ccb4f1c5de66d5eaa85ca673141b10e3d614b33c84ff887c228d465d",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:d7fec1fb54953f1901cc505c225af94cb61f2206d0503be12313169a4b915e18",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:d3a64fcef3de79a97541b21c71ddd00d4cca9039c930bc660d6c5479eabf5f26",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:8a03d482b5294f7452b2f9ce31ebb6aea9eefac002281c1b9152fbb1a0341987",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:a05178831a546e2001e52f065fc6969f36d2292efaee2971fe7a7e882cc8c813",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:3be681b78e919bfd82eb186c7393718f1d37abd0b1bb8b1a8571aefa11e7a248",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:60774007011889671c28158f599032f0db253c153ccae70f5e2f5840f2dc490b",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:89c972ec7d2ab305c91c23bc248562c76f0ae645a9ed9f94d312e2f57c4d38fe",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:a1613e90865db93fb578b8ee1a4ee40bd396c6c9f2fb2a14757acacecb9f23e8",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:b98687828b1d222ea73ebb8457450913dac58dd0be2e430a93bb7e98ba816505",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:e291d6c021eaa01cc3c446b76c94aafde444936b8ba3f08a7fe7cbe66a23366b",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:150815dd62da40fee60ad5ceb988938c3be01e03aa54a025772b33a7a2c11311",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:9ee276ed9d036a4483bb8d1bd6f6d697b161a04276c6ce5f1d3f40d48e04bccb",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:ccc3cb2dcb7a534361cc911f27ff4e869902a150b68e236cf6eb209a99d4ee22",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:3f9c95f3827b785f49ac4a270d4c3a703dceba673c452838744ec5064cf43cbd",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:56187c1c980cc0680f4dbc433ed2c8507e7dc9ab00000615b63ea08c086b7ab2",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:fbb81a7811f7a11b1c95eec20c3df63beef9e007f0b3d2713f13ad80029d7249",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:e2b2dddbce49fab5f01ba75fae8796ab7c9fd8280c652f78d06a2644246bd16d",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:2b783576612dcf10ab151fee03084f8ae1667c044a9e2e9404a2a139e7c6c884",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:f826f984b23d0701a1b72de5882b9c0e7bae87ef49d9edfea156654f489f8b2b",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:a410db5c56d4f39f6ea71e7d5bb6d4a2bd518015d1e34f38fbc0d7bbd4e872d4",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:88f4bd19a6cf6eba5e6f2b5bba80819b5ccddb0476aadc53c8df13f9c45b1e58",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:7d9bd2fe016ca8860e8fab4a430b3aae4c7b7bea55f8ccd7775ad470172e2886",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:598a136b7027cb9b4fef6bfa34715979d41c2f62c9d8bec5d50b633a17790f7b",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:65e0cfe367ae4d54cf8bf509cb05e063c9eb6f2fea8dadcf746cdd85adc31d88",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:1830b4aa42ef492c13b62f63fe941970869ba19bd9abde4dea5c97f9e38ffd68",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:ac8b1fea0b678d7630033a8900be5641b934306961b39a29c79c6d72f34f7d1c",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:d74b76ce8c2c7306cc3f012d1ec56b1d5c67788748f56ecd505f257d342f97ee",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:1bc0542cf8a3746d0fe25c397a93c8206963f1f287246c6fb864eedfc9ffa4a7",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:b60670fdcf91b50d97720f601d92277efedbd690bd887000ccd9a46b3fa8b314",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:b13eed593b31a9cc0174774b97701c7da876f91ccdfc951b67a3134d59ccd8b5",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:4494013eac1ad337673f084242aa8ebffb4a149243475b448bee9266401f2896",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:63400fedea4a6ddb8fced58d33e60560791f29cd439169998f337d09fb50a7d4",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:7dfe1e8dac6d759479ae3dfd415fdd2662bbed9ff0f4da6093279efd1bacae31",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:688fcc0b7ef3c48cf7d602eefd7fefae7bcad4f0dc71c9fe9432c2ce5bbd9daa",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:431d836b2be015212d8c15b4290d5ce5bb45282cbf3fc52696f632d84ce34dfe",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:9a12db30090023c60e3d7bcd5b07142cdc6d84c77e25ddb1cf41a4c490e52f09",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:39961756e07f6f49ddf2ff277dc04a63fa4d5b4fb035480945bd2f665ba1dd4d",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:7bf42ff57ce2a31db0da7d6c5926552f4e51e9f25cded77bd634eb5cd35eadab",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:942d06ec1f7033ea4c729b84ee09f5491481770efe10151ba581479ac7f3f9dc",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:86c87a4169bdf75c6d3a2f11d3a7e20b6364b2db97c74bc7eb62b1b22bc54401",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:ebbace15f986288bba7681f44a111b14bcc7cae00b7a1faadaa838bd51897357",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:14bd7e305e13795e0d37c613dfa3ead3a3219d28c32b27ad6527d3592361923d",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:aac9be36fc9c345245b4a0db66bfb9ff8df25e36ae0c1ae89eca9bcf88e052e4",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:48cf5ab32f6af8f2283d4d4834e8dd262aa412be7ea07c2292483e150d614bef",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:5f0ae954b5955c86623e68cd81ccf8505a89f260003b8a3be6a93bd76f18452c",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:d65b4bb6fa49198237f9b704ec471d71dfd94b87290f4d03c1c34d12f6efeb95",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:9bd5cb588664e8427bc8bebde0cdf5e14315916624ab6b1979dde60f6eae4278",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:c8daa43a4504f9a4b6c106baf8a56aa0d256fc3c71bd417ea75b9c7fd830a9b7",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:b3201777d78ee13ee45ddbd982af5999ce058907b5dc552669644931b79c5f51",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:824fe37d58cadac2f23678c9eb95c29b4acb1852df97cf799e77aa7e8034b54e",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:86acbe8d77b05c1fe9bb0168443a579b1d4538f9733813db4e72e4a4a2be29e3",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:20787251df57a108bbf9c40e30f041b71ac36c8a10900fb699e574ee7e259bf2",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:ff44071d53a2ed543c2ddad99cca8fc25493cbefc5d7ad869f9b6dbda340a465",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:8677b34fa73f258b1a599d18419f6fbbb8961bb1ca2ae5b0f9abdcc4f93b319e",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:5d5c8c7e9c78e3b8827ad38771efb44951d1c3c1692cf4e07b138c1c8c42bd5b",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:1b05dd5abad5a31380c859bc33e7851158c24333fda837ca9facf869005f81fe",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:2434cd04a437c06f59d67ee2580443c0ba676c39440cd0f74cca768ec57577f9",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:de74076fc5073ad07ffa78fed6e7cd8f10133d99c1c73149b4ac74428699a6d1",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:4eb6a2e34173a2b6ca7db031cecce56c0bed711691abf1c8d6bfe6cb7ca45dc0",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:6eb95e39b9771c4dde5f9954a74cef6be90522c28c7c4aa767ebe7a9d55fcdf9",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:1c68255945533ed4e3368125bc46e19f3fe348d7ec507a85a35038dbb976003f",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:9ebc5843faeb852bbbe3d53f03182197f6595a928ffa3f5d7a530749ee1e4ec8",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:aa5b658fd4a95c724b61eddadecdbcbc1b2a813ae681318ab092a2ed03954825",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:e740cc0a580639b887bda0039a779e750a32835be1fd8c64aa01183b4cbb98bf",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:4f4ef59861c0566d22bd76369d22369d43130f5ccdb35a5fc2c8a236cf33651f",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:b359ca3cdc68b6e5031f65975df38a8b96c19ddc4c367e1e3463fc8484a0b3b7",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:884357540f4be2a74e608e2c7a31f2371ee3b4d29be2fe39a371c0b131d84aa6",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:ec6abd65541b5bded814de19c9d064e6c21e3d8b424dba7cb25b2fdc52d45a2b",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:3afab9512fd4d56a13c95b530c805ac8b2bc872572ec5bb435eccdd59fbbc8b6",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:a8ce7406c87f64972f0b70f1823c2aad05516c71fe375c6c97737459c2448825",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:8dfdbe51193bdcfc3db41b5b9f317f009bfab6373e6ed3c5475466b8772a85e1",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:3b4ce7fc4e2778758881feedf6ea19b65e99aa3672e19a7dd62977efe3b910b9",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:b3230630a471b806a9153669d187508350cdb2b368a68f8c439c82abad038c3f",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:6952dfc6a8f583c9aeafb16d5d34208d7e39fd7ec8628c5aa8ccde039acbe548",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:5a4c0187b96690e0088057f7656c67d399fad44b28b86644e3434c581377c229",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:ce8c1f1ce3cb2cc0166dcaad17f35e84278ec39ea9bf232e24130d3ff3271923",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:9ecc8aa9af05ba704cec879618afeda5ff92d8233811e2d6080aa02e0b5ceddf",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:5ad0d1b4e641e5d2fe7f6385ace0f827a431c5a52c6dc3516d85e655caca880f",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:64922311f45700f2f4f98d78efbdfa240987a6a2b1396ffe694d30e2b5f34ac3",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:aa783a91b1823b7b056575e6276df35910eb2e0d4b72121cf5649651c7d23a16",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:df0a39eb6b91c4a8f481c22445cbbd88334bf5e0a6e1dd5fb240981eb031c4eb",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:251fd875421da4708b76c15c7f5ba478d50b74d7e4242071a621625eac51a767",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:0e59b422e35eee975ba68e6e4de022c8f145feec7e169e86e0244d2fdad2f590",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:1446032720fb8e0090190828fcea294a86fc7f83edd70f6089e3446770ba0438",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:54cb827278ae474cbab1f05e0fbee0355bee2674d46a804f1c2b78ff80a48caa",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:29e2b62e9e63f25139a6863c863c3b534660440d7dec0c985807302a6895dbaf",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:942707884401498938fba6e2439dc923d4e2d81f4bac205f4e73d458e9879927",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:ddad78d00b09c6c85d46c06dcba4c951f7f7dfc9b2dab195bf45aa3f5a1fdc41",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:cbfc109588fa0e34bdc408dbb37dadf7873fb5788dd3fd8cd04c17c75f26e6db",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:be899d3e806441b1c46811c0ffe9f4e01f4ea4e1544f9cc32630254853e3f3a5",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:b09015ae5fb5772b73bc7932991aaf6e1f6d509432af605a565ef53d2d50606a",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:27701cda24f5f6386e0173745aabc4f6df28052975e73529854432c35399cfc8",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:32f8cbb3be91f589d569a2e737130f29c752f78eebc61e287af17f207e1b8c58",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:49bac21d5cdf863fccfcc32bf070e582d204706e35ee9f60b3e69df694bff87d",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:599549d72d26b48c45156585a5698898c853e56469142e202d3749b781428465",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:66bb5b2e99d2c74b82943fe61fe9b9a3674350b0242f69a6854ec9718dcf5e07",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:af66820023c984d8b981ecac715d0c2daec1f89dcb69bed76ddf58b0ee80c1b1",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:be998dfbcc9ca8e3021ac4f56ed723cfa3fa1517524e89ee0b636f623abe995f",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:64567be564634937bd918d33a3f04017808d29269a5b0891a0f4d4aecad6161b",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:052d04c9a6697c6e5aa546546ae5058d547fc4a4f474d2805a3e45dbf69193c6",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:b35256e417fd94c7efb1212f2f36b5e6b224ff5b9e8733774d4fbdc652078099",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:c1d754773972b5f4ca157c0afa45d6767901d965a91f381660c72740d682df63",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:fb06aa3d8059406a23694ddafe0ef340ca627dd68bf3f351f094de58ef30fb2c",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:729fb595040f1e2e71ff0a8c1c22ebe4b7187f78b816af8e6a8d93c03fc5d844",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:b58828b2f1ce4f7778d3f511c61ee8925042b9752aea526c23d33fd7533aa975",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:f9ccea65ecf98f4dfac65d25986d08efa62a1d1c0db9db0a061e7408d6805a1a",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:8402d3aabfc02c16f3789f3f93338dbee2448db8a49956002b83aff5390922d9",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:a7452c18c2cffc266ec36c54105b884c4d63181f20cebd705e33730534cb9093",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:ed84414c9b2190d3026f58db78dffd8bc3a9ad40311cb0adb8ff8e3c7c06ca60",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:7c1a229f4a36ac8b077e0514f68f311229652121528b0f8a2a7434c618276dcb",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:cb4fb9b3733440ea15b3309c88d9471c4165aa7b71b4dbc5d0fb5bfcd97b2f2e",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:ae219ad5ecc0233271c3fd61263f817c646eecece19a8f075e7aa4dd9ff8698e",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:a7f040de29d2414cc99fcffcd9ed3fa9d06ecc7aecd783ec3d2eef769e2389f1",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:ad50ed0c4f4c956e3b59ac9fc7bf5fba22068a661ea75a46eb81bc2209af4cc5",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:9c8a274158a6fe97598e33900cd51e171f7e7517ccfc8ad6351873e69b225986",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:9465f2f1103697207a52d15edd716ab72dc6c281823c60f424cd064d706c7a51",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:c9ba05cb46a9cb52e3325ca20c457a377361abcd0e5a7dda776ba19481770467",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:5b8a205f3d4bde162e01a821fdacbc10ebfa01b88ec61b166b4b6317c45910c4",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:15f70393f706ea0ac6c622563268d9c00509ef376e3e087c1c05007b49894ee9",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:10883ce95852cc9ae9b4e0d435b100a25f8fe5c0ea4677eb4a0b39f4f8def886",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:9fa1959637c902dfeb19a0f16c7f42f7da4aab293f7c025c66d39debad6dbc34",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:3b76bc46dd279404408d34946cfdb0c3899359a1c6b48e614e63d1259a94262a",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:e851ba0019baa83e1bebbe92e1a1cf629694ccf3b42c5ff84e0ed7bea74931d3",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:44cfb58b368fba586981aa838a7f3974ac1d66d2b3b695f88d7b1d2e9c81a0b6",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:4375c398dff722a29bd1700bc8dc8b528345412d1e17d8d9d1176d9774962957",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:95a89032291b05a0e483f336ea29897d951e8845b0f347a4117de90ef3ef3467",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:640afe5b9d499c9a7efc1d23cce8c54e3e3704d92eb7e7a93a048f97d1e983e1",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:9cf9b01f2c727e3576a8aa71fd7fe1bf4ec9ed1c9f50b756657cf9aeae18418f",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:80cf220a3314f965c088e03d2b750426767db0b36b6b7c5e8059b9217ff4de6d",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:2b098bc6f8004270ee9eac9f63980b364b5fe19394dc73a230b3c846cf488b1b",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:b2e862283ac97b1d8b1ede2034ead452ac7dc4ff308593306275b1b0ae5b4102",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:25fc5d288536e1973436da38357690575ed58e03e17ca48d2b3840364f830659",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:04152a3a608d022a58830c0e3dac0818e2c060469b0f41d8d731f659981a4464",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:c019d23ed2cb3ceb0ac9757a72c3e8b1d31f2a524b889e18049cc7d923bc9466",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:0b7d24759aac33303ff4b101c111dea03ff2529efc95661140e22f629cc1ab7a",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:e2566356943c1c7485d206b858dd6ae3be37c28bfec2a43f869193f3b5b9cd23",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:3c2a641f118ab2e8b08df6dd2da72a60121d02df8d932b4afa2920eb80392875",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:42fcfac5037eab4099648e0f0ed3eb2aec6eb6a23a9e3808f9b69619ea7c44e3",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:ade8105796f5c1201a3efc8bcc654788cfc88c3815297b346845062a8c29cd59",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:0d51c1319ee78978e6ea5a49b815c2078b4ffd4d575e98c70e54ca01c3390eb8",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:8b148415fb6a583ef131d0ddff44f3209c30d0299fde7b20cd3ea385590927c1",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:d1e244b8b5ce7404846e97d96c762c8c18ff6447301f6fc63f50e615029aa7cd",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:d7b8b5815b72fb157de26579362383e357e026ae6ac2599c451fb336fe995555",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:ad6d7d9767e05978b14a39c08dba59ddc4396584576df194f77ed310a0816ae0",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:3f2cb9092d6f55f84dd9eacd5359dfb354772e5f38308328027c7758f4a06fb6",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:45fc2608b746fd841dd25919e9e4d44834154758aec8fb8b529c014b11c7917d",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:ec64add7d60a70fbaf14a083929f22bd2637c33d20d2a30b7e842caa6040f817",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:3343d9e7c90bd58e1e44ee07e7c59bb570ffc74da50f0607c5f5681a00b70e76",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:dedd37a96262c35763ab2dcbc19838f5cc39a2a3a392a650a80bd6d5ae42ff8b",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:3589b982ac0c2f5f6b47cde5cb7ec33c2c01d756dabf8c4ca64f6d9d0d78b35e",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:4c80ade4ac0889316930a8d181ea43fa2d1b2f1a6a5703c22f2b3ba191346eec",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:156709efeaa1dfac72cc189d7e99de12d7c4b2069445da5d34fa807582e85719",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:e5efc87172d7081559137feaa221047385a5e248ffafd9794c2bfc73b61f8f37",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:933bdb4cc6e14b2ebb1ca76c14ca176c13d271a2d1e88632f237392777d11808",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:6794fe48004c0403c29fc779b49f0fbea436123b96783a2df225eef2f0858795",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:5db7c0e949bd9172b9645237e72f6139d4ffcf14defad487262b8ad25b427daf",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:15f08ce979e48fd25be5e16d63d1c95c57f9abff7704005137ea00b958442939",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:7df4fa1a29772696d92866e890af6fbe006088f3407ed3e67b0e7867ef58d899",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:5c91890bf33527b9fb422cbed17600e761750a4e596fad3f0d0fa419070e82b0",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:0bace0cf41921db39247c99bfccb228818b83b68c7b8be7c8c4a92ea298a9a29",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:4a7b63b32f176b8861f6ac7363bc8010caea0c323eaa83167227118f05603022",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:ccdfb24da56aa394a64cf2f0c6ac6d15d0ebd6054686bd2ab27641a5502329be",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:536a157da5332c0bdacb3e5891e3012b79b18fcdedb63b393110d6eb8b04e428",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:8df97dcfb42c1667b5d2e4150012eaf96f58eeac4f7b879e0928c8c36e3a7604",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:3cd56dea57c00e2c4a9d5aac69a1e843ebef581ba76dde9d9878082fa1215485",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:d49f0b1c8ecf9bc808ae93e9298a40fbcc124fe67c3bbdd37705b6b5d8cfdd87",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:d439ffbe20c8c0e8244e31c0324d60cf959dc1cd6cecc575d7b34509a73e9386",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:7c7eff31251dedcc3285a8b08c1b18f7fd9ee2e07dff86ad090f45a81e19e85e",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:8a0c00a69f9cb3a9ffacaf1cdc162c38a1faca76c9b976cb177bdc988902f2d4",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:f3908831ae53f43b07a4e196850d0e59cc89b50c97d838538c3185fd0eb0d569",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:52fe378ffab317ec4d26ae5fc0389dec874002a8d70a9413cefb68c7b16b0612",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:be7ba234b6c48717ac0f69fb5868b3caa6ef09fbfc76c42a47b367578cd19444",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:af992ad02594b68f17d2da41104a26aee41d02639edf22332d7dbb1fe9af58a5",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:a7da5590635b9c19afafc7dd247604194a5ce7d8d863dc600b8cb86accb2e469",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:7dd93baaf69a8004ae2cd3b9e6660b862d0b6f399d53c05a27a48a2e276ef1ee",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:0b290954bc2868b3dfc976b2b7a13ea8aeade76eeafc17674ff8e721049a5bf7",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:b79bb6af3e1650ba812c8affe42772ea566b164222a7d4d8e2f7efa867dc6849",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:b1111e77a5fdbacaa04acc90d3844706158bc5892173862928705620b8910adb",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:6aa0c6420a03f20e18842da9de611d823580efb8f6da93a94dafb48d59c2a070",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:129adf9147d5d120546ca8e0fb5f165761106d386d366fe82591e372754d0b4a",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:8ee8c4bbf024b998ffb77a6b4194a2306ac21c5a6fcf70c8c81a0fbf38f7c7fc",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:34411604a91c301dc8489285065c68f3a2f50910717097fedcaade6481c7469e",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:ec58d03c60386bfb8aed2af3d2a49f8c6e5ccb4d3fd592cf75fef3342be137c3",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:f77cad4c497f11c5b5bd7c9a29fc1f5f5574f8443cc4496e3bd98e680b363124",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:55bafcdf9c31b1456af3bf584bfe7ac745a03f4decd17197ea97b498d68b3b82",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:0fc0193d95d69c780b6feb1cb74759ca2d4804701b3de936dac8429cfbe0f2e9",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:9ade87dbb32f27e7f38ec981002ddc5a2189cc6f5ad5f24bada3b71cfa9167fd",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:15f2fc89b7bd39dcd3f6f8db30f56b76b65df311d7ad9852d498fbbc5c7d2aa2",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:6f5f53b66f7c3bf6958f6f163788583265ff0360188620c3b0f7ddedeac3d1f4",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:724cca9919bb7b0183b030aca216d4d51de70bf35c2cc5e8325a21a52ca15ceb",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:02654432f3853c9ae39c7601b5b0606c9d5eb5eef1d95e3e6f0074501842941f",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:d2abba1a0523bd9df5073900593ab13ec2ed2e391440be4d883314fa154370f8",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:cb0c64cc81e0b384bbc9d27ffcb2a655b13c91a799aad8972264aed1767926a3",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:f1150f9e17beaef09aca0f291e10db8c3ee5566fbf4c929b7672334410fa74e9",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:f1c79039f4c6ba0fad88590c2cb55a96489449c334a671cc18c0bf424a4548b8",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:4cd01a3135b9e72906eaf4552e29929334dcccee2ed092a38bf60698522ecd5f",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:c9f3d536c1fa73de90836147d15db06dc2025e84a44034bda6c66b9c4b60be58",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:136a9cbae9c225be60718fdc8cc8988a55235d6502e451df77d1c5c765143850",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:54b740cf7a75a7215168970378d9a1d6b9a5e4eb81159a874ce8ea5990436641",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:ee664c392a97cdd272f57980c6856b2c57567005fa0ad9cb16c388b645d014f1",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:9d220d8ee28cd0adf28e8fef547af92c3ec66e238747165939cf8e1a413ddf83",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:27dd9c78e41c04b5151a2b9ac150d3ebb89f2ca7a23e4896dfc718f19a000be3",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:024dd8a75eb5472692d0291292d25939b97a0295e5ab0958dcd22600d392eaae",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:c50ff544430830086ce484b20a2b6eaa934c82b6277a6f4fb02fc8cbc9e25db7",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:96e0c019cb91d8deefb7664cfe417807d23562d2a1bfd2cbfd1051e243136b57",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:ffe5076b9018efdb1612c487f637af39ab6c3c79ec37311978935cfa357ecd61",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:932a37ddd2a990a22a1ee7811d204552e8860e39a3e0c050ed618a535ae8c78c",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:684aae86de55bd42215c136777613211f596788d3b6405d8fa645fb967904354",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:84c338b327a3fb2f6edb79caa2242804fff8c83ffa3db0d9227f55eef4107b2a",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:a336d2e77255df4783f52762e44efcc8d77b044a3e39c7f577d5535212848280",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:4dd6100e477d88a4987b6eebfddecff168f38c7ff47cbb12f2fecba1e87c10d9",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:a280c633b73517da167b91298fc97aeee2eb5fcc253c038ae0ce4b8478d3a103",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:ee1681ee1ae6a3f86a876562939fbfe415ba78b0a803059e1b6d6cd63b0fa1a3",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:f14d3b113e2c3ba3f8ab7a8146439924f38487c20dd533062616f17f500ff46b",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:14cf772225c04c005add71372fce866e90f7144c27bbb8e846ce7887e0d286e0",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:7f555c600b35ba798d8c0a63e30a1a12e917231730e1a44f48161ba0fe4b5973",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:699c1a3ff311bbaa2380c085fb4f516aa08be474bed02bcd1569d0bbf5b22d07",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:e5bf9266edf112540ec662bd492ce4bda3ed8d5e33d763b9f2318c42963a1d1b",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:1de2be4fe5280ec3097305d9e671f5f2c768267f90d255edf2075eecb0c0afe9",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:78db9007c08fa51f177210e47343b8e733ce0751826abb357ca96429836588db",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:750da30da0289d5e2ad9ca297dda44e5ca18dbed0c3e0d4200379bc1818c22f3",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:97197411bca68cfba1ef6bab1fdd4b41c95ec71c36f1e67f525b963cf60598fd",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:334d63914e7ff6fe8cfce0c8f80006c6cf2ab0615cd044a6ee588809395499e5",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:2cee64e12b295b74d2f4b008c7628ef3a01ef4149905fc4a7ae14b304da5f53b",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:ea5f929563fb9ca0cf08da250c62c93d4755f4a41c1aca23eeeaf3e58e90d766",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:8c560f3927e36e41657067e4bdc741fd8f3b55b497f0fc3c2331fb361ba8de8b",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:90bc2171f438ffa7488a9c69cd86bb1de175807be468f285c8ca16cf8dd4a83c",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:c3e2a3c23288899456fb996f3074c10637bcd4886bc446698cb1efa2734c1e4d",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:5f156c2a950699d5cb9a21349cce049b3c8bfdcc4fcc780665fe2d3103f576c1",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:cc1be420582afb6360f380ff301c5e3d873f69fe1f7e00e4450bf2daa40ef9ff",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:6f669ae6f70cfa80917adf4ae9d5e86fbd9d31ee308a9a3408a19be3afc46f7b",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:2db6d80760ab0e99f4e9c9816615e4f06b967bbb23a8c8c941b3f2d4b5f176c2",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:9976e6228a10fa2761f1265a2a7666578d79ca57819837e5d1fbecc53324f1b9",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:4fca21cfdcbed052e3e9e1eff74c22fb8ffb1fbbeb63e87e2aa540e43a8c0d09",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:82e0d8f1e0dccc6d18acd04b7806350343140d9c91da7a216f93167dcf650a61",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:d027a3ff0712e3e98d7d2358f8c526fb8d143b2386c353aadcc27199cffe125b",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:9dcc75ac945924ce496c9280e7ac31b88886d94a6494d0710725a81dd9d42c9a",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:d61ea8b6299f00397f740b73de146ef4daa6d6bb5863d525459765fa0f23a991",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:ec12fef82d73314e3e4cb6e962f8de27e78989fa104dde0599a4480a53817647",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:1bdde5dc99a5588a8983f70b7b3e45e7006215d529c72adfec118c3bcbf7b01c",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:84702d6395a9577c1a268184f123cfd4b15bc2287f01033625ba388a34ec2338",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:9194788f87e4a1aa8835f1305d290cc2cd67cee6a5b1ab82643d3a068c0145b6",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:140708561a2ec1c7709fd38d8b1b115d02da710b80eeecd65c2b8387d9d78ef9",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:c0fff40dc1092e18ed3e608bc6143c89a0d7775b9e0553319bb2caca7d324d80",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:3f7861ea2d8b4380b567f629a86fa31951a55f46f6eee017cb84ed87baf2c19e",
+                "check_gpg": true
+              }
+            ]
+          }
+        },
+        {
+          "name": "org.osbuild.fix-bls",
+          "options": {}
+        },
+        {
+          "name": "org.osbuild.locale",
+          "options": {
+            "language": "en_US"
+          }
+        },
+        {
+          "name": "org.osbuild.systemd",
+          "options": {
+            "enabled_services": [
+              "NetworkManager.service",
+              "firewalld.service",
+              "rngd.service",
+              "sshd.service",
+              "zram-swap.service"
+            ]
+          }
+        },
+        {
+          "name": "org.osbuild.selinux",
+          "options": {
+            "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
+          }
+        },
+        {
+          "name": "org.osbuild.rpm-ostree",
+          "options": {
+            "etc_group_members": [
+              "wheel",
+              "docker"
+            ]
+          }
+        }
+      ],
+      "assembler": {
+        "name": "org.osbuild.ostree.commit",
+        "options": {
+          "ref": "fedora/32/x86_64/iot",
+          "tar": {
+            "filename": "commit.tar"
+          }
+        }
+      }
+    }
+  },
+  "rpmmd": {
+    "build-packages": [
+      {
+        "name": "acl",
+        "epoch": 0,
+        "version": "2.2.53",
+        "release": "5.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/a/acl-2.2.53-5.fc32.x86_64.rpm",
+        "checksum": "sha256:705bdb96aab3a0f9d9e2ff48ead1208e2dbc1927d713d8637632af936235217b",
+        "check_gpg": true
+      },
+      {
+        "name": "alternatives",
+        "epoch": 0,
+        "version": "1.11",
+        "release": "6.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/a/alternatives-1.11-6.fc32.x86_64.rpm",
+        "checksum": "sha256:c574c5432197acbe08ea15c7837be7577cd0b49902a3e65227792f051d73ce5c",
+        "check_gpg": true
+      },
+      {
+        "name": "audit-libs",
+        "epoch": 0,
+        "version": "3.0",
+        "release": "0.19.20191104git1c2f876.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/a/audit-libs-3.0-0.19.20191104git1c2f876.fc32.x86_64.rpm",
+        "checksum": "sha256:22d311f22902d592f72bd0fb4010a682f796e5a4698d5ea209848468a2d5aa96",
+        "check_gpg": true
+      },
+      {
+        "name": "basesystem",
+        "epoch": 0,
+        "version": "11",
+        "release": "9.fc32",
+        "arch": "noarch",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/b/basesystem-11-9.fc32.noarch.rpm",
+        "checksum": "sha256:a346990bb07adca8c323a15f31b093ef6e639bde6ca84adf1a3abebc4dc9adce",
+        "check_gpg": true
+      },
+      {
+        "name": "bash",
+        "epoch": 0,
+        "version": "5.0.11",
+        "release": "2.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/b/bash-5.0.11-2.fc32.x86_64.rpm",
+        "checksum": "sha256:7a97e71cd552285ead303d07dbb6417403edf45c0a531e02cf4ebfb0efda4975",
+        "check_gpg": true
+      },
+      {
+        "name": "bubblewrap",
+        "epoch": 0,
+        "version": "0.4.1",
+        "release": "1.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/b/bubblewrap-0.4.1-1.fc32.x86_64.rpm",
+        "checksum": "sha256:cd01ae91895e60f189106a159bb551f906a8b663110f421ad6ee83c9e008851e",
+        "check_gpg": true
+      },
+      {
+        "name": "bzip2-libs",
+        "epoch": 0,
+        "version": "1.0.8",
+        "release": "2.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/b/bzip2-libs-1.0.8-2.fc32.x86_64.rpm",
+        "checksum": "sha256:842f7a38be2e8dbb14eff3ede4091db214ebe241e1fde7a128e88c4e686b63b0",
+        "check_gpg": true
+      },
+      {
+        "name": "ca-certificates",
+        "epoch": 0,
+        "version": "2020.2.40",
+        "release": "3.fc32",
+        "arch": "noarch",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/c/ca-certificates-2020.2.40-3.fc32.noarch.rpm",
+        "checksum": "sha256:73f6a9108f7d5ec3cd89c31dbbaa874ae28cd5cb443ef69700a1218903ee2fc4",
+        "check_gpg": true
+      },
+      {
+        "name": "coreutils",
+        "epoch": 0,
+        "version": "8.32",
+        "release": "3.fc32.1",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/c/coreutils-8.32-3.fc32.1.x86_64.rpm",
+        "checksum": "sha256:7023687eb65baa56a9b4c3ffde1e439b3d41b03ac4ad35a1a1fc3903464548f7",
+        "check_gpg": true
+      },
+      {
+        "name": "coreutils-common",
+        "epoch": 0,
+        "version": "8.32",
+        "release": "3.fc32.1",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/c/coreutils-common-8.32-3.fc32.1.x86_64.rpm",
+        "checksum": "sha256:5323eb8d89b2d0c905a633513e04ca7df633c21eec288ee8c50f3f5170534e37",
+        "check_gpg": true
+      },
+      {
+        "name": "cpio",
+        "epoch": 0,
+        "version": "2.13",
+        "release": "4.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/c/cpio-2.13-4.fc32.x86_64.rpm",
+        "checksum": "sha256:116b9d121fad9886f245cd5e1ef678fdba889cd23a39e91447e75649214a6a8d",
+        "check_gpg": true
+      },
+      {
+        "name": "cracklib",
+        "epoch": 0,
+        "version": "2.9.6",
+        "release": "22.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/c/cracklib-2.9.6-22.fc32.x86_64.rpm",
+        "checksum": "sha256:862e75c10377098a9cc50407a0395e5f3a81d14b5b6fecfb3f223325c8867829",
+        "check_gpg": true
+      },
+      {
+        "name": "cracklib-dicts",
+        "epoch": 0,
+        "version": "2.9.6",
+        "release": "22.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/c/cracklib-dicts-2.9.6-22.fc32.x86_64.rpm",
+        "checksum": "sha256:1aee865249b031e591a5e94d62d05b69ad1a6118a26adccf2dfd46b0002716e5",
+        "check_gpg": true
+      },
+      {
+        "name": "crypto-policies",
+        "epoch": 0,
+        "version": "20191128",
+        "release": "5.gitcd267a5.fc32",
+        "arch": "noarch",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/c/crypto-policies-20191128-5.gitcd267a5.fc32.noarch.rpm",
+        "checksum": "sha256:3f8dcae27ad3609b7de298d0ca8d34a2790b9898f5f1b03f3f9f8784374e307b",
+        "check_gpg": true
+      },
+      {
+        "name": "crypto-policies-scripts",
+        "epoch": 0,
+        "version": "20191128",
+        "release": "5.gitcd267a5.fc32",
+        "arch": "noarch",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/c/crypto-policies-scripts-20191128-5.gitcd267a5.fc32.noarch.rpm",
+        "checksum": "sha256:b821e9e8bf66abacaed4a386f9ed8ffa17f4f8be3db55e1ac31d52ba2d1faa1b",
+        "check_gpg": true
+      },
+      {
+        "name": "cryptsetup-libs",
+        "epoch": 0,
+        "version": "2.3.0",
+        "release": "1.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/c/cryptsetup-libs-2.3.0-1.fc32.x86_64.rpm",
+        "checksum": "sha256:eaffaa8de8fd28ad124da12524a2ca5db86252404d70d66c7c42921dad6b69c1",
+        "check_gpg": true
+      },
+      {
+        "name": "curl",
+        "epoch": 0,
+        "version": "7.69.1",
+        "release": "1.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/c/curl-7.69.1-1.fc32.x86_64.rpm",
+        "checksum": "sha256:6eeebf21f245bf0d6f58962dc49b6dfb51f55acb6a595c6b9cbe9628806b80a4",
+        "check_gpg": true
+      },
+      {
+        "name": "cyrus-sasl-lib",
+        "epoch": 0,
+        "version": "2.1.27",
+        "release": "4.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/c/cyrus-sasl-lib-2.1.27-4.fc32.x86_64.rpm",
+        "checksum": "sha256:fefa4162a563eba24714ac43874c508d1ba036afb5127c5d21bbcbeaf238a740",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus",
+        "epoch": 1,
+        "version": "1.12.16",
+        "release": "4.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/d/dbus-1.12.16-4.fc32.x86_64.rpm",
+        "checksum": "sha256:ed36d759746e75a2834866fbeaa783df397f8813cae2ed79fcc4d146656bf6a6",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-broker",
+        "epoch": 0,
+        "version": "22",
+        "release": "1.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/d/dbus-broker-22-1.fc32.x86_64.rpm",
+        "checksum": "sha256:213c17fb822ffa50fad16989ed363aa023de106c6262ccc3f16e52a154b7133f",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-common",
+        "epoch": 1,
+        "version": "1.12.16",
+        "release": "4.fc32",
+        "arch": "noarch",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/d/dbus-common-1.12.16-4.fc32.noarch.rpm",
+        "checksum": "sha256:6fc1b9a27eeb368a98f50dba5fc514f20a5eb23f8e0ee7dd92c4051ef8b4a940",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-libs",
+        "epoch": 1,
+        "version": "1.12.16",
+        "release": "4.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/d/dbus-libs-1.12.16-4.fc32.x86_64.rpm",
+        "checksum": "sha256:474fd088c7e7234221d251153e9fda6081b0aa8979bf5ae25810c9862e1e9960",
+        "check_gpg": true
+      },
+      {
+        "name": "deltarpm",
+        "epoch": 0,
+        "version": "3.6.2",
+        "release": "5.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/d/deltarpm-3.6.2-5.fc32.x86_64.rpm",
+        "checksum": "sha256:b70d1c93e3448b1a0b5e3f50488290283a260ff46e22bff4fb704469e6017fa8",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper",
+        "epoch": 0,
+        "version": "1.02.171",
+        "release": "1.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/d/device-mapper-1.02.171-1.fc32.x86_64.rpm",
+        "checksum": "sha256:c132999a3f110029cd427f7578965ad558e91374637087d5230ee11c626ebcd4",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper-libs",
+        "epoch": 0,
+        "version": "1.02.171",
+        "release": "1.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/d/device-mapper-libs-1.02.171-1.fc32.x86_64.rpm",
+        "checksum": "sha256:61cae80187ef2924857fdfc48a240646d23b331482cf181e7d8c661b02c15949",
+        "check_gpg": true
+      },
+      {
+        "name": "diffutils",
+        "epoch": 0,
+        "version": "3.7",
+        "release": "4.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/d/diffutils-3.7-4.fc32.x86_64.rpm",
+        "checksum": "sha256:187dd61be71efcca6adf9819a523d432217abb335afcb2b95ef27b72928aff4b",
+        "check_gpg": true
+      },
+      {
+        "name": "dnf",
+        "epoch": 0,
+        "version": "4.2.19",
+        "release": "1.fc32",
+        "arch": "noarch",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/d/dnf-4.2.19-1.fc32.noarch.rpm",
+        "checksum": "sha256:78e1aa11379eec2906eedf843216f47bcbdfe4da4713d566fb44ca313c893f3f",
+        "check_gpg": true
+      },
+      {
+        "name": "dnf-data",
+        "epoch": 0,
+        "version": "4.2.19",
+        "release": "1.fc32",
+        "arch": "noarch",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/d/dnf-data-4.2.19-1.fc32.noarch.rpm",
+        "checksum": "sha256:80d407bbc5f6bb8d95504cfdb51faaca937f6c4c08df4c4aadcd46fe703c8a57",
+        "check_gpg": true
+      },
+      {
+        "name": "dosfstools",
+        "epoch": 0,
+        "version": "4.1",
+        "release": "10.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/d/dosfstools-4.1-10.fc32.x86_64.rpm",
+        "checksum": "sha256:c3f7089ae50f79cf4d2cb59e01091d33c70cab89ae08f95c547339a87404c3ec",
+        "check_gpg": true
+      },
+      {
+        "name": "dracut",
+        "epoch": 0,
+        "version": "050",
+        "release": "26.git20200316.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/d/dracut-050-26.git20200316.fc32.x86_64.rpm",
+        "checksum": "sha256:993680d5cd133a0c21184be92b3df405d757613d0ca25c4abf08b203d8d26b79",
+        "check_gpg": true
+      },
+      {
+        "name": "e2fsprogs",
+        "epoch": 0,
+        "version": "1.45.5",
+        "release": "3.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/e/e2fsprogs-1.45.5-3.fc32.x86_64.rpm",
+        "checksum": "sha256:2fa5e252441852dae918b522a2ff3f46a5bbee4ce8936e06702bf65f57d7ff99",
+        "check_gpg": true
+      },
+      {
+        "name": "e2fsprogs-libs",
+        "epoch": 0,
+        "version": "1.45.5",
+        "release": "3.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/e/e2fsprogs-libs-1.45.5-3.fc32.x86_64.rpm",
+        "checksum": "sha256:26db62c2bc52c3eee5f3039cdbdf19498f675d0f45aec0c2a1c61c635f01479e",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-debuginfod-client",
+        "epoch": 0,
+        "version": "0.179",
+        "release": "1.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/e/elfutils-debuginfod-client-0.179-1.fc32.x86_64.rpm",
+        "checksum": "sha256:4f318cec61cb69fc233ba5505b7e24f679afdfb0b5defbaef507f1b471e7dbb5",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-default-yama-scope",
+        "epoch": 0,
+        "version": "0.179",
+        "release": "1.fc32",
+        "arch": "noarch",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/e/elfutils-default-yama-scope-0.179-1.fc32.noarch.rpm",
+        "checksum": "sha256:af62d0611b995b9f2b2c7b4d4852e03e521d66979534871ccb5a71275a15518d",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-libelf",
+        "epoch": 0,
+        "version": "0.179",
+        "release": "1.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/e/elfutils-libelf-0.179-1.fc32.x86_64.rpm",
+        "checksum": "sha256:f3eb795f68c80ccf870f1d27f8fd019878db748c0c19275634c48cf5cea5bc46",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-libs",
+        "epoch": 0,
+        "version": "0.179",
+        "release": "1.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/e/elfutils-libs-0.179-1.fc32.x86_64.rpm",
+        "checksum": "sha256:99f87b4ec7c5852d45028f3eae65fc813f3ef107e128777f265b09a19ce262e0",
+        "check_gpg": true
+      },
+      {
+        "name": "expat",
+        "epoch": 0,
+        "version": "2.2.8",
+        "release": "2.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/e/expat-2.2.8-2.fc32.x86_64.rpm",
+        "checksum": "sha256:8fc2ae85f242105987d8fa7f05e4fa19358a7c81dff5fa163cf021eb6b9905e9",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-gpg-keys",
+        "epoch": 0,
+        "version": "32",
+        "release": "1",
+        "arch": "noarch",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/f/fedora-gpg-keys-32-1.noarch.rpm",
+        "checksum": "sha256:09fea9af8b695af862b19c1a8fbe1b1e8854257825ee4f663f67b3782a75d58a",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release",
+        "epoch": 0,
+        "version": "32",
+        "release": "1",
+        "arch": "noarch",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/f/fedora-release-32-1.noarch.rpm",
+        "checksum": "sha256:1f2ba0fc562864ad1bea31a42da124030fc188d23a84d144be616c2d066e1531",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release-common",
+        "epoch": 0,
+        "version": "32",
+        "release": "1",
+        "arch": "noarch",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/f/fedora-release-common-32-1.noarch.rpm",
+        "checksum": "sha256:a1835a7929d3c1613f3890caef878e9bdf857dcc0f63eb4d63a1140370b3f21b",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-repos",
+        "epoch": 0,
+        "version": "32",
+        "release": "1",
+        "arch": "noarch",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/f/fedora-repos-32-1.noarch.rpm",
+        "checksum": "sha256:21e3fd914a3bcc65b79de022782967903c55a4aed9a3c7d3464bc2fef32d02b3",
+        "check_gpg": true
+      },
+      {
+        "name": "file",
+        "epoch": 0,
+        "version": "5.38",
+        "release": "2.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/f/file-5.38-2.fc32.x86_64.rpm",
+        "checksum": "sha256:28656826cb0dfbae9b6e8d1e5c5691773d84000493c4be47f727092fec6dc6f4",
+        "check_gpg": true
+      },
+      {
+        "name": "file-libs",
+        "epoch": 0,
+        "version": "5.38",
+        "release": "2.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/f/file-libs-5.38-2.fc32.x86_64.rpm",
+        "checksum": "sha256:e0b1da98020a740991dbb70b42c0ff1eece9e268a461e555a5ec763bda1645f5",
+        "check_gpg": true
+      },
+      {
+        "name": "filesystem",
+        "epoch": 0,
+        "version": "3.14",
+        "release": "2.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/f/filesystem-3.14-2.fc32.x86_64.rpm",
+        "checksum": "sha256:1110261787146443e089955912255d99daf7ba042c3743e13648a9eb3d80ceb4",
+        "check_gpg": true
+      },
+      {
+        "name": "findutils",
+        "epoch": 1,
+        "version": "4.7.0",
+        "release": "3.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/f/findutils-4.7.0-3.fc32.x86_64.rpm",
+        "checksum": "sha256:0b7cd6f6cb3b7cd9e0704dd6c62b65254b04cb870ab638b9bed4951564436e24",
+        "check_gpg": true
+      },
+      {
+        "name": "fuse",
+        "epoch": 0,
+        "version": "2.9.9",
+        "release": "9.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/f/fuse-2.9.9-9.fc32.x86_64.rpm",
+        "checksum": "sha256:9369d4fed30402f45705b7a5cb51b6eeefb1dabbe0942c84514c6fdf1edac5e0",
+        "check_gpg": true
+      },
+      {
+        "name": "fuse-common",
+        "epoch": 0,
+        "version": "3.9.1",
+        "release": "1.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/f/fuse-common-3.9.1-1.fc32.x86_64.rpm",
+        "checksum": "sha256:45132e53c649def28d63c199d8c3a3b9fd16fa8bca7426ad4e9c202e52a233b4",
+        "check_gpg": true
+      },
+      {
+        "name": "fuse-libs",
+        "epoch": 0,
+        "version": "2.9.9",
+        "release": "9.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/f/fuse-libs-2.9.9-9.fc32.x86_64.rpm",
+        "checksum": "sha256:53992752850779218421994f61f1589eda5d368e28d340dccaae3f67de06e7f2",
+        "check_gpg": true
+      },
+      {
+        "name": "gawk",
+        "epoch": 0,
+        "version": "5.0.1",
+        "release": "7.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/g/gawk-5.0.1-7.fc32.x86_64.rpm",
+        "checksum": "sha256:d0e5d0104cf20c8dd332053a5903aab9b7fdadb84b35a1bfb3a6456f3399eb32",
+        "check_gpg": true
+      },
+      {
+        "name": "gdbm-libs",
+        "epoch": 1,
+        "version": "1.18.1",
+        "release": "3.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/g/gdbm-libs-1.18.1-3.fc32.x86_64.rpm",
+        "checksum": "sha256:9899cfd32ada2537693af30b60051da21c6264b0d0db51ba709fceb179d4c836",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext",
+        "epoch": 0,
+        "version": "0.20.1",
+        "release": "4.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/g/gettext-0.20.1-4.fc32.x86_64.rpm",
+        "checksum": "sha256:349af433b2f6d45ff2e1ea5a38f847ec692fef0a8dd656a9a07d423a981946d0",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext-libs",
+        "epoch": 0,
+        "version": "0.20.1",
+        "release": "4.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/g/gettext-libs-0.20.1-4.fc32.x86_64.rpm",
+        "checksum": "sha256:fdb9bc612957a16fc44b717605a5a26e16a33850c0ff74a80a299cc2bab740e4",
+        "check_gpg": true
+      },
+      {
+        "name": "glib2",
+        "epoch": 0,
+        "version": "2.64.1",
+        "release": "1.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/g/glib2-2.64.1-1.fc32.x86_64.rpm",
+        "checksum": "sha256:6fe524feb38312f9c370b2190aeb42330acc9ce42f3a45e9cd05748b4aa00db2",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc",
+        "epoch": 0,
+        "version": "2.31",
+        "release": "2.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/g/glibc-2.31-2.fc32.x86_64.rpm",
+        "checksum": "sha256:dc9c0401522bcf73fe5a692184c141b214947ad83364be97de0413ab46b712e5",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-all-langpacks",
+        "epoch": 0,
+        "version": "2.31",
+        "release": "2.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/g/glibc-all-langpacks-2.31-2.fc32.x86_64.rpm",
+        "checksum": "sha256:129d919e55c09edecaa8edd0fd4058dbf7460aaae5d1c5625ca11f6df7defefe",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-common",
+        "epoch": 0,
+        "version": "2.31",
+        "release": "2.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/g/glibc-common-2.31-2.fc32.x86_64.rpm",
+        "checksum": "sha256:e80533822e2a892345b869395b2c17c0bcc98d3c3c47787da30123096835db00",
+        "check_gpg": true
+      },
+      {
+        "name": "gmp",
+        "epoch": 1,
+        "version": "6.1.2",
+        "release": "13.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/g/gmp-6.1.2-13.fc32.x86_64.rpm",
+        "checksum": "sha256:178e4470a6dfca84ec133932606737bfe167094560bf473940504c511354ddc9",
+        "check_gpg": true
+      },
+      {
+        "name": "gnupg2",
+        "epoch": 0,
+        "version": "2.2.19",
+        "release": "1.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/g/gnupg2-2.2.19-1.fc32.x86_64.rpm",
+        "checksum": "sha256:cc3396df93ce0e8f439b83fb6b4d210903876846b0bd3a22c19c7770cf5a9050",
+        "check_gpg": true
+      },
+      {
+        "name": "gnupg2-smime",
+        "epoch": 0,
+        "version": "2.2.19",
+        "release": "1.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/g/gnupg2-smime-2.2.19-1.fc32.x86_64.rpm",
+        "checksum": "sha256:966084f83e0fedb7a217aa102b484ac8a63082ccfe99517544ed2cb102191204",
+        "check_gpg": true
+      },
+      {
+        "name": "gnutls",
+        "epoch": 0,
+        "version": "3.6.13",
+        "release": "1.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/g/gnutls-3.6.13-1.fc32.x86_64.rpm",
+        "checksum": "sha256:9d4f1290565b852e56f9e9babc14b141b0283998121f78b0eb83dec367cf0abb",
+        "check_gpg": true
+      },
+      {
+        "name": "gpgme",
+        "epoch": 0,
+        "version": "1.13.1",
+        "release": "6.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/g/gpgme-1.13.1-6.fc32.x86_64.rpm",
+        "checksum": "sha256:13a0c9c767f71164cc678ee36d89b7fddcdd6fb8243e3daf8b47cca0d1d14c4f",
+        "check_gpg": true
+      },
+      {
+        "name": "grep",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "4.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/g/grep-3.3-4.fc32.x86_64.rpm",
+        "checksum": "sha256:759165656ac8141b0c0ada230c258ffcd4516c4c8d132d7fbaf762cd5a5e4095",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-common",
+        "epoch": 1,
+        "version": "2.04",
+        "release": "12.fc32",
+        "arch": "noarch",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/g/grub2-common-2.04-12.fc32.noarch.rpm",
+        "checksum": "sha256:01173d218dccdf88c1159bba4af332ce703fc0dcd7171cd279cb3e16f12b30a9",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-pc",
+        "epoch": 1,
+        "version": "2.04",
+        "release": "12.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/g/grub2-pc-2.04-12.fc32.x86_64.rpm",
+        "checksum": "sha256:110f538d82f15f009d95e89d8c1e3669dc7358feb9aa7724301fef037f8b67fe",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-pc-modules",
+        "epoch": 1,
+        "version": "2.04",
+        "release": "12.fc32",
+        "arch": "noarch",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/g/grub2-pc-modules-2.04-12.fc32.noarch.rpm",
+        "checksum": "sha256:c2197913bc8db9548b0a40ffddf840a31956b18e932ad4eec77a48d87d2289ce",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-tools",
+        "epoch": 1,
+        "version": "2.04",
+        "release": "12.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/g/grub2-tools-2.04-12.fc32.x86_64.rpm",
+        "checksum": "sha256:7f6d2841ec9402ee5e57f1a46b9886935138c02005d860899f3c746c7885c7b9",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-tools-minimal",
+        "epoch": 1,
+        "version": "2.04",
+        "release": "12.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/g/grub2-tools-minimal-2.04-12.fc32.x86_64.rpm",
+        "checksum": "sha256:d1c6f183b9deaf6127db4ad7040046bd7f1aa62de177961aac39501605d2c815",
+        "check_gpg": true
+      },
+      {
+        "name": "gzip",
+        "epoch": 0,
+        "version": "1.10",
+        "release": "2.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/g/gzip-1.10-2.fc32.x86_64.rpm",
+        "checksum": "sha256:53f1e8570b175e8b58895646df6d8068a7e1f3cb1bafdde714ddd038bcf91e85",
+        "check_gpg": true
+      },
+      {
+        "name": "ima-evm-utils",
+        "epoch": 0,
+        "version": "1.2.1",
+        "release": "3.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/i/ima-evm-utils-1.2.1-3.fc32.x86_64.rpm",
+        "checksum": "sha256:c1f957511b5e011e6f7995ed7bca9196703cf1214068f209e86b1dc4fd0e98bf",
+        "check_gpg": true
+      },
+      {
+        "name": "iptables-libs",
+        "epoch": 0,
+        "version": "1.8.4",
+        "release": "7.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/i/iptables-libs-1.8.4-7.fc32.x86_64.rpm",
+        "checksum": "sha256:f4eb6d332b9aea8d8ef0a6ea8dc2b073d6bf5f2599d64f24111d8da2ee82ad48",
+        "check_gpg": true
+      },
+      {
+        "name": "json-c",
+        "epoch": 0,
+        "version": "0.13.1",
+        "release": "9.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/j/json-c-0.13.1-9.fc32.x86_64.rpm",
+        "checksum": "sha256:d3a64fcef3de79a97541b21c71ddd00d4cca9039c930bc660d6c5479eabf5f26",
+        "check_gpg": true
+      },
+      {
+        "name": "json-glib",
+        "epoch": 0,
+        "version": "1.4.4",
+        "release": "4.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/j/json-glib-1.4.4-4.fc32.x86_64.rpm",
+        "checksum": "sha256:8a03d482b5294f7452b2f9ce31ebb6aea9eefac002281c1b9152fbb1a0341987",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd",
+        "epoch": 0,
+        "version": "2.2.0",
+        "release": "1.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/k/kbd-2.2.0-1.fc32.x86_64.rpm",
+        "checksum": "sha256:a05178831a546e2001e52f065fc6969f36d2292efaee2971fe7a7e882cc8c813",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd-legacy",
+        "epoch": 0,
+        "version": "2.2.0",
+        "release": "1.fc32",
+        "arch": "noarch",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/k/kbd-legacy-2.2.0-1.fc32.noarch.rpm",
+        "checksum": "sha256:3be681b78e919bfd82eb186c7393718f1d37abd0b1bb8b1a8571aefa11e7a248",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd-misc",
+        "epoch": 0,
+        "version": "2.2.0",
+        "release": "1.fc32",
+        "arch": "noarch",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/k/kbd-misc-2.2.0-1.fc32.noarch.rpm",
+        "checksum": "sha256:60774007011889671c28158f599032f0db253c153ccae70f5e2f5840f2dc490b",
+        "check_gpg": true
+      },
+      {
+        "name": "keyutils-libs",
+        "epoch": 0,
+        "version": "1.6",
+        "release": "4.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/k/keyutils-libs-1.6-4.fc32.x86_64.rpm",
+        "checksum": "sha256:ccc3cb2dcb7a534361cc911f27ff4e869902a150b68e236cf6eb209a99d4ee22",
+        "check_gpg": true
+      },
+      {
+        "name": "kmod",
+        "epoch": 0,
+        "version": "27",
+        "release": "1.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/k/kmod-27-1.fc32.x86_64.rpm",
+        "checksum": "sha256:3f9c95f3827b785f49ac4a270d4c3a703dceba673c452838744ec5064cf43cbd",
+        "check_gpg": true
+      },
+      {
+        "name": "kmod-libs",
+        "epoch": 0,
+        "version": "27",
+        "release": "1.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/k/kmod-libs-27-1.fc32.x86_64.rpm",
+        "checksum": "sha256:56187c1c980cc0680f4dbc433ed2c8507e7dc9ab00000615b63ea08c086b7ab2",
+        "check_gpg": true
+      },
+      {
+        "name": "kpartx",
+        "epoch": 0,
+        "version": "0.8.2",
+        "release": "3.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/k/kpartx-0.8.2-3.fc32.x86_64.rpm",
+        "checksum": "sha256:fbb81a7811f7a11b1c95eec20c3df63beef9e007f0b3d2713f13ad80029d7249",
+        "check_gpg": true
+      },
+      {
+        "name": "krb5-libs",
+        "epoch": 0,
+        "version": "1.18",
+        "release": "1.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/k/krb5-libs-1.18-1.fc32.x86_64.rpm",
+        "checksum": "sha256:e2b2dddbce49fab5f01ba75fae8796ab7c9fd8280c652f78d06a2644246bd16d",
+        "check_gpg": true
+      },
+      {
+        "name": "libacl",
+        "epoch": 0,
+        "version": "2.2.53",
+        "release": "5.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libacl-2.2.53-5.fc32.x86_64.rpm",
+        "checksum": "sha256:f826f984b23d0701a1b72de5882b9c0e7bae87ef49d9edfea156654f489f8b2b",
+        "check_gpg": true
+      },
+      {
+        "name": "libaio",
+        "epoch": 0,
+        "version": "0.3.111",
+        "release": "7.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libaio-0.3.111-7.fc32.x86_64.rpm",
+        "checksum": "sha256:a410db5c56d4f39f6ea71e7d5bb6d4a2bd518015d1e34f38fbc0d7bbd4e872d4",
+        "check_gpg": true
+      },
+      {
+        "name": "libarchive",
+        "epoch": 0,
+        "version": "3.4.2",
+        "release": "1.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libarchive-3.4.2-1.fc32.x86_64.rpm",
+        "checksum": "sha256:88f4bd19a6cf6eba5e6f2b5bba80819b5ccddb0476aadc53c8df13f9c45b1e58",
+        "check_gpg": true
+      },
+      {
+        "name": "libargon2",
+        "epoch": 0,
+        "version": "20171227",
+        "release": "4.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libargon2-20171227-4.fc32.x86_64.rpm",
+        "checksum": "sha256:7d9bd2fe016ca8860e8fab4a430b3aae4c7b7bea55f8ccd7775ad470172e2886",
+        "check_gpg": true
+      },
+      {
+        "name": "libassuan",
+        "epoch": 0,
+        "version": "2.5.3",
+        "release": "3.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libassuan-2.5.3-3.fc32.x86_64.rpm",
+        "checksum": "sha256:598a136b7027cb9b4fef6bfa34715979d41c2f62c9d8bec5d50b633a17790f7b",
+        "check_gpg": true
+      },
+      {
+        "name": "libattr",
+        "epoch": 0,
+        "version": "2.4.48",
+        "release": "8.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libattr-2.4.48-8.fc32.x86_64.rpm",
+        "checksum": "sha256:65e0cfe367ae4d54cf8bf509cb05e063c9eb6f2fea8dadcf746cdd85adc31d88",
+        "check_gpg": true
+      },
+      {
+        "name": "libblkid",
+        "epoch": 0,
+        "version": "2.35.1",
+        "release": "7.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libblkid-2.35.1-7.fc32.x86_64.rpm",
+        "checksum": "sha256:1830b4aa42ef492c13b62f63fe941970869ba19bd9abde4dea5c97f9e38ffd68",
+        "check_gpg": true
+      },
+      {
+        "name": "libbrotli",
+        "epoch": 0,
+        "version": "1.0.7",
+        "release": "10.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libbrotli-1.0.7-10.fc32.x86_64.rpm",
+        "checksum": "sha256:ac8b1fea0b678d7630033a8900be5641b934306961b39a29c79c6d72f34f7d1c",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap",
+        "epoch": 0,
+        "version": "2.26",
+        "release": "7.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libcap-2.26-7.fc32.x86_64.rpm",
+        "checksum": "sha256:1bc0542cf8a3746d0fe25c397a93c8206963f1f287246c6fb864eedfc9ffa4a7",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap-ng",
+        "epoch": 0,
+        "version": "0.7.10",
+        "release": "2.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libcap-ng-0.7.10-2.fc32.x86_64.rpm",
+        "checksum": "sha256:b60670fdcf91b50d97720f601d92277efedbd690bd887000ccd9a46b3fa8b314",
+        "check_gpg": true
+      },
+      {
+        "name": "libcom_err",
+        "epoch": 0,
+        "version": "1.45.5",
+        "release": "3.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libcom_err-1.45.5-3.fc32.x86_64.rpm",
+        "checksum": "sha256:4494013eac1ad337673f084242aa8ebffb4a149243475b448bee9266401f2896",
+        "check_gpg": true
+      },
+      {
+        "name": "libcomps",
+        "epoch": 0,
+        "version": "0.1.14",
+        "release": "4.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libcomps-0.1.14-4.fc32.x86_64.rpm",
+        "checksum": "sha256:e9a3ace2c71c2388ed6402e92ba148acb8d19b5c3495a47148b9e88cc6d6d1eb",
+        "check_gpg": true
+      },
+      {
+        "name": "libcroco",
+        "epoch": 0,
+        "version": "0.6.13",
+        "release": "3.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libcroco-0.6.13-3.fc32.x86_64.rpm",
+        "checksum": "sha256:63400fedea4a6ddb8fced58d33e60560791f29cd439169998f337d09fb50a7d4",
+        "check_gpg": true
+      },
+      {
+        "name": "libcurl",
+        "epoch": 0,
+        "version": "7.69.1",
+        "release": "1.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libcurl-7.69.1-1.fc32.x86_64.rpm",
+        "checksum": "sha256:7dfe1e8dac6d759479ae3dfd415fdd2662bbed9ff0f4da6093279efd1bacae31",
+        "check_gpg": true
+      },
+      {
+        "name": "libdb",
+        "epoch": 0,
+        "version": "5.3.28",
+        "release": "40.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libdb-5.3.28-40.fc32.x86_64.rpm",
+        "checksum": "sha256:688fcc0b7ef3c48cf7d602eefd7fefae7bcad4f0dc71c9fe9432c2ce5bbd9daa",
+        "check_gpg": true
+      },
+      {
+        "name": "libdb-utils",
+        "epoch": 0,
+        "version": "5.3.28",
+        "release": "40.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libdb-utils-5.3.28-40.fc32.x86_64.rpm",
+        "checksum": "sha256:431d836b2be015212d8c15b4290d5ce5bb45282cbf3fc52696f632d84ce34dfe",
+        "check_gpg": true
+      },
+      {
+        "name": "libdnf",
+        "epoch": 0,
+        "version": "0.45.0",
+        "release": "3.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libdnf-0.45.0-3.fc32.x86_64.rpm",
+        "checksum": "sha256:fa08dccd7a2e38dfbab999613bdb41df2034b506d21964d0ef368af6e56c4cf9",
+        "check_gpg": true
+      },
+      {
+        "name": "libevent",
+        "epoch": 0,
+        "version": "2.1.8",
+        "release": "8.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libevent-2.1.8-8.fc32.x86_64.rpm",
+        "checksum": "sha256:7bf42ff57ce2a31db0da7d6c5926552f4e51e9f25cded77bd634eb5cd35eadab",
+        "check_gpg": true
+      },
+      {
+        "name": "libfdisk",
+        "epoch": 0,
+        "version": "2.35.1",
+        "release": "7.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libfdisk-2.35.1-7.fc32.x86_64.rpm",
+        "checksum": "sha256:942d06ec1f7033ea4c729b84ee09f5491481770efe10151ba581479ac7f3f9dc",
+        "check_gpg": true
+      },
+      {
+        "name": "libffi",
+        "epoch": 0,
+        "version": "3.1",
+        "release": "24.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libffi-3.1-24.fc32.x86_64.rpm",
+        "checksum": "sha256:86c87a4169bdf75c6d3a2f11d3a7e20b6364b2db97c74bc7eb62b1b22bc54401",
+        "check_gpg": true
+      },
+      {
+        "name": "libgcc",
+        "epoch": 0,
+        "version": "10.0.1",
+        "release": "0.11.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libgcc-10.0.1-0.11.fc32.x86_64.rpm",
+        "checksum": "sha256:48cf5ab32f6af8f2283d4d4834e8dd262aa412be7ea07c2292483e150d614bef",
+        "check_gpg": true
+      },
+      {
+        "name": "libgcrypt",
+        "epoch": 0,
+        "version": "1.8.5",
+        "release": "3.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libgcrypt-1.8.5-3.fc32.x86_64.rpm",
+        "checksum": "sha256:5f0ae954b5955c86623e68cd81ccf8505a89f260003b8a3be6a93bd76f18452c",
+        "check_gpg": true
+      },
+      {
+        "name": "libgomp",
+        "epoch": 0,
+        "version": "10.0.1",
+        "release": "0.11.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libgomp-10.0.1-0.11.fc32.x86_64.rpm",
+        "checksum": "sha256:d65b4bb6fa49198237f9b704ec471d71dfd94b87290f4d03c1c34d12f6efeb95",
+        "check_gpg": true
+      },
+      {
+        "name": "libgpg-error",
+        "epoch": 0,
+        "version": "1.36",
+        "release": "3.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libgpg-error-1.36-3.fc32.x86_64.rpm",
+        "checksum": "sha256:9bd5cb588664e8427bc8bebde0cdf5e14315916624ab6b1979dde60f6eae4278",
+        "check_gpg": true
+      },
+      {
+        "name": "libidn2",
+        "epoch": 0,
+        "version": "2.3.0",
+        "release": "2.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libidn2-2.3.0-2.fc32.x86_64.rpm",
+        "checksum": "sha256:20787251df57a108bbf9c40e30f041b71ac36c8a10900fb699e574ee7e259bf2",
+        "check_gpg": true
+      },
+      {
+        "name": "libkcapi",
+        "epoch": 0,
+        "version": "1.1.5",
+        "release": "2.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libkcapi-1.1.5-2.fc32.x86_64.rpm",
+        "checksum": "sha256:8677b34fa73f258b1a599d18419f6fbbb8961bb1ca2ae5b0f9abdcc4f93b319e",
+        "check_gpg": true
+      },
+      {
+        "name": "libkcapi-hmaccalc",
+        "epoch": 0,
+        "version": "1.1.5",
+        "release": "2.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libkcapi-hmaccalc-1.1.5-2.fc32.x86_64.rpm",
+        "checksum": "sha256:5d5c8c7e9c78e3b8827ad38771efb44951d1c3c1692cf4e07b138c1c8c42bd5b",
+        "check_gpg": true
+      },
+      {
+        "name": "libksba",
+        "epoch": 0,
+        "version": "1.3.5",
+        "release": "11.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libksba-1.3.5-11.fc32.x86_64.rpm",
+        "checksum": "sha256:1b05dd5abad5a31380c859bc33e7851158c24333fda837ca9facf869005f81fe",
+        "check_gpg": true
+      },
+      {
+        "name": "libmetalink",
+        "epoch": 0,
+        "version": "0.1.3",
+        "release": "10.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libmetalink-0.1.3-10.fc32.x86_64.rpm",
+        "checksum": "sha256:6eb95e39b9771c4dde5f9954a74cef6be90522c28c7c4aa767ebe7a9d55fcdf9",
+        "check_gpg": true
+      },
+      {
+        "name": "libmnl",
+        "epoch": 0,
+        "version": "1.0.4",
+        "release": "11.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libmnl-1.0.4-11.fc32.x86_64.rpm",
+        "checksum": "sha256:1c68255945533ed4e3368125bc46e19f3fe348d7ec507a85a35038dbb976003f",
+        "check_gpg": true
+      },
+      {
+        "name": "libmodulemd",
+        "epoch": 0,
+        "version": "2.9.1",
+        "release": "1.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libmodulemd-2.9.1-1.fc32.x86_64.rpm",
+        "checksum": "sha256:f98f854a86c68b534f71e1f35852fabddbe2cbfe481b01bb15291b3363013b2a",
+        "check_gpg": true
+      },
+      {
+        "name": "libmodulemd1",
+        "epoch": 0,
+        "version": "1.8.16",
+        "release": "2.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libmodulemd1-1.8.16-2.fc32.x86_64.rpm",
+        "checksum": "sha256:aa5b658fd4a95c724b61eddadecdbcbc1b2a813ae681318ab092a2ed03954825",
+        "check_gpg": true
+      },
+      {
+        "name": "libmount",
+        "epoch": 0,
+        "version": "2.35.1",
+        "release": "7.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libmount-2.35.1-7.fc32.x86_64.rpm",
+        "checksum": "sha256:e740cc0a580639b887bda0039a779e750a32835be1fd8c64aa01183b4cbb98bf",
+        "check_gpg": true
+      },
+      {
+        "name": "libnetfilter_conntrack",
+        "epoch": 0,
+        "version": "1.0.7",
+        "release": "4.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libnetfilter_conntrack-1.0.7-4.fc32.x86_64.rpm",
+        "checksum": "sha256:884357540f4be2a74e608e2c7a31f2371ee3b4d29be2fe39a371c0b131d84aa6",
+        "check_gpg": true
+      },
+      {
+        "name": "libnfnetlink",
+        "epoch": 0,
+        "version": "1.0.1",
+        "release": "17.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libnfnetlink-1.0.1-17.fc32.x86_64.rpm",
+        "checksum": "sha256:ec6abd65541b5bded814de19c9d064e6c21e3d8b424dba7cb25b2fdc52d45a2b",
+        "check_gpg": true
+      },
+      {
+        "name": "libnghttp2",
+        "epoch": 0,
+        "version": "1.40.0",
+        "release": "2.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libnghttp2-1.40.0-2.fc32.x86_64.rpm",
+        "checksum": "sha256:a8ce7406c87f64972f0b70f1823c2aad05516c71fe375c6c97737459c2448825",
+        "check_gpg": true
+      },
+      {
+        "name": "libnsl2",
+        "epoch": 0,
+        "version": "1.2.0",
+        "release": "6.20180605git4a062cf.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libnsl2-1.2.0-6.20180605git4a062cf.fc32.x86_64.rpm",
+        "checksum": "sha256:3b4ce7fc4e2778758881feedf6ea19b65e99aa3672e19a7dd62977efe3b910b9",
+        "check_gpg": true
+      },
+      {
+        "name": "libpcap",
+        "epoch": 14,
+        "version": "1.9.1",
+        "release": "3.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libpcap-1.9.1-3.fc32.x86_64.rpm",
+        "checksum": "sha256:b3230630a471b806a9153669d187508350cdb2b368a68f8c439c82abad038c3f",
+        "check_gpg": true
+      },
+      {
+        "name": "libpsl",
+        "epoch": 0,
+        "version": "0.21.0",
+        "release": "4.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libpsl-0.21.0-4.fc32.x86_64.rpm",
+        "checksum": "sha256:ce8c1f1ce3cb2cc0166dcaad17f35e84278ec39ea9bf232e24130d3ff3271923",
+        "check_gpg": true
+      },
+      {
+        "name": "libpwquality",
+        "epoch": 0,
+        "version": "1.4.2",
+        "release": "2.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libpwquality-1.4.2-2.fc32.x86_64.rpm",
+        "checksum": "sha256:9ecc8aa9af05ba704cec879618afeda5ff92d8233811e2d6080aa02e0b5ceddf",
+        "check_gpg": true
+      },
+      {
+        "name": "librepo",
+        "epoch": 0,
+        "version": "1.11.1",
+        "release": "4.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/librepo-1.11.1-4.fc32.x86_64.rpm",
+        "checksum": "sha256:aa783a91b1823b7b056575e6276df35910eb2e0d4b72121cf5649651c7d23a16",
+        "check_gpg": true
+      },
+      {
+        "name": "libreport-filesystem",
+        "epoch": 0,
+        "version": "2.12.0",
+        "release": "3.fc32",
+        "arch": "noarch",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libreport-filesystem-2.12.0-3.fc32.noarch.rpm",
+        "checksum": "sha256:3d33c29bcc4a39be16d6647a70a0d7ae2f08baf26dcea5c802289df1128d5f21",
+        "check_gpg": true
+      },
+      {
+        "name": "libseccomp",
+        "epoch": 0,
+        "version": "2.4.2",
+        "release": "3.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libseccomp-2.4.2-3.fc32.x86_64.rpm",
+        "checksum": "sha256:df0a39eb6b91c4a8f481c22445cbbd88334bf5e0a6e1dd5fb240981eb031c4eb",
+        "check_gpg": true
+      },
+      {
+        "name": "libsecret",
+        "epoch": 0,
+        "version": "0.20.2",
+        "release": "2.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libsecret-0.20.2-2.fc32.x86_64.rpm",
+        "checksum": "sha256:251fd875421da4708b76c15c7f5ba478d50b74d7e4242071a621625eac51a767",
+        "check_gpg": true
+      },
+      {
+        "name": "libselinux",
+        "epoch": 0,
+        "version": "3.0",
+        "release": "3.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libselinux-3.0-3.fc32.x86_64.rpm",
+        "checksum": "sha256:0e59b422e35eee975ba68e6e4de022c8f145feec7e169e86e0244d2fdad2f590",
+        "check_gpg": true
+      },
+      {
+        "name": "libselinux-utils",
+        "epoch": 0,
+        "version": "3.0",
+        "release": "3.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libselinux-utils-3.0-3.fc32.x86_64.rpm",
+        "checksum": "sha256:1446032720fb8e0090190828fcea294a86fc7f83edd70f6089e3446770ba0438",
+        "check_gpg": true
+      },
+      {
+        "name": "libsemanage",
+        "epoch": 0,
+        "version": "3.0",
+        "release": "3.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libsemanage-3.0-3.fc32.x86_64.rpm",
+        "checksum": "sha256:54cb827278ae474cbab1f05e0fbee0355bee2674d46a804f1c2b78ff80a48caa",
+        "check_gpg": true
+      },
+      {
+        "name": "libsepol",
+        "epoch": 0,
+        "version": "3.0",
+        "release": "3.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libsepol-3.0-3.fc32.x86_64.rpm",
+        "checksum": "sha256:29e2b62e9e63f25139a6863c863c3b534660440d7dec0c985807302a6895dbaf",
+        "check_gpg": true
+      },
+      {
+        "name": "libsigsegv",
+        "epoch": 0,
+        "version": "2.11",
+        "release": "10.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libsigsegv-2.11-10.fc32.x86_64.rpm",
+        "checksum": "sha256:942707884401498938fba6e2439dc923d4e2d81f4bac205f4e73d458e9879927",
+        "check_gpg": true
+      },
+      {
+        "name": "libsmartcols",
+        "epoch": 0,
+        "version": "2.35.1",
+        "release": "7.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libsmartcols-2.35.1-7.fc32.x86_64.rpm",
+        "checksum": "sha256:ddad78d00b09c6c85d46c06dcba4c951f7f7dfc9b2dab195bf45aa3f5a1fdc41",
+        "check_gpg": true
+      },
+      {
+        "name": "libsolv",
+        "epoch": 0,
+        "version": "0.7.11",
+        "release": "2.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libsolv-0.7.11-2.fc32.x86_64.rpm",
+        "checksum": "sha256:be899d3e806441b1c46811c0ffe9f4e01f4ea4e1544f9cc32630254853e3f3a5",
+        "check_gpg": true
+      },
+      {
+        "name": "libss",
+        "epoch": 0,
+        "version": "1.45.5",
+        "release": "3.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libss-1.45.5-3.fc32.x86_64.rpm",
+        "checksum": "sha256:27701cda24f5f6386e0173745aabc4f6df28052975e73529854432c35399cfc8",
+        "check_gpg": true
+      },
+      {
+        "name": "libssh",
+        "epoch": 0,
+        "version": "0.9.3",
+        "release": "2.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libssh-0.9.3-2.fc32.x86_64.rpm",
+        "checksum": "sha256:32f8cbb3be91f589d569a2e737130f29c752f78eebc61e287af17f207e1b8c58",
+        "check_gpg": true
+      },
+      {
+        "name": "libssh-config",
+        "epoch": 0,
+        "version": "0.9.3",
+        "release": "2.fc32",
+        "arch": "noarch",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libssh-config-0.9.3-2.fc32.noarch.rpm",
+        "checksum": "sha256:49bac21d5cdf863fccfcc32bf070e582d204706e35ee9f60b3e69df694bff87d",
+        "check_gpg": true
+      },
+      {
+        "name": "libstdc++",
+        "epoch": 0,
+        "version": "10.0.1",
+        "release": "0.11.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libstdc++-10.0.1-0.11.fc32.x86_64.rpm",
+        "checksum": "sha256:be998dfbcc9ca8e3021ac4f56ed723cfa3fa1517524e89ee0b636f623abe995f",
+        "check_gpg": true
+      },
+      {
+        "name": "libtasn1",
+        "epoch": 0,
+        "version": "4.16.0",
+        "release": "1.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libtasn1-4.16.0-1.fc32.x86_64.rpm",
+        "checksum": "sha256:052d04c9a6697c6e5aa546546ae5058d547fc4a4f474d2805a3e45dbf69193c6",
+        "check_gpg": true
+      },
+      {
+        "name": "libtextstyle",
+        "epoch": 0,
+        "version": "0.20.1",
+        "release": "4.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libtextstyle-0.20.1-4.fc32.x86_64.rpm",
+        "checksum": "sha256:b35256e417fd94c7efb1212f2f36b5e6b224ff5b9e8733774d4fbdc652078099",
+        "check_gpg": true
+      },
+      {
+        "name": "libtirpc",
+        "epoch": 0,
+        "version": "1.2.5",
+        "release": "1.rc2.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libtirpc-1.2.5-1.rc2.fc32.x86_64.rpm",
+        "checksum": "sha256:c1d754773972b5f4ca157c0afa45d6767901d965a91f381660c72740d682df63",
+        "check_gpg": true
+      },
+      {
+        "name": "libunistring",
+        "epoch": 0,
+        "version": "0.9.10",
+        "release": "7.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libunistring-0.9.10-7.fc32.x86_64.rpm",
+        "checksum": "sha256:fb06aa3d8059406a23694ddafe0ef340ca627dd68bf3f351f094de58ef30fb2c",
+        "check_gpg": true
+      },
+      {
+        "name": "libusbx",
+        "epoch": 0,
+        "version": "1.0.23",
+        "release": "1.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libusbx-1.0.23-1.fc32.x86_64.rpm",
+        "checksum": "sha256:729fb595040f1e2e71ff0a8c1c22ebe4b7187f78b816af8e6a8d93c03fc5d844",
+        "check_gpg": true
+      },
+      {
+        "name": "libutempter",
+        "epoch": 0,
+        "version": "1.1.6",
+        "release": "18.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libutempter-1.1.6-18.fc32.x86_64.rpm",
+        "checksum": "sha256:f9ccea65ecf98f4dfac65d25986d08efa62a1d1c0db9db0a061e7408d6805a1a",
+        "check_gpg": true
+      },
+      {
+        "name": "libuuid",
+        "epoch": 0,
+        "version": "2.35.1",
+        "release": "7.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libuuid-2.35.1-7.fc32.x86_64.rpm",
+        "checksum": "sha256:8402d3aabfc02c16f3789f3f93338dbee2448db8a49956002b83aff5390922d9",
+        "check_gpg": true
+      },
+      {
+        "name": "libverto",
+        "epoch": 0,
+        "version": "0.3.0",
+        "release": "9.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libverto-0.3.0-9.fc32.x86_64.rpm",
+        "checksum": "sha256:ed84414c9b2190d3026f58db78dffd8bc3a9ad40311cb0adb8ff8e3c7c06ca60",
+        "check_gpg": true
+      },
+      {
+        "name": "libxcrypt",
+        "epoch": 0,
+        "version": "4.4.16",
+        "release": "1.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libxcrypt-4.4.16-1.fc32.x86_64.rpm",
+        "checksum": "sha256:7c1a229f4a36ac8b077e0514f68f311229652121528b0f8a2a7434c618276dcb",
+        "check_gpg": true
+      },
+      {
+        "name": "libxcrypt-compat",
+        "epoch": 0,
+        "version": "4.4.16",
+        "release": "1.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libxcrypt-compat-4.4.16-1.fc32.x86_64.rpm",
+        "checksum": "sha256:cb4fb9b3733440ea15b3309c88d9471c4165aa7b71b4dbc5d0fb5bfcd97b2f2e",
+        "check_gpg": true
+      },
+      {
+        "name": "libxkbcommon",
+        "epoch": 0,
+        "version": "0.10.0",
+        "release": "2.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libxkbcommon-0.10.0-2.fc32.x86_64.rpm",
+        "checksum": "sha256:ae219ad5ecc0233271c3fd61263f817c646eecece19a8f075e7aa4dd9ff8698e",
+        "check_gpg": true
+      },
+      {
+        "name": "libxml2",
+        "epoch": 0,
+        "version": "2.9.10",
+        "release": "3.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libxml2-2.9.10-3.fc32.x86_64.rpm",
+        "checksum": "sha256:a7f040de29d2414cc99fcffcd9ed3fa9d06ecc7aecd783ec3d2eef769e2389f1",
+        "check_gpg": true
+      },
+      {
+        "name": "libyaml",
+        "epoch": 0,
+        "version": "0.2.2",
+        "release": "3.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libyaml-0.2.2-3.fc32.x86_64.rpm",
+        "checksum": "sha256:9c8a274158a6fe97598e33900cd51e171f7e7517ccfc8ad6351873e69b225986",
+        "check_gpg": true
+      },
+      {
+        "name": "libzstd",
+        "epoch": 0,
+        "version": "1.4.4",
+        "release": "2.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libzstd-1.4.4-2.fc32.x86_64.rpm",
+        "checksum": "sha256:9465f2f1103697207a52d15edd716ab72dc6c281823c60f424cd064d706c7a51",
+        "check_gpg": true
+      },
+      {
+        "name": "lua-libs",
+        "epoch": 0,
+        "version": "5.3.5",
+        "release": "7.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/lua-libs-5.3.5-7.fc32.x86_64.rpm",
+        "checksum": "sha256:10883ce95852cc9ae9b4e0d435b100a25f8fe5c0ea4677eb4a0b39f4f8def886",
+        "check_gpg": true
+      },
+      {
+        "name": "lz4-libs",
+        "epoch": 0,
+        "version": "1.9.1",
+        "release": "2.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/lz4-libs-1.9.1-2.fc32.x86_64.rpm",
+        "checksum": "sha256:44cfb58b368fba586981aa838a7f3974ac1d66d2b3b695f88d7b1d2e9c81a0b6",
+        "check_gpg": true
+      },
+      {
+        "name": "mkpasswd",
+        "epoch": 0,
+        "version": "5.5.6",
+        "release": "1.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/m/mkpasswd-5.5.6-1.fc32.x86_64.rpm",
+        "checksum": "sha256:640afe5b9d499c9a7efc1d23cce8c54e3e3704d92eb7e7a93a048f97d1e983e1",
+        "check_gpg": true
+      },
+      {
+        "name": "mpfr",
+        "epoch": 0,
+        "version": "4.0.2",
+        "release": "3.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/m/mpfr-4.0.2-3.fc32.x86_64.rpm",
+        "checksum": "sha256:2b098bc6f8004270ee9eac9f63980b364b5fe19394dc73a230b3c846cf488b1b",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses",
+        "epoch": 0,
+        "version": "6.1",
+        "release": "15.20191109.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/n/ncurses-6.1-15.20191109.fc32.x86_64.rpm",
+        "checksum": "sha256:b2e862283ac97b1d8b1ede2034ead452ac7dc4ff308593306275b1b0ae5b4102",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses-base",
+        "epoch": 0,
+        "version": "6.1",
+        "release": "15.20191109.fc32",
+        "arch": "noarch",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/n/ncurses-base-6.1-15.20191109.fc32.noarch.rpm",
+        "checksum": "sha256:25fc5d288536e1973436da38357690575ed58e03e17ca48d2b3840364f830659",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses-libs",
+        "epoch": 0,
+        "version": "6.1",
+        "release": "15.20191109.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/n/ncurses-libs-6.1-15.20191109.fc32.x86_64.rpm",
+        "checksum": "sha256:04152a3a608d022a58830c0e3dac0818e2c060469b0f41d8d731f659981a4464",
+        "check_gpg": true
+      },
+      {
+        "name": "nettle",
+        "epoch": 0,
+        "version": "3.5.1",
+        "release": "5.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/n/nettle-3.5.1-5.fc32.x86_64.rpm",
+        "checksum": "sha256:c019d23ed2cb3ceb0ac9757a72c3e8b1d31f2a524b889e18049cc7d923bc9466",
+        "check_gpg": true
+      },
+      {
+        "name": "npth",
+        "epoch": 0,
+        "version": "1.6",
+        "release": "4.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/n/npth-1.6-4.fc32.x86_64.rpm",
+        "checksum": "sha256:3c2a641f118ab2e8b08df6dd2da72a60121d02df8d932b4afa2920eb80392875",
+        "check_gpg": true
+      },
+      {
+        "name": "openldap",
+        "epoch": 0,
+        "version": "2.4.47",
+        "release": "4.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/o/openldap-2.4.47-4.fc32.x86_64.rpm",
+        "checksum": "sha256:ade8105796f5c1201a3efc8bcc654788cfc88c3815297b346845062a8c29cd59",
+        "check_gpg": true
+      },
+      {
+        "name": "openssl",
+        "epoch": 1,
+        "version": "1.1.1d",
+        "release": "7.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/o/openssl-1.1.1d-7.fc32.x86_64.rpm",
+        "checksum": "sha256:d7b8b5815b72fb157de26579362383e357e026ae6ac2599c451fb336fe995555",
+        "check_gpg": true
+      },
+      {
+        "name": "openssl-libs",
+        "epoch": 1,
+        "version": "1.1.1d",
+        "release": "7.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/o/openssl-libs-1.1.1d-7.fc32.x86_64.rpm",
+        "checksum": "sha256:ad6d7d9767e05978b14a39c08dba59ddc4396584576df194f77ed310a0816ae0",
+        "check_gpg": true
+      },
+      {
+        "name": "openssl-pkcs11",
+        "epoch": 0,
+        "version": "0.4.10",
+        "release": "5.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/o/openssl-pkcs11-0.4.10-5.fc32.x86_64.rpm",
+        "checksum": "sha256:3f2cb9092d6f55f84dd9eacd5359dfb354772e5f38308328027c7758f4a06fb6",
+        "check_gpg": true
+      },
+      {
+        "name": "os-prober",
+        "epoch": 0,
+        "version": "1.77",
+        "release": "4.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/o/os-prober-1.77-4.fc32.x86_64.rpm",
+        "checksum": "sha256:45fc2608b746fd841dd25919e9e4d44834154758aec8fb8b529c014b11c7917d",
+        "check_gpg": true
+      },
+      {
+        "name": "ostree",
+        "epoch": 0,
+        "version": "2020.3",
+        "release": "2.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/o/ostree-2020.3-2.fc32.x86_64.rpm",
+        "checksum": "sha256:ec64add7d60a70fbaf14a083929f22bd2637c33d20d2a30b7e842caa6040f817",
+        "check_gpg": true
+      },
+      {
+        "name": "ostree-libs",
+        "epoch": 0,
+        "version": "2020.3",
+        "release": "2.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/o/ostree-libs-2020.3-2.fc32.x86_64.rpm",
+        "checksum": "sha256:3343d9e7c90bd58e1e44ee07e7c59bb570ffc74da50f0607c5f5681a00b70e76",
+        "check_gpg": true
+      },
+      {
+        "name": "p11-kit",
+        "epoch": 0,
+        "version": "0.23.20",
+        "release": "1.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/p/p11-kit-0.23.20-1.fc32.x86_64.rpm",
+        "checksum": "sha256:dedd37a96262c35763ab2dcbc19838f5cc39a2a3a392a650a80bd6d5ae42ff8b",
+        "check_gpg": true
+      },
+      {
+        "name": "p11-kit-trust",
+        "epoch": 0,
+        "version": "0.23.20",
+        "release": "1.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/p/p11-kit-trust-0.23.20-1.fc32.x86_64.rpm",
+        "checksum": "sha256:3589b982ac0c2f5f6b47cde5cb7ec33c2c01d756dabf8c4ca64f6d9d0d78b35e",
+        "check_gpg": true
+      },
+      {
+        "name": "pam",
+        "epoch": 0,
+        "version": "1.3.1",
+        "release": "24.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/p/pam-1.3.1-24.fc32.x86_64.rpm",
+        "checksum": "sha256:4c80ade4ac0889316930a8d181ea43fa2d1b2f1a6a5703c22f2b3ba191346eec",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre",
+        "epoch": 0,
+        "version": "8.44",
+        "release": "1.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/p/pcre-8.44-1.fc32.x86_64.rpm",
+        "checksum": "sha256:933bdb4cc6e14b2ebb1ca76c14ca176c13d271a2d1e88632f237392777d11808",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre2",
+        "epoch": 0,
+        "version": "10.34",
+        "release": "9.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/p/pcre2-10.34-9.fc32.x86_64.rpm",
+        "checksum": "sha256:6794fe48004c0403c29fc779b49f0fbea436123b96783a2df225eef2f0858795",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre2-syntax",
+        "epoch": 0,
+        "version": "10.34",
+        "release": "9.fc32",
+        "arch": "noarch",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/p/pcre2-syntax-10.34-9.fc32.noarch.rpm",
+        "checksum": "sha256:5db7c0e949bd9172b9645237e72f6139d4ffcf14defad487262b8ad25b427daf",
+        "check_gpg": true
+      },
+      {
+        "name": "pigz",
+        "epoch": 0,
+        "version": "2.4",
+        "release": "6.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/p/pigz-2.4-6.fc32.x86_64.rpm",
+        "checksum": "sha256:15f08ce979e48fd25be5e16d63d1c95c57f9abff7704005137ea00b958442939",
+        "check_gpg": true
+      },
+      {
+        "name": "pinentry",
+        "epoch": 0,
+        "version": "1.1.0",
+        "release": "7.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/p/pinentry-1.1.0-7.fc32.x86_64.rpm",
+        "checksum": "sha256:7df4fa1a29772696d92866e890af6fbe006088f3407ed3e67b0e7867ef58d899",
+        "check_gpg": true
+      },
+      {
+        "name": "policycoreutils",
+        "epoch": 0,
+        "version": "3.0",
+        "release": "2.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/p/policycoreutils-3.0-2.fc32.x86_64.rpm",
+        "checksum": "sha256:8df97dcfb42c1667b5d2e4150012eaf96f58eeac4f7b879e0928c8c36e3a7604",
+        "check_gpg": true
+      },
+      {
+        "name": "polkit-libs",
+        "epoch": 0,
+        "version": "0.116",
+        "release": "7.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/p/polkit-libs-0.116-7.fc32.x86_64.rpm",
+        "checksum": "sha256:d439ffbe20c8c0e8244e31c0324d60cf959dc1cd6cecc575d7b34509a73e9386",
+        "check_gpg": true
+      },
+      {
+        "name": "popt",
+        "epoch": 0,
+        "version": "1.16",
+        "release": "19.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/p/popt-1.16-19.fc32.x86_64.rpm",
+        "checksum": "sha256:8a0c00a69f9cb3a9ffacaf1cdc162c38a1faca76c9b976cb177bdc988902f2d4",
+        "check_gpg": true
+      },
+      {
+        "name": "procps-ng",
+        "epoch": 0,
+        "version": "3.3.15",
+        "release": "7.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/p/procps-ng-3.3.15-7.fc32.x86_64.rpm",
+        "checksum": "sha256:f3908831ae53f43b07a4e196850d0e59cc89b50c97d838538c3185fd0eb0d569",
+        "check_gpg": true
+      },
+      {
+        "name": "publicsuffix-list-dafsa",
+        "epoch": 0,
+        "version": "20190417",
+        "release": "3.fc32",
+        "arch": "noarch",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/p/publicsuffix-list-dafsa-20190417-3.fc32.noarch.rpm",
+        "checksum": "sha256:af992ad02594b68f17d2da41104a26aee41d02639edf22332d7dbb1fe9af58a5",
+        "check_gpg": true
+      },
+      {
+        "name": "python-pip-wheel",
+        "epoch": 0,
+        "version": "19.3.1",
+        "release": "2.fc32",
+        "arch": "noarch",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/p/python-pip-wheel-19.3.1-2.fc32.noarch.rpm",
+        "checksum": "sha256:a7da5590635b9c19afafc7dd247604194a5ce7d8d863dc600b8cb86accb2e469",
+        "check_gpg": true
+      },
+      {
+        "name": "python-setuptools-wheel",
+        "epoch": 0,
+        "version": "41.6.0",
+        "release": "2.fc32",
+        "arch": "noarch",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/p/python-setuptools-wheel-41.6.0-2.fc32.noarch.rpm",
+        "checksum": "sha256:7dd93baaf69a8004ae2cd3b9e6660b862d0b6f399d53c05a27a48a2e276ef1ee",
+        "check_gpg": true
+      },
+      {
+        "name": "python-unversioned-command",
+        "epoch": 0,
+        "version": "3.8.2",
+        "release": "2.fc32",
+        "arch": "noarch",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/p/python-unversioned-command-3.8.2-2.fc32.noarch.rpm",
+        "checksum": "sha256:0b290954bc2868b3dfc976b2b7a13ea8aeade76eeafc17674ff8e721049a5bf7",
+        "check_gpg": true
+      },
+      {
+        "name": "python3",
+        "epoch": 0,
+        "version": "3.8.2",
+        "release": "2.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/p/python3-3.8.2-2.fc32.x86_64.rpm",
+        "checksum": "sha256:b79bb6af3e1650ba812c8affe42772ea566b164222a7d4d8e2f7efa867dc6849",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-dnf",
+        "epoch": 0,
+        "version": "4.2.19",
+        "release": "1.fc32",
+        "arch": "noarch",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/p/python3-dnf-4.2.19-1.fc32.noarch.rpm",
+        "checksum": "sha256:632aedc06003e319a1c3fa98876055fc3bd3b44c1188b44d3b7a455cef0d40e4",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-gpg",
+        "epoch": 0,
+        "version": "1.13.1",
+        "release": "6.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/p/python3-gpg-1.13.1-6.fc32.x86_64.rpm",
+        "checksum": "sha256:9de8eb13fbdf8b8c5c3e04c52a890ccc5b667351ff17152786d12ffc66210433",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-hawkey",
+        "epoch": 0,
+        "version": "0.45.0",
+        "release": "3.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/p/python3-hawkey-0.45.0-3.fc32.x86_64.rpm",
+        "checksum": "sha256:6a2f4706a37bc5ad229f6fdddbd70fbcf82da85ec577a8deeb455513cbedc174",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libcomps",
+        "epoch": 0,
+        "version": "0.1.14",
+        "release": "4.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/p/python3-libcomps-0.1.14-4.fc32.x86_64.rpm",
+        "checksum": "sha256:0d9d80adb91ccc8eed62bea68b23da5edb77675b1ec93227e2179d028449a2f7",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libdnf",
+        "epoch": 0,
+        "version": "0.45.0",
+        "release": "3.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/p/python3-libdnf-0.45.0-3.fc32.x86_64.rpm",
+        "checksum": "sha256:44fabecae31a5900fe10837863ed231303f6863bd9fa5efa40a93a0fc059344f",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libs",
+        "epoch": 0,
+        "version": "3.8.2",
+        "release": "2.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/p/python3-libs-3.8.2-2.fc32.x86_64.rpm",
+        "checksum": "sha256:ec58d03c60386bfb8aed2af3d2a49f8c6e5ccb4d3fd592cf75fef3342be137c3",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-pip",
+        "epoch": 0,
+        "version": "19.3.1",
+        "release": "2.fc32",
+        "arch": "noarch",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/p/python3-pip-19.3.1-2.fc32.noarch.rpm",
+        "checksum": "sha256:9ade87dbb32f27e7f38ec981002ddc5a2189cc6f5ad5f24bada3b71cfa9167fd",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-rpm",
+        "epoch": 0,
+        "version": "4.15.1",
+        "release": "2.fc32.1",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/p/python3-rpm-4.15.1-2.fc32.1.x86_64.rpm",
+        "checksum": "sha256:355a095bb3c6d58f927277ff53267f88eb0729adbcafd8082b8d97e4815ee206",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-setuptools",
+        "epoch": 0,
+        "version": "41.6.0",
+        "release": "2.fc32",
+        "arch": "noarch",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/p/python3-setuptools-41.6.0-2.fc32.noarch.rpm",
+        "checksum": "sha256:724cca9919bb7b0183b030aca216d4d51de70bf35c2cc5e8325a21a52ca15ceb",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-unbound",
+        "epoch": 0,
+        "version": "1.9.6",
+        "release": "2.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/p/python3-unbound-1.9.6-2.fc32.x86_64.rpm",
+        "checksum": "sha256:517ff9662e5a1897b74f4ab4fbc8a88eccaad9880bc18be9cf4df6aba9824bd5",
+        "check_gpg": true
+      },
+      {
+        "name": "qemu-img",
+        "epoch": 2,
+        "version": "4.2.0",
+        "release": "7.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/q/qemu-img-4.2.0-7.fc32.x86_64.rpm",
+        "checksum": "sha256:475b6de876914aec2187ac4858a13ae75585f5c4cb5d739c637f79a5ca6f05f9",
+        "check_gpg": true
+      },
+      {
+        "name": "qrencode-libs",
+        "epoch": 0,
+        "version": "4.0.2",
+        "release": "5.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/q/qrencode-libs-4.0.2-5.fc32.x86_64.rpm",
+        "checksum": "sha256:f1150f9e17beaef09aca0f291e10db8c3ee5566fbf4c929b7672334410fa74e9",
+        "check_gpg": true
+      },
+      {
+        "name": "readline",
+        "epoch": 0,
+        "version": "8.0",
+        "release": "4.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/r/readline-8.0-4.fc32.x86_64.rpm",
+        "checksum": "sha256:f1c79039f4c6ba0fad88590c2cb55a96489449c334a671cc18c0bf424a4548b8",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm",
+        "epoch": 0,
+        "version": "4.15.1",
+        "release": "2.fc32.1",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/r/rpm-4.15.1-2.fc32.1.x86_64.rpm",
+        "checksum": "sha256:136a9cbae9c225be60718fdc8cc8988a55235d6502e451df77d1c5c765143850",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-build-libs",
+        "epoch": 0,
+        "version": "4.15.1",
+        "release": "2.fc32.1",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/r/rpm-build-libs-4.15.1-2.fc32.1.x86_64.rpm",
+        "checksum": "sha256:3151132084577032b4c827eb577a1509950601888c6ff13a0a30b24252ee26d2",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-libs",
+        "epoch": 0,
+        "version": "4.15.1",
+        "release": "2.fc32.1",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/r/rpm-libs-4.15.1-2.fc32.1.x86_64.rpm",
+        "checksum": "sha256:54b740cf7a75a7215168970378d9a1d6b9a5e4eb81159a874ce8ea5990436641",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-ostree",
+        "epoch": 0,
+        "version": "2020.1",
+        "release": "1.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/r/rpm-ostree-2020.1-1.fc32.x86_64.rpm",
+        "checksum": "sha256:ee664c392a97cdd272f57980c6856b2c57567005fa0ad9cb16c388b645d014f1",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-ostree-libs",
+        "epoch": 0,
+        "version": "2020.1",
+        "release": "1.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/r/rpm-ostree-libs-2020.1-1.fc32.x86_64.rpm",
+        "checksum": "sha256:9d220d8ee28cd0adf28e8fef547af92c3ec66e238747165939cf8e1a413ddf83",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-plugin-systemd-inhibit",
+        "epoch": 0,
+        "version": "4.15.1",
+        "release": "2.fc32.1",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/r/rpm-plugin-systemd-inhibit-4.15.1-2.fc32.1.x86_64.rpm",
+        "checksum": "sha256:e2a04f4de125ff60a3cdc3d2b3718a4530a9c9240c9cf14f55938444c229539f",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-sign-libs",
+        "epoch": 0,
+        "version": "4.15.1",
+        "release": "2.fc32.1",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/r/rpm-sign-libs-4.15.1-2.fc32.1.x86_64.rpm",
+        "checksum": "sha256:630ad20496ff00f76764e01b9302ccbe94e3e91d76ececef88bd9e8a890b1ac3",
+        "check_gpg": true
+      },
+      {
+        "name": "sed",
+        "epoch": 0,
+        "version": "4.5",
+        "release": "5.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/s/sed-4.5-5.fc32.x86_64.rpm",
+        "checksum": "sha256:ffe5076b9018efdb1612c487f637af39ab6c3c79ec37311978935cfa357ecd61",
+        "check_gpg": true
+      },
+      {
+        "name": "setup",
+        "epoch": 0,
+        "version": "2.13.6",
+        "release": "2.fc32",
+        "arch": "noarch",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/s/setup-2.13.6-2.fc32.noarch.rpm",
+        "checksum": "sha256:a336d2e77255df4783f52762e44efcc8d77b044a3e39c7f577d5535212848280",
+        "check_gpg": true
+      },
+      {
+        "name": "shadow-utils",
+        "epoch": 2,
+        "version": "4.8.1",
+        "release": "2.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/s/shadow-utils-4.8.1-2.fc32.x86_64.rpm",
+        "checksum": "sha256:4dd6100e477d88a4987b6eebfddecff168f38c7ff47cbb12f2fecba1e87c10d9",
+        "check_gpg": true
+      },
+      {
+        "name": "shared-mime-info",
+        "epoch": 0,
+        "version": "1.15",
+        "release": "3.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/s/shared-mime-info-1.15-3.fc32.x86_64.rpm",
+        "checksum": "sha256:a280c633b73517da167b91298fc97aeee2eb5fcc253c038ae0ce4b8478d3a103",
+        "check_gpg": true
+      },
+      {
+        "name": "sqlite-libs",
+        "epoch": 0,
+        "version": "3.31.1",
+        "release": "1.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/s/sqlite-libs-3.31.1-1.fc32.x86_64.rpm",
+        "checksum": "sha256:7f555c600b35ba798d8c0a63e30a1a12e917231730e1a44f48161ba0fe4b5973",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd",
+        "epoch": 0,
+        "version": "245.4",
+        "release": "1.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/s/systemd-245.4-1.fc32.x86_64.rpm",
+        "checksum": "sha256:1de2be4fe5280ec3097305d9e671f5f2c768267f90d255edf2075eecb0c0afe9",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-libs",
+        "epoch": 0,
+        "version": "245.4",
+        "release": "1.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/s/systemd-libs-245.4-1.fc32.x86_64.rpm",
+        "checksum": "sha256:78db9007c08fa51f177210e47343b8e733ce0751826abb357ca96429836588db",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-pam",
+        "epoch": 0,
+        "version": "245.4",
+        "release": "1.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/s/systemd-pam-245.4-1.fc32.x86_64.rpm",
+        "checksum": "sha256:750da30da0289d5e2ad9ca297dda44e5ca18dbed0c3e0d4200379bc1818c22f3",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-rpm-macros",
+        "epoch": 0,
+        "version": "245.4",
+        "release": "1.fc32",
+        "arch": "noarch",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/s/systemd-rpm-macros-245.4-1.fc32.noarch.rpm",
+        "checksum": "sha256:97197411bca68cfba1ef6bab1fdd4b41c95ec71c36f1e67f525b963cf60598fd",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-udev",
+        "epoch": 0,
+        "version": "245.4",
+        "release": "1.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/s/systemd-udev-245.4-1.fc32.x86_64.rpm",
+        "checksum": "sha256:334d63914e7ff6fe8cfce0c8f80006c6cf2ab0615cd044a6ee588809395499e5",
+        "check_gpg": true
+      },
+      {
+        "name": "tar",
+        "epoch": 2,
+        "version": "1.32",
+        "release": "4.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/t/tar-1.32-4.fc32.x86_64.rpm",
+        "checksum": "sha256:2cee64e12b295b74d2f4b008c7628ef3a01ef4149905fc4a7ae14b304da5f53b",
+        "check_gpg": true
+      },
+      {
+        "name": "trousers",
+        "epoch": 0,
+        "version": "0.3.13",
+        "release": "13.fc31",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/t/trousers-0.3.13-13.fc31.x86_64.rpm",
+        "checksum": "sha256:5f156c2a950699d5cb9a21349cce049b3c8bfdcc4fcc780665fe2d3103f576c1",
+        "check_gpg": true
+      },
+      {
+        "name": "trousers-lib",
+        "epoch": 0,
+        "version": "0.3.13",
+        "release": "13.fc31",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/t/trousers-lib-0.3.13-13.fc31.x86_64.rpm",
+        "checksum": "sha256:cc1be420582afb6360f380ff301c5e3d873f69fe1f7e00e4450bf2daa40ef9ff",
+        "check_gpg": true
+      },
+      {
+        "name": "tss2",
+        "epoch": 0,
+        "version": "1331",
+        "release": "4.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/t/tss2-1331-4.fc32.x86_64.rpm",
+        "checksum": "sha256:6f669ae6f70cfa80917adf4ae9d5e86fbd9d31ee308a9a3408a19be3afc46f7b",
+        "check_gpg": true
+      },
+      {
+        "name": "tzdata",
+        "epoch": 0,
+        "version": "2019c",
+        "release": "3.fc32",
+        "arch": "noarch",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/t/tzdata-2019c-3.fc32.noarch.rpm",
+        "checksum": "sha256:2db6d80760ab0e99f4e9c9816615e4f06b967bbb23a8c8c941b3f2d4b5f176c2",
+        "check_gpg": true
+      },
+      {
+        "name": "unbound-libs",
+        "epoch": 0,
+        "version": "1.9.6",
+        "release": "2.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/u/unbound-libs-1.9.6-2.fc32.x86_64.rpm",
+        "checksum": "sha256:29d7df69d66f51f6dddd637d3f599e70bdaa9bd476669002250bc038735a318c",
+        "check_gpg": true
+      },
+      {
+        "name": "util-linux",
+        "epoch": 0,
+        "version": "2.35.1",
+        "release": "7.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/u/util-linux-2.35.1-7.fc32.x86_64.rpm",
+        "checksum": "sha256:9976e6228a10fa2761f1265a2a7666578d79ca57819837e5d1fbecc53324f1b9",
+        "check_gpg": true
+      },
+      {
+        "name": "which",
+        "epoch": 0,
+        "version": "2.21",
+        "release": "19.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/w/which-2.21-19.fc32.x86_64.rpm",
+        "checksum": "sha256:82e0d8f1e0dccc6d18acd04b7806350343140d9c91da7a216f93167dcf650a61",
+        "check_gpg": true
+      },
+      {
+        "name": "whois-nls",
+        "epoch": 0,
+        "version": "5.5.6",
+        "release": "1.fc32",
+        "arch": "noarch",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/w/whois-nls-5.5.6-1.fc32.noarch.rpm",
+        "checksum": "sha256:d027a3ff0712e3e98d7d2358f8c526fb8d143b2386c353aadcc27199cffe125b",
+        "check_gpg": true
+      },
+      {
+        "name": "xkeyboard-config",
+        "epoch": 0,
+        "version": "2.29",
+        "release": "1.fc32",
+        "arch": "noarch",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/x/xkeyboard-config-2.29-1.fc32.noarch.rpm",
+        "checksum": "sha256:ec12fef82d73314e3e4cb6e962f8de27e78989fa104dde0599a4480a53817647",
+        "check_gpg": true
+      },
+      {
+        "name": "xz",
+        "epoch": 0,
+        "version": "5.2.5",
+        "release": "1.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/x/xz-5.2.5-1.fc32.x86_64.rpm",
+        "checksum": "sha256:1bdde5dc99a5588a8983f70b7b3e45e7006215d529c72adfec118c3bcbf7b01c",
+        "check_gpg": true
+      },
+      {
+        "name": "xz-libs",
+        "epoch": 0,
+        "version": "5.2.5",
+        "release": "1.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/x/xz-libs-5.2.5-1.fc32.x86_64.rpm",
+        "checksum": "sha256:84702d6395a9577c1a268184f123cfd4b15bc2287f01033625ba388a34ec2338",
+        "check_gpg": true
+      },
+      {
+        "name": "zchunk-libs",
+        "epoch": 0,
+        "version": "1.1.5",
+        "release": "2.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/z/zchunk-libs-1.1.5-2.fc32.x86_64.rpm",
+        "checksum": "sha256:140708561a2ec1c7709fd38d8b1b115d02da710b80eeecd65c2b8387d9d78ef9",
+        "check_gpg": true
+      },
+      {
+        "name": "zlib",
+        "epoch": 0,
+        "version": "1.2.11",
+        "release": "21.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/z/zlib-1.2.11-21.fc32.x86_64.rpm",
+        "checksum": "sha256:c0fff40dc1092e18ed3e608bc6143c89a0d7775b9e0553319bb2caca7d324d80",
+        "check_gpg": true
+      }
+    ],
+    "packages": [
+      {
+        "name": "ModemManager",
+        "epoch": 0,
+        "version": "1.12.8",
+        "release": "1.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/m/ModemManager-1.12.8-1.fc32.x86_64.rpm",
+        "checksum": "sha256:fc8a8027325828861bae0c41d2582d61f8cb4b9ed42a50e49c57939eabcad1b7",
+        "check_gpg": true
+      },
+      {
+        "name": "ModemManager-glib",
+        "epoch": 0,
+        "version": "1.12.8",
+        "release": "1.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/m/ModemManager-glib-1.12.8-1.fc32.x86_64.rpm",
+        "checksum": "sha256:605c3cf38451c6b93f331b605ab03ca611e37aa11d14a4019de61278add04f74",
+        "check_gpg": true
+      },
+      {
+        "name": "NetworkManager",
+        "epoch": 1,
+        "version": "1.22.10",
+        "release": "1.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/n/NetworkManager-1.22.10-1.fc32.x86_64.rpm",
+        "checksum": "sha256:342bdf0143d9145f8846e1b5c3401685e0d1274b66df39ac8cbfb78013313861",
+        "check_gpg": true
+      },
+      {
+        "name": "NetworkManager-libnm",
+        "epoch": 1,
+        "version": "1.22.10",
+        "release": "1.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/n/NetworkManager-libnm-1.22.10-1.fc32.x86_64.rpm",
+        "checksum": "sha256:fd2a2dd726d855f877296227fb351883d647df28b1b0085f525d87df622d49e4",
+        "check_gpg": true
+      },
+      {
+        "name": "NetworkManager-wifi",
+        "epoch": 1,
+        "version": "1.22.10",
+        "release": "1.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/n/NetworkManager-wifi-1.22.10-1.fc32.x86_64.rpm",
+        "checksum": "sha256:df174a90fd6bd3f9fae3b75433ae7f1869ff2db7102667fb243c8aede5b858d3",
+        "check_gpg": true
+      },
+      {
+        "name": "NetworkManager-wwan",
+        "epoch": 1,
+        "version": "1.22.10",
+        "release": "1.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/n/NetworkManager-wwan-1.22.10-1.fc32.x86_64.rpm",
+        "checksum": "sha256:cd5d539fd0c469f2ebae012a9a8f2ed280363c355f205edc8fc735678ac0adb8",
+        "check_gpg": true
+      },
+      {
+        "name": "abattis-cantarell-fonts",
+        "epoch": 0,
+        "version": "0.201",
+        "release": "2.fc32",
+        "arch": "noarch",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/a/abattis-cantarell-fonts-0.201-2.fc32.noarch.rpm",
+        "checksum": "sha256:a9d5719cf5d4fdc4ae28099d623a751b0470264e7d2280be2669a066348b4ce1",
+        "check_gpg": true
+      },
+      {
+        "name": "acl",
+        "epoch": 0,
+        "version": "2.2.53",
+        "release": "5.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/a/acl-2.2.53-5.fc32.x86_64.rpm",
+        "checksum": "sha256:705bdb96aab3a0f9d9e2ff48ead1208e2dbc1927d713d8637632af936235217b",
+        "check_gpg": true
+      },
+      {
+        "name": "adobe-source-code-pro-fonts",
+        "epoch": 0,
+        "version": "2.030.1.050",
+        "release": "8.fc32",
+        "arch": "noarch",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/a/adobe-source-code-pro-fonts-2.030.1.050-8.fc32.noarch.rpm",
+        "checksum": "sha256:a4706de7a0d59f2b1e9e73f48c4279429676410c77fb93f82abf1b7b34330f82",
+        "check_gpg": true
+      },
+      {
+        "name": "alternatives",
+        "epoch": 0,
+        "version": "1.11",
+        "release": "6.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/a/alternatives-1.11-6.fc32.x86_64.rpm",
+        "checksum": "sha256:c574c5432197acbe08ea15c7837be7577cd0b49902a3e65227792f051d73ce5c",
+        "check_gpg": true
+      },
+      {
+        "name": "attr",
+        "epoch": 0,
+        "version": "2.4.48",
+        "release": "8.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/a/attr-2.4.48-8.fc32.x86_64.rpm",
+        "checksum": "sha256:00d0bb6a08f20bea2b6bd0d2c4de99b51c770b2dab266d1d3da85891efeded01",
+        "check_gpg": true
+      },
+      {
+        "name": "audit",
+        "epoch": 0,
+        "version": "3.0",
+        "release": "0.19.20191104git1c2f876.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/a/audit-3.0-0.19.20191104git1c2f876.fc32.x86_64.rpm",
+        "checksum": "sha256:f09047c09660bc998460f710b9ac0561b4f6028214168d4d40f2f4d99f61a94d",
+        "check_gpg": true
+      },
+      {
+        "name": "audit-libs",
+        "epoch": 0,
+        "version": "3.0",
+        "release": "0.19.20191104git1c2f876.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/a/audit-libs-3.0-0.19.20191104git1c2f876.fc32.x86_64.rpm",
+        "checksum": "sha256:22d311f22902d592f72bd0fb4010a682f796e5a4698d5ea209848468a2d5aa96",
+        "check_gpg": true
+      },
+      {
+        "name": "basesystem",
+        "epoch": 0,
+        "version": "11",
+        "release": "9.fc32",
+        "arch": "noarch",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/b/basesystem-11-9.fc32.noarch.rpm",
+        "checksum": "sha256:a346990bb07adca8c323a15f31b093ef6e639bde6ca84adf1a3abebc4dc9adce",
+        "check_gpg": true
+      },
+      {
+        "name": "bash",
+        "epoch": 0,
+        "version": "5.0.11",
+        "release": "2.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/b/bash-5.0.11-2.fc32.x86_64.rpm",
+        "checksum": "sha256:7a97e71cd552285ead303d07dbb6417403edf45c0a531e02cf4ebfb0efda4975",
+        "check_gpg": true
+      },
+      {
+        "name": "bash-completion",
+        "epoch": 1,
+        "version": "2.8",
+        "release": "8.fc32",
+        "arch": "noarch",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/b/bash-completion-2.8-8.fc32.noarch.rpm",
+        "checksum": "sha256:c07fd5357963f99610bc676b25f1dfcbf1bae0b63538b5e1cd82ce42b79fd819",
+        "check_gpg": true
+      },
+      {
+        "name": "bluez",
+        "epoch": 0,
+        "version": "5.54",
+        "release": "1.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/b/bluez-5.54-1.fc32.x86_64.rpm",
+        "checksum": "sha256:bfeba60bfb137f270e3b28db96ecfe8b226ea05e1761f6cb5ccc64c48c73c748",
+        "check_gpg": true
+      },
+      {
+        "name": "bluez-libs",
+        "epoch": 0,
+        "version": "5.54",
+        "release": "1.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/b/bluez-libs-5.54-1.fc32.x86_64.rpm",
+        "checksum": "sha256:af18c71bca1121ac3cdeace9f7249079ee0568fcbb15ca7e46131fa9b9b521f8",
+        "check_gpg": true
+      },
+      {
+        "name": "bluez-mesh",
+        "epoch": 0,
+        "version": "5.54",
+        "release": "1.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/b/bluez-mesh-5.54-1.fc32.x86_64.rpm",
+        "checksum": "sha256:2141f1dec8fe7a442c061f603bf4ee6203e10a290990789af0f4ef9db5523679",
+        "check_gpg": true
+      },
+      {
+        "name": "btrfs-progs",
+        "epoch": 0,
+        "version": "5.6",
+        "release": "1.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/b/btrfs-progs-5.6-1.fc32.x86_64.rpm",
+        "checksum": "sha256:b67f1634acc7b84b284bda8afeef546aed4a3388dc7df67417001704aa444af1",
+        "check_gpg": true
+      },
+      {
+        "name": "bubblewrap",
+        "epoch": 0,
+        "version": "0.4.1",
+        "release": "1.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/b/bubblewrap-0.4.1-1.fc32.x86_64.rpm",
+        "checksum": "sha256:cd01ae91895e60f189106a159bb551f906a8b663110f421ad6ee83c9e008851e",
+        "check_gpg": true
+      },
+      {
+        "name": "bzip2-libs",
+        "epoch": 0,
+        "version": "1.0.8",
+        "release": "2.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/b/bzip2-libs-1.0.8-2.fc32.x86_64.rpm",
+        "checksum": "sha256:842f7a38be2e8dbb14eff3ede4091db214ebe241e1fde7a128e88c4e686b63b0",
+        "check_gpg": true
+      },
+      {
+        "name": "ca-certificates",
+        "epoch": 0,
+        "version": "2020.2.40",
+        "release": "3.fc32",
+        "arch": "noarch",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/c/ca-certificates-2020.2.40-3.fc32.noarch.rpm",
+        "checksum": "sha256:73f6a9108f7d5ec3cd89c31dbbaa874ae28cd5cb443ef69700a1218903ee2fc4",
+        "check_gpg": true
+      },
+      {
+        "name": "checkpolicy",
+        "epoch": 0,
+        "version": "3.0",
+        "release": "3.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/c/checkpolicy-3.0-3.fc32.x86_64.rpm",
+        "checksum": "sha256:703fb5ca1651bb72d8ab58576ce3d78c9479cbb2e78ff8666ae3a3d1cd9bb0da",
+        "check_gpg": true
+      },
+      {
+        "name": "chrony",
+        "epoch": 0,
+        "version": "3.5",
+        "release": "8.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/c/chrony-3.5-8.fc32.x86_64.rpm",
+        "checksum": "sha256:398ce75ffc673f048ffd47d417b17ef086abc43f318b2b77d2869095ec764d57",
+        "check_gpg": true
+      },
+      {
+        "name": "clevis",
+        "epoch": 0,
+        "version": "12",
+        "release": "2.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/c/clevis-12-2.fc32.x86_64.rpm",
+        "checksum": "sha256:624b9079b4a571218adced203e19bdaca1d2cf57891f9653f409dd1db92fbf86",
+        "check_gpg": true
+      },
+      {
+        "name": "clevis-dracut",
+        "epoch": 0,
+        "version": "12",
+        "release": "2.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/c/clevis-dracut-12-2.fc32.x86_64.rpm",
+        "checksum": "sha256:5d520576b7ac63cb029c4b0b86398e2b71589df3bafa618018b3729d81036203",
+        "check_gpg": true
+      },
+      {
+        "name": "clevis-luks",
+        "epoch": 0,
+        "version": "12",
+        "release": "2.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/c/clevis-luks-12-2.fc32.x86_64.rpm",
+        "checksum": "sha256:c55b30a3a8c0d36a219953e20960185263ae63dada0f050446066be1e873ce08",
+        "check_gpg": true
+      },
+      {
+        "name": "clevis-systemd",
+        "epoch": 0,
+        "version": "12",
+        "release": "2.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/c/clevis-systemd-12-2.fc32.x86_64.rpm",
+        "checksum": "sha256:0065bc128a5c8b08b57f92651bfa62895221a9f001f1169447a56a8a6671bbae",
+        "check_gpg": true
+      },
+      {
+        "name": "compat-readline5",
+        "epoch": 0,
+        "version": "5.2",
+        "release": "36.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/c/compat-readline5-5.2-36.fc32.x86_64.rpm",
+        "checksum": "sha256:449d2888d6b835d207a55a2d9b4478eff1b926581fcead6260b6508e4db1b782",
+        "check_gpg": true
+      },
+      {
+        "name": "conmon",
+        "epoch": 2,
+        "version": "2.0.14",
+        "release": "1.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/c/conmon-2.0.14-1.fc32.x86_64.rpm",
+        "checksum": "sha256:769e34caae25f05786ae53e535c6e3c64f5c548f06c422325d68598b7abb99b7",
+        "check_gpg": true
+      },
+      {
+        "name": "container-selinux",
+        "epoch": 2,
+        "version": "2.130.0",
+        "release": "1.fc32",
+        "arch": "noarch",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/c/container-selinux-2.130.0-1.fc32.noarch.rpm",
+        "checksum": "sha256:28d1118b3debda3daee76fc89f250576627a28b3ec39069256ddc212d993ddbc",
+        "check_gpg": true
+      },
+      {
+        "name": "containernetworking-plugins",
+        "epoch": 0,
+        "version": "0.8.5",
+        "release": "1.1.gitf5c3d1b.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/c/containernetworking-plugins-0.8.5-1.1.gitf5c3d1b.fc32.x86_64.rpm",
+        "checksum": "sha256:0608e0a9922e6748b39bd1719e2dabd6fe283b22cf590f1a3350327ae6c13561",
+        "check_gpg": true
+      },
+      {
+        "name": "containers-common",
+        "epoch": 1,
+        "version": "0.1.41",
+        "release": "1.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/c/containers-common-0.1.41-1.fc32.x86_64.rpm",
+        "checksum": "sha256:30c5f02ed28d59a4d72e020097602091bb8e34d65a6f3be69f4b1dd63a46f892",
+        "check_gpg": true
+      },
+      {
+        "name": "coreutils",
+        "epoch": 0,
+        "version": "8.32",
+        "release": "3.fc32.1",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/c/coreutils-8.32-3.fc32.1.x86_64.rpm",
+        "checksum": "sha256:7023687eb65baa56a9b4c3ffde1e439b3d41b03ac4ad35a1a1fc3903464548f7",
+        "check_gpg": true
+      },
+      {
+        "name": "coreutils-common",
+        "epoch": 0,
+        "version": "8.32",
+        "release": "3.fc32.1",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/c/coreutils-common-8.32-3.fc32.1.x86_64.rpm",
+        "checksum": "sha256:5323eb8d89b2d0c905a633513e04ca7df633c21eec288ee8c50f3f5170534e37",
+        "check_gpg": true
+      },
+      {
+        "name": "cpio",
+        "epoch": 0,
+        "version": "2.13",
+        "release": "4.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/c/cpio-2.13-4.fc32.x86_64.rpm",
+        "checksum": "sha256:116b9d121fad9886f245cd5e1ef678fdba889cd23a39e91447e75649214a6a8d",
+        "check_gpg": true
+      },
+      {
+        "name": "cracklib",
+        "epoch": 0,
+        "version": "2.9.6",
+        "release": "22.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/c/cracklib-2.9.6-22.fc32.x86_64.rpm",
+        "checksum": "sha256:862e75c10377098a9cc50407a0395e5f3a81d14b5b6fecfb3f223325c8867829",
+        "check_gpg": true
+      },
+      {
+        "name": "cracklib-dicts",
+        "epoch": 0,
+        "version": "2.9.6",
+        "release": "22.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/c/cracklib-dicts-2.9.6-22.fc32.x86_64.rpm",
+        "checksum": "sha256:1aee865249b031e591a5e94d62d05b69ad1a6118a26adccf2dfd46b0002716e5",
+        "check_gpg": true
+      },
+      {
+        "name": "criu",
+        "epoch": 0,
+        "version": "3.13",
+        "release": "5.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/c/criu-3.13-5.fc32.x86_64.rpm",
+        "checksum": "sha256:59be778afcf464d79f7dc440d6b49de8a9527fd73e7b514573d389bf8a51b246",
+        "check_gpg": true
+      },
+      {
+        "name": "crun",
+        "epoch": 0,
+        "version": "0.13",
+        "release": "1.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/c/crun-0.13-1.fc32.x86_64.rpm",
+        "checksum": "sha256:d5acde111b4cafc918decc8b9c530c9a7dfd6cc77b75538d33b32478219ae5da",
+        "check_gpg": true
+      },
+      {
+        "name": "crypto-policies",
+        "epoch": 0,
+        "version": "20191128",
+        "release": "5.gitcd267a5.fc32",
+        "arch": "noarch",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/c/crypto-policies-20191128-5.gitcd267a5.fc32.noarch.rpm",
+        "checksum": "sha256:3f8dcae27ad3609b7de298d0ca8d34a2790b9898f5f1b03f3f9f8784374e307b",
+        "check_gpg": true
+      },
+      {
+        "name": "crypto-policies-scripts",
+        "epoch": 0,
+        "version": "20191128",
+        "release": "5.gitcd267a5.fc32",
+        "arch": "noarch",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/c/crypto-policies-scripts-20191128-5.gitcd267a5.fc32.noarch.rpm",
+        "checksum": "sha256:b821e9e8bf66abacaed4a386f9ed8ffa17f4f8be3db55e1ac31d52ba2d1faa1b",
+        "check_gpg": true
+      },
+      {
+        "name": "cryptsetup",
+        "epoch": 0,
+        "version": "2.3.0",
+        "release": "1.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/c/cryptsetup-2.3.0-1.fc32.x86_64.rpm",
+        "checksum": "sha256:e0f9c4327d62e35ee2a066c95dfa37f86021b405515d0f902b72a7437b7b98e9",
+        "check_gpg": true
+      },
+      {
+        "name": "cryptsetup-libs",
+        "epoch": 0,
+        "version": "2.3.0",
+        "release": "1.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/c/cryptsetup-libs-2.3.0-1.fc32.x86_64.rpm",
+        "checksum": "sha256:eaffaa8de8fd28ad124da12524a2ca5db86252404d70d66c7c42921dad6b69c1",
+        "check_gpg": true
+      },
+      {
+        "name": "curl",
+        "epoch": 0,
+        "version": "7.69.1",
+        "release": "1.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/c/curl-7.69.1-1.fc32.x86_64.rpm",
+        "checksum": "sha256:6eeebf21f245bf0d6f58962dc49b6dfb51f55acb6a595c6b9cbe9628806b80a4",
+        "check_gpg": true
+      },
+      {
+        "name": "cyrus-sasl-lib",
+        "epoch": 0,
+        "version": "2.1.27",
+        "release": "4.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/c/cyrus-sasl-lib-2.1.27-4.fc32.x86_64.rpm",
+        "checksum": "sha256:fefa4162a563eba24714ac43874c508d1ba036afb5127c5d21bbcbeaf238a740",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus",
+        "epoch": 1,
+        "version": "1.12.16",
+        "release": "4.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/d/dbus-1.12.16-4.fc32.x86_64.rpm",
+        "checksum": "sha256:ed36d759746e75a2834866fbeaa783df397f8813cae2ed79fcc4d146656bf6a6",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-broker",
+        "epoch": 0,
+        "version": "22",
+        "release": "1.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/d/dbus-broker-22-1.fc32.x86_64.rpm",
+        "checksum": "sha256:213c17fb822ffa50fad16989ed363aa023de106c6262ccc3f16e52a154b7133f",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-common",
+        "epoch": 1,
+        "version": "1.12.16",
+        "release": "4.fc32",
+        "arch": "noarch",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/d/dbus-common-1.12.16-4.fc32.noarch.rpm",
+        "checksum": "sha256:6fc1b9a27eeb368a98f50dba5fc514f20a5eb23f8e0ee7dd92c4051ef8b4a940",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-libs",
+        "epoch": 1,
+        "version": "1.12.16",
+        "release": "4.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/d/dbus-libs-1.12.16-4.fc32.x86_64.rpm",
+        "checksum": "sha256:474fd088c7e7234221d251153e9fda6081b0aa8979bf5ae25810c9862e1e9960",
+        "check_gpg": true
+      },
+      {
+        "name": "dbxtool",
+        "epoch": 0,
+        "version": "8",
+        "release": "11.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/d/dbxtool-8-11.fc32.x86_64.rpm",
+        "checksum": "sha256:f729c554ed4ac6335a548380a6f6335a332a3a2aca5321a322415a208701607d",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper",
+        "epoch": 0,
+        "version": "1.02.171",
+        "release": "1.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/d/device-mapper-1.02.171-1.fc32.x86_64.rpm",
+        "checksum": "sha256:c132999a3f110029cd427f7578965ad558e91374637087d5230ee11c626ebcd4",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper-event",
+        "epoch": 0,
+        "version": "1.02.171",
+        "release": "1.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/d/device-mapper-event-1.02.171-1.fc32.x86_64.rpm",
+        "checksum": "sha256:9a2beeeede69d8910115608c2d98efa6a8dba73ab2df246df5b0f10e2fa37f54",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper-event-libs",
+        "epoch": 0,
+        "version": "1.02.171",
+        "release": "1.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/d/device-mapper-event-libs-1.02.171-1.fc32.x86_64.rpm",
+        "checksum": "sha256:8aa8258a1a13c1120d6c28321f618385111cb9363dae09eea2e4af481053e28b",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper-libs",
+        "epoch": 0,
+        "version": "1.02.171",
+        "release": "1.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/d/device-mapper-libs-1.02.171-1.fc32.x86_64.rpm",
+        "checksum": "sha256:61cae80187ef2924857fdfc48a240646d23b331482cf181e7d8c661b02c15949",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper-persistent-data",
+        "epoch": 0,
+        "version": "0.8.5",
+        "release": "3.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/d/device-mapper-persistent-data-0.8.5-3.fc32.x86_64.rpm",
+        "checksum": "sha256:7a525abda7230bfbc87763dfe58bf7684e385b3c78ca242a1685a589300909e9",
+        "check_gpg": true
+      },
+      {
+        "name": "diffutils",
+        "epoch": 0,
+        "version": "3.7",
+        "release": "4.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/d/diffutils-3.7-4.fc32.x86_64.rpm",
+        "checksum": "sha256:187dd61be71efcca6adf9819a523d432217abb335afcb2b95ef27b72928aff4b",
+        "check_gpg": true
+      },
+      {
+        "name": "dmidecode",
+        "epoch": 1,
+        "version": "3.2",
+        "release": "5.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/d/dmidecode-3.2-5.fc32.x86_64.rpm",
+        "checksum": "sha256:e40be03bd5808e640bb5fb18196499680a7b7b1d3fce47617f987baee849c0e5",
+        "check_gpg": true
+      },
+      {
+        "name": "dnsmasq",
+        "epoch": 0,
+        "version": "2.80",
+        "release": "14.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/d/dnsmasq-2.80-14.fc32.x86_64.rpm",
+        "checksum": "sha256:e712179ba8b9b6e93d14c902a6d6a390ba142153384dab9291c808a447b7ed0c",
+        "check_gpg": true
+      },
+      {
+        "name": "dosfstools",
+        "epoch": 0,
+        "version": "4.1",
+        "release": "10.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/d/dosfstools-4.1-10.fc32.x86_64.rpm",
+        "checksum": "sha256:c3f7089ae50f79cf4d2cb59e01091d33c70cab89ae08f95c547339a87404c3ec",
+        "check_gpg": true
+      },
+      {
+        "name": "dracut",
+        "epoch": 0,
+        "version": "050",
+        "release": "26.git20200316.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/d/dracut-050-26.git20200316.fc32.x86_64.rpm",
+        "checksum": "sha256:993680d5cd133a0c21184be92b3df405d757613d0ca25c4abf08b203d8d26b79",
+        "check_gpg": true
+      },
+      {
+        "name": "dracut-config-generic",
+        "epoch": 0,
+        "version": "050",
+        "release": "26.git20200316.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/d/dracut-config-generic-050-26.git20200316.fc32.x86_64.rpm",
+        "checksum": "sha256:4819b3ce25b997d8d3e5e4e4be4ba270e8b66852576b474daf0e6d61b6e22d73",
+        "check_gpg": true
+      },
+      {
+        "name": "dracut-network",
+        "epoch": 0,
+        "version": "050",
+        "release": "26.git20200316.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/d/dracut-network-050-26.git20200316.fc32.x86_64.rpm",
+        "checksum": "sha256:11d6aa88c7e5bbaad38353bbb557ad8370452cd258f2a0d16bfd490116138d67",
+        "check_gpg": true
+      },
+      {
+        "name": "e2fsprogs",
+        "epoch": 0,
+        "version": "1.45.5",
+        "release": "3.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/e/e2fsprogs-1.45.5-3.fc32.x86_64.rpm",
+        "checksum": "sha256:2fa5e252441852dae918b522a2ff3f46a5bbee4ce8936e06702bf65f57d7ff99",
+        "check_gpg": true
+      },
+      {
+        "name": "e2fsprogs-libs",
+        "epoch": 0,
+        "version": "1.45.5",
+        "release": "3.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/e/e2fsprogs-libs-1.45.5-3.fc32.x86_64.rpm",
+        "checksum": "sha256:26db62c2bc52c3eee5f3039cdbdf19498f675d0f45aec0c2a1c61c635f01479e",
+        "check_gpg": true
+      },
+      {
+        "name": "efi-filesystem",
+        "epoch": 0,
+        "version": "4",
+        "release": "4.fc32",
+        "arch": "noarch",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/e/efi-filesystem-4-4.fc32.noarch.rpm",
+        "checksum": "sha256:b743aafa82f3326f8f2e6d5464ae7fa57fabab3ad791099eaf2d151b43208b42",
+        "check_gpg": true
+      },
+      {
+        "name": "efibootmgr",
+        "epoch": 0,
+        "version": "16",
+        "release": "7.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/e/efibootmgr-16-7.fc32.x86_64.rpm",
+        "checksum": "sha256:a7deef0a324ccb272a25f5eb6b30c72d0a842bf2c602c31fe3b60f984b2e50af",
+        "check_gpg": true
+      },
+      {
+        "name": "efivar-libs",
+        "epoch": 0,
+        "version": "37",
+        "release": "7.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/e/efivar-libs-37-7.fc32.x86_64.rpm",
+        "checksum": "sha256:05efccb06aa336d2547eb8fd5b7e0935c883f89084688f32ce0b09954149b796",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-debuginfod-client",
+        "epoch": 0,
+        "version": "0.179",
+        "release": "1.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/e/elfutils-debuginfod-client-0.179-1.fc32.x86_64.rpm",
+        "checksum": "sha256:4f318cec61cb69fc233ba5505b7e24f679afdfb0b5defbaef507f1b471e7dbb5",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-default-yama-scope",
+        "epoch": 0,
+        "version": "0.179",
+        "release": "1.fc32",
+        "arch": "noarch",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/e/elfutils-default-yama-scope-0.179-1.fc32.noarch.rpm",
+        "checksum": "sha256:af62d0611b995b9f2b2c7b4d4852e03e521d66979534871ccb5a71275a15518d",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-libelf",
+        "epoch": 0,
+        "version": "0.179",
+        "release": "1.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/e/elfutils-libelf-0.179-1.fc32.x86_64.rpm",
+        "checksum": "sha256:f3eb795f68c80ccf870f1d27f8fd019878db748c0c19275634c48cf5cea5bc46",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-libs",
+        "epoch": 0,
+        "version": "0.179",
+        "release": "1.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/e/elfutils-libs-0.179-1.fc32.x86_64.rpm",
+        "checksum": "sha256:99f87b4ec7c5852d45028f3eae65fc813f3ef107e128777f265b09a19ce262e0",
+        "check_gpg": true
+      },
+      {
+        "name": "expat",
+        "epoch": 0,
+        "version": "2.2.8",
+        "release": "2.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/e/expat-2.2.8-2.fc32.x86_64.rpm",
+        "checksum": "sha256:8fc2ae85f242105987d8fa7f05e4fa19358a7c81dff5fa163cf021eb6b9905e9",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-gpg-keys",
+        "epoch": 0,
+        "version": "32",
+        "release": "1",
+        "arch": "noarch",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/f/fedora-gpg-keys-32-1.noarch.rpm",
+        "checksum": "sha256:09fea9af8b695af862b19c1a8fbe1b1e8854257825ee4f663f67b3782a75d58a",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release-common",
+        "epoch": 0,
+        "version": "32",
+        "release": "1",
+        "arch": "noarch",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/f/fedora-release-common-32-1.noarch.rpm",
+        "checksum": "sha256:a1835a7929d3c1613f3890caef878e9bdf857dcc0f63eb4d63a1140370b3f21b",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release-iot",
+        "epoch": 0,
+        "version": "32",
+        "release": "1",
+        "arch": "noarch",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/f/fedora-release-iot-32-1.noarch.rpm",
+        "checksum": "sha256:5e7a16df5bdfab2acfd8ac061827ace0642f2e5521689d6b9f0812f2a6ece231",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-repos",
+        "epoch": 0,
+        "version": "32",
+        "release": "1",
+        "arch": "noarch",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/f/fedora-repos-32-1.noarch.rpm",
+        "checksum": "sha256:21e3fd914a3bcc65b79de022782967903c55a4aed9a3c7d3464bc2fef32d02b3",
+        "check_gpg": true
+      },
+      {
+        "name": "file",
+        "epoch": 0,
+        "version": "5.38",
+        "release": "2.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/f/file-5.38-2.fc32.x86_64.rpm",
+        "checksum": "sha256:28656826cb0dfbae9b6e8d1e5c5691773d84000493c4be47f727092fec6dc6f4",
+        "check_gpg": true
+      },
+      {
+        "name": "file-libs",
+        "epoch": 0,
+        "version": "5.38",
+        "release": "2.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/f/file-libs-5.38-2.fc32.x86_64.rpm",
+        "checksum": "sha256:e0b1da98020a740991dbb70b42c0ff1eece9e268a461e555a5ec763bda1645f5",
+        "check_gpg": true
+      },
+      {
+        "name": "filesystem",
+        "epoch": 0,
+        "version": "3.14",
+        "release": "2.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/f/filesystem-3.14-2.fc32.x86_64.rpm",
+        "checksum": "sha256:1110261787146443e089955912255d99daf7ba042c3743e13648a9eb3d80ceb4",
+        "check_gpg": true
+      },
+      {
+        "name": "findutils",
+        "epoch": 1,
+        "version": "4.7.0",
+        "release": "3.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/f/findutils-4.7.0-3.fc32.x86_64.rpm",
+        "checksum": "sha256:0b7cd6f6cb3b7cd9e0704dd6c62b65254b04cb870ab638b9bed4951564436e24",
+        "check_gpg": true
+      },
+      {
+        "name": "fipscheck",
+        "epoch": 0,
+        "version": "1.5.0",
+        "release": "8.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/f/fipscheck-1.5.0-8.fc32.x86_64.rpm",
+        "checksum": "sha256:907393755387a351806ec2afff376e7491f177116caadd12f07d0fcbed796750",
+        "check_gpg": true
+      },
+      {
+        "name": "fipscheck-lib",
+        "epoch": 0,
+        "version": "1.5.0",
+        "release": "8.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/f/fipscheck-lib-1.5.0-8.fc32.x86_64.rpm",
+        "checksum": "sha256:f2715fc8a04d33716f40f5b34466e082140df7ff3b7b972c29655d4dfc6e3a72",
+        "check_gpg": true
+      },
+      {
+        "name": "firewalld",
+        "epoch": 0,
+        "version": "0.8.2",
+        "release": "2.fc32",
+        "arch": "noarch",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/f/firewalld-0.8.2-2.fc32.noarch.rpm",
+        "checksum": "sha256:b8ecd7fa0e7e072828e374dfb0d61bb8eecca7c190f3661050cee5e3fc8854b4",
+        "check_gpg": true
+      },
+      {
+        "name": "firewalld-filesystem",
+        "epoch": 0,
+        "version": "0.8.2",
+        "release": "2.fc32",
+        "arch": "noarch",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/f/firewalld-filesystem-0.8.2-2.fc32.noarch.rpm",
+        "checksum": "sha256:47538b1db9720be4699329a8da32d873187d0c6c22f45252614ac5b8a8312482",
+        "check_gpg": true
+      },
+      {
+        "name": "flashrom",
+        "epoch": 0,
+        "version": "1.2",
+        "release": "2.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/f/flashrom-1.2-2.fc32.x86_64.rpm",
+        "checksum": "sha256:317654c97a9dc11fe498b61d4189ff31cd1277250993d826e9bc5815d0485f29",
+        "check_gpg": true
+      },
+      {
+        "name": "fonts-filesystem",
+        "epoch": 0,
+        "version": "2.0.3",
+        "release": "1.fc32",
+        "arch": "noarch",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/f/fonts-filesystem-2.0.3-1.fc32.noarch.rpm",
+        "checksum": "sha256:879ba2533610771dbf3fa103fdbde878edf255b771b53aa8a170009d01446012",
+        "check_gpg": true
+      },
+      {
+        "name": "fuse",
+        "epoch": 0,
+        "version": "2.9.9",
+        "release": "9.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/f/fuse-2.9.9-9.fc32.x86_64.rpm",
+        "checksum": "sha256:9369d4fed30402f45705b7a5cb51b6eeefb1dabbe0942c84514c6fdf1edac5e0",
+        "check_gpg": true
+      },
+      {
+        "name": "fuse-common",
+        "epoch": 0,
+        "version": "3.9.1",
+        "release": "1.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/f/fuse-common-3.9.1-1.fc32.x86_64.rpm",
+        "checksum": "sha256:45132e53c649def28d63c199d8c3a3b9fd16fa8bca7426ad4e9c202e52a233b4",
+        "check_gpg": true
+      },
+      {
+        "name": "fuse-libs",
+        "epoch": 0,
+        "version": "2.9.9",
+        "release": "9.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/f/fuse-libs-2.9.9-9.fc32.x86_64.rpm",
+        "checksum": "sha256:53992752850779218421994f61f1589eda5d368e28d340dccaae3f67de06e7f2",
+        "check_gpg": true
+      },
+      {
+        "name": "fuse-overlayfs",
+        "epoch": 0,
+        "version": "0.7.8",
+        "release": "1.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/f/fuse-overlayfs-0.7.8-1.fc32.x86_64.rpm",
+        "checksum": "sha256:929f1c5ce4775b28439a1b5726e98c38204930d5880dc6096fc56e8d3eab275f",
+        "check_gpg": true
+      },
+      {
+        "name": "fuse3",
+        "epoch": 0,
+        "version": "3.9.1",
+        "release": "1.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/f/fuse3-3.9.1-1.fc32.x86_64.rpm",
+        "checksum": "sha256:8df8541abd806578e43fe28a7ea2c41efbbb813866bed35fabe779274790a538",
+        "check_gpg": true
+      },
+      {
+        "name": "fuse3-libs",
+        "epoch": 0,
+        "version": "3.9.1",
+        "release": "1.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/f/fuse3-libs-3.9.1-1.fc32.x86_64.rpm",
+        "checksum": "sha256:ab4c27523d6b5a0df75febac43cafa2dd9897dc3c1bb2f0d6990ca603b6168fe",
+        "check_gpg": true
+      },
+      {
+        "name": "fwupd",
+        "epoch": 0,
+        "version": "1.3.9",
+        "release": "2.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/f/fwupd-1.3.9-2.fc32.x86_64.rpm",
+        "checksum": "sha256:ff5dd4d0c157cf1be9c8dbddce06640c67b2d02ae5a48d6b108bd70fc5c96211",
+        "check_gpg": true
+      },
+      {
+        "name": "gawk",
+        "epoch": 0,
+        "version": "5.0.1",
+        "release": "7.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/g/gawk-5.0.1-7.fc32.x86_64.rpm",
+        "checksum": "sha256:d0e5d0104cf20c8dd332053a5903aab9b7fdadb84b35a1bfb3a6456f3399eb32",
+        "check_gpg": true
+      },
+      {
+        "name": "gdbm-libs",
+        "epoch": 1,
+        "version": "1.18.1",
+        "release": "3.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/g/gdbm-libs-1.18.1-3.fc32.x86_64.rpm",
+        "checksum": "sha256:9899cfd32ada2537693af30b60051da21c6264b0d0db51ba709fceb179d4c836",
+        "check_gpg": true
+      },
+      {
+        "name": "gdisk",
+        "epoch": 0,
+        "version": "1.0.5",
+        "release": "1.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/g/gdisk-1.0.5-1.fc32.x86_64.rpm",
+        "checksum": "sha256:397f0b024d3c58ca6e174c6de5abcb19304d7c58903199e1e6fe02e84d5bcb3a",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext",
+        "epoch": 0,
+        "version": "0.20.1",
+        "release": "4.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/g/gettext-0.20.1-4.fc32.x86_64.rpm",
+        "checksum": "sha256:349af433b2f6d45ff2e1ea5a38f847ec692fef0a8dd656a9a07d423a981946d0",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext-libs",
+        "epoch": 0,
+        "version": "0.20.1",
+        "release": "4.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/g/gettext-libs-0.20.1-4.fc32.x86_64.rpm",
+        "checksum": "sha256:fdb9bc612957a16fc44b717605a5a26e16a33850c0ff74a80a299cc2bab740e4",
+        "check_gpg": true
+      },
+      {
+        "name": "glib-networking",
+        "epoch": 0,
+        "version": "2.64.1",
+        "release": "1.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/g/glib-networking-2.64.1-1.fc32.x86_64.rpm",
+        "checksum": "sha256:5fc2fd0cb5b6fdce1203e43d6f2df6a3098ec9522b04815d896ecedbb1489063",
+        "check_gpg": true
+      },
+      {
+        "name": "glib2",
+        "epoch": 0,
+        "version": "2.64.1",
+        "release": "1.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/g/glib2-2.64.1-1.fc32.x86_64.rpm",
+        "checksum": "sha256:6fe524feb38312f9c370b2190aeb42330acc9ce42f3a45e9cd05748b4aa00db2",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc",
+        "epoch": 0,
+        "version": "2.31",
+        "release": "2.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/g/glibc-2.31-2.fc32.x86_64.rpm",
+        "checksum": "sha256:dc9c0401522bcf73fe5a692184c141b214947ad83364be97de0413ab46b712e5",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-common",
+        "epoch": 0,
+        "version": "2.31",
+        "release": "2.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/g/glibc-common-2.31-2.fc32.x86_64.rpm",
+        "checksum": "sha256:e80533822e2a892345b869395b2c17c0bcc98d3c3c47787da30123096835db00",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-minimal-langpack",
+        "epoch": 0,
+        "version": "2.31",
+        "release": "2.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/g/glibc-minimal-langpack-2.31-2.fc32.x86_64.rpm",
+        "checksum": "sha256:f36550dfc144e4608da672616fa44b2f2341f99bb38972e66e4a8fef4b59172c",
+        "check_gpg": true
+      },
+      {
+        "name": "gmp",
+        "epoch": 1,
+        "version": "6.1.2",
+        "release": "13.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/g/gmp-6.1.2-13.fc32.x86_64.rpm",
+        "checksum": "sha256:178e4470a6dfca84ec133932606737bfe167094560bf473940504c511354ddc9",
+        "check_gpg": true
+      },
+      {
+        "name": "gnupg2",
+        "epoch": 0,
+        "version": "2.2.19",
+        "release": "1.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/g/gnupg2-2.2.19-1.fc32.x86_64.rpm",
+        "checksum": "sha256:cc3396df93ce0e8f439b83fb6b4d210903876846b0bd3a22c19c7770cf5a9050",
+        "check_gpg": true
+      },
+      {
+        "name": "gnupg2-smime",
+        "epoch": 0,
+        "version": "2.2.19",
+        "release": "1.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/g/gnupg2-smime-2.2.19-1.fc32.x86_64.rpm",
+        "checksum": "sha256:966084f83e0fedb7a217aa102b484ac8a63082ccfe99517544ed2cb102191204",
+        "check_gpg": true
+      },
+      {
+        "name": "gnutls",
+        "epoch": 0,
+        "version": "3.6.13",
+        "release": "1.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/g/gnutls-3.6.13-1.fc32.x86_64.rpm",
+        "checksum": "sha256:9d4f1290565b852e56f9e9babc14b141b0283998121f78b0eb83dec367cf0abb",
+        "check_gpg": true
+      },
+      {
+        "name": "gobject-introspection",
+        "epoch": 0,
+        "version": "1.64.1",
+        "release": "1.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/g/gobject-introspection-1.64.1-1.fc32.x86_64.rpm",
+        "checksum": "sha256:052ddc487a29acce1b5d44532f79f8ab594d0ac6565504071f4c7706d97fc552",
+        "check_gpg": true
+      },
+      {
+        "name": "gpgme",
+        "epoch": 0,
+        "version": "1.13.1",
+        "release": "6.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/g/gpgme-1.13.1-6.fc32.x86_64.rpm",
+        "checksum": "sha256:13a0c9c767f71164cc678ee36d89b7fddcdd6fb8243e3daf8b47cca0d1d14c4f",
+        "check_gpg": true
+      },
+      {
+        "name": "greenboot",
+        "epoch": 0,
+        "version": "0.9",
+        "release": "1.fc32",
+        "arch": "noarch",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/g/greenboot-0.9-1.fc32.noarch.rpm",
+        "checksum": "sha256:70794c8537fb3cf197f051cfce3b23956d587062daf114f8480770754804f339",
+        "check_gpg": true
+      },
+      {
+        "name": "greenboot-grub2",
+        "epoch": 0,
+        "version": "0.9",
+        "release": "1.fc32",
+        "arch": "noarch",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/g/greenboot-grub2-0.9-1.fc32.noarch.rpm",
+        "checksum": "sha256:fbaf44214a3e93d4bdccb1519768849db5ea204c886df851b49f107e0c443e4a",
+        "check_gpg": true
+      },
+      {
+        "name": "greenboot-reboot",
+        "epoch": 0,
+        "version": "0.9",
+        "release": "1.fc32",
+        "arch": "noarch",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/g/greenboot-reboot-0.9-1.fc32.noarch.rpm",
+        "checksum": "sha256:1ec84749250a0095d645f11fa0dcdf8c4500e0bbc303af696762a12616375757",
+        "check_gpg": true
+      },
+      {
+        "name": "greenboot-rpm-ostree-grub2",
+        "epoch": 0,
+        "version": "0.9",
+        "release": "1.fc32",
+        "arch": "noarch",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/g/greenboot-rpm-ostree-grub2-0.9-1.fc32.noarch.rpm",
+        "checksum": "sha256:4546444c0647efaa8fa8bf604ace7f7dbd152e74761b8d7a11fa185bc72bece8",
+        "check_gpg": true
+      },
+      {
+        "name": "greenboot-status",
+        "epoch": 0,
+        "version": "0.9",
+        "release": "1.fc32",
+        "arch": "noarch",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/g/greenboot-status-0.9-1.fc32.noarch.rpm",
+        "checksum": "sha256:3ab2173d9d4016febcdaf283408f9939d0a7b2fdba3e46a2d45fbef88a1463a0",
+        "check_gpg": true
+      },
+      {
+        "name": "grep",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "4.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/g/grep-3.3-4.fc32.x86_64.rpm",
+        "checksum": "sha256:759165656ac8141b0c0ada230c258ffcd4516c4c8d132d7fbaf762cd5a5e4095",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-common",
+        "epoch": 1,
+        "version": "2.04",
+        "release": "12.fc32",
+        "arch": "noarch",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/g/grub2-common-2.04-12.fc32.noarch.rpm",
+        "checksum": "sha256:01173d218dccdf88c1159bba4af332ce703fc0dcd7171cd279cb3e16f12b30a9",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-efi-x64",
+        "epoch": 1,
+        "version": "2.04",
+        "release": "12.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/g/grub2-efi-x64-2.04-12.fc32.x86_64.rpm",
+        "checksum": "sha256:aa353206ef29b7d908554ccb7cd6f4c01a1f6c3c1c6358abb7452f4a745939d0",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-pc",
+        "epoch": 1,
+        "version": "2.04",
+        "release": "12.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/g/grub2-pc-2.04-12.fc32.x86_64.rpm",
+        "checksum": "sha256:110f538d82f15f009d95e89d8c1e3669dc7358feb9aa7724301fef037f8b67fe",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-pc-modules",
+        "epoch": 1,
+        "version": "2.04",
+        "release": "12.fc32",
+        "arch": "noarch",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/g/grub2-pc-modules-2.04-12.fc32.noarch.rpm",
+        "checksum": "sha256:c2197913bc8db9548b0a40ffddf840a31956b18e932ad4eec77a48d87d2289ce",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-tools",
+        "epoch": 1,
+        "version": "2.04",
+        "release": "12.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/g/grub2-tools-2.04-12.fc32.x86_64.rpm",
+        "checksum": "sha256:7f6d2841ec9402ee5e57f1a46b9886935138c02005d860899f3c746c7885c7b9",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-tools-minimal",
+        "epoch": 1,
+        "version": "2.04",
+        "release": "12.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/g/grub2-tools-minimal-2.04-12.fc32.x86_64.rpm",
+        "checksum": "sha256:d1c6f183b9deaf6127db4ad7040046bd7f1aa62de177961aac39501605d2c815",
+        "check_gpg": true
+      },
+      {
+        "name": "gsettings-desktop-schemas",
+        "epoch": 0,
+        "version": "3.36.0",
+        "release": "1.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/g/gsettings-desktop-schemas-3.36.0-1.fc32.x86_64.rpm",
+        "checksum": "sha256:d1a369d501e3ce1c17d06418c9cd57c4ada551ecc3b45a581e162215e8bd77f5",
+        "check_gpg": true
+      },
+      {
+        "name": "gzip",
+        "epoch": 0,
+        "version": "1.10",
+        "release": "2.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/g/gzip-1.10-2.fc32.x86_64.rpm",
+        "checksum": "sha256:53f1e8570b175e8b58895646df6d8068a7e1f3cb1bafdde714ddd038bcf91e85",
+        "check_gpg": true
+      },
+      {
+        "name": "hostname",
+        "epoch": 0,
+        "version": "3.23",
+        "release": "2.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/h/hostname-3.23-2.fc32.x86_64.rpm",
+        "checksum": "sha256:def89a494acbfd6aae1fb70700dd18275ddd3050893bc962f1853499af9dd823",
+        "check_gpg": true
+      },
+      {
+        "name": "ignition",
+        "epoch": 0,
+        "version": "2.2.1",
+        "release": "3.git2d3ff58.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/i/ignition-2.2.1-3.git2d3ff58.fc32.x86_64.rpm",
+        "checksum": "sha256:6749bd0b96339c32b57635b69b474583b50c94e4bbaa3eb8753fa604b9d1c521",
+        "check_gpg": true
+      },
+      {
+        "name": "ima-evm-utils",
+        "epoch": 0,
+        "version": "1.2.1",
+        "release": "3.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/i/ima-evm-utils-1.2.1-3.fc32.x86_64.rpm",
+        "checksum": "sha256:c1f957511b5e011e6f7995ed7bca9196703cf1214068f209e86b1dc4fd0e98bf",
+        "check_gpg": true
+      },
+      {
+        "name": "initscripts",
+        "epoch": 0,
+        "version": "10.02",
+        "release": "3.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/i/initscripts-10.02-3.fc32.x86_64.rpm",
+        "checksum": "sha256:bca13571cf1452f3e41c8e89b8c64aa33d3d0f4e414571f9dde32a556591b339",
+        "check_gpg": true
+      },
+      {
+        "name": "iproute",
+        "epoch": 0,
+        "version": "5.5.0",
+        "release": "1.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/i/iproute-5.5.0-1.fc32.x86_64.rpm",
+        "checksum": "sha256:865c7677d2664287bb4ba2874c83bc805232e1b3a02cf6ba96e047266d9ef684",
+        "check_gpg": true
+      },
+      {
+        "name": "iproute-tc",
+        "epoch": 0,
+        "version": "5.5.0",
+        "release": "1.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/i/iproute-tc-5.5.0-1.fc32.x86_64.rpm",
+        "checksum": "sha256:0c6f4c1fbbdaf02014bf81726264e3301cbfe0ecda610765be11dbbfe99e34ae",
+        "check_gpg": true
+      },
+      {
+        "name": "ipset",
+        "epoch": 0,
+        "version": "7.6",
+        "release": "1.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/i/ipset-7.6-1.fc32.x86_64.rpm",
+        "checksum": "sha256:7c21c21c3e3dbace06bee03fe4835ae6cb1e3ef86750ba2853f39d40dead2309",
+        "check_gpg": true
+      },
+      {
+        "name": "ipset-libs",
+        "epoch": 0,
+        "version": "7.6",
+        "release": "1.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/i/ipset-libs-7.6-1.fc32.x86_64.rpm",
+        "checksum": "sha256:f60fc561675e41ffa2c48b229960291e2438441d5ed758c1f28cb06b5d4e4ea9",
+        "check_gpg": true
+      },
+      {
+        "name": "iptables",
+        "epoch": 0,
+        "version": "1.8.4",
+        "release": "7.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/i/iptables-1.8.4-7.fc32.x86_64.rpm",
+        "checksum": "sha256:28f4bcbf53258114ebbf0a167351d67e204ff6f717b49b3893c2372845e6bd0a",
+        "check_gpg": true
+      },
+      {
+        "name": "iptables-libs",
+        "epoch": 0,
+        "version": "1.8.4",
+        "release": "7.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/i/iptables-libs-1.8.4-7.fc32.x86_64.rpm",
+        "checksum": "sha256:f4eb6d332b9aea8d8ef0a6ea8dc2b073d6bf5f2599d64f24111d8da2ee82ad48",
+        "check_gpg": true
+      },
+      {
+        "name": "iptables-nft",
+        "epoch": 0,
+        "version": "1.8.4",
+        "release": "7.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/i/iptables-nft-1.8.4-7.fc32.x86_64.rpm",
+        "checksum": "sha256:08c41c10745c172c34880e384cf5cff014a9627f4895e59fa482948b27e2ce9e",
+        "check_gpg": true
+      },
+      {
+        "name": "iputils",
+        "epoch": 0,
+        "version": "20190515",
+        "release": "5.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/i/iputils-20190515-5.fc32.x86_64.rpm",
+        "checksum": "sha256:6a3282927f525629bc0aaf4090e108d33b0709d3d5b35bc442000c2837e7b9b4",
+        "check_gpg": true
+      },
+      {
+        "name": "iwd",
+        "epoch": 0,
+        "version": "1.6",
+        "release": "1.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/i/iwd-1.6-1.fc32.x86_64.rpm",
+        "checksum": "sha256:1a2f22eed83ef568021c464cce841ef98725b614093f2c518307e85d5b6e759b",
+        "check_gpg": true
+      },
+      {
+        "name": "iwl100-firmware",
+        "epoch": 0,
+        "version": "39.31.5.1",
+        "release": "106.fc32",
+        "arch": "noarch",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/i/iwl100-firmware-39.31.5.1-106.fc32.noarch.rpm",
+        "checksum": "sha256:65e5209398c6b2c196cb42f3bc3f82e00af1026f623026857a9b330ec92d0330",
+        "check_gpg": true
+      },
+      {
+        "name": "iwl1000-firmware",
+        "epoch": 1,
+        "version": "39.31.5.1",
+        "release": "106.fc32",
+        "arch": "noarch",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/i/iwl1000-firmware-39.31.5.1-106.fc32.noarch.rpm",
+        "checksum": "sha256:032e4944fe53dc7a11ae62d746579177a5c52b00a4ad5540da8221aa287fdf18",
+        "check_gpg": true
+      },
+      {
+        "name": "iwl105-firmware",
+        "epoch": 0,
+        "version": "18.168.6.1",
+        "release": "106.fc32",
+        "arch": "noarch",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/i/iwl105-firmware-18.168.6.1-106.fc32.noarch.rpm",
+        "checksum": "sha256:79e22d23ba0a156b3d74ec4b0da8fd71bc632386366ade2c48006ba82074055d",
+        "check_gpg": true
+      },
+      {
+        "name": "iwl135-firmware",
+        "epoch": 0,
+        "version": "18.168.6.1",
+        "release": "106.fc32",
+        "arch": "noarch",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/i/iwl135-firmware-18.168.6.1-106.fc32.noarch.rpm",
+        "checksum": "sha256:b286141f38cd88b8c632515677423f49c81365f2ae99c5a7906205f35a273fb2",
+        "check_gpg": true
+      },
+      {
+        "name": "iwl2000-firmware",
+        "epoch": 0,
+        "version": "18.168.6.1",
+        "release": "106.fc32",
+        "arch": "noarch",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/i/iwl2000-firmware-18.168.6.1-106.fc32.noarch.rpm",
+        "checksum": "sha256:caa3625b22908cf4f91faf2c281b0e7ab7d981c35ed1d761deb53b7b78d13cf8",
+        "check_gpg": true
+      },
+      {
+        "name": "iwl2030-firmware",
+        "epoch": 0,
+        "version": "18.168.6.1",
+        "release": "106.fc32",
+        "arch": "noarch",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/i/iwl2030-firmware-18.168.6.1-106.fc32.noarch.rpm",
+        "checksum": "sha256:5d933f9bf444d4c8732caa65e9227b27127c625840859a0453a32a5719916f48",
+        "check_gpg": true
+      },
+      {
+        "name": "iwl3160-firmware",
+        "epoch": 1,
+        "version": "25.30.13.0",
+        "release": "106.fc32",
+        "arch": "noarch",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/i/iwl3160-firmware-25.30.13.0-106.fc32.noarch.rpm",
+        "checksum": "sha256:4659e7b76850ce5dedbe80fb0a64947e83f15f907b35c5819d91be6ed0523653",
+        "check_gpg": true
+      },
+      {
+        "name": "iwl5000-firmware",
+        "epoch": 0,
+        "version": "8.83.5.1_1",
+        "release": "106.fc32",
+        "arch": "noarch",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/i/iwl5000-firmware-8.83.5.1_1-106.fc32.noarch.rpm",
+        "checksum": "sha256:d7f57b9190c9cf05c36fe9fb3229330cdb9f0a1af1214a47b0a38dcc8ce929ee",
+        "check_gpg": true
+      },
+      {
+        "name": "iwl5150-firmware",
+        "epoch": 0,
+        "version": "8.24.2.2",
+        "release": "106.fc32",
+        "arch": "noarch",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/i/iwl5150-firmware-8.24.2.2-106.fc32.noarch.rpm",
+        "checksum": "sha256:88d283c2d5aa96c2b0899f6bd6c0409a5d5c6fda2958e8eae19eb49c3ede58d6",
+        "check_gpg": true
+      },
+      {
+        "name": "iwl6000-firmware",
+        "epoch": 0,
+        "version": "9.221.4.1",
+        "release": "106.fc32",
+        "arch": "noarch",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/i/iwl6000-firmware-9.221.4.1-106.fc32.noarch.rpm",
+        "checksum": "sha256:89f85f749bfee7d083c84845e908a3471297a3d8a75f7397903d15eb7f403297",
+        "check_gpg": true
+      },
+      {
+        "name": "iwl6050-firmware",
+        "epoch": 0,
+        "version": "41.28.5.1",
+        "release": "106.fc32",
+        "arch": "noarch",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/i/iwl6050-firmware-41.28.5.1-106.fc32.noarch.rpm",
+        "checksum": "sha256:83a08b7066000ebbdf8a6c5706485a19b5dfe2d492b1faaac1922e8f0c42cd0c",
+        "check_gpg": true
+      },
+      {
+        "name": "iwl7260-firmware",
+        "epoch": 1,
+        "version": "25.30.13.0",
+        "release": "106.fc32",
+        "arch": "noarch",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/i/iwl7260-firmware-25.30.13.0-106.fc32.noarch.rpm",
+        "checksum": "sha256:a3f80bb7068618dff795b3e0a3d32fa3c640e492c8f175b16bb3c7ff64a88a8e",
+        "check_gpg": true
+      },
+      {
+        "name": "jansson",
+        "epoch": 0,
+        "version": "2.12",
+        "release": "5.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/j/jansson-2.12-5.fc32.x86_64.rpm",
+        "checksum": "sha256:975719a0c73cf5cb5bcbc8ad11b816ed75923dccd9c091baa4a6c6000753dcd8",
+        "check_gpg": true
+      },
+      {
+        "name": "jitterentropy",
+        "epoch": 0,
+        "version": "2.2.0",
+        "release": "2.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/j/jitterentropy-2.2.0-2.fc32.x86_64.rpm",
+        "checksum": "sha256:872639e4ccb4f1c5de66d5eaa85ca673141b10e3d614b33c84ff887c228d465d",
+        "check_gpg": true
+      },
+      {
+        "name": "jose",
+        "epoch": 0,
+        "version": "10",
+        "release": "6.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/j/jose-10-6.fc32.x86_64.rpm",
+        "checksum": "sha256:d7fec1fb54953f1901cc505c225af94cb61f2206d0503be12313169a4b915e18",
+        "check_gpg": true
+      },
+      {
+        "name": "json-c",
+        "epoch": 0,
+        "version": "0.13.1",
+        "release": "9.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/j/json-c-0.13.1-9.fc32.x86_64.rpm",
+        "checksum": "sha256:d3a64fcef3de79a97541b21c71ddd00d4cca9039c930bc660d6c5479eabf5f26",
+        "check_gpg": true
+      },
+      {
+        "name": "json-glib",
+        "epoch": 0,
+        "version": "1.4.4",
+        "release": "4.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/j/json-glib-1.4.4-4.fc32.x86_64.rpm",
+        "checksum": "sha256:8a03d482b5294f7452b2f9ce31ebb6aea9eefac002281c1b9152fbb1a0341987",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd",
+        "epoch": 0,
+        "version": "2.2.0",
+        "release": "1.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/k/kbd-2.2.0-1.fc32.x86_64.rpm",
+        "checksum": "sha256:a05178831a546e2001e52f065fc6969f36d2292efaee2971fe7a7e882cc8c813",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd-legacy",
+        "epoch": 0,
+        "version": "2.2.0",
+        "release": "1.fc32",
+        "arch": "noarch",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/k/kbd-legacy-2.2.0-1.fc32.noarch.rpm",
+        "checksum": "sha256:3be681b78e919bfd82eb186c7393718f1d37abd0b1bb8b1a8571aefa11e7a248",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd-misc",
+        "epoch": 0,
+        "version": "2.2.0",
+        "release": "1.fc32",
+        "arch": "noarch",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/k/kbd-misc-2.2.0-1.fc32.noarch.rpm",
+        "checksum": "sha256:60774007011889671c28158f599032f0db253c153ccae70f5e2f5840f2dc490b",
+        "check_gpg": true
+      },
+      {
+        "name": "kernel",
+        "epoch": 0,
+        "version": "5.6.6",
+        "release": "300.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/k/kernel-5.6.6-300.fc32.x86_64.rpm",
+        "checksum": "sha256:89c972ec7d2ab305c91c23bc248562c76f0ae645a9ed9f94d312e2f57c4d38fe",
+        "check_gpg": true
+      },
+      {
+        "name": "kernel-core",
+        "epoch": 0,
+        "version": "5.6.6",
+        "release": "300.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/k/kernel-core-5.6.6-300.fc32.x86_64.rpm",
+        "checksum": "sha256:a1613e90865db93fb578b8ee1a4ee40bd396c6c9f2fb2a14757acacecb9f23e8",
+        "check_gpg": true
+      },
+      {
+        "name": "kernel-modules",
+        "epoch": 0,
+        "version": "5.6.6",
+        "release": "300.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/k/kernel-modules-5.6.6-300.fc32.x86_64.rpm",
+        "checksum": "sha256:b98687828b1d222ea73ebb8457450913dac58dd0be2e430a93bb7e98ba816505",
+        "check_gpg": true
+      },
+      {
+        "name": "kernel-tools",
+        "epoch": 0,
+        "version": "5.6.6",
+        "release": "300.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/k/kernel-tools-5.6.6-300.fc32.x86_64.rpm",
+        "checksum": "sha256:e291d6c021eaa01cc3c446b76c94aafde444936b8ba3f08a7fe7cbe66a23366b",
+        "check_gpg": true
+      },
+      {
+        "name": "kernel-tools-libs",
+        "epoch": 0,
+        "version": "5.6.6",
+        "release": "300.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/k/kernel-tools-libs-5.6.6-300.fc32.x86_64.rpm",
+        "checksum": "sha256:150815dd62da40fee60ad5ceb988938c3be01e03aa54a025772b33a7a2c11311",
+        "check_gpg": true
+      },
+      {
+        "name": "keyutils",
+        "epoch": 0,
+        "version": "1.6",
+        "release": "4.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/k/keyutils-1.6-4.fc32.x86_64.rpm",
+        "checksum": "sha256:9ee276ed9d036a4483bb8d1bd6f6d697b161a04276c6ce5f1d3f40d48e04bccb",
+        "check_gpg": true
+      },
+      {
+        "name": "keyutils-libs",
+        "epoch": 0,
+        "version": "1.6",
+        "release": "4.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/k/keyutils-libs-1.6-4.fc32.x86_64.rpm",
+        "checksum": "sha256:ccc3cb2dcb7a534361cc911f27ff4e869902a150b68e236cf6eb209a99d4ee22",
+        "check_gpg": true
+      },
+      {
+        "name": "kmod",
+        "epoch": 0,
+        "version": "27",
+        "release": "1.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/k/kmod-27-1.fc32.x86_64.rpm",
+        "checksum": "sha256:3f9c95f3827b785f49ac4a270d4c3a703dceba673c452838744ec5064cf43cbd",
+        "check_gpg": true
+      },
+      {
+        "name": "kmod-libs",
+        "epoch": 0,
+        "version": "27",
+        "release": "1.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/k/kmod-libs-27-1.fc32.x86_64.rpm",
+        "checksum": "sha256:56187c1c980cc0680f4dbc433ed2c8507e7dc9ab00000615b63ea08c086b7ab2",
+        "check_gpg": true
+      },
+      {
+        "name": "kpartx",
+        "epoch": 0,
+        "version": "0.8.2",
+        "release": "3.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/k/kpartx-0.8.2-3.fc32.x86_64.rpm",
+        "checksum": "sha256:fbb81a7811f7a11b1c95eec20c3df63beef9e007f0b3d2713f13ad80029d7249",
+        "check_gpg": true
+      },
+      {
+        "name": "krb5-libs",
+        "epoch": 0,
+        "version": "1.18",
+        "release": "1.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/k/krb5-libs-1.18-1.fc32.x86_64.rpm",
+        "checksum": "sha256:e2b2dddbce49fab5f01ba75fae8796ab7c9fd8280c652f78d06a2644246bd16d",
+        "check_gpg": true
+      },
+      {
+        "name": "less",
+        "epoch": 0,
+        "version": "551",
+        "release": "3.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/less-551-3.fc32.x86_64.rpm",
+        "checksum": "sha256:2b783576612dcf10ab151fee03084f8ae1667c044a9e2e9404a2a139e7c6c884",
+        "check_gpg": true
+      },
+      {
+        "name": "libacl",
+        "epoch": 0,
+        "version": "2.2.53",
+        "release": "5.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libacl-2.2.53-5.fc32.x86_64.rpm",
+        "checksum": "sha256:f826f984b23d0701a1b72de5882b9c0e7bae87ef49d9edfea156654f489f8b2b",
+        "check_gpg": true
+      },
+      {
+        "name": "libaio",
+        "epoch": 0,
+        "version": "0.3.111",
+        "release": "7.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libaio-0.3.111-7.fc32.x86_64.rpm",
+        "checksum": "sha256:a410db5c56d4f39f6ea71e7d5bb6d4a2bd518015d1e34f38fbc0d7bbd4e872d4",
+        "check_gpg": true
+      },
+      {
+        "name": "libarchive",
+        "epoch": 0,
+        "version": "3.4.2",
+        "release": "1.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libarchive-3.4.2-1.fc32.x86_64.rpm",
+        "checksum": "sha256:88f4bd19a6cf6eba5e6f2b5bba80819b5ccddb0476aadc53c8df13f9c45b1e58",
+        "check_gpg": true
+      },
+      {
+        "name": "libargon2",
+        "epoch": 0,
+        "version": "20171227",
+        "release": "4.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libargon2-20171227-4.fc32.x86_64.rpm",
+        "checksum": "sha256:7d9bd2fe016ca8860e8fab4a430b3aae4c7b7bea55f8ccd7775ad470172e2886",
+        "check_gpg": true
+      },
+      {
+        "name": "libassuan",
+        "epoch": 0,
+        "version": "2.5.3",
+        "release": "3.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libassuan-2.5.3-3.fc32.x86_64.rpm",
+        "checksum": "sha256:598a136b7027cb9b4fef6bfa34715979d41c2f62c9d8bec5d50b633a17790f7b",
+        "check_gpg": true
+      },
+      {
+        "name": "libattr",
+        "epoch": 0,
+        "version": "2.4.48",
+        "release": "8.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libattr-2.4.48-8.fc32.x86_64.rpm",
+        "checksum": "sha256:65e0cfe367ae4d54cf8bf509cb05e063c9eb6f2fea8dadcf746cdd85adc31d88",
+        "check_gpg": true
+      },
+      {
+        "name": "libblkid",
+        "epoch": 0,
+        "version": "2.35.1",
+        "release": "7.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libblkid-2.35.1-7.fc32.x86_64.rpm",
+        "checksum": "sha256:1830b4aa42ef492c13b62f63fe941970869ba19bd9abde4dea5c97f9e38ffd68",
+        "check_gpg": true
+      },
+      {
+        "name": "libbrotli",
+        "epoch": 0,
+        "version": "1.0.7",
+        "release": "10.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libbrotli-1.0.7-10.fc32.x86_64.rpm",
+        "checksum": "sha256:ac8b1fea0b678d7630033a8900be5641b934306961b39a29c79c6d72f34f7d1c",
+        "check_gpg": true
+      },
+      {
+        "name": "libbsd",
+        "epoch": 0,
+        "version": "0.10.0",
+        "release": "2.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libbsd-0.10.0-2.fc32.x86_64.rpm",
+        "checksum": "sha256:d74b76ce8c2c7306cc3f012d1ec56b1d5c67788748f56ecd505f257d342f97ee",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap",
+        "epoch": 0,
+        "version": "2.26",
+        "release": "7.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libcap-2.26-7.fc32.x86_64.rpm",
+        "checksum": "sha256:1bc0542cf8a3746d0fe25c397a93c8206963f1f287246c6fb864eedfc9ffa4a7",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap-ng",
+        "epoch": 0,
+        "version": "0.7.10",
+        "release": "2.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libcap-ng-0.7.10-2.fc32.x86_64.rpm",
+        "checksum": "sha256:b60670fdcf91b50d97720f601d92277efedbd690bd887000ccd9a46b3fa8b314",
+        "check_gpg": true
+      },
+      {
+        "name": "libcbor",
+        "epoch": 0,
+        "version": "0.5.0",
+        "release": "7.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libcbor-0.5.0-7.fc32.x86_64.rpm",
+        "checksum": "sha256:b13eed593b31a9cc0174774b97701c7da876f91ccdfc951b67a3134d59ccd8b5",
+        "check_gpg": true
+      },
+      {
+        "name": "libcom_err",
+        "epoch": 0,
+        "version": "1.45.5",
+        "release": "3.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libcom_err-1.45.5-3.fc32.x86_64.rpm",
+        "checksum": "sha256:4494013eac1ad337673f084242aa8ebffb4a149243475b448bee9266401f2896",
+        "check_gpg": true
+      },
+      {
+        "name": "libcroco",
+        "epoch": 0,
+        "version": "0.6.13",
+        "release": "3.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libcroco-0.6.13-3.fc32.x86_64.rpm",
+        "checksum": "sha256:63400fedea4a6ddb8fced58d33e60560791f29cd439169998f337d09fb50a7d4",
+        "check_gpg": true
+      },
+      {
+        "name": "libcurl",
+        "epoch": 0,
+        "version": "7.69.1",
+        "release": "1.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libcurl-7.69.1-1.fc32.x86_64.rpm",
+        "checksum": "sha256:7dfe1e8dac6d759479ae3dfd415fdd2662bbed9ff0f4da6093279efd1bacae31",
+        "check_gpg": true
+      },
+      {
+        "name": "libdb",
+        "epoch": 0,
+        "version": "5.3.28",
+        "release": "40.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libdb-5.3.28-40.fc32.x86_64.rpm",
+        "checksum": "sha256:688fcc0b7ef3c48cf7d602eefd7fefae7bcad4f0dc71c9fe9432c2ce5bbd9daa",
+        "check_gpg": true
+      },
+      {
+        "name": "libdb-utils",
+        "epoch": 0,
+        "version": "5.3.28",
+        "release": "40.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libdb-utils-5.3.28-40.fc32.x86_64.rpm",
+        "checksum": "sha256:431d836b2be015212d8c15b4290d5ce5bb45282cbf3fc52696f632d84ce34dfe",
+        "check_gpg": true
+      },
+      {
+        "name": "libedit",
+        "epoch": 0,
+        "version": "3.1",
+        "release": "32.20191231cvs.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libedit-3.1-32.20191231cvs.fc32.x86_64.rpm",
+        "checksum": "sha256:9a12db30090023c60e3d7bcd5b07142cdc6d84c77e25ddb1cf41a4c490e52f09",
+        "check_gpg": true
+      },
+      {
+        "name": "libell",
+        "epoch": 0,
+        "version": "0.30",
+        "release": "1.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libell-0.30-1.fc32.x86_64.rpm",
+        "checksum": "sha256:39961756e07f6f49ddf2ff277dc04a63fa4d5b4fb035480945bd2f665ba1dd4d",
+        "check_gpg": true
+      },
+      {
+        "name": "libevent",
+        "epoch": 0,
+        "version": "2.1.8",
+        "release": "8.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libevent-2.1.8-8.fc32.x86_64.rpm",
+        "checksum": "sha256:7bf42ff57ce2a31db0da7d6c5926552f4e51e9f25cded77bd634eb5cd35eadab",
+        "check_gpg": true
+      },
+      {
+        "name": "libfdisk",
+        "epoch": 0,
+        "version": "2.35.1",
+        "release": "7.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libfdisk-2.35.1-7.fc32.x86_64.rpm",
+        "checksum": "sha256:942d06ec1f7033ea4c729b84ee09f5491481770efe10151ba581479ac7f3f9dc",
+        "check_gpg": true
+      },
+      {
+        "name": "libffi",
+        "epoch": 0,
+        "version": "3.1",
+        "release": "24.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libffi-3.1-24.fc32.x86_64.rpm",
+        "checksum": "sha256:86c87a4169bdf75c6d3a2f11d3a7e20b6364b2db97c74bc7eb62b1b22bc54401",
+        "check_gpg": true
+      },
+      {
+        "name": "libfido2",
+        "epoch": 0,
+        "version": "1.3.1",
+        "release": "1.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libfido2-1.3.1-1.fc32.x86_64.rpm",
+        "checksum": "sha256:ebbace15f986288bba7681f44a111b14bcc7cae00b7a1faadaa838bd51897357",
+        "check_gpg": true
+      },
+      {
+        "name": "libftdi",
+        "epoch": 0,
+        "version": "1.4",
+        "release": "2.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libftdi-1.4-2.fc32.x86_64.rpm",
+        "checksum": "sha256:14bd7e305e13795e0d37c613dfa3ead3a3219d28c32b27ad6527d3592361923d",
+        "check_gpg": true
+      },
+      {
+        "name": "libgcab1",
+        "epoch": 0,
+        "version": "1.4",
+        "release": "2.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libgcab1-1.4-2.fc32.x86_64.rpm",
+        "checksum": "sha256:aac9be36fc9c345245b4a0db66bfb9ff8df25e36ae0c1ae89eca9bcf88e052e4",
+        "check_gpg": true
+      },
+      {
+        "name": "libgcc",
+        "epoch": 0,
+        "version": "10.0.1",
+        "release": "0.11.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libgcc-10.0.1-0.11.fc32.x86_64.rpm",
+        "checksum": "sha256:48cf5ab32f6af8f2283d4d4834e8dd262aa412be7ea07c2292483e150d614bef",
+        "check_gpg": true
+      },
+      {
+        "name": "libgcrypt",
+        "epoch": 0,
+        "version": "1.8.5",
+        "release": "3.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libgcrypt-1.8.5-3.fc32.x86_64.rpm",
+        "checksum": "sha256:5f0ae954b5955c86623e68cd81ccf8505a89f260003b8a3be6a93bd76f18452c",
+        "check_gpg": true
+      },
+      {
+        "name": "libgomp",
+        "epoch": 0,
+        "version": "10.0.1",
+        "release": "0.11.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libgomp-10.0.1-0.11.fc32.x86_64.rpm",
+        "checksum": "sha256:d65b4bb6fa49198237f9b704ec471d71dfd94b87290f4d03c1c34d12f6efeb95",
+        "check_gpg": true
+      },
+      {
+        "name": "libgpg-error",
+        "epoch": 0,
+        "version": "1.36",
+        "release": "3.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libgpg-error-1.36-3.fc32.x86_64.rpm",
+        "checksum": "sha256:9bd5cb588664e8427bc8bebde0cdf5e14315916624ab6b1979dde60f6eae4278",
+        "check_gpg": true
+      },
+      {
+        "name": "libgpiod",
+        "epoch": 0,
+        "version": "1.5.1",
+        "release": "1.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libgpiod-1.5.1-1.fc32.x86_64.rpm",
+        "checksum": "sha256:c8daa43a4504f9a4b6c106baf8a56aa0d256fc3c71bd417ea75b9c7fd830a9b7",
+        "check_gpg": true
+      },
+      {
+        "name": "libgpiod-utils",
+        "epoch": 0,
+        "version": "1.5.1",
+        "release": "1.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libgpiod-utils-1.5.1-1.fc32.x86_64.rpm",
+        "checksum": "sha256:b3201777d78ee13ee45ddbd982af5999ce058907b5dc552669644931b79c5f51",
+        "check_gpg": true
+      },
+      {
+        "name": "libgudev",
+        "epoch": 0,
+        "version": "232",
+        "release": "7.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libgudev-232-7.fc32.x86_64.rpm",
+        "checksum": "sha256:824fe37d58cadac2f23678c9eb95c29b4acb1852df97cf799e77aa7e8034b54e",
+        "check_gpg": true
+      },
+      {
+        "name": "libgusb",
+        "epoch": 0,
+        "version": "0.3.4",
+        "release": "1.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libgusb-0.3.4-1.fc32.x86_64.rpm",
+        "checksum": "sha256:86acbe8d77b05c1fe9bb0168443a579b1d4538f9733813db4e72e4a4a2be29e3",
+        "check_gpg": true
+      },
+      {
+        "name": "libidn2",
+        "epoch": 0,
+        "version": "2.3.0",
+        "release": "2.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libidn2-2.3.0-2.fc32.x86_64.rpm",
+        "checksum": "sha256:20787251df57a108bbf9c40e30f041b71ac36c8a10900fb699e574ee7e259bf2",
+        "check_gpg": true
+      },
+      {
+        "name": "libjose",
+        "epoch": 0,
+        "version": "10",
+        "release": "6.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libjose-10-6.fc32.x86_64.rpm",
+        "checksum": "sha256:ff44071d53a2ed543c2ddad99cca8fc25493cbefc5d7ad869f9b6dbda340a465",
+        "check_gpg": true
+      },
+      {
+        "name": "libkcapi",
+        "epoch": 0,
+        "version": "1.1.5",
+        "release": "2.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libkcapi-1.1.5-2.fc32.x86_64.rpm",
+        "checksum": "sha256:8677b34fa73f258b1a599d18419f6fbbb8961bb1ca2ae5b0f9abdcc4f93b319e",
+        "check_gpg": true
+      },
+      {
+        "name": "libkcapi-hmaccalc",
+        "epoch": 0,
+        "version": "1.1.5",
+        "release": "2.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libkcapi-hmaccalc-1.1.5-2.fc32.x86_64.rpm",
+        "checksum": "sha256:5d5c8c7e9c78e3b8827ad38771efb44951d1c3c1692cf4e07b138c1c8c42bd5b",
+        "check_gpg": true
+      },
+      {
+        "name": "libksba",
+        "epoch": 0,
+        "version": "1.3.5",
+        "release": "11.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libksba-1.3.5-11.fc32.x86_64.rpm",
+        "checksum": "sha256:1b05dd5abad5a31380c859bc33e7851158c24333fda837ca9facf869005f81fe",
+        "check_gpg": true
+      },
+      {
+        "name": "libluksmeta",
+        "epoch": 0,
+        "version": "9",
+        "release": "7.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libluksmeta-9-7.fc32.x86_64.rpm",
+        "checksum": "sha256:2434cd04a437c06f59d67ee2580443c0ba676c39440cd0f74cca768ec57577f9",
+        "check_gpg": true
+      },
+      {
+        "name": "libmbim",
+        "epoch": 0,
+        "version": "1.22.0",
+        "release": "1.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libmbim-1.22.0-1.fc32.x86_64.rpm",
+        "checksum": "sha256:de74076fc5073ad07ffa78fed6e7cd8f10133d99c1c73149b4ac74428699a6d1",
+        "check_gpg": true
+      },
+      {
+        "name": "libmbim-utils",
+        "epoch": 0,
+        "version": "1.22.0",
+        "release": "1.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libmbim-utils-1.22.0-1.fc32.x86_64.rpm",
+        "checksum": "sha256:4eb6a2e34173a2b6ca7db031cecce56c0bed711691abf1c8d6bfe6cb7ca45dc0",
+        "check_gpg": true
+      },
+      {
+        "name": "libmetalink",
+        "epoch": 0,
+        "version": "0.1.3",
+        "release": "10.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libmetalink-0.1.3-10.fc32.x86_64.rpm",
+        "checksum": "sha256:6eb95e39b9771c4dde5f9954a74cef6be90522c28c7c4aa767ebe7a9d55fcdf9",
+        "check_gpg": true
+      },
+      {
+        "name": "libmnl",
+        "epoch": 0,
+        "version": "1.0.4",
+        "release": "11.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libmnl-1.0.4-11.fc32.x86_64.rpm",
+        "checksum": "sha256:1c68255945533ed4e3368125bc46e19f3fe348d7ec507a85a35038dbb976003f",
+        "check_gpg": true
+      },
+      {
+        "name": "libmodman",
+        "epoch": 0,
+        "version": "2.0.1",
+        "release": "21.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libmodman-2.0.1-21.fc32.x86_64.rpm",
+        "checksum": "sha256:9ebc5843faeb852bbbe3d53f03182197f6595a928ffa3f5d7a530749ee1e4ec8",
+        "check_gpg": true
+      },
+      {
+        "name": "libmodulemd1",
+        "epoch": 0,
+        "version": "1.8.16",
+        "release": "2.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libmodulemd1-1.8.16-2.fc32.x86_64.rpm",
+        "checksum": "sha256:aa5b658fd4a95c724b61eddadecdbcbc1b2a813ae681318ab092a2ed03954825",
+        "check_gpg": true
+      },
+      {
+        "name": "libmount",
+        "epoch": 0,
+        "version": "2.35.1",
+        "release": "7.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libmount-2.35.1-7.fc32.x86_64.rpm",
+        "checksum": "sha256:e740cc0a580639b887bda0039a779e750a32835be1fd8c64aa01183b4cbb98bf",
+        "check_gpg": true
+      },
+      {
+        "name": "libndp",
+        "epoch": 0,
+        "version": "1.7",
+        "release": "5.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libndp-1.7-5.fc32.x86_64.rpm",
+        "checksum": "sha256:4f4ef59861c0566d22bd76369d22369d43130f5ccdb35a5fc2c8a236cf33651f",
+        "check_gpg": true
+      },
+      {
+        "name": "libnet",
+        "epoch": 0,
+        "version": "1.1.6",
+        "release": "19.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libnet-1.1.6-19.fc32.x86_64.rpm",
+        "checksum": "sha256:b359ca3cdc68b6e5031f65975df38a8b96c19ddc4c367e1e3463fc8484a0b3b7",
+        "check_gpg": true
+      },
+      {
+        "name": "libnetfilter_conntrack",
+        "epoch": 0,
+        "version": "1.0.7",
+        "release": "4.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libnetfilter_conntrack-1.0.7-4.fc32.x86_64.rpm",
+        "checksum": "sha256:884357540f4be2a74e608e2c7a31f2371ee3b4d29be2fe39a371c0b131d84aa6",
+        "check_gpg": true
+      },
+      {
+        "name": "libnfnetlink",
+        "epoch": 0,
+        "version": "1.0.1",
+        "release": "17.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libnfnetlink-1.0.1-17.fc32.x86_64.rpm",
+        "checksum": "sha256:ec6abd65541b5bded814de19c9d064e6c21e3d8b424dba7cb25b2fdc52d45a2b",
+        "check_gpg": true
+      },
+      {
+        "name": "libnftnl",
+        "epoch": 0,
+        "version": "1.1.5",
+        "release": "2.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libnftnl-1.1.5-2.fc32.x86_64.rpm",
+        "checksum": "sha256:3afab9512fd4d56a13c95b530c805ac8b2bc872572ec5bb435eccdd59fbbc8b6",
+        "check_gpg": true
+      },
+      {
+        "name": "libnghttp2",
+        "epoch": 0,
+        "version": "1.40.0",
+        "release": "2.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libnghttp2-1.40.0-2.fc32.x86_64.rpm",
+        "checksum": "sha256:a8ce7406c87f64972f0b70f1823c2aad05516c71fe375c6c97737459c2448825",
+        "check_gpg": true
+      },
+      {
+        "name": "libnl3",
+        "epoch": 0,
+        "version": "3.5.0",
+        "release": "2.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libnl3-3.5.0-2.fc32.x86_64.rpm",
+        "checksum": "sha256:8dfdbe51193bdcfc3db41b5b9f317f009bfab6373e6ed3c5475466b8772a85e1",
+        "check_gpg": true
+      },
+      {
+        "name": "libnsl2",
+        "epoch": 0,
+        "version": "1.2.0",
+        "release": "6.20180605git4a062cf.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libnsl2-1.2.0-6.20180605git4a062cf.fc32.x86_64.rpm",
+        "checksum": "sha256:3b4ce7fc4e2778758881feedf6ea19b65e99aa3672e19a7dd62977efe3b910b9",
+        "check_gpg": true
+      },
+      {
+        "name": "libpcap",
+        "epoch": 14,
+        "version": "1.9.1",
+        "release": "3.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libpcap-1.9.1-3.fc32.x86_64.rpm",
+        "checksum": "sha256:b3230630a471b806a9153669d187508350cdb2b368a68f8c439c82abad038c3f",
+        "check_gpg": true
+      },
+      {
+        "name": "libpkgconf",
+        "epoch": 0,
+        "version": "1.6.3",
+        "release": "3.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libpkgconf-1.6.3-3.fc32.x86_64.rpm",
+        "checksum": "sha256:6952dfc6a8f583c9aeafb16d5d34208d7e39fd7ec8628c5aa8ccde039acbe548",
+        "check_gpg": true
+      },
+      {
+        "name": "libproxy",
+        "epoch": 0,
+        "version": "0.4.15",
+        "release": "17.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libproxy-0.4.15-17.fc32.x86_64.rpm",
+        "checksum": "sha256:5a4c0187b96690e0088057f7656c67d399fad44b28b86644e3434c581377c229",
+        "check_gpg": true
+      },
+      {
+        "name": "libpsl",
+        "epoch": 0,
+        "version": "0.21.0",
+        "release": "4.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libpsl-0.21.0-4.fc32.x86_64.rpm",
+        "checksum": "sha256:ce8c1f1ce3cb2cc0166dcaad17f35e84278ec39ea9bf232e24130d3ff3271923",
+        "check_gpg": true
+      },
+      {
+        "name": "libpwquality",
+        "epoch": 0,
+        "version": "1.4.2",
+        "release": "2.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libpwquality-1.4.2-2.fc32.x86_64.rpm",
+        "checksum": "sha256:9ecc8aa9af05ba704cec879618afeda5ff92d8233811e2d6080aa02e0b5ceddf",
+        "check_gpg": true
+      },
+      {
+        "name": "libqmi",
+        "epoch": 0,
+        "version": "1.24.8",
+        "release": "1.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libqmi-1.24.8-1.fc32.x86_64.rpm",
+        "checksum": "sha256:5ad0d1b4e641e5d2fe7f6385ace0f827a431c5a52c6dc3516d85e655caca880f",
+        "check_gpg": true
+      },
+      {
+        "name": "libqmi-utils",
+        "epoch": 0,
+        "version": "1.24.8",
+        "release": "1.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libqmi-utils-1.24.8-1.fc32.x86_64.rpm",
+        "checksum": "sha256:64922311f45700f2f4f98d78efbdfa240987a6a2b1396ffe694d30e2b5f34ac3",
+        "check_gpg": true
+      },
+      {
+        "name": "librepo",
+        "epoch": 0,
+        "version": "1.11.1",
+        "release": "4.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/librepo-1.11.1-4.fc32.x86_64.rpm",
+        "checksum": "sha256:aa783a91b1823b7b056575e6276df35910eb2e0d4b72121cf5649651c7d23a16",
+        "check_gpg": true
+      },
+      {
+        "name": "libseccomp",
+        "epoch": 0,
+        "version": "2.4.2",
+        "release": "3.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libseccomp-2.4.2-3.fc32.x86_64.rpm",
+        "checksum": "sha256:df0a39eb6b91c4a8f481c22445cbbd88334bf5e0a6e1dd5fb240981eb031c4eb",
+        "check_gpg": true
+      },
+      {
+        "name": "libsecret",
+        "epoch": 0,
+        "version": "0.20.2",
+        "release": "2.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libsecret-0.20.2-2.fc32.x86_64.rpm",
+        "checksum": "sha256:251fd875421da4708b76c15c7f5ba478d50b74d7e4242071a621625eac51a767",
+        "check_gpg": true
+      },
+      {
+        "name": "libselinux",
+        "epoch": 0,
+        "version": "3.0",
+        "release": "3.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libselinux-3.0-3.fc32.x86_64.rpm",
+        "checksum": "sha256:0e59b422e35eee975ba68e6e4de022c8f145feec7e169e86e0244d2fdad2f590",
+        "check_gpg": true
+      },
+      {
+        "name": "libselinux-utils",
+        "epoch": 0,
+        "version": "3.0",
+        "release": "3.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libselinux-utils-3.0-3.fc32.x86_64.rpm",
+        "checksum": "sha256:1446032720fb8e0090190828fcea294a86fc7f83edd70f6089e3446770ba0438",
+        "check_gpg": true
+      },
+      {
+        "name": "libsemanage",
+        "epoch": 0,
+        "version": "3.0",
+        "release": "3.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libsemanage-3.0-3.fc32.x86_64.rpm",
+        "checksum": "sha256:54cb827278ae474cbab1f05e0fbee0355bee2674d46a804f1c2b78ff80a48caa",
+        "check_gpg": true
+      },
+      {
+        "name": "libsepol",
+        "epoch": 0,
+        "version": "3.0",
+        "release": "3.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libsepol-3.0-3.fc32.x86_64.rpm",
+        "checksum": "sha256:29e2b62e9e63f25139a6863c863c3b534660440d7dec0c985807302a6895dbaf",
+        "check_gpg": true
+      },
+      {
+        "name": "libsigsegv",
+        "epoch": 0,
+        "version": "2.11",
+        "release": "10.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libsigsegv-2.11-10.fc32.x86_64.rpm",
+        "checksum": "sha256:942707884401498938fba6e2439dc923d4e2d81f4bac205f4e73d458e9879927",
+        "check_gpg": true
+      },
+      {
+        "name": "libsmartcols",
+        "epoch": 0,
+        "version": "2.35.1",
+        "release": "7.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libsmartcols-2.35.1-7.fc32.x86_64.rpm",
+        "checksum": "sha256:ddad78d00b09c6c85d46c06dcba4c951f7f7dfc9b2dab195bf45aa3f5a1fdc41",
+        "check_gpg": true
+      },
+      {
+        "name": "libsmbios",
+        "epoch": 0,
+        "version": "2.4.2",
+        "release": "7.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libsmbios-2.4.2-7.fc32.x86_64.rpm",
+        "checksum": "sha256:cbfc109588fa0e34bdc408dbb37dadf7873fb5788dd3fd8cd04c17c75f26e6db",
+        "check_gpg": true
+      },
+      {
+        "name": "libsolv",
+        "epoch": 0,
+        "version": "0.7.11",
+        "release": "2.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libsolv-0.7.11-2.fc32.x86_64.rpm",
+        "checksum": "sha256:be899d3e806441b1c46811c0ffe9f4e01f4ea4e1544f9cc32630254853e3f3a5",
+        "check_gpg": true
+      },
+      {
+        "name": "libsoup",
+        "epoch": 0,
+        "version": "2.70.0",
+        "release": "1.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libsoup-2.70.0-1.fc32.x86_64.rpm",
+        "checksum": "sha256:b09015ae5fb5772b73bc7932991aaf6e1f6d509432af605a565ef53d2d50606a",
+        "check_gpg": true
+      },
+      {
+        "name": "libss",
+        "epoch": 0,
+        "version": "1.45.5",
+        "release": "3.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libss-1.45.5-3.fc32.x86_64.rpm",
+        "checksum": "sha256:27701cda24f5f6386e0173745aabc4f6df28052975e73529854432c35399cfc8",
+        "check_gpg": true
+      },
+      {
+        "name": "libssh",
+        "epoch": 0,
+        "version": "0.9.3",
+        "release": "2.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libssh-0.9.3-2.fc32.x86_64.rpm",
+        "checksum": "sha256:32f8cbb3be91f589d569a2e737130f29c752f78eebc61e287af17f207e1b8c58",
+        "check_gpg": true
+      },
+      {
+        "name": "libssh-config",
+        "epoch": 0,
+        "version": "0.9.3",
+        "release": "2.fc32",
+        "arch": "noarch",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libssh-config-0.9.3-2.fc32.noarch.rpm",
+        "checksum": "sha256:49bac21d5cdf863fccfcc32bf070e582d204706e35ee9f60b3e69df694bff87d",
+        "check_gpg": true
+      },
+      {
+        "name": "libsss_idmap",
+        "epoch": 0,
+        "version": "2.2.3",
+        "release": "13.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libsss_idmap-2.2.3-13.fc32.x86_64.rpm",
+        "checksum": "sha256:599549d72d26b48c45156585a5698898c853e56469142e202d3749b781428465",
+        "check_gpg": true
+      },
+      {
+        "name": "libsss_nss_idmap",
+        "epoch": 0,
+        "version": "2.2.3",
+        "release": "13.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libsss_nss_idmap-2.2.3-13.fc32.x86_64.rpm",
+        "checksum": "sha256:66bb5b2e99d2c74b82943fe61fe9b9a3674350b0242f69a6854ec9718dcf5e07",
+        "check_gpg": true
+      },
+      {
+        "name": "libsss_sudo",
+        "epoch": 0,
+        "version": "2.2.3",
+        "release": "13.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libsss_sudo-2.2.3-13.fc32.x86_64.rpm",
+        "checksum": "sha256:af66820023c984d8b981ecac715d0c2daec1f89dcb69bed76ddf58b0ee80c1b1",
+        "check_gpg": true
+      },
+      {
+        "name": "libstdc++",
+        "epoch": 0,
+        "version": "10.0.1",
+        "release": "0.11.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libstdc++-10.0.1-0.11.fc32.x86_64.rpm",
+        "checksum": "sha256:be998dfbcc9ca8e3021ac4f56ed723cfa3fa1517524e89ee0b636f623abe995f",
+        "check_gpg": true
+      },
+      {
+        "name": "libsysfs",
+        "epoch": 0,
+        "version": "2.1.0",
+        "release": "28.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libsysfs-2.1.0-28.fc32.x86_64.rpm",
+        "checksum": "sha256:64567be564634937bd918d33a3f04017808d29269a5b0891a0f4d4aecad6161b",
+        "check_gpg": true
+      },
+      {
+        "name": "libtasn1",
+        "epoch": 0,
+        "version": "4.16.0",
+        "release": "1.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libtasn1-4.16.0-1.fc32.x86_64.rpm",
+        "checksum": "sha256:052d04c9a6697c6e5aa546546ae5058d547fc4a4f474d2805a3e45dbf69193c6",
+        "check_gpg": true
+      },
+      {
+        "name": "libtextstyle",
+        "epoch": 0,
+        "version": "0.20.1",
+        "release": "4.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libtextstyle-0.20.1-4.fc32.x86_64.rpm",
+        "checksum": "sha256:b35256e417fd94c7efb1212f2f36b5e6b224ff5b9e8733774d4fbdc652078099",
+        "check_gpg": true
+      },
+      {
+        "name": "libtirpc",
+        "epoch": 0,
+        "version": "1.2.5",
+        "release": "1.rc2.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libtirpc-1.2.5-1.rc2.fc32.x86_64.rpm",
+        "checksum": "sha256:c1d754773972b5f4ca157c0afa45d6767901d965a91f381660c72740d682df63",
+        "check_gpg": true
+      },
+      {
+        "name": "libunistring",
+        "epoch": 0,
+        "version": "0.9.10",
+        "release": "7.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libunistring-0.9.10-7.fc32.x86_64.rpm",
+        "checksum": "sha256:fb06aa3d8059406a23694ddafe0ef340ca627dd68bf3f351f094de58ef30fb2c",
+        "check_gpg": true
+      },
+      {
+        "name": "libusbx",
+        "epoch": 0,
+        "version": "1.0.23",
+        "release": "1.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libusbx-1.0.23-1.fc32.x86_64.rpm",
+        "checksum": "sha256:729fb595040f1e2e71ff0a8c1c22ebe4b7187f78b816af8e6a8d93c03fc5d844",
+        "check_gpg": true
+      },
+      {
+        "name": "libuser",
+        "epoch": 0,
+        "version": "0.62",
+        "release": "24.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libuser-0.62-24.fc32.x86_64.rpm",
+        "checksum": "sha256:b58828b2f1ce4f7778d3f511c61ee8925042b9752aea526c23d33fd7533aa975",
+        "check_gpg": true
+      },
+      {
+        "name": "libutempter",
+        "epoch": 0,
+        "version": "1.1.6",
+        "release": "18.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libutempter-1.1.6-18.fc32.x86_64.rpm",
+        "checksum": "sha256:f9ccea65ecf98f4dfac65d25986d08efa62a1d1c0db9db0a061e7408d6805a1a",
+        "check_gpg": true
+      },
+      {
+        "name": "libuuid",
+        "epoch": 0,
+        "version": "2.35.1",
+        "release": "7.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libuuid-2.35.1-7.fc32.x86_64.rpm",
+        "checksum": "sha256:8402d3aabfc02c16f3789f3f93338dbee2448db8a49956002b83aff5390922d9",
+        "check_gpg": true
+      },
+      {
+        "name": "libvarlink-util",
+        "epoch": 0,
+        "version": "18",
+        "release": "3.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libvarlink-util-18-3.fc32.x86_64.rpm",
+        "checksum": "sha256:a7452c18c2cffc266ec36c54105b884c4d63181f20cebd705e33730534cb9093",
+        "check_gpg": true
+      },
+      {
+        "name": "libverto",
+        "epoch": 0,
+        "version": "0.3.0",
+        "release": "9.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libverto-0.3.0-9.fc32.x86_64.rpm",
+        "checksum": "sha256:ed84414c9b2190d3026f58db78dffd8bc3a9ad40311cb0adb8ff8e3c7c06ca60",
+        "check_gpg": true
+      },
+      {
+        "name": "libxcrypt",
+        "epoch": 0,
+        "version": "4.4.16",
+        "release": "1.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libxcrypt-4.4.16-1.fc32.x86_64.rpm",
+        "checksum": "sha256:7c1a229f4a36ac8b077e0514f68f311229652121528b0f8a2a7434c618276dcb",
+        "check_gpg": true
+      },
+      {
+        "name": "libxcrypt-compat",
+        "epoch": 0,
+        "version": "4.4.16",
+        "release": "1.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libxcrypt-compat-4.4.16-1.fc32.x86_64.rpm",
+        "checksum": "sha256:cb4fb9b3733440ea15b3309c88d9471c4165aa7b71b4dbc5d0fb5bfcd97b2f2e",
+        "check_gpg": true
+      },
+      {
+        "name": "libxkbcommon",
+        "epoch": 0,
+        "version": "0.10.0",
+        "release": "2.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libxkbcommon-0.10.0-2.fc32.x86_64.rpm",
+        "checksum": "sha256:ae219ad5ecc0233271c3fd61263f817c646eecece19a8f075e7aa4dd9ff8698e",
+        "check_gpg": true
+      },
+      {
+        "name": "libxml2",
+        "epoch": 0,
+        "version": "2.9.10",
+        "release": "3.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libxml2-2.9.10-3.fc32.x86_64.rpm",
+        "checksum": "sha256:a7f040de29d2414cc99fcffcd9ed3fa9d06ecc7aecd783ec3d2eef769e2389f1",
+        "check_gpg": true
+      },
+      {
+        "name": "libxmlb",
+        "epoch": 0,
+        "version": "0.1.14",
+        "release": "2.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libxmlb-0.1.14-2.fc32.x86_64.rpm",
+        "checksum": "sha256:ad50ed0c4f4c956e3b59ac9fc7bf5fba22068a661ea75a46eb81bc2209af4cc5",
+        "check_gpg": true
+      },
+      {
+        "name": "libyaml",
+        "epoch": 0,
+        "version": "0.2.2",
+        "release": "3.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libyaml-0.2.2-3.fc32.x86_64.rpm",
+        "checksum": "sha256:9c8a274158a6fe97598e33900cd51e171f7e7517ccfc8ad6351873e69b225986",
+        "check_gpg": true
+      },
+      {
+        "name": "libzstd",
+        "epoch": 0,
+        "version": "1.4.4",
+        "release": "2.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/libzstd-1.4.4-2.fc32.x86_64.rpm",
+        "checksum": "sha256:9465f2f1103697207a52d15edd716ab72dc6c281823c60f424cd064d706c7a51",
+        "check_gpg": true
+      },
+      {
+        "name": "linux-atm-libs",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "26.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/linux-atm-libs-2.5.1-26.fc32.x86_64.rpm",
+        "checksum": "sha256:c9ba05cb46a9cb52e3325ca20c457a377361abcd0e5a7dda776ba19481770467",
+        "check_gpg": true
+      },
+      {
+        "name": "linux-firmware",
+        "epoch": 0,
+        "version": "20200316",
+        "release": "106.fc32",
+        "arch": "noarch",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/linux-firmware-20200316-106.fc32.noarch.rpm",
+        "checksum": "sha256:5b8a205f3d4bde162e01a821fdacbc10ebfa01b88ec61b166b4b6317c45910c4",
+        "check_gpg": true
+      },
+      {
+        "name": "linux-firmware-whence",
+        "epoch": 0,
+        "version": "20200316",
+        "release": "106.fc32",
+        "arch": "noarch",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/linux-firmware-whence-20200316-106.fc32.noarch.rpm",
+        "checksum": "sha256:15f70393f706ea0ac6c622563268d9c00509ef376e3e087c1c05007b49894ee9",
+        "check_gpg": true
+      },
+      {
+        "name": "lua-libs",
+        "epoch": 0,
+        "version": "5.3.5",
+        "release": "7.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/lua-libs-5.3.5-7.fc32.x86_64.rpm",
+        "checksum": "sha256:10883ce95852cc9ae9b4e0d435b100a25f8fe5c0ea4677eb4a0b39f4f8def886",
+        "check_gpg": true
+      },
+      {
+        "name": "luksmeta",
+        "epoch": 0,
+        "version": "9",
+        "release": "7.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/luksmeta-9-7.fc32.x86_64.rpm",
+        "checksum": "sha256:9fa1959637c902dfeb19a0f16c7f42f7da4aab293f7c025c66d39debad6dbc34",
+        "check_gpg": true
+      },
+      {
+        "name": "lvm2",
+        "epoch": 0,
+        "version": "2.03.09",
+        "release": "1.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/lvm2-2.03.09-1.fc32.x86_64.rpm",
+        "checksum": "sha256:3b76bc46dd279404408d34946cfdb0c3899359a1c6b48e614e63d1259a94262a",
+        "check_gpg": true
+      },
+      {
+        "name": "lvm2-libs",
+        "epoch": 0,
+        "version": "2.03.09",
+        "release": "1.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/lvm2-libs-2.03.09-1.fc32.x86_64.rpm",
+        "checksum": "sha256:e851ba0019baa83e1bebbe92e1a1cf629694ccf3b42c5ff84e0ed7bea74931d3",
+        "check_gpg": true
+      },
+      {
+        "name": "lz4-libs",
+        "epoch": 0,
+        "version": "1.9.1",
+        "release": "2.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/lz4-libs-1.9.1-2.fc32.x86_64.rpm",
+        "checksum": "sha256:44cfb58b368fba586981aa838a7f3974ac1d66d2b3b695f88d7b1d2e9c81a0b6",
+        "check_gpg": true
+      },
+      {
+        "name": "lzo",
+        "epoch": 0,
+        "version": "2.10",
+        "release": "2.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/l/lzo-2.10-2.fc32.x86_64.rpm",
+        "checksum": "sha256:4375c398dff722a29bd1700bc8dc8b528345412d1e17d8d9d1176d9774962957",
+        "check_gpg": true
+      },
+      {
+        "name": "microcode_ctl",
+        "epoch": 2,
+        "version": "2.1",
+        "release": "35.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/m/microcode_ctl-2.1-35.fc32.x86_64.rpm",
+        "checksum": "sha256:95a89032291b05a0e483f336ea29897d951e8845b0f347a4117de90ef3ef3467",
+        "check_gpg": true
+      },
+      {
+        "name": "mkpasswd",
+        "epoch": 0,
+        "version": "5.5.6",
+        "release": "1.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/m/mkpasswd-5.5.6-1.fc32.x86_64.rpm",
+        "checksum": "sha256:640afe5b9d499c9a7efc1d23cce8c54e3e3704d92eb7e7a93a048f97d1e983e1",
+        "check_gpg": true
+      },
+      {
+        "name": "mokutil",
+        "epoch": 2,
+        "version": "0.3.0",
+        "release": "15.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/m/mokutil-0.3.0-15.fc32.x86_64.rpm",
+        "checksum": "sha256:9cf9b01f2c727e3576a8aa71fd7fe1bf4ec9ed1c9f50b756657cf9aeae18418f",
+        "check_gpg": true
+      },
+      {
+        "name": "mozjs60",
+        "epoch": 0,
+        "version": "60.9.0",
+        "release": "5.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/m/mozjs60-60.9.0-5.fc32.x86_64.rpm",
+        "checksum": "sha256:80cf220a3314f965c088e03d2b750426767db0b36b6b7c5e8059b9217ff4de6d",
+        "check_gpg": true
+      },
+      {
+        "name": "mpfr",
+        "epoch": 0,
+        "version": "4.0.2",
+        "release": "3.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/m/mpfr-4.0.2-3.fc32.x86_64.rpm",
+        "checksum": "sha256:2b098bc6f8004270ee9eac9f63980b364b5fe19394dc73a230b3c846cf488b1b",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses",
+        "epoch": 0,
+        "version": "6.1",
+        "release": "15.20191109.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/n/ncurses-6.1-15.20191109.fc32.x86_64.rpm",
+        "checksum": "sha256:b2e862283ac97b1d8b1ede2034ead452ac7dc4ff308593306275b1b0ae5b4102",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses-base",
+        "epoch": 0,
+        "version": "6.1",
+        "release": "15.20191109.fc32",
+        "arch": "noarch",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/n/ncurses-base-6.1-15.20191109.fc32.noarch.rpm",
+        "checksum": "sha256:25fc5d288536e1973436da38357690575ed58e03e17ca48d2b3840364f830659",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses-libs",
+        "epoch": 0,
+        "version": "6.1",
+        "release": "15.20191109.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/n/ncurses-libs-6.1-15.20191109.fc32.x86_64.rpm",
+        "checksum": "sha256:04152a3a608d022a58830c0e3dac0818e2c060469b0f41d8d731f659981a4464",
+        "check_gpg": true
+      },
+      {
+        "name": "nettle",
+        "epoch": 0,
+        "version": "3.5.1",
+        "release": "5.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/n/nettle-3.5.1-5.fc32.x86_64.rpm",
+        "checksum": "sha256:c019d23ed2cb3ceb0ac9757a72c3e8b1d31f2a524b889e18049cc7d923bc9466",
+        "check_gpg": true
+      },
+      {
+        "name": "nftables",
+        "epoch": 1,
+        "version": "0.9.3",
+        "release": "2.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/n/nftables-0.9.3-2.fc32.x86_64.rpm",
+        "checksum": "sha256:0b7d24759aac33303ff4b101c111dea03ff2529efc95661140e22f629cc1ab7a",
+        "check_gpg": true
+      },
+      {
+        "name": "nmap-ncat",
+        "epoch": 2,
+        "version": "7.80",
+        "release": "3.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/n/nmap-ncat-7.80-3.fc32.x86_64.rpm",
+        "checksum": "sha256:e2566356943c1c7485d206b858dd6ae3be37c28bfec2a43f869193f3b5b9cd23",
+        "check_gpg": true
+      },
+      {
+        "name": "npth",
+        "epoch": 0,
+        "version": "1.6",
+        "release": "4.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/n/npth-1.6-4.fc32.x86_64.rpm",
+        "checksum": "sha256:3c2a641f118ab2e8b08df6dd2da72a60121d02df8d932b4afa2920eb80392875",
+        "check_gpg": true
+      },
+      {
+        "name": "nss-altfiles",
+        "epoch": 0,
+        "version": "2.18.1",
+        "release": "16.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/n/nss-altfiles-2.18.1-16.fc32.x86_64.rpm",
+        "checksum": "sha256:42fcfac5037eab4099648e0f0ed3eb2aec6eb6a23a9e3808f9b69619ea7c44e3",
+        "check_gpg": true
+      },
+      {
+        "name": "openldap",
+        "epoch": 0,
+        "version": "2.4.47",
+        "release": "4.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/o/openldap-2.4.47-4.fc32.x86_64.rpm",
+        "checksum": "sha256:ade8105796f5c1201a3efc8bcc654788cfc88c3815297b346845062a8c29cd59",
+        "check_gpg": true
+      },
+      {
+        "name": "openssh",
+        "epoch": 0,
+        "version": "8.2p1",
+        "release": "2.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/o/openssh-8.2p1-2.fc32.x86_64.rpm",
+        "checksum": "sha256:0d51c1319ee78978e6ea5a49b815c2078b4ffd4d575e98c70e54ca01c3390eb8",
+        "check_gpg": true
+      },
+      {
+        "name": "openssh-clients",
+        "epoch": 0,
+        "version": "8.2p1",
+        "release": "2.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/o/openssh-clients-8.2p1-2.fc32.x86_64.rpm",
+        "checksum": "sha256:8b148415fb6a583ef131d0ddff44f3209c30d0299fde7b20cd3ea385590927c1",
+        "check_gpg": true
+      },
+      {
+        "name": "openssh-server",
+        "epoch": 0,
+        "version": "8.2p1",
+        "release": "2.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/o/openssh-server-8.2p1-2.fc32.x86_64.rpm",
+        "checksum": "sha256:d1e244b8b5ce7404846e97d96c762c8c18ff6447301f6fc63f50e615029aa7cd",
+        "check_gpg": true
+      },
+      {
+        "name": "openssl",
+        "epoch": 1,
+        "version": "1.1.1d",
+        "release": "7.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/o/openssl-1.1.1d-7.fc32.x86_64.rpm",
+        "checksum": "sha256:d7b8b5815b72fb157de26579362383e357e026ae6ac2599c451fb336fe995555",
+        "check_gpg": true
+      },
+      {
+        "name": "openssl-libs",
+        "epoch": 1,
+        "version": "1.1.1d",
+        "release": "7.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/o/openssl-libs-1.1.1d-7.fc32.x86_64.rpm",
+        "checksum": "sha256:ad6d7d9767e05978b14a39c08dba59ddc4396584576df194f77ed310a0816ae0",
+        "check_gpg": true
+      },
+      {
+        "name": "openssl-pkcs11",
+        "epoch": 0,
+        "version": "0.4.10",
+        "release": "5.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/o/openssl-pkcs11-0.4.10-5.fc32.x86_64.rpm",
+        "checksum": "sha256:3f2cb9092d6f55f84dd9eacd5359dfb354772e5f38308328027c7758f4a06fb6",
+        "check_gpg": true
+      },
+      {
+        "name": "os-prober",
+        "epoch": 0,
+        "version": "1.77",
+        "release": "4.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/o/os-prober-1.77-4.fc32.x86_64.rpm",
+        "checksum": "sha256:45fc2608b746fd841dd25919e9e4d44834154758aec8fb8b529c014b11c7917d",
+        "check_gpg": true
+      },
+      {
+        "name": "ostree",
+        "epoch": 0,
+        "version": "2020.3",
+        "release": "2.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/o/ostree-2020.3-2.fc32.x86_64.rpm",
+        "checksum": "sha256:ec64add7d60a70fbaf14a083929f22bd2637c33d20d2a30b7e842caa6040f817",
+        "check_gpg": true
+      },
+      {
+        "name": "ostree-libs",
+        "epoch": 0,
+        "version": "2020.3",
+        "release": "2.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/o/ostree-libs-2020.3-2.fc32.x86_64.rpm",
+        "checksum": "sha256:3343d9e7c90bd58e1e44ee07e7c59bb570ffc74da50f0607c5f5681a00b70e76",
+        "check_gpg": true
+      },
+      {
+        "name": "p11-kit",
+        "epoch": 0,
+        "version": "0.23.20",
+        "release": "1.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/p/p11-kit-0.23.20-1.fc32.x86_64.rpm",
+        "checksum": "sha256:dedd37a96262c35763ab2dcbc19838f5cc39a2a3a392a650a80bd6d5ae42ff8b",
+        "check_gpg": true
+      },
+      {
+        "name": "p11-kit-trust",
+        "epoch": 0,
+        "version": "0.23.20",
+        "release": "1.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/p/p11-kit-trust-0.23.20-1.fc32.x86_64.rpm",
+        "checksum": "sha256:3589b982ac0c2f5f6b47cde5cb7ec33c2c01d756dabf8c4ca64f6d9d0d78b35e",
+        "check_gpg": true
+      },
+      {
+        "name": "pam",
+        "epoch": 0,
+        "version": "1.3.1",
+        "release": "24.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/p/pam-1.3.1-24.fc32.x86_64.rpm",
+        "checksum": "sha256:4c80ade4ac0889316930a8d181ea43fa2d1b2f1a6a5703c22f2b3ba191346eec",
+        "check_gpg": true
+      },
+      {
+        "name": "passwd",
+        "epoch": 0,
+        "version": "0.80",
+        "release": "8.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/p/passwd-0.80-8.fc32.x86_64.rpm",
+        "checksum": "sha256:156709efeaa1dfac72cc189d7e99de12d7c4b2069445da5d34fa807582e85719",
+        "check_gpg": true
+      },
+      {
+        "name": "pciutils-libs",
+        "epoch": 0,
+        "version": "3.6.4",
+        "release": "1.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/p/pciutils-libs-3.6.4-1.fc32.x86_64.rpm",
+        "checksum": "sha256:e5efc87172d7081559137feaa221047385a5e248ffafd9794c2bfc73b61f8f37",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre",
+        "epoch": 0,
+        "version": "8.44",
+        "release": "1.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/p/pcre-8.44-1.fc32.x86_64.rpm",
+        "checksum": "sha256:933bdb4cc6e14b2ebb1ca76c14ca176c13d271a2d1e88632f237392777d11808",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre2",
+        "epoch": 0,
+        "version": "10.34",
+        "release": "9.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/p/pcre2-10.34-9.fc32.x86_64.rpm",
+        "checksum": "sha256:6794fe48004c0403c29fc779b49f0fbea436123b96783a2df225eef2f0858795",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre2-syntax",
+        "epoch": 0,
+        "version": "10.34",
+        "release": "9.fc32",
+        "arch": "noarch",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/p/pcre2-syntax-10.34-9.fc32.noarch.rpm",
+        "checksum": "sha256:5db7c0e949bd9172b9645237e72f6139d4ffcf14defad487262b8ad25b427daf",
+        "check_gpg": true
+      },
+      {
+        "name": "pigz",
+        "epoch": 0,
+        "version": "2.4",
+        "release": "6.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/p/pigz-2.4-6.fc32.x86_64.rpm",
+        "checksum": "sha256:15f08ce979e48fd25be5e16d63d1c95c57f9abff7704005137ea00b958442939",
+        "check_gpg": true
+      },
+      {
+        "name": "pinentry",
+        "epoch": 0,
+        "version": "1.1.0",
+        "release": "7.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/p/pinentry-1.1.0-7.fc32.x86_64.rpm",
+        "checksum": "sha256:7df4fa1a29772696d92866e890af6fbe006088f3407ed3e67b0e7867ef58d899",
+        "check_gpg": true
+      },
+      {
+        "name": "pkgconf",
+        "epoch": 0,
+        "version": "1.6.3",
+        "release": "3.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/p/pkgconf-1.6.3-3.fc32.x86_64.rpm",
+        "checksum": "sha256:5c91890bf33527b9fb422cbed17600e761750a4e596fad3f0d0fa419070e82b0",
+        "check_gpg": true
+      },
+      {
+        "name": "pkgconf-m4",
+        "epoch": 0,
+        "version": "1.6.3",
+        "release": "3.fc32",
+        "arch": "noarch",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/p/pkgconf-m4-1.6.3-3.fc32.noarch.rpm",
+        "checksum": "sha256:0bace0cf41921db39247c99bfccb228818b83b68c7b8be7c8c4a92ea298a9a29",
+        "check_gpg": true
+      },
+      {
+        "name": "pkgconf-pkg-config",
+        "epoch": 0,
+        "version": "1.6.3",
+        "release": "3.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/p/pkgconf-pkg-config-1.6.3-3.fc32.x86_64.rpm",
+        "checksum": "sha256:4a7b63b32f176b8861f6ac7363bc8010caea0c323eaa83167227118f05603022",
+        "check_gpg": true
+      },
+      {
+        "name": "podman",
+        "epoch": 2,
+        "version": "1.8.2",
+        "release": "2.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/p/podman-1.8.2-2.fc32.x86_64.rpm",
+        "checksum": "sha256:ccdfb24da56aa394a64cf2f0c6ac6d15d0ebd6054686bd2ab27641a5502329be",
+        "check_gpg": true
+      },
+      {
+        "name": "podman-plugins",
+        "epoch": 2,
+        "version": "1.8.2",
+        "release": "2.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/p/podman-plugins-1.8.2-2.fc32.x86_64.rpm",
+        "checksum": "sha256:536a157da5332c0bdacb3e5891e3012b79b18fcdedb63b393110d6eb8b04e428",
+        "check_gpg": true
+      },
+      {
+        "name": "policycoreutils",
+        "epoch": 0,
+        "version": "3.0",
+        "release": "2.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/p/policycoreutils-3.0-2.fc32.x86_64.rpm",
+        "checksum": "sha256:8df97dcfb42c1667b5d2e4150012eaf96f58eeac4f7b879e0928c8c36e3a7604",
+        "check_gpg": true
+      },
+      {
+        "name": "policycoreutils-python-utils",
+        "epoch": 0,
+        "version": "3.0",
+        "release": "2.fc32",
+        "arch": "noarch",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/p/policycoreutils-python-utils-3.0-2.fc32.noarch.rpm",
+        "checksum": "sha256:3cd56dea57c00e2c4a9d5aac69a1e843ebef581ba76dde9d9878082fa1215485",
+        "check_gpg": true
+      },
+      {
+        "name": "polkit",
+        "epoch": 0,
+        "version": "0.116",
+        "release": "7.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/p/polkit-0.116-7.fc32.x86_64.rpm",
+        "checksum": "sha256:d49f0b1c8ecf9bc808ae93e9298a40fbcc124fe67c3bbdd37705b6b5d8cfdd87",
+        "check_gpg": true
+      },
+      {
+        "name": "polkit-libs",
+        "epoch": 0,
+        "version": "0.116",
+        "release": "7.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/p/polkit-libs-0.116-7.fc32.x86_64.rpm",
+        "checksum": "sha256:d439ffbe20c8c0e8244e31c0324d60cf959dc1cd6cecc575d7b34509a73e9386",
+        "check_gpg": true
+      },
+      {
+        "name": "polkit-pkla-compat",
+        "epoch": 0,
+        "version": "0.1",
+        "release": "16.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/p/polkit-pkla-compat-0.1-16.fc32.x86_64.rpm",
+        "checksum": "sha256:7c7eff31251dedcc3285a8b08c1b18f7fd9ee2e07dff86ad090f45a81e19e85e",
+        "check_gpg": true
+      },
+      {
+        "name": "popt",
+        "epoch": 0,
+        "version": "1.16",
+        "release": "19.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/p/popt-1.16-19.fc32.x86_64.rpm",
+        "checksum": "sha256:8a0c00a69f9cb3a9ffacaf1cdc162c38a1faca76c9b976cb177bdc988902f2d4",
+        "check_gpg": true
+      },
+      {
+        "name": "procps-ng",
+        "epoch": 0,
+        "version": "3.3.15",
+        "release": "7.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/p/procps-ng-3.3.15-7.fc32.x86_64.rpm",
+        "checksum": "sha256:f3908831ae53f43b07a4e196850d0e59cc89b50c97d838538c3185fd0eb0d569",
+        "check_gpg": true
+      },
+      {
+        "name": "protobuf-c",
+        "epoch": 0,
+        "version": "1.3.2",
+        "release": "2.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/p/protobuf-c-1.3.2-2.fc32.x86_64.rpm",
+        "checksum": "sha256:52fe378ffab317ec4d26ae5fc0389dec874002a8d70a9413cefb68c7b16b0612",
+        "check_gpg": true
+      },
+      {
+        "name": "psmisc",
+        "epoch": 0,
+        "version": "23.3",
+        "release": "3.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/p/psmisc-23.3-3.fc32.x86_64.rpm",
+        "checksum": "sha256:be7ba234b6c48717ac0f69fb5868b3caa6ef09fbfc76c42a47b367578cd19444",
+        "check_gpg": true
+      },
+      {
+        "name": "publicsuffix-list-dafsa",
+        "epoch": 0,
+        "version": "20190417",
+        "release": "3.fc32",
+        "arch": "noarch",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/p/publicsuffix-list-dafsa-20190417-3.fc32.noarch.rpm",
+        "checksum": "sha256:af992ad02594b68f17d2da41104a26aee41d02639edf22332d7dbb1fe9af58a5",
+        "check_gpg": true
+      },
+      {
+        "name": "python-pip-wheel",
+        "epoch": 0,
+        "version": "19.3.1",
+        "release": "2.fc32",
+        "arch": "noarch",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/p/python-pip-wheel-19.3.1-2.fc32.noarch.rpm",
+        "checksum": "sha256:a7da5590635b9c19afafc7dd247604194a5ce7d8d863dc600b8cb86accb2e469",
+        "check_gpg": true
+      },
+      {
+        "name": "python-setuptools-wheel",
+        "epoch": 0,
+        "version": "41.6.0",
+        "release": "2.fc32",
+        "arch": "noarch",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/p/python-setuptools-wheel-41.6.0-2.fc32.noarch.rpm",
+        "checksum": "sha256:7dd93baaf69a8004ae2cd3b9e6660b862d0b6f399d53c05a27a48a2e276ef1ee",
+        "check_gpg": true
+      },
+      {
+        "name": "python-unversioned-command",
+        "epoch": 0,
+        "version": "3.8.2",
+        "release": "2.fc32",
+        "arch": "noarch",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/p/python-unversioned-command-3.8.2-2.fc32.noarch.rpm",
+        "checksum": "sha256:0b290954bc2868b3dfc976b2b7a13ea8aeade76eeafc17674ff8e721049a5bf7",
+        "check_gpg": true
+      },
+      {
+        "name": "python3",
+        "epoch": 0,
+        "version": "3.8.2",
+        "release": "2.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/p/python3-3.8.2-2.fc32.x86_64.rpm",
+        "checksum": "sha256:b79bb6af3e1650ba812c8affe42772ea566b164222a7d4d8e2f7efa867dc6849",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-audit",
+        "epoch": 0,
+        "version": "3.0",
+        "release": "0.19.20191104git1c2f876.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/p/python3-audit-3.0-0.19.20191104git1c2f876.fc32.x86_64.rpm",
+        "checksum": "sha256:b1111e77a5fdbacaa04acc90d3844706158bc5892173862928705620b8910adb",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-dbus",
+        "epoch": 0,
+        "version": "1.2.16",
+        "release": "1.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/p/python3-dbus-1.2.16-1.fc32.x86_64.rpm",
+        "checksum": "sha256:6aa0c6420a03f20e18842da9de611d823580efb8f6da93a94dafb48d59c2a070",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-decorator",
+        "epoch": 0,
+        "version": "4.4.0",
+        "release": "6.fc32",
+        "arch": "noarch",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/p/python3-decorator-4.4.0-6.fc32.noarch.rpm",
+        "checksum": "sha256:129adf9147d5d120546ca8e0fb5f165761106d386d366fe82591e372754d0b4a",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-firewall",
+        "epoch": 0,
+        "version": "0.8.2",
+        "release": "2.fc32",
+        "arch": "noarch",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/p/python3-firewall-0.8.2-2.fc32.noarch.rpm",
+        "checksum": "sha256:8ee8c4bbf024b998ffb77a6b4194a2306ac21c5a6fcf70c8c81a0fbf38f7c7fc",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-gobject-base",
+        "epoch": 0,
+        "version": "3.36.0",
+        "release": "2.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/p/python3-gobject-base-3.36.0-2.fc32.x86_64.rpm",
+        "checksum": "sha256:34411604a91c301dc8489285065c68f3a2f50910717097fedcaade6481c7469e",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libs",
+        "epoch": 0,
+        "version": "3.8.2",
+        "release": "2.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/p/python3-libs-3.8.2-2.fc32.x86_64.rpm",
+        "checksum": "sha256:ec58d03c60386bfb8aed2af3d2a49f8c6e5ccb4d3fd592cf75fef3342be137c3",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libselinux",
+        "epoch": 0,
+        "version": "3.0",
+        "release": "3.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/p/python3-libselinux-3.0-3.fc32.x86_64.rpm",
+        "checksum": "sha256:f77cad4c497f11c5b5bd7c9a29fc1f5f5574f8443cc4496e3bd98e680b363124",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libsemanage",
+        "epoch": 0,
+        "version": "3.0",
+        "release": "3.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/p/python3-libsemanage-3.0-3.fc32.x86_64.rpm",
+        "checksum": "sha256:55bafcdf9c31b1456af3bf584bfe7ac745a03f4decd17197ea97b498d68b3b82",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-nftables",
+        "epoch": 1,
+        "version": "0.9.3",
+        "release": "2.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/p/python3-nftables-0.9.3-2.fc32.x86_64.rpm",
+        "checksum": "sha256:0fc0193d95d69c780b6feb1cb74759ca2d4804701b3de936dac8429cfbe0f2e9",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-pip",
+        "epoch": 0,
+        "version": "19.3.1",
+        "release": "2.fc32",
+        "arch": "noarch",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/p/python3-pip-19.3.1-2.fc32.noarch.rpm",
+        "checksum": "sha256:9ade87dbb32f27e7f38ec981002ddc5a2189cc6f5ad5f24bada3b71cfa9167fd",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-policycoreutils",
+        "epoch": 0,
+        "version": "3.0",
+        "release": "2.fc32",
+        "arch": "noarch",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/p/python3-policycoreutils-3.0-2.fc32.noarch.rpm",
+        "checksum": "sha256:15f2fc89b7bd39dcd3f6f8db30f56b76b65df311d7ad9852d498fbbc5c7d2aa2",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-setools",
+        "epoch": 0,
+        "version": "4.3.0",
+        "release": "1.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/p/python3-setools-4.3.0-1.fc32.x86_64.rpm",
+        "checksum": "sha256:6f5f53b66f7c3bf6958f6f163788583265ff0360188620c3b0f7ddedeac3d1f4",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-setuptools",
+        "epoch": 0,
+        "version": "41.6.0",
+        "release": "2.fc32",
+        "arch": "noarch",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/p/python3-setuptools-41.6.0-2.fc32.noarch.rpm",
+        "checksum": "sha256:724cca9919bb7b0183b030aca216d4d51de70bf35c2cc5e8325a21a52ca15ceb",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-six",
+        "epoch": 0,
+        "version": "1.14.0",
+        "release": "2.fc32",
+        "arch": "noarch",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/p/python3-six-1.14.0-2.fc32.noarch.rpm",
+        "checksum": "sha256:02654432f3853c9ae39c7601b5b0606c9d5eb5eef1d95e3e6f0074501842941f",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-slip",
+        "epoch": 0,
+        "version": "0.6.4",
+        "release": "19.fc32",
+        "arch": "noarch",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/p/python3-slip-0.6.4-19.fc32.noarch.rpm",
+        "checksum": "sha256:d2abba1a0523bd9df5073900593ab13ec2ed2e391440be4d883314fa154370f8",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-slip-dbus",
+        "epoch": 0,
+        "version": "0.6.4",
+        "release": "19.fc32",
+        "arch": "noarch",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/p/python3-slip-dbus-0.6.4-19.fc32.noarch.rpm",
+        "checksum": "sha256:cb0c64cc81e0b384bbc9d27ffcb2a655b13c91a799aad8972264aed1767926a3",
+        "check_gpg": true
+      },
+      {
+        "name": "qrencode-libs",
+        "epoch": 0,
+        "version": "4.0.2",
+        "release": "5.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/q/qrencode-libs-4.0.2-5.fc32.x86_64.rpm",
+        "checksum": "sha256:f1150f9e17beaef09aca0f291e10db8c3ee5566fbf4c929b7672334410fa74e9",
+        "check_gpg": true
+      },
+      {
+        "name": "readline",
+        "epoch": 0,
+        "version": "8.0",
+        "release": "4.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/r/readline-8.0-4.fc32.x86_64.rpm",
+        "checksum": "sha256:f1c79039f4c6ba0fad88590c2cb55a96489449c334a671cc18c0bf424a4548b8",
+        "check_gpg": true
+      },
+      {
+        "name": "rng-tools",
+        "epoch": 0,
+        "version": "6.9",
+        "release": "3.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/r/rng-tools-6.9-3.fc32.x86_64.rpm",
+        "checksum": "sha256:4cd01a3135b9e72906eaf4552e29929334dcccee2ed092a38bf60698522ecd5f",
+        "check_gpg": true
+      },
+      {
+        "name": "rootfiles",
+        "epoch": 0,
+        "version": "8.1",
+        "release": "27.fc32",
+        "arch": "noarch",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/r/rootfiles-8.1-27.fc32.noarch.rpm",
+        "checksum": "sha256:c9f3d536c1fa73de90836147d15db06dc2025e84a44034bda6c66b9c4b60be58",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm",
+        "epoch": 0,
+        "version": "4.15.1",
+        "release": "2.fc32.1",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/r/rpm-4.15.1-2.fc32.1.x86_64.rpm",
+        "checksum": "sha256:136a9cbae9c225be60718fdc8cc8988a55235d6502e451df77d1c5c765143850",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-libs",
+        "epoch": 0,
+        "version": "4.15.1",
+        "release": "2.fc32.1",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/r/rpm-libs-4.15.1-2.fc32.1.x86_64.rpm",
+        "checksum": "sha256:54b740cf7a75a7215168970378d9a1d6b9a5e4eb81159a874ce8ea5990436641",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-ostree",
+        "epoch": 0,
+        "version": "2020.1",
+        "release": "1.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/r/rpm-ostree-2020.1-1.fc32.x86_64.rpm",
+        "checksum": "sha256:ee664c392a97cdd272f57980c6856b2c57567005fa0ad9cb16c388b645d014f1",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-ostree-libs",
+        "epoch": 0,
+        "version": "2020.1",
+        "release": "1.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/r/rpm-ostree-libs-2020.1-1.fc32.x86_64.rpm",
+        "checksum": "sha256:9d220d8ee28cd0adf28e8fef547af92c3ec66e238747165939cf8e1a413ddf83",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-plugin-selinux",
+        "epoch": 0,
+        "version": "4.15.1",
+        "release": "2.fc32.1",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/r/rpm-plugin-selinux-4.15.1-2.fc32.1.x86_64.rpm",
+        "checksum": "sha256:27dd9c78e41c04b5151a2b9ac150d3ebb89f2ca7a23e4896dfc718f19a000be3",
+        "check_gpg": true
+      },
+      {
+        "name": "rsync",
+        "epoch": 0,
+        "version": "3.1.3",
+        "release": "11.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/r/rsync-3.1.3-11.fc32.x86_64.rpm",
+        "checksum": "sha256:024dd8a75eb5472692d0291292d25939b97a0295e5ab0958dcd22600d392eaae",
+        "check_gpg": true
+      },
+      {
+        "name": "runc",
+        "epoch": 2,
+        "version": "1.0.0",
+        "release": "144.dev.gite6555cc.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/r/runc-1.0.0-144.dev.gite6555cc.fc32.x86_64.rpm",
+        "checksum": "sha256:c50ff544430830086ce484b20a2b6eaa934c82b6277a6f4fb02fc8cbc9e25db7",
+        "check_gpg": true
+      },
+      {
+        "name": "screen",
+        "epoch": 0,
+        "version": "4.8.0",
+        "release": "2.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/s/screen-4.8.0-2.fc32.x86_64.rpm",
+        "checksum": "sha256:96e0c019cb91d8deefb7664cfe417807d23562d2a1bfd2cbfd1051e243136b57",
+        "check_gpg": true
+      },
+      {
+        "name": "sed",
+        "epoch": 0,
+        "version": "4.5",
+        "release": "5.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/s/sed-4.5-5.fc32.x86_64.rpm",
+        "checksum": "sha256:ffe5076b9018efdb1612c487f637af39ab6c3c79ec37311978935cfa357ecd61",
+        "check_gpg": true
+      },
+      {
+        "name": "selinux-policy",
+        "epoch": 0,
+        "version": "3.14.5",
+        "release": "32.fc32",
+        "arch": "noarch",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/s/selinux-policy-3.14.5-32.fc32.noarch.rpm",
+        "checksum": "sha256:932a37ddd2a990a22a1ee7811d204552e8860e39a3e0c050ed618a535ae8c78c",
+        "check_gpg": true
+      },
+      {
+        "name": "selinux-policy-targeted",
+        "epoch": 0,
+        "version": "3.14.5",
+        "release": "32.fc32",
+        "arch": "noarch",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/s/selinux-policy-targeted-3.14.5-32.fc32.noarch.rpm",
+        "checksum": "sha256:684aae86de55bd42215c136777613211f596788d3b6405d8fa645fb967904354",
+        "check_gpg": true
+      },
+      {
+        "name": "setools-console",
+        "epoch": 0,
+        "version": "4.3.0",
+        "release": "1.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/s/setools-console-4.3.0-1.fc32.x86_64.rpm",
+        "checksum": "sha256:84c338b327a3fb2f6edb79caa2242804fff8c83ffa3db0d9227f55eef4107b2a",
+        "check_gpg": true
+      },
+      {
+        "name": "setup",
+        "epoch": 0,
+        "version": "2.13.6",
+        "release": "2.fc32",
+        "arch": "noarch",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/s/setup-2.13.6-2.fc32.noarch.rpm",
+        "checksum": "sha256:a336d2e77255df4783f52762e44efcc8d77b044a3e39c7f577d5535212848280",
+        "check_gpg": true
+      },
+      {
+        "name": "shadow-utils",
+        "epoch": 2,
+        "version": "4.8.1",
+        "release": "2.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/s/shadow-utils-4.8.1-2.fc32.x86_64.rpm",
+        "checksum": "sha256:4dd6100e477d88a4987b6eebfddecff168f38c7ff47cbb12f2fecba1e87c10d9",
+        "check_gpg": true
+      },
+      {
+        "name": "shared-mime-info",
+        "epoch": 0,
+        "version": "1.15",
+        "release": "3.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/s/shared-mime-info-1.15-3.fc32.x86_64.rpm",
+        "checksum": "sha256:a280c633b73517da167b91298fc97aeee2eb5fcc253c038ae0ce4b8478d3a103",
+        "check_gpg": true
+      },
+      {
+        "name": "shim-x64",
+        "epoch": 0,
+        "version": "15",
+        "release": "8",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/s/shim-x64-15-8.x86_64.rpm",
+        "checksum": "sha256:ee1681ee1ae6a3f86a876562939fbfe415ba78b0a803059e1b6d6cd63b0fa1a3",
+        "check_gpg": true
+      },
+      {
+        "name": "skopeo",
+        "epoch": 1,
+        "version": "0.1.41",
+        "release": "1.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/s/skopeo-0.1.41-1.fc32.x86_64.rpm",
+        "checksum": "sha256:f14d3b113e2c3ba3f8ab7a8146439924f38487c20dd533062616f17f500ff46b",
+        "check_gpg": true
+      },
+      {
+        "name": "slirp4netns",
+        "epoch": 0,
+        "version": "0.4.3",
+        "release": "6.0.dev.gita8414d1.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/s/slirp4netns-0.4.3-6.0.dev.gita8414d1.fc32.x86_64.rpm",
+        "checksum": "sha256:14cf772225c04c005add71372fce866e90f7144c27bbb8e846ce7887e0d286e0",
+        "check_gpg": true
+      },
+      {
+        "name": "sqlite-libs",
+        "epoch": 0,
+        "version": "3.31.1",
+        "release": "1.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/s/sqlite-libs-3.31.1-1.fc32.x86_64.rpm",
+        "checksum": "sha256:7f555c600b35ba798d8c0a63e30a1a12e917231730e1a44f48161ba0fe4b5973",
+        "check_gpg": true
+      },
+      {
+        "name": "sssd-client",
+        "epoch": 0,
+        "version": "2.2.3",
+        "release": "13.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/s/sssd-client-2.2.3-13.fc32.x86_64.rpm",
+        "checksum": "sha256:699c1a3ff311bbaa2380c085fb4f516aa08be474bed02bcd1569d0bbf5b22d07",
+        "check_gpg": true
+      },
+      {
+        "name": "sudo",
+        "epoch": 0,
+        "version": "1.9.0",
+        "release": "0.1.b4.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/s/sudo-1.9.0-0.1.b4.fc32.x86_64.rpm",
+        "checksum": "sha256:e5bf9266edf112540ec662bd492ce4bda3ed8d5e33d763b9f2318c42963a1d1b",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd",
+        "epoch": 0,
+        "version": "245.4",
+        "release": "1.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/s/systemd-245.4-1.fc32.x86_64.rpm",
+        "checksum": "sha256:1de2be4fe5280ec3097305d9e671f5f2c768267f90d255edf2075eecb0c0afe9",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-libs",
+        "epoch": 0,
+        "version": "245.4",
+        "release": "1.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/s/systemd-libs-245.4-1.fc32.x86_64.rpm",
+        "checksum": "sha256:78db9007c08fa51f177210e47343b8e733ce0751826abb357ca96429836588db",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-pam",
+        "epoch": 0,
+        "version": "245.4",
+        "release": "1.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/s/systemd-pam-245.4-1.fc32.x86_64.rpm",
+        "checksum": "sha256:750da30da0289d5e2ad9ca297dda44e5ca18dbed0c3e0d4200379bc1818c22f3",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-rpm-macros",
+        "epoch": 0,
+        "version": "245.4",
+        "release": "1.fc32",
+        "arch": "noarch",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/s/systemd-rpm-macros-245.4-1.fc32.noarch.rpm",
+        "checksum": "sha256:97197411bca68cfba1ef6bab1fdd4b41c95ec71c36f1e67f525b963cf60598fd",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-udev",
+        "epoch": 0,
+        "version": "245.4",
+        "release": "1.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/s/systemd-udev-245.4-1.fc32.x86_64.rpm",
+        "checksum": "sha256:334d63914e7ff6fe8cfce0c8f80006c6cf2ab0615cd044a6ee588809395499e5",
+        "check_gpg": true
+      },
+      {
+        "name": "tar",
+        "epoch": 2,
+        "version": "1.32",
+        "release": "4.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/t/tar-1.32-4.fc32.x86_64.rpm",
+        "checksum": "sha256:2cee64e12b295b74d2f4b008c7628ef3a01ef4149905fc4a7ae14b304da5f53b",
+        "check_gpg": true
+      },
+      {
+        "name": "tmux",
+        "epoch": 0,
+        "version": "3.0a",
+        "release": "2.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/t/tmux-3.0a-2.fc32.x86_64.rpm",
+        "checksum": "sha256:ea5f929563fb9ca0cf08da250c62c93d4755f4a41c1aca23eeeaf3e58e90d766",
+        "check_gpg": true
+      },
+      {
+        "name": "tpm2-tools",
+        "epoch": 0,
+        "version": "4.1",
+        "release": "2.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/t/tpm2-tools-4.1-2.fc32.x86_64.rpm",
+        "checksum": "sha256:8c560f3927e36e41657067e4bdc741fd8f3b55b497f0fc3c2331fb361ba8de8b",
+        "check_gpg": true
+      },
+      {
+        "name": "tpm2-tss",
+        "epoch": 0,
+        "version": "2.4.0",
+        "release": "1.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/t/tpm2-tss-2.4.0-1.fc32.x86_64.rpm",
+        "checksum": "sha256:90bc2171f438ffa7488a9c69cd86bb1de175807be468f285c8ca16cf8dd4a83c",
+        "check_gpg": true
+      },
+      {
+        "name": "traceroute",
+        "epoch": 3,
+        "version": "2.1.0",
+        "release": "10.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/t/traceroute-2.1.0-10.fc32.x86_64.rpm",
+        "checksum": "sha256:c3e2a3c23288899456fb996f3074c10637bcd4886bc446698cb1efa2734c1e4d",
+        "check_gpg": true
+      },
+      {
+        "name": "trousers",
+        "epoch": 0,
+        "version": "0.3.13",
+        "release": "13.fc31",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/t/trousers-0.3.13-13.fc31.x86_64.rpm",
+        "checksum": "sha256:5f156c2a950699d5cb9a21349cce049b3c8bfdcc4fcc780665fe2d3103f576c1",
+        "check_gpg": true
+      },
+      {
+        "name": "trousers-lib",
+        "epoch": 0,
+        "version": "0.3.13",
+        "release": "13.fc31",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/t/trousers-lib-0.3.13-13.fc31.x86_64.rpm",
+        "checksum": "sha256:cc1be420582afb6360f380ff301c5e3d873f69fe1f7e00e4450bf2daa40ef9ff",
+        "check_gpg": true
+      },
+      {
+        "name": "tss2",
+        "epoch": 0,
+        "version": "1331",
+        "release": "4.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/t/tss2-1331-4.fc32.x86_64.rpm",
+        "checksum": "sha256:6f669ae6f70cfa80917adf4ae9d5e86fbd9d31ee308a9a3408a19be3afc46f7b",
+        "check_gpg": true
+      },
+      {
+        "name": "tzdata",
+        "epoch": 0,
+        "version": "2019c",
+        "release": "3.fc32",
+        "arch": "noarch",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/t/tzdata-2019c-3.fc32.noarch.rpm",
+        "checksum": "sha256:2db6d80760ab0e99f4e9c9816615e4f06b967bbb23a8c8c941b3f2d4b5f176c2",
+        "check_gpg": true
+      },
+      {
+        "name": "util-linux",
+        "epoch": 0,
+        "version": "2.35.1",
+        "release": "7.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/u/util-linux-2.35.1-7.fc32.x86_64.rpm",
+        "checksum": "sha256:9976e6228a10fa2761f1265a2a7666578d79ca57819837e5d1fbecc53324f1b9",
+        "check_gpg": true
+      },
+      {
+        "name": "vim-minimal",
+        "epoch": 2,
+        "version": "8.2.525",
+        "release": "1.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/v/vim-minimal-8.2.525-1.fc32.x86_64.rpm",
+        "checksum": "sha256:4fca21cfdcbed052e3e9e1eff74c22fb8ffb1fbbeb63e87e2aa540e43a8c0d09",
+        "check_gpg": true
+      },
+      {
+        "name": "which",
+        "epoch": 0,
+        "version": "2.21",
+        "release": "19.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/w/which-2.21-19.fc32.x86_64.rpm",
+        "checksum": "sha256:82e0d8f1e0dccc6d18acd04b7806350343140d9c91da7a216f93167dcf650a61",
+        "check_gpg": true
+      },
+      {
+        "name": "whois-nls",
+        "epoch": 0,
+        "version": "5.5.6",
+        "release": "1.fc32",
+        "arch": "noarch",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/w/whois-nls-5.5.6-1.fc32.noarch.rpm",
+        "checksum": "sha256:d027a3ff0712e3e98d7d2358f8c526fb8d143b2386c353aadcc27199cffe125b",
+        "check_gpg": true
+      },
+      {
+        "name": "wpa_supplicant",
+        "epoch": 1,
+        "version": "2.9",
+        "release": "3.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/w/wpa_supplicant-2.9-3.fc32.x86_64.rpm",
+        "checksum": "sha256:9dcc75ac945924ce496c9280e7ac31b88886d94a6494d0710725a81dd9d42c9a",
+        "check_gpg": true
+      },
+      {
+        "name": "wpan-tools",
+        "epoch": 0,
+        "version": "0.9",
+        "release": "4.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/w/wpan-tools-0.9-4.fc32.x86_64.rpm",
+        "checksum": "sha256:d61ea8b6299f00397f740b73de146ef4daa6d6bb5863d525459765fa0f23a991",
+        "check_gpg": true
+      },
+      {
+        "name": "xkeyboard-config",
+        "epoch": 0,
+        "version": "2.29",
+        "release": "1.fc32",
+        "arch": "noarch",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/x/xkeyboard-config-2.29-1.fc32.noarch.rpm",
+        "checksum": "sha256:ec12fef82d73314e3e4cb6e962f8de27e78989fa104dde0599a4480a53817647",
+        "check_gpg": true
+      },
+      {
+        "name": "xz",
+        "epoch": 0,
+        "version": "5.2.5",
+        "release": "1.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/x/xz-5.2.5-1.fc32.x86_64.rpm",
+        "checksum": "sha256:1bdde5dc99a5588a8983f70b7b3e45e7006215d529c72adfec118c3bcbf7b01c",
+        "check_gpg": true
+      },
+      {
+        "name": "xz-libs",
+        "epoch": 0,
+        "version": "5.2.5",
+        "release": "1.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/x/xz-libs-5.2.5-1.fc32.x86_64.rpm",
+        "checksum": "sha256:84702d6395a9577c1a268184f123cfd4b15bc2287f01033625ba388a34ec2338",
+        "check_gpg": true
+      },
+      {
+        "name": "yajl",
+        "epoch": 0,
+        "version": "2.1.0",
+        "release": "14.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/y/yajl-2.1.0-14.fc32.x86_64.rpm",
+        "checksum": "sha256:9194788f87e4a1aa8835f1305d290cc2cd67cee6a5b1ab82643d3a068c0145b6",
+        "check_gpg": true
+      },
+      {
+        "name": "zchunk-libs",
+        "epoch": 0,
+        "version": "1.1.5",
+        "release": "2.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/z/zchunk-libs-1.1.5-2.fc32.x86_64.rpm",
+        "checksum": "sha256:140708561a2ec1c7709fd38d8b1b115d02da710b80eeecd65c2b8387d9d78ef9",
+        "check_gpg": true
+      },
+      {
+        "name": "zlib",
+        "epoch": 0,
+        "version": "1.2.11",
+        "release": "21.fc32",
+        "arch": "x86_64",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/z/zlib-1.2.11-21.fc32.x86_64.rpm",
+        "checksum": "sha256:c0fff40dc1092e18ed3e608bc6143c89a0d7775b9e0553319bb2caca7d324d80",
+        "check_gpg": true
+      },
+      {
+        "name": "zram",
+        "epoch": 0,
+        "version": "0.4",
+        "release": "1.fc32",
+        "arch": "noarch",
+        "remote_location": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/Packages/z/zram-0.4-1.fc32.noarch.rpm",
+        "checksum": "sha256:3f7861ea2d8b4380b567f629a86fa31951a55f46f6eee017cb84ed87baf2c19e",
+        "check_gpg": true
+      }
+    ],
+    "checksums": {
+      "0": "sha256:c7f7c29a8ca90e226d2efee6d5856f2dea1d64ea758dfd114d75b4b20b56de1c"
+    }
+  },
+  "image-info": {
+    "firewall-enabled": [
+      "ssh",
+      "mdns",
+      "dhcpv6-client"
+    ],
+    "groups": [
+      "root:x:0:",
+      "wheel:x:10:"
+    ],
+    "groups-system": [
+      "adm:x:4:",
+      "audio:x:63:",
+      "bin:x:1:",
+      "cdrom:x:11:",
+      "chrony:x:992:",
+      "clevis:x:998:",
+      "daemon:x:2:",
+      "dbus:x:81:",
+      "dialout:x:18:",
+      "disk:x:6:",
+      "dnsmasq:x:991:",
+      "floppy:x:19:",
+      "ftp:x:50:",
+      "games:x:20:",
+      "input:x:997:",
+      "kmem:x:9:",
+      "kvm:x:36:",
+      "lock:x:54:",
+      "lp:x:7:",
+      "mail:x:12:",
+      "man:x:15:",
+      "mem:x:8:",
+      "nobody:x:65534:",
+      "polkitd:x:993:",
+      "render:x:996:",
+      "screen:x:84:",
+      "ssh_keys:x:999:",
+      "sshd:x:74:",
+      "sys:x:3:",
+      "systemd-coredump:x:995:",
+      "systemd-journal:x:190:",
+      "systemd-network:x:192:",
+      "systemd-resolve:x:193:",
+      "systemd-timesync:x:994:",
+      "tape:x:33:",
+      "tss:x:59:",
+      "tty:x:5:",
+      "users:x:100:",
+      "utempter:x:35:",
+      "utmp:x:22:",
+      "video:x:39:",
+      "wheel:x:10:"
+    ],
+    "os-release": {
+      "ANSI_COLOR": "0;34",
+      "BUG_REPORT_URL": "https://bugzilla.redhat.com/",
+      "CPE_NAME": "cpe:/o:fedoraproject:fedora:32",
+      "DOCUMENTATION_URL": "https://docs.fedoraproject.org/en-US/fedora/f32/system-administrators-guide/",
+      "HOME_URL": "https://fedoraproject.org/",
+      "ID": "fedora",
+      "LOGO": "fedora-logo-icon",
+      "NAME": "Fedora",
+      "PLATFORM_ID": "platform:f32",
+      "PRETTY_NAME": "Fedora 32 (IoT Edition)",
+      "PRIVACY_POLICY_URL": "https://fedoraproject.org/wiki/Legal:PrivacyPolicy",
+      "REDHAT_BUGZILLA_PRODUCT": "Fedora",
+      "REDHAT_BUGZILLA_PRODUCT_VERSION": "32",
+      "REDHAT_SUPPORT_PRODUCT": "Fedora",
+      "REDHAT_SUPPORT_PRODUCT_VERSION": "32",
+      "SUPPORT_URL": "https://fedoraproject.org/wiki/Communicating_and_getting_help",
+      "VARIANT": "IoT Edition",
+      "VARIANT_ID": "iot",
+      "VERSION": "32 (IoT Edition)",
+      "VERSION_CODENAME": "",
+      "VERSION_ID": "32"
+    },
+    "ostree": {
+      "refs": {
+        "fedora/32/x86_64/iot": {
+          "inputhash": "f854371427eb9499107eee4e2a732884c6f4b6995dc91e58de65c2dc52a472e1"
+        }
+      },
+      "repo": {
+        "core.mode": "archive-z2"
+      }
+    },
+    "packages": [
+      "ModemManager-1.12.8-1.fc32.x86_64",
+      "ModemManager-glib-1.12.8-1.fc32.x86_64",
+      "NetworkManager-1.22.10-1.fc32.x86_64",
+      "NetworkManager-libnm-1.22.10-1.fc32.x86_64",
+      "NetworkManager-wifi-1.22.10-1.fc32.x86_64",
+      "NetworkManager-wwan-1.22.10-1.fc32.x86_64",
+      "abattis-cantarell-fonts-0.201-2.fc32.noarch",
+      "acl-2.2.53-5.fc32.x86_64",
+      "adobe-source-code-pro-fonts-2.030.1.050-8.fc32.noarch",
+      "alternatives-1.11-6.fc32.x86_64",
+      "attr-2.4.48-8.fc32.x86_64",
+      "audit-3.0-0.19.20191104git1c2f876.fc32.x86_64",
+      "audit-libs-3.0-0.19.20191104git1c2f876.fc32.x86_64",
+      "basesystem-11-9.fc32.noarch",
+      "bash-5.0.11-2.fc32.x86_64",
+      "bash-completion-2.8-8.fc32.noarch",
+      "bluez-5.54-1.fc32.x86_64",
+      "bluez-libs-5.54-1.fc32.x86_64",
+      "bluez-mesh-5.54-1.fc32.x86_64",
+      "btrfs-progs-5.6-1.fc32.x86_64",
+      "bubblewrap-0.4.1-1.fc32.x86_64",
+      "bzip2-libs-1.0.8-2.fc32.x86_64",
+      "ca-certificates-2020.2.40-3.fc32.noarch",
+      "checkpolicy-3.0-3.fc32.x86_64",
+      "chrony-3.5-8.fc32.x86_64",
+      "clevis-12-2.fc32.x86_64",
+      "clevis-dracut-12-2.fc32.x86_64",
+      "clevis-luks-12-2.fc32.x86_64",
+      "clevis-systemd-12-2.fc32.x86_64",
+      "compat-readline5-5.2-36.fc32.x86_64",
+      "conmon-2.0.14-1.fc32.x86_64",
+      "container-selinux-2.130.0-1.fc32.noarch",
+      "containernetworking-plugins-0.8.5-1.1.gitf5c3d1b.fc32.x86_64",
+      "containers-common-0.1.41-1.fc32.x86_64",
+      "coreutils-8.32-3.fc32.1.x86_64",
+      "coreutils-common-8.32-3.fc32.1.x86_64",
+      "cpio-2.13-4.fc32.x86_64",
+      "cracklib-2.9.6-22.fc32.x86_64",
+      "cracklib-dicts-2.9.6-22.fc32.x86_64",
+      "criu-3.13-5.fc32.x86_64",
+      "crun-0.13-1.fc32.x86_64",
+      "crypto-policies-20191128-5.gitcd267a5.fc32.noarch",
+      "crypto-policies-scripts-20191128-5.gitcd267a5.fc32.noarch",
+      "cryptsetup-2.3.0-1.fc32.x86_64",
+      "cryptsetup-libs-2.3.0-1.fc32.x86_64",
+      "curl-7.69.1-1.fc32.x86_64",
+      "cyrus-sasl-lib-2.1.27-4.fc32.x86_64",
+      "dbus-1.12.16-4.fc32.x86_64",
+      "dbus-broker-22-1.fc32.x86_64",
+      "dbus-common-1.12.16-4.fc32.noarch",
+      "dbus-libs-1.12.16-4.fc32.x86_64",
+      "dbxtool-8-11.fc32.x86_64",
+      "device-mapper-1.02.171-1.fc32.x86_64",
+      "device-mapper-event-1.02.171-1.fc32.x86_64",
+      "device-mapper-event-libs-1.02.171-1.fc32.x86_64",
+      "device-mapper-libs-1.02.171-1.fc32.x86_64",
+      "device-mapper-persistent-data-0.8.5-3.fc32.x86_64",
+      "diffutils-3.7-4.fc32.x86_64",
+      "dmidecode-3.2-5.fc32.x86_64",
+      "dnsmasq-2.80-14.fc32.x86_64",
+      "dosfstools-4.1-10.fc32.x86_64",
+      "dracut-050-26.git20200316.fc32.x86_64",
+      "dracut-config-generic-050-26.git20200316.fc32.x86_64",
+      "dracut-network-050-26.git20200316.fc32.x86_64",
+      "e2fsprogs-1.45.5-3.fc32.x86_64",
+      "e2fsprogs-libs-1.45.5-3.fc32.x86_64",
+      "efi-filesystem-4-4.fc32.noarch",
+      "efibootmgr-16-7.fc32.x86_64",
+      "efivar-libs-37-7.fc32.x86_64",
+      "elfutils-debuginfod-client-0.179-1.fc32.x86_64",
+      "elfutils-default-yama-scope-0.179-1.fc32.noarch",
+      "elfutils-libelf-0.179-1.fc32.x86_64",
+      "elfutils-libs-0.179-1.fc32.x86_64",
+      "expat-2.2.8-2.fc32.x86_64",
+      "fedora-gpg-keys-32-1.noarch",
+      "fedora-release-common-32-1.noarch",
+      "fedora-release-iot-32-1.noarch",
+      "fedora-repos-32-1.noarch",
+      "file-5.38-2.fc32.x86_64",
+      "file-libs-5.38-2.fc32.x86_64",
+      "filesystem-3.14-2.fc32.x86_64",
+      "findutils-4.7.0-3.fc32.x86_64",
+      "fipscheck-1.5.0-8.fc32.x86_64",
+      "fipscheck-lib-1.5.0-8.fc32.x86_64",
+      "firewalld-0.8.2-2.fc32.noarch",
+      "firewalld-filesystem-0.8.2-2.fc32.noarch",
+      "flashrom-1.2-2.fc32.x86_64",
+      "fonts-filesystem-2.0.3-1.fc32.noarch",
+      "fuse-2.9.9-9.fc32.x86_64",
+      "fuse-common-3.9.1-1.fc32.x86_64",
+      "fuse-libs-2.9.9-9.fc32.x86_64",
+      "fuse-overlayfs-0.7.8-1.fc32.x86_64",
+      "fuse3-3.9.1-1.fc32.x86_64",
+      "fuse3-libs-3.9.1-1.fc32.x86_64",
+      "fwupd-1.3.9-2.fc32.x86_64",
+      "gawk-5.0.1-7.fc32.x86_64",
+      "gdbm-libs-1.18.1-3.fc32.x86_64",
+      "gdisk-1.0.5-1.fc32.x86_64",
+      "gettext-0.20.1-4.fc32.x86_64",
+      "gettext-libs-0.20.1-4.fc32.x86_64",
+      "glib-networking-2.64.1-1.fc32.x86_64",
+      "glib2-2.64.1-1.fc32.x86_64",
+      "glibc-2.31-2.fc32.x86_64",
+      "glibc-common-2.31-2.fc32.x86_64",
+      "glibc-minimal-langpack-2.31-2.fc32.x86_64",
+      "gmp-6.1.2-13.fc32.x86_64",
+      "gnupg2-2.2.19-1.fc32.x86_64",
+      "gnupg2-smime-2.2.19-1.fc32.x86_64",
+      "gnutls-3.6.13-1.fc32.x86_64",
+      "gobject-introspection-1.64.1-1.fc32.x86_64",
+      "gpg-pubkey-12c944d0-5d5156ab",
+      "gpgme-1.13.1-6.fc32.x86_64",
+      "greenboot-0.9-1.fc32.noarch",
+      "greenboot-grub2-0.9-1.fc32.noarch",
+      "greenboot-reboot-0.9-1.fc32.noarch",
+      "greenboot-rpm-ostree-grub2-0.9-1.fc32.noarch",
+      "greenboot-status-0.9-1.fc32.noarch",
+      "grep-3.3-4.fc32.x86_64",
+      "grub2-common-2.04-12.fc32.noarch",
+      "grub2-efi-x64-2.04-12.fc32.x86_64",
+      "grub2-pc-2.04-12.fc32.x86_64",
+      "grub2-pc-modules-2.04-12.fc32.noarch",
+      "grub2-tools-2.04-12.fc32.x86_64",
+      "grub2-tools-minimal-2.04-12.fc32.x86_64",
+      "gsettings-desktop-schemas-3.36.0-1.fc32.x86_64",
+      "gzip-1.10-2.fc32.x86_64",
+      "hostname-3.23-2.fc32.x86_64",
+      "ignition-2.2.1-3.git2d3ff58.fc32.x86_64",
+      "ima-evm-utils-1.2.1-3.fc32.x86_64",
+      "initscripts-10.02-3.fc32.x86_64",
+      "iproute-5.5.0-1.fc32.x86_64",
+      "iproute-tc-5.5.0-1.fc32.x86_64",
+      "ipset-7.6-1.fc32.x86_64",
+      "ipset-libs-7.6-1.fc32.x86_64",
+      "iptables-1.8.4-7.fc32.x86_64",
+      "iptables-libs-1.8.4-7.fc32.x86_64",
+      "iptables-nft-1.8.4-7.fc32.x86_64",
+      "iputils-20190515-5.fc32.x86_64",
+      "iwd-1.6-1.fc32.x86_64",
+      "iwl100-firmware-39.31.5.1-106.fc32.noarch",
+      "iwl1000-firmware-39.31.5.1-106.fc32.noarch",
+      "iwl105-firmware-18.168.6.1-106.fc32.noarch",
+      "iwl135-firmware-18.168.6.1-106.fc32.noarch",
+      "iwl2000-firmware-18.168.6.1-106.fc32.noarch",
+      "iwl2030-firmware-18.168.6.1-106.fc32.noarch",
+      "iwl3160-firmware-25.30.13.0-106.fc32.noarch",
+      "iwl5000-firmware-8.83.5.1_1-106.fc32.noarch",
+      "iwl5150-firmware-8.24.2.2-106.fc32.noarch",
+      "iwl6000-firmware-9.221.4.1-106.fc32.noarch",
+      "iwl6050-firmware-41.28.5.1-106.fc32.noarch",
+      "iwl7260-firmware-25.30.13.0-106.fc32.noarch",
+      "jansson-2.12-5.fc32.x86_64",
+      "jitterentropy-2.2.0-2.fc32.x86_64",
+      "jose-10-6.fc32.x86_64",
+      "json-c-0.13.1-9.fc32.x86_64",
+      "json-glib-1.4.4-4.fc32.x86_64",
+      "kbd-2.2.0-1.fc32.x86_64",
+      "kbd-legacy-2.2.0-1.fc32.noarch",
+      "kbd-misc-2.2.0-1.fc32.noarch",
+      "kernel-5.6.6-300.fc32.x86_64",
+      "kernel-core-5.6.6-300.fc32.x86_64",
+      "kernel-modules-5.6.6-300.fc32.x86_64",
+      "kernel-tools-5.6.6-300.fc32.x86_64",
+      "kernel-tools-libs-5.6.6-300.fc32.x86_64",
+      "keyutils-1.6-4.fc32.x86_64",
+      "keyutils-libs-1.6-4.fc32.x86_64",
+      "kmod-27-1.fc32.x86_64",
+      "kmod-libs-27-1.fc32.x86_64",
+      "kpartx-0.8.2-3.fc32.x86_64",
+      "krb5-libs-1.18-1.fc32.x86_64",
+      "less-551-3.fc32.x86_64",
+      "libacl-2.2.53-5.fc32.x86_64",
+      "libaio-0.3.111-7.fc32.x86_64",
+      "libarchive-3.4.2-1.fc32.x86_64",
+      "libargon2-20171227-4.fc32.x86_64",
+      "libassuan-2.5.3-3.fc32.x86_64",
+      "libattr-2.4.48-8.fc32.x86_64",
+      "libblkid-2.35.1-7.fc32.x86_64",
+      "libbrotli-1.0.7-10.fc32.x86_64",
+      "libbsd-0.10.0-2.fc32.x86_64",
+      "libcap-2.26-7.fc32.x86_64",
+      "libcap-ng-0.7.10-2.fc32.x86_64",
+      "libcbor-0.5.0-7.fc32.x86_64",
+      "libcom_err-1.45.5-3.fc32.x86_64",
+      "libcroco-0.6.13-3.fc32.x86_64",
+      "libcurl-7.69.1-1.fc32.x86_64",
+      "libdb-5.3.28-40.fc32.x86_64",
+      "libdb-utils-5.3.28-40.fc32.x86_64",
+      "libedit-3.1-32.20191231cvs.fc32.x86_64",
+      "libell-0.30-1.fc32.x86_64",
+      "libevent-2.1.8-8.fc32.x86_64",
+      "libfdisk-2.35.1-7.fc32.x86_64",
+      "libffi-3.1-24.fc32.x86_64",
+      "libfido2-1.3.1-1.fc32.x86_64",
+      "libftdi-1.4-2.fc32.x86_64",
+      "libgcab1-1.4-2.fc32.x86_64",
+      "libgcc-10.0.1-0.11.fc32.x86_64",
+      "libgcrypt-1.8.5-3.fc32.x86_64",
+      "libgomp-10.0.1-0.11.fc32.x86_64",
+      "libgpg-error-1.36-3.fc32.x86_64",
+      "libgpiod-1.5.1-1.fc32.x86_64",
+      "libgpiod-utils-1.5.1-1.fc32.x86_64",
+      "libgudev-232-7.fc32.x86_64",
+      "libgusb-0.3.4-1.fc32.x86_64",
+      "libidn2-2.3.0-2.fc32.x86_64",
+      "libjose-10-6.fc32.x86_64",
+      "libkcapi-1.1.5-2.fc32.x86_64",
+      "libkcapi-hmaccalc-1.1.5-2.fc32.x86_64",
+      "libksba-1.3.5-11.fc32.x86_64",
+      "libluksmeta-9-7.fc32.x86_64",
+      "libmbim-1.22.0-1.fc32.x86_64",
+      "libmbim-utils-1.22.0-1.fc32.x86_64",
+      "libmetalink-0.1.3-10.fc32.x86_64",
+      "libmnl-1.0.4-11.fc32.x86_64",
+      "libmodman-2.0.1-21.fc32.x86_64",
+      "libmodulemd1-1.8.16-2.fc32.x86_64",
+      "libmount-2.35.1-7.fc32.x86_64",
+      "libndp-1.7-5.fc32.x86_64",
+      "libnet-1.1.6-19.fc32.x86_64",
+      "libnetfilter_conntrack-1.0.7-4.fc32.x86_64",
+      "libnfnetlink-1.0.1-17.fc32.x86_64",
+      "libnftnl-1.1.5-2.fc32.x86_64",
+      "libnghttp2-1.40.0-2.fc32.x86_64",
+      "libnl3-3.5.0-2.fc32.x86_64",
+      "libnsl2-1.2.0-6.20180605git4a062cf.fc32.x86_64",
+      "libpcap-1.9.1-3.fc32.x86_64",
+      "libpkgconf-1.6.3-3.fc32.x86_64",
+      "libproxy-0.4.15-17.fc32.x86_64",
+      "libpsl-0.21.0-4.fc32.x86_64",
+      "libpwquality-1.4.2-2.fc32.x86_64",
+      "libqmi-1.24.8-1.fc32.x86_64",
+      "libqmi-utils-1.24.8-1.fc32.x86_64",
+      "librepo-1.11.1-4.fc32.x86_64",
+      "libseccomp-2.4.2-3.fc32.x86_64",
+      "libsecret-0.20.2-2.fc32.x86_64",
+      "libselinux-3.0-3.fc32.x86_64",
+      "libselinux-utils-3.0-3.fc32.x86_64",
+      "libsemanage-3.0-3.fc32.x86_64",
+      "libsepol-3.0-3.fc32.x86_64",
+      "libsigsegv-2.11-10.fc32.x86_64",
+      "libsmartcols-2.35.1-7.fc32.x86_64",
+      "libsmbios-2.4.2-7.fc32.x86_64",
+      "libsolv-0.7.11-2.fc32.x86_64",
+      "libsoup-2.70.0-1.fc32.x86_64",
+      "libss-1.45.5-3.fc32.x86_64",
+      "libssh-0.9.3-2.fc32.x86_64",
+      "libssh-config-0.9.3-2.fc32.noarch",
+      "libsss_idmap-2.2.3-13.fc32.x86_64",
+      "libsss_nss_idmap-2.2.3-13.fc32.x86_64",
+      "libsss_sudo-2.2.3-13.fc32.x86_64",
+      "libstdc++-10.0.1-0.11.fc32.x86_64",
+      "libsysfs-2.1.0-28.fc32.x86_64",
+      "libtasn1-4.16.0-1.fc32.x86_64",
+      "libtextstyle-0.20.1-4.fc32.x86_64",
+      "libtirpc-1.2.5-1.rc2.fc32.x86_64",
+      "libunistring-0.9.10-7.fc32.x86_64",
+      "libusbx-1.0.23-1.fc32.x86_64",
+      "libuser-0.62-24.fc32.x86_64",
+      "libutempter-1.1.6-18.fc32.x86_64",
+      "libuuid-2.35.1-7.fc32.x86_64",
+      "libvarlink-util-18-3.fc32.x86_64",
+      "libverto-0.3.0-9.fc32.x86_64",
+      "libxcrypt-4.4.16-1.fc32.x86_64",
+      "libxcrypt-compat-4.4.16-1.fc32.x86_64",
+      "libxkbcommon-0.10.0-2.fc32.x86_64",
+      "libxml2-2.9.10-3.fc32.x86_64",
+      "libxmlb-0.1.14-2.fc32.x86_64",
+      "libyaml-0.2.2-3.fc32.x86_64",
+      "libzstd-1.4.4-2.fc32.x86_64",
+      "linux-atm-libs-2.5.1-26.fc32.x86_64",
+      "linux-firmware-20200316-106.fc32.noarch",
+      "linux-firmware-whence-20200316-106.fc32.noarch",
+      "lua-libs-5.3.5-7.fc32.x86_64",
+      "luksmeta-9-7.fc32.x86_64",
+      "lvm2-2.03.09-1.fc32.x86_64",
+      "lvm2-libs-2.03.09-1.fc32.x86_64",
+      "lz4-libs-1.9.1-2.fc32.x86_64",
+      "lzo-2.10-2.fc32.x86_64",
+      "microcode_ctl-2.1-35.fc32.x86_64",
+      "mkpasswd-5.5.6-1.fc32.x86_64",
+      "mokutil-0.3.0-15.fc32.x86_64",
+      "mozjs60-60.9.0-5.fc32.x86_64",
+      "mpfr-4.0.2-3.fc32.x86_64",
+      "ncurses-6.1-15.20191109.fc32.x86_64",
+      "ncurses-base-6.1-15.20191109.fc32.noarch",
+      "ncurses-libs-6.1-15.20191109.fc32.x86_64",
+      "nettle-3.5.1-5.fc32.x86_64",
+      "nftables-0.9.3-2.fc32.x86_64",
+      "nmap-ncat-7.80-3.fc32.x86_64",
+      "npth-1.6-4.fc32.x86_64",
+      "nss-altfiles-2.18.1-16.fc32.x86_64",
+      "openldap-2.4.47-4.fc32.x86_64",
+      "openssh-8.2p1-2.fc32.x86_64",
+      "openssh-clients-8.2p1-2.fc32.x86_64",
+      "openssh-server-8.2p1-2.fc32.x86_64",
+      "openssl-1.1.1d-7.fc32.x86_64",
+      "openssl-libs-1.1.1d-7.fc32.x86_64",
+      "openssl-pkcs11-0.4.10-5.fc32.x86_64",
+      "os-prober-1.77-4.fc32.x86_64",
+      "ostree-2020.3-2.fc32.x86_64",
+      "ostree-libs-2020.3-2.fc32.x86_64",
+      "p11-kit-0.23.20-1.fc32.x86_64",
+      "p11-kit-trust-0.23.20-1.fc32.x86_64",
+      "pam-1.3.1-24.fc32.x86_64",
+      "passwd-0.80-8.fc32.x86_64",
+      "pciutils-libs-3.6.4-1.fc32.x86_64",
+      "pcre-8.44-1.fc32.x86_64",
+      "pcre2-10.34-9.fc32.x86_64",
+      "pcre2-syntax-10.34-9.fc32.noarch",
+      "pigz-2.4-6.fc32.x86_64",
+      "pinentry-1.1.0-7.fc32.x86_64",
+      "pkgconf-1.6.3-3.fc32.x86_64",
+      "pkgconf-m4-1.6.3-3.fc32.noarch",
+      "pkgconf-pkg-config-1.6.3-3.fc32.x86_64",
+      "podman-1.8.2-2.fc32.x86_64",
+      "podman-plugins-1.8.2-2.fc32.x86_64",
+      "policycoreutils-3.0-2.fc32.x86_64",
+      "policycoreutils-python-utils-3.0-2.fc32.noarch",
+      "polkit-0.116-7.fc32.x86_64",
+      "polkit-libs-0.116-7.fc32.x86_64",
+      "polkit-pkla-compat-0.1-16.fc32.x86_64",
+      "popt-1.16-19.fc32.x86_64",
+      "procps-ng-3.3.15-7.fc32.x86_64",
+      "protobuf-c-1.3.2-2.fc32.x86_64",
+      "psmisc-23.3-3.fc32.x86_64",
+      "publicsuffix-list-dafsa-20190417-3.fc32.noarch",
+      "python-pip-wheel-19.3.1-2.fc32.noarch",
+      "python-setuptools-wheel-41.6.0-2.fc32.noarch",
+      "python-unversioned-command-3.8.2-2.fc32.noarch",
+      "python3-3.8.2-2.fc32.x86_64",
+      "python3-audit-3.0-0.19.20191104git1c2f876.fc32.x86_64",
+      "python3-dbus-1.2.16-1.fc32.x86_64",
+      "python3-decorator-4.4.0-6.fc32.noarch",
+      "python3-firewall-0.8.2-2.fc32.noarch",
+      "python3-gobject-base-3.36.0-2.fc32.x86_64",
+      "python3-libs-3.8.2-2.fc32.x86_64",
+      "python3-libselinux-3.0-3.fc32.x86_64",
+      "python3-libsemanage-3.0-3.fc32.x86_64",
+      "python3-nftables-0.9.3-2.fc32.x86_64",
+      "python3-pip-19.3.1-2.fc32.noarch",
+      "python3-policycoreutils-3.0-2.fc32.noarch",
+      "python3-setools-4.3.0-1.fc32.x86_64",
+      "python3-setuptools-41.6.0-2.fc32.noarch",
+      "python3-six-1.14.0-2.fc32.noarch",
+      "python3-slip-0.6.4-19.fc32.noarch",
+      "python3-slip-dbus-0.6.4-19.fc32.noarch",
+      "qrencode-libs-4.0.2-5.fc32.x86_64",
+      "readline-8.0-4.fc32.x86_64",
+      "rng-tools-6.9-3.fc32.x86_64",
+      "rootfiles-8.1-27.fc32.noarch",
+      "rpm-4.15.1-2.fc32.1.x86_64",
+      "rpm-libs-4.15.1-2.fc32.1.x86_64",
+      "rpm-ostree-2020.1-1.fc32.x86_64",
+      "rpm-ostree-libs-2020.1-1.fc32.x86_64",
+      "rpm-plugin-selinux-4.15.1-2.fc32.1.x86_64",
+      "rsync-3.1.3-11.fc32.x86_64",
+      "runc-1.0.0-144.dev.gite6555cc.fc32.x86_64",
+      "screen-4.8.0-2.fc32.x86_64",
+      "sed-4.5-5.fc32.x86_64",
+      "selinux-policy-3.14.5-32.fc32.noarch",
+      "selinux-policy-targeted-3.14.5-32.fc32.noarch",
+      "setools-console-4.3.0-1.fc32.x86_64",
+      "setup-2.13.6-2.fc32.noarch",
+      "shadow-utils-4.8.1-2.fc32.x86_64",
+      "shared-mime-info-1.15-3.fc32.x86_64",
+      "shim-x64-15-8.x86_64",
+      "skopeo-0.1.41-1.fc32.x86_64",
+      "slirp4netns-0.4.3-6.0.dev.gita8414d1.fc32.x86_64",
+      "sqlite-libs-3.31.1-1.fc32.x86_64",
+      "sssd-client-2.2.3-13.fc32.x86_64",
+      "sudo-1.9.0-0.1.b4.fc32.x86_64",
+      "systemd-245.4-1.fc32.x86_64",
+      "systemd-libs-245.4-1.fc32.x86_64",
+      "systemd-pam-245.4-1.fc32.x86_64",
+      "systemd-rpm-macros-245.4-1.fc32.noarch",
+      "systemd-udev-245.4-1.fc32.x86_64",
+      "tar-1.32-4.fc32.x86_64",
+      "tmux-3.0a-2.fc32.x86_64",
+      "tpm2-tools-4.1-2.fc32.x86_64",
+      "tpm2-tss-2.4.0-1.fc32.x86_64",
+      "traceroute-2.1.0-10.fc32.x86_64",
+      "trousers-0.3.13-13.fc31.x86_64",
+      "trousers-lib-0.3.13-13.fc31.x86_64",
+      "tss2-1331-4.fc32.x86_64",
+      "tzdata-2019c-3.fc32.noarch",
+      "util-linux-2.35.1-7.fc32.x86_64",
+      "vim-minimal-8.2.525-1.fc32.x86_64",
+      "which-2.21-19.fc32.x86_64",
+      "whois-nls-5.5.6-1.fc32.noarch",
+      "wpa_supplicant-2.9-3.fc32.x86_64",
+      "wpan-tools-0.9-4.fc32.x86_64",
+      "xkeyboard-config-2.29-1.fc32.noarch",
+      "xz-5.2.5-1.fc32.x86_64",
+      "xz-libs-5.2.5-1.fc32.x86_64",
+      "yajl-2.1.0-14.fc32.x86_64",
+      "zchunk-libs-1.1.5-2.fc32.x86_64",
+      "zlib-1.2.11-21.fc32.x86_64",
+      "zram-0.4-1.fc32.noarch"
+    ],
+    "passwd": [
+      "root:x:0:0:root:/root:/bin/bash"
+    ],
+    "passwd-system": [
+      "adm:x:3:4:adm:/var/adm:/sbin/nologin",
+      "bin:x:1:1:bin:/bin:/sbin/nologin",
+      "chrony:x:995:992::/var/lib/chrony:/sbin/nologin",
+      "clevis:x:999:998:Clevis Decryption Framework unprivileged user:/var/cache/clevis:/sbin/nologin",
+      "daemon:x:2:2:daemon:/sbin:/sbin/nologin",
+      "dbus:x:81:81:System message bus:/:/sbin/nologin",
+      "dnsmasq:x:991:991:Dnsmasq DHCP and DNS server:/var/lib/dnsmasq:/usr/sbin/nologin",
+      "ftp:x:14:50:FTP User:/var/ftp:/sbin/nologin",
+      "games:x:12:100:games:/usr/games:/sbin/nologin",
+      "halt:x:7:0:halt:/sbin:/sbin/halt",
+      "lp:x:4:7:lp:/var/spool/lpd:/sbin/nologin",
+      "mail:x:8:12:mail:/var/spool/mail:/sbin/nologin",
+      "nobody:x:65534:65534:Kernel Overflow User:/:/sbin/nologin",
+      "operator:x:11:0:operator:/root:/sbin/nologin",
+      "polkitd:x:996:993:User for polkitd:/:/sbin/nologin",
+      "shutdown:x:6:0:shutdown:/sbin:/sbin/shutdown",
+      "sshd:x:74:74:Privilege-separated SSH:/var/empty/sshd:/sbin/nologin",
+      "sync:x:5:0:sync:/sbin:/bin/sync",
+      "systemd-coredump:x:998:995:systemd Core Dumper:/:/sbin/nologin",
+      "systemd-network:x:192:192:systemd Network Management:/:/sbin/nologin",
+      "systemd-resolve:x:193:193:systemd Resolver:/:/sbin/nologin",
+      "systemd-timesync:x:997:994:systemd Time Synchronization:/:/sbin/nologin",
+      "tss:x:59:59:Account used by the trousers package to sandbox the tcsd daemon:/dev/null:/sbin/nologin"
+    ],
+    "services-disabled": [
+      "blk-availability.service",
+      "bluetooth-mesh.service",
+      "chrony-dnssrv@.timer",
+      "chrony-wait.service",
+      "clevis-luks-askpass.path",
+      "console-getty.service",
+      "cpupower.service",
+      "debug-shell.service",
+      "dnsmasq.service",
+      "ead.service",
+      "exit.target",
+      "fwupd-refresh.timer",
+      "greenboot.target",
+      "halt.target",
+      "ignition-firstboot-complete.service",
+      "io.podman.service",
+      "io.podman.socket",
+      "iwd.service",
+      "kexec.target",
+      "loadmodules.service",
+      "nftables.service",
+      "nis-domainname.service",
+      "ostree-finalize-staged.path",
+      "podman.service",
+      "podman.socket",
+      "poweroff.target",
+      "proc-sys-fs-binfmt_misc.mount",
+      "rdisc.service",
+      "remote-cryptsetup.target",
+      "rpm-ostree-bootstatus.service",
+      "rpm-ostreed-automatic.timer",
+      "runlevel0.target",
+      "serial-getty@.service",
+      "sshd-keygen@.service",
+      "sshd.socket",
+      "systemd-boot-check-no-failures.service",
+      "systemd-network-generator.service",
+      "systemd-networkd-wait-online.service",
+      "systemd-networkd.service",
+      "systemd-networkd.socket",
+      "systemd-pstore.service",
+      "systemd-resolved.service",
+      "systemd-time-wait-sync.service",
+      "systemd-timesyncd.service",
+      "tcsd.service",
+      "wpa_supplicant.service"
+    ],
+    "services-enabled": [
+      "ModemManager.service",
+      "NetworkManager-dispatcher.service",
+      "NetworkManager-wait-online.service",
+      "NetworkManager.service",
+      "auditd.service",
+      "autovt@.service",
+      "bluetooth.service",
+      "chronyd.service",
+      "ctrl-alt-del.target",
+      "dbus-broker.service",
+      "dbus-org.bluez.service",
+      "dbus-org.fedoraproject.FirewallD1.service",
+      "dbus-org.freedesktop.ModemManager1.service",
+      "dbus-org.freedesktop.nm-dispatcher.service",
+      "dbus.service",
+      "dbus.socket",
+      "dbxtool.service",
+      "dm-event.socket",
+      "firewalld.service",
+      "fstrim.timer",
+      "getty@.service",
+      "greenboot-grub2-set-counter.service",
+      "greenboot-grub2-set-success.service",
+      "greenboot-healthcheck.service",
+      "greenboot-rpm-ostree-grub2-check-fallback.service",
+      "greenboot-status.service",
+      "greenboot.service",
+      "import-state.service",
+      "lvm2-lvmpolld.socket",
+      "lvm2-monitor.service",
+      "ostree-remount.service",
+      "reboot.target",
+      "redboot-auto-reboot.service",
+      "redboot.service",
+      "remote-fs.target",
+      "rngd.service",
+      "runlevel6.target",
+      "selinux-autorelabel-mark.service",
+      "sshd.service",
+      "zram-swap.service"
+    ],
+    "type": "ostree/commit"
+  }
+}

--- a/test/cases/rhel_8-x86_64-rhel_edge_commit-boot.json
+++ b/test/cases/rhel_8-x86_64-rhel_edge_commit-boot.json
@@ -3131,36 +3131,6 @@
           "options": {}
         },
         {
-          "name": "org.osbuild.fstab",
-          "options": {
-            "filesystems": [
-              {
-                "label": "root",
-                "vfs_type": "ext4",
-                "path": "/",
-                "options": "defaults",
-                "freq": 1,
-                "passno": 1
-              },
-              {
-                "label": "boot",
-                "vfs_type": "ext4",
-                "path": "/boot",
-                "options": "defaults",
-                "freq": 1,
-                "passno": 1
-              },
-              {
-                "label": "EFI-SYSTEM",
-                "vfs_type": "vfat",
-                "path": "/boot/efi",
-                "options": "umask=0077,shortname=winnt",
-                "passno": 2
-              }
-            ]
-          }
-        },
-        {
           "name": "org.osbuild.locale",
           "options": {
             "language": "en_US"
@@ -8791,32 +8761,6 @@
       "dhcpv6-client",
       "cockpit"
     ],
-    "fstab": [
-      [
-        "LABEL=EFI-SYSTEM",
-        "/boot/efi",
-        "vfat",
-        "umask=0077,shortname=winnt",
-        "0",
-        "2"
-      ],
-      [
-        "LABEL=boot",
-        "/boot",
-        "ext4",
-        "defaults",
-        "1",
-        "1"
-      ],
-      [
-        "LABEL=root",
-        "/",
-        "ext4",
-        "defaults",
-        "1",
-        "1"
-      ]
-    ],
     "groups": [
       "root:x:0:",
       "wheel:x:10:"
@@ -8884,7 +8828,7 @@
     "ostree": {
       "refs": {
         "rhel/8/x86_64/edge": {
-          "inputhash": "b458ad7246fbf8126d2ff81bf3ec24d70b1c573d26e178da5545bc3d27c7c193"
+          "inputhash": "4a6ade151f1a98ff6304ebb8c7df8de307fea23ad415bfc34b9e268b70f760fc"
         }
       },
       "repo": {


### PR DESCRIPTION
How exactly the final file system layout looks like is determined by the installer (anaconda) and thus can not be known at commit creation time. Thus creating an `/etc/fstab` file is unnecessary and the information in it probably wrong. The file wont be used though because it will be overwritten during the installation process.