### PR TITLE
Use minimal images for RHEL mockbuild

### DIFF
--- a/schutzbot/Jenkinsfile
+++ b/schutzbot/Jenkinsfile
@@ -64,7 +64,7 @@ pipeline {
                     }
                 }
                 stage('RHEL 8 CDN') {
-                    agent { label "rhel8" }
+                    agent { label "rhel8cdn && minimal" }
                     environment {
                         AWS_CREDS = credentials('aws-credentials-osbuildci')
                     }
@@ -79,9 +79,11 @@ pipeline {
                 }
                 // NOTE(mhayden): RHEL 8.3 is only available in PSI for now.
                 stage('RHEL 8.3 Nightly') {
-                    agent { label "rhel83 && psi" }
+                    agent { label "rhel83nightly && minimal" }
                     environment {
                         AWS_CREDS = credentials('aws-credentials-osbuildci')
+                        NIGHTLY_REPO = credentials('rhel8-nightly-repo')
+                        NIGHTLY_MOCK_TEMPLATE = credentials('rhel8-nightly-mock-template')
                     }
                     steps {
                         sh "schutzbot/ci_details.sh"

--- a/schutzbot/deploy.sh
+++ b/schutzbot/deploy.sh
@@ -24,6 +24,13 @@ source /etc/os-release
 # Restart systemd to work around some Fedora issues in cloud images.
 sudo systemctl restart systemd-journald
 
+# Remove Fedora's modular repositories to speed up dnf.
+sudo rm -f /etc/yum.repos.d/fedora*modular*
+
+# Enable fastestmirror and disable weak dependency installation to speed up
+# dnf operations.
+echo -e "fastestmirror=1\ninstall_weak_deps=0" | sudo tee -a /etc/dnf/dnf.conf
+
 # Add osbuild team ssh keys.
 cat schutzbot/team_ssh_keys.txt | tee -a ~/.ssh/authorized_keys > /dev/null
 

--- a/schutzbot/mockbuild.sh
+++ b/schutzbot/mockbuild.sh
@@ -9,11 +9,12 @@ function greenprint {
 # Get OS details.
 source /etc/os-release
 
-# Prepare dnf on Fedora for performance.
-if [[ $ID == fedora ]]; then
-    sudo rm -f /etc/yum.repos.d/fedora*modular*
-    echo -e "fastestmirror=1\ninstall_weak_deps=0" | sudo tee -a /etc/dnf/dnf.conf
-fi
+# Remove Fedora's modular repositories to speed up dnf.
+sudo rm -f /etc/yum.repos.d/fedora*modular*
+
+# Enable fastestmirror and disable weak dependency installation to speed up
+# dnf operations.
+echo -e "fastestmirror=1\ninstall_weak_deps=0" | sudo tee -a /etc/dnf/dnf.conf
 
 # Install requirements for building RPMs in mock.
 greenprint "📦 Installing mock requirements"


### PR DESCRIPTION
Now that we have minimal images built by osbuild-compsoer for CI, let's
use those for RHEL mock builds.

This PR depends on osbuild/osbuild-composer#808 to merge first.
