### PR TITLE
Shutzbot: install only osbuild-composer-tests

### DIFF
--- a/osbuild-composer.spec
+++ b/osbuild-composer.spec
@@ -237,6 +237,7 @@ systemctl stop "osbuild-worker@*.service" "osbuild-remote-worker@*.service"
 %package tests
 Summary:    Integration tests
 Requires:   %{name} = %{version}-%{release}
+Requires:   %{name}-rcm = %{version}-%{release}
 Requires:   composer-cli
 Requires:   createrepo_c
 Requires:   genisoimage

--- a/schutzbot/deploy.sh
+++ b/schutzbot/deploy.sh
@@ -32,9 +32,8 @@ sudo cp osbuild-mock.repo /etc/yum.repos.d/osbuild-mock.repo
 sudo dnf repository-packages osbuild-mock list
 
 # Install the Image Builder packages.
-retry sudo dnf -y install composer-cli osbuild osbuild-ostree \
-    osbuild-composer osbuild-composer-rcm osbuild-composer-tests \
-    osbuild-composer-worker python3-osbuild
+# Note: installing only -tests to catch missing dependencies
+retry sudo dnf -y install osbuild-composer-tests
 
 # Copy the internal repositories into place when needed.
 if curl -fs http://download.devel.redhat.com > /dev/null; then


### PR DESCRIPTION
in order to catch missing dependencies

Note: I saw this as a comment somewhere in the recent pull requests.

Note2: not sure if related to the `execv()` error I'm seeing internally, more precisely why it doesn't happen in Schutzbot.