### PR TITLE
Switch Fedora mock builds to minimal images

### DIFF
--- a/schutzbot/Jenkinsfile
+++ b/schutzbot/Jenkinsfile
@@ -84,6 +84,7 @@ pipeline {
                         AWS_CREDS = credentials('aws-credentials-osbuildci')
                     }
                     steps {
+                        sh "schutzbot/ci_details.sh"
                         sh "schutzbot/mockbuild.sh"
                         stash (
                             includes: 'osbuild-mock.repo',

--- a/schutzbot/Jenkinsfile
+++ b/schutzbot/Jenkinsfile
@@ -36,7 +36,7 @@ pipeline {
 
             parallel {
                 stage('Fedora 31') {
-                    agent { label "fedora31" }
+                    agent { label "f31 && minimal" }
                     environment {
                         AWS_CREDS = credentials('aws-credentials-osbuildci')
                     }
@@ -50,7 +50,7 @@ pipeline {
                     }
                 }
                 stage('Fedora 32') {
-                    agent { label "fedora32" }
+                    agent { label "f32 && minimal" }
                     environment {
                         AWS_CREDS = credentials('aws-credentials-osbuildci')
                     }

--- a/schutzbot/ci_details.sh
+++ b/schutzbot/ci_details.sh
@@ -30,3 +30,13 @@ echo -e "\033[0m"
 echo "List of installed packages:"
 rpm -qa | sort
 echo "------------------------------------------------------------------------------"
+
+# Ensure cloud-init has completely finished on the instance. This ensures that
+# the instance is fully ready to go.
+while true; do
+  if [[ -f /var/lib/cloud/instance/boot-finished ]]; then
+    break
+  fi
+  echo -e "\n🤔 Waiting for cloud-init to finish running..."
+  sleep 5
+done

--- a/schutzbot/mockbuild.sh
+++ b/schutzbot/mockbuild.sh
@@ -9,10 +9,26 @@ function greenprint {
 # Get OS details.
 source /etc/os-release
 
+# Prepare dnf on Fedora for performance.
+if [[ $ID == fedora ]]; then
+    sudo rm -f /etc/yum.repos.d/fedora*modular*
+    echo -e "fastestmirror=1\ninstall_weak_deps=0" | sudo tee -a /etc/dnf/dnf.conf
+fi
+
+# Install requirements for building RPMs in mock.
+greenprint "📦 Installing mock requirements"
+sudo dnf -y install createrepo_c make mock rpm-build
+
 # Install s3cmd if it is not present.
-if ! s3cmd --version; then
+if ! s3cmd --version > /dev/null 2>&1; then
     greenprint "📦 Installing s3cmd"
     sudo pip3 install s3cmd
+fi
+
+# Enable fastestmirror for mock on Fedora.
+if [[ $ID == fedora ]]; then
+    sudo sed -i '/^install_weak_deps=.*/a fastestmirror=1' \
+        /etc/mock/templates/fedora-branched.tpl
 fi
 
 # Jenkins sets a workspace variable as the root of its working directory.


### PR DESCRIPTION
Use minimal images when building RPMs via mock on Fedora (PR for RHEL
will come later).

Signed-off-by: Major Hayden <major@redhat.com>