### PR TITLE
worker: set the osbuild success to false even on non-osbuild errors

### DIFF
--- a/cmd/osbuild-worker/main.go
+++ b/cmd/osbuild-worker/main.go
@@ -252,6 +252,13 @@ func main() {
 					Success: false,
 				}
 			}
+
+			// set the success to false on every error. This is hacky but composer
+			// currently relies only on this flag to decide whether a compose was
+			// successful. There's no different way how to inform composer that
+			// e.g. an upload fail. Therefore, this line reuses the osbuild success
+			// flag to indicate all error kinds.
+			result.Success = false
 		} else {
 			log.Printf("  🎉 Job completed successfully: %s", job.Id)
 			status = common.IBFinished


### PR DESCRIPTION
composer uses the success field to decide whether a build succeeded or failed.
This is bad.

Unfortunately, fixing this requires kinda big code changes. This commit
changes the worker's behaviour to set the osbuild success flag to false
even on errors which weren't caused by osbuild (e.g. an upload error).
This is certainly hacky but I think it's still essential to tell the user
that an error occurred.

Fixes #789