### PR TITLE
Worker API improvements

### DIFF
--- a/cmd/osbuild-worker/main.go
+++ b/cmd/osbuild-worker/main.go
@@ -234,18 +234,14 @@ func main() {
 		ctx, cancel := context.WithCancel(context.Background())
 		go WatchJob(ctx, client, job)
 
-		var status common.ImageBuildState
 		result, err := RunJob(job, store, client.UploadImage)
 		if err != nil {
 			log.Printf("  Job failed: %v", err)
-			status = common.IBFailed
 
 			// If the error comes from osbuild, retrieve the result
 			if osbuildError, ok := err.(*OSBuildError); ok {
 				result = &worker.OSBuildJobResult{OSBuildOutput: osbuildError.Result}
 			}
-		} else {
-			status = common.IBFinished
 		}
 
 		// signal to WatchJob() that it can stop watching
@@ -262,7 +258,7 @@ func main() {
 			}
 		}
 
-		err = client.UpdateJob(job, status, result)
+		err = client.UpdateJob(job, result)
 		if err != nil {
 			log.Fatalf("Error reporting job result: %v", err)
 		}

--- a/cmd/osbuild-worker/main.go
+++ b/cmd/osbuild-worker/main.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/tls"
 	"crypto/x509"
+	"encoding/json"
 	"errors"
 	"flag"
 	"fmt"
@@ -225,8 +226,13 @@ func main() {
 		go WatchJob(ctx, client, job)
 
 		result := RunJob(job, store, client.UploadImage)
-		// TODO: print at least something here in case of failure
-		// log.Printf("  Job failed: %v", err)
+		if !result.Successful() {
+			resultJson, err := json.MarshalIndent(result, "", "  ")
+			if err != nil {
+				panic(err)
+			}
+			log.Printf("Job failed, dumping the whole result:\n%s", string(resultJson))
+		}
 
 		// signal to WatchJob() that it can stop watching
 		cancel()

--- a/internal/worker/client.go
+++ b/internal/worker/client.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/google/uuid"
 
-	"github.com/osbuild/osbuild-composer/internal/common"
 	"github.com/osbuild/osbuild-composer/internal/distro"
 	"github.com/osbuild/osbuild-composer/internal/target"
 )
@@ -111,9 +110,9 @@ func (c *Client) JobCanceled(job *Job) bool {
 	return jr.Canceled
 }
 
