### PR TITLE
Use minimal images for mock build

### DIFF
--- a/schutzbot/Jenkinsfile
+++ b/schutzbot/Jenkinsfile
@@ -4,18 +4,6 @@ pipeline {
     environment {
         AWS_REGION = "us-east-2"
         AWS_BUCKET = "imagebuilder-jenkins-testing-use2"
-        // Colorful Ansible always looks nicer.
-        ANSIBLE_FORCE_COLOR="True"
-        // Time each task and display stdout as YAML (easier to read).
-        ANSIBLE_LOAD_CALLBACK_PLUGINS="True"
-        ANSIBLE_CALLBACK_WHITELIST="profile_tasks"
-        ANSIBLE_STDOUT_CALLBACK="yaml"
-        // Don't display those ugly purple deprecation warnings.
-        ANSIBLE_DEPRECATION_WARNINGS="False"
-        // Our host keys are constantly changing.
-        ANSIBLE_HOST_KEY_CHECKING="False"
-        // Enable ssh pipelining for faster deployments to remote nodes.
-        ANSIBLE_PIPELINING="True"
     }
 
     options {
@@ -36,7 +24,7 @@ pipeline {
 
             parallel {
                 stage('Fedora 31') {
-                    agent { label "fedora31" }
+                    agent { label "f31 && minimal" }
                     environment {
                         AWS_CREDS = credentials('aws-credentials-osbuildci')
                     }
@@ -50,7 +38,7 @@ pipeline {
                     }
                 }
                 stage('Fedora 32') {
-                    agent { label "fedora32" }
+                    agent { label "f32 && minimal" }
                     environment {
                         AWS_CREDS = credentials('aws-credentials-osbuildci')
                     }
@@ -64,7 +52,7 @@ pipeline {
                     }
                 }
                 stage('RHEL 8 CDN') {
-                    agent { label "rhel8" }
+                    agent { label "rhel8cdn && minimal" }
                     environment {
                         AWS_CREDS = credentials('aws-credentials-osbuildci')
                     }
@@ -79,7 +67,7 @@ pipeline {
                 }
                 // NOTE(mhayden): RHEL 8.3 is only available in PSI for now.
                 stage('RHEL 8.3 Nightly') {
-                    agent { label "rhel83 && psi" }
+                    agent { label "rhel83nightly && minimal" }
                     environment {
                         AWS_CREDS = credentials('aws-credentials-osbuildci')
                     }

--- a/schutzbot/mockbuild.sh
+++ b/schutzbot/mockbuild.sh
@@ -9,11 +9,22 @@ function greenprint {
 # Get OS details.
 source /etc/os-release
 
-# Install s3cmd if it is not present.
-if ! s3cmd --version; then
-    greenprint "📦 Installing s3cmd"
-    sudo pip3 install s3cmd
+# Install EPEL for RHEL so we can get mock.
+if [[ $ID == rhel ]]; then
+    greenprint "📦 Installing EPEL for RHEL"
+    sudo curl -Ls --retry 5 --output /tmp/epel.rpm \
+        https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
+    sudo rpm -Uvh /tmp/epel.rpm
+    sudo dnf makecache
 fi
+
+# Install packages.
+greenprint "📦 Installing packages for mock build"
+sudo dnf -qy install createrepo_c make mock rpm-build
+
+# Install s3cmd if it is not present.
+greenprint "📦 Installing s3cmd"
+sudo pip3 -qq install s3cmd
 
 # Jenkins sets a workspace variable as the root of its working directory.
 WORKSPACE=${WORKSPACE:-$(pwd)}


### PR DESCRIPTION
Now that we have CI images built by osbuild-composer, let's use them!

Signed-off-by: Major Hayden <major@redhat.com>