### PR TITLE
dnf-json: change confusing error message associated with dnf errors

### DIFF
--- a/dnf-json
+++ b/dnf-json
@@ -107,7 +107,7 @@ with tempfile.TemporaryDirectory() as persistdir:
     try:
         base = create_base(repos, module_platform_id, persistdir, cachedir, arch)
     except dnf.exceptions.Error as e:
-        exit_with_dnf_error("RepoError", f"Error occurred when setting up repo: {e}")
+        exit_with_dnf_error(type(e).__name__, f"Error occurred when setting up repo: {e}")
 
     if command == "dump":
         packages = []


### PR DESCRIPTION
The issue was introduced in 0d3c8329c069dbb8856c6d2fc15ff42a7ff517ea.
The patch correctly changed the base exception class, but it didn't
change the unfortunate use of hardcoded type name. This patch uses
Python's internal `__name__` attribute to get the type (exception) name.