-func (c *Client) UpdateJob(job *Job, status common.ImageBuildState, result *OSBuildJobResult) error {
+func (c *Client) UpdateJob(job *Job, result *OSBuildJobResult) error {
 	var b bytes.Buffer
-	err := json.NewEncoder(&b).Encode(&updateJobRequest{status, result})
+	err := json.NewEncoder(&b).Encode(&updateJobRequest{result})
 	if err != nil {
 		panic(err)
 	}

--- a/internal/worker/client.go
+++ b/internal/worker/client.go
@@ -111,7 +111,7 @@ func (c *Client) JobCanceled(job *Job) bool {
 	return jr.Canceled
 }
 
-func (c *Client) UpdateJob(job *Job, status common.ImageBuildState, result *common.ComposeResult) error {
+func (c *Client) UpdateJob(job *Job, status common.ImageBuildState, result *OSBuildJobResult) error {
 	var b bytes.Buffer
 	err := json.NewEncoder(&b).Encode(&updateJobRequest{status, result})
 	if err != nil {

--- a/internal/worker/json.go
+++ b/internal/worker/json.go
@@ -48,8 +48,7 @@ type jobResponse struct {
 }
 
 type updateJobRequest struct {
-	Status common.ImageBuildState `json:"status"`
-	Result *OSBuildJobResult      `json:"result"`
+	Result *OSBuildJobResult `json:"result"`
 }
 
 type updateJobResponse struct {

--- a/internal/worker/json.go
+++ b/internal/worker/json.go
@@ -1,6 +1,8 @@
 package worker
 
 import (
+	"fmt"
+
 	"github.com/google/uuid"
 
 	"github.com/osbuild/osbuild-composer/internal/common"
@@ -24,6 +26,10 @@ type TargetError struct {
 
 func (e *TargetError) Error() string {
 	return e.Message
+}
+
+func NewTargetError(format string, a ...interface{}) *TargetError {
+	return &TargetError{fmt.Sprintf(format, a...)}
 }
 
 type TargetResult struct {

--- a/internal/worker/json.go
+++ b/internal/worker/json.go
@@ -17,8 +17,23 @@ type OSBuildJob struct {
 	Targets  []*target.Target `json:"targets,omitempty"`
 }
 
+// must be serializable!
+type TargetError struct {
+	Message string `json:"err"`
+}
+
+func (e *TargetError) Error() string {
+	return e.Message
+}
+
+type TargetResult struct {
+	Target target.Target `json:"target"`
+	Error  *TargetError  `json:"error,omitempty"`
+}
+
 type OSBuildJobResult struct {
 	OSBuildOutput *common.ComposeResult `json:"osbuild_output,omitempty"`
+	Targets       []TargetResult        `json:"targets,omitempty"`
 	GenericError  string                `json:"generic_error,omitempty"`
 }
 

--- a/internal/worker/json.go
+++ b/internal/worker/json.go
@@ -43,6 +43,20 @@ type OSBuildJobResult struct {
 	GenericError  string                `json:"generic_error,omitempty"`
 }
 
+func (r *OSBuildJobResult) Successful() bool {
+	if r.OSBuildOutput != nil && !r.OSBuildOutput.Success {
+		return false
+	}
+
+	for _, t := range r.Targets {
+		if t.Error != nil {
+			return false
+		}
+	}
+
+	return r.GenericError == ""
+}
+
 //
 // JSON-serializable types for the HTTP API
 //

--- a/internal/worker/json.go
+++ b/internal/worker/json.go
@@ -19,6 +19,7 @@ type OSBuildJob struct {
 
 type OSBuildJobResult struct {
 	OSBuildOutput *common.ComposeResult `json:"osbuild_output,omitempty"`
+	GenericError  string                `json:"generic_error,omitempty"`
 }
 
 //

--- a/internal/worker/json.go
+++ b/internal/worker/json.go
@@ -49,7 +49,7 @@ type jobResponse struct {
 
 type updateJobRequest struct {
 	Status common.ImageBuildState `json:"status"`
-	Result *common.ComposeResult  `json:"result"`
+	Result *OSBuildJobResult      `json:"result"`
 }
 
 type updateJobResponse struct {

--- a/internal/worker/json_test.go
+++ b/internal/worker/json_test.go
@@ -1,0 +1,69 @@
+package worker
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/osbuild/osbuild-composer/internal/common"
+)
+
+func TestOSBuildJobResultSuccessful(t *testing.T) {
+	type fields struct {
+		OSBuildOutput *common.ComposeResult
+		Targets       []TargetResult
+		GenericError  string
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   bool
+	}{
+		{
+			name: "unsuccessful osbuild",
+			fields: struct {
+				OSBuildOutput *common.ComposeResult
+				Targets       []TargetResult
+				GenericError  string
+			}{OSBuildOutput: &common.ComposeResult{Success: false}},
+			want: false,
+		},
+		{
+			name: "unsuccessful target",
+			fields: struct {
+				OSBuildOutput *common.ComposeResult
+				Targets       []TargetResult
+				GenericError  string
+			}{OSBuildOutput: &common.ComposeResult{Success: true}, Targets: []TargetResult{{Error: NewTargetError("test")}}},
+			want: false,
+		},
+		{
+			name: "non-empty generic error",
+			fields: struct {
+				OSBuildOutput *common.ComposeResult
+				Targets       []TargetResult
+				GenericError  string
+			}{OSBuildOutput: &common.ComposeResult{Success: true}, GenericError: "test"},
+			want: false,
+		},
+		{
+			name: "successful",
+			fields: struct {
+				OSBuildOutput *common.ComposeResult
+				Targets       []TargetResult
+				GenericError  string
+			}{OSBuildOutput: &common.ComposeResult{Success: true}},
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &OSBuildJobResult{
+				OSBuildOutput: tt.fields.OSBuildOutput,
+				Targets:       tt.fields.Targets,
+				GenericError:  tt.fields.GenericError,
+			}
+			require.Equal(t, tt.want, r.Successful())
+		})
+	}
+}

--- a/internal/worker/server.go
+++ b/internal/worker/server.go
@@ -276,7 +276,7 @@ func (s *Server) updateJobHandler(writer http.ResponseWriter, request *http.Requ
 		return
 	}
 
-	err = s.jobs.FinishJob(id, OSBuildJobResult{OSBuildOutput: body.Result})
+	err = s.jobs.FinishJob(id, body.Result)
 	if err != nil {
 		switch err {
 		case jobqueue.ErrNotExist:

--- a/internal/worker/server.go
+++ b/internal/worker/server.go
@@ -103,7 +103,7 @@ func (s *Server) JobStatus(id uuid.UUID) (*JobStatus, error) {
 	if canceled {
 		state = common.CFailed
 	} else if !finished.IsZero() {
-		if result.OSBuildOutput != nil && result.OSBuildOutput.Success {
+		if result.Successful() {
 			state = common.CFinished
 		} else {
 			state = common.CFailed

--- a/internal/worker/server.go
+++ b/internal/worker/server.go
@@ -268,14 +268,6 @@ func (s *Server) updateJobHandler(writer http.ResponseWriter, request *http.Requ
 		return
 	}
 
-	// The jobqueue doesn't support setting the status before a job is
-	// finished. This branch should never be hit, because the worker
-	// doesn't attempt this. Change the API to remove this awkwardness.
-	if body.Status != common.IBFinished && body.Status != common.IBFailed {
-		jsonErrorf(writer, http.StatusBadRequest, "setting status of a job to waiting or running is not supported")
-		return
-	}
-
 	err = s.jobs.FinishJob(id, body.Result)
 	if err != nil {
 		switch err {


### PR DESCRIPTION
The main intent of this PR is to fix #789. Basically, a job is currently not failed if a target fails.

I would love to get this in RHEL 8.3. This change is kinda big though... I tried but I wasn't able to find a way to make it smaller without ugly hacks. The advantage of this PR is that the user does get information about what failed. And when uploading an image, a lot of things can fail.