### PR TITLE
Fix azure tests leaking disks

### DIFF
--- a/cmd/osbuild-image-tests/azuretest/azure.go
+++ b/cmd/osbuild-image-tests/azuretest/azure.go
@@ -180,7 +180,6 @@ func WithBootedImageInAzure(creds *azureCredentials, imageName, testId, publicKe
 	// Let's create all of them here from the test id so we can delete them
 	// later.
 	deploymentName := testId
-	tag := "tag-" + testId
 	imagePath := fmt.Sprintf("https://%s.blob.core.windows.net/%s/%s", creds.StorageAccount, creds.ContainerName, imageName)
 
 	parameters := deploymentParameters{
@@ -191,7 +190,6 @@ func WithBootedImageInAzure(creds *azureCredentials, imageName, testId, publicKe
 		VirtualMachineName:       newDeploymentParameter("vm-" + testId),
 		DiskName:                 newDeploymentParameter("disk-" + testId),
 		ImageName:                newDeploymentParameter("image-" + testId),
-		Tag:                      newDeploymentParameter(tag),
 		Location:                 newDeploymentParameter(creds.Location),
 		ImagePath:                newDeploymentParameter(imagePath),
 		AdminUsername:            newDeploymentParameter("redhat"),
@@ -280,7 +278,7 @@ func WithBootedImageInAzure(creds *azureCredentials, imageName, testId, publicKe
 		// Delete the deployment
 		// This actually does not delete any resources created by the
 		// deployment as one might think. Therefore the code above
-		// and the tagging are needed.
+		// is needed.
 		result, err := deploymentsClient.Delete(context.Background(), creds.ResourceGroup, deploymentName)
 		if err != nil {
 			retErr = wrapErrorf(retErr, "cannot create the request for the deployment deletion: %v", err)

--- a/cmd/osbuild-image-tests/azuretest/azure.go
+++ b/cmd/osbuild-image-tests/azuretest/azure.go
@@ -219,24 +219,24 @@ func WithBootedImageInAzure(creds *azureCredentials, imageName, testId, publicKe
 
 	// Azure requires a lot of names - for a virtual machine, a virtual network,
 	// a virtual interface and so on and so forth.
-	// In the Go code, it's just need to know the public IP address name,
-	// the tag name and the deployment name. Let's set these here to names
-	// based on the test id.
-	// The rest of the names are set from the test id inside the deployment
-	// template because they're irrelevant to the Go code.
+	// Let's create all of them here from the test id.
 	deploymentName := testId
 	tag := "tag-" + testId
-	publicIPAddressName := "address-" + testId
 	imagePath := fmt.Sprintf("https://%s.blob.core.windows.net/%s/%s", creds.StorageAccount, creds.ContainerName, imageName)
 
 	parameters := deploymentParameters{
-		Location:            newDeploymentParameter(creds.Location),
-		TestId:              newDeploymentParameter(testId),
-		Tag:                 newDeploymentParameter(tag),
-		PublicIPAddressName: newDeploymentParameter(publicIPAddressName),
-		ImagePath:           newDeploymentParameter(imagePath),
-		AdminUsername:       newDeploymentParameter("redhat"),
-		AdminPublicKey:      newDeploymentParameter(publicKey),
+		NetworkInterfaceName:     newDeploymentParameter("iface-" + testId),
+		NetworkSecurityGroupName: newDeploymentParameter("nsg-" + testId),
+		VirtualNetworkName:       newDeploymentParameter("vnet-" + testId),
+		PublicIPAddressName:      newDeploymentParameter("ip-" + testId),
+		VirtualMachineName:       newDeploymentParameter("vm-" + testId),
+		DiskName:                 newDeploymentParameter("disk-" + testId),
+		ImageName:                newDeploymentParameter("image-" + testId),
+		Tag:                      newDeploymentParameter(tag),
+		Location:                 newDeploymentParameter(creds.Location),
+		ImagePath:                newDeploymentParameter(imagePath),
+		AdminUsername:            newDeploymentParameter("redhat"),
+		AdminPublicKey:           newDeploymentParameter(publicKey),
 	}
 
 	deploymentsClient := resources.NewDeploymentsClient(creds.SubscriptionID)
@@ -319,7 +319,7 @@ func WithBootedImageInAzure(creds *azureCredentials, imageName, testId, publicKe
 	publicIPAddressClient := network.NewPublicIPAddressesClient(creds.SubscriptionID)
 	publicIPAddressClient.Authorizer = authorizer
 
-	publicIPAddress, err := publicIPAddressClient.Get(context.Background(), creds.ResourceGroup, publicIPAddressName, "")
+	publicIPAddress, err := publicIPAddressClient.Get(context.Background(), creds.ResourceGroup, parameters.PublicIPAddressName.Value, "")
 	if err != nil {
 		return fmt.Errorf("cannot get the ip address details: %v", err)
 	}

--- a/cmd/osbuild-image-tests/azuretest/deployment.go
+++ b/cmd/osbuild-image-tests/azuretest/deployment.go
@@ -49,7 +49,6 @@ type deploymentParameters struct {
 	VirtualMachineName       deploymentParameter `json:"virtualMachineName"`
 	DiskName                 deploymentParameter `json:"diskName"`
 	ImageName                deploymentParameter `json:"imageName"`
-	Tag                      deploymentParameter `json:"tag"`
 	Location                 deploymentParameter `json:"location"`
 	ImagePath                deploymentParameter `json:"imagePath"`
 	AdminUsername            deploymentParameter `json:"adminUsername"`

--- a/cmd/osbuild-image-tests/azuretest/deployment.go
+++ b/cmd/osbuild-image-tests/azuretest/deployment.go
@@ -33,20 +33,25 @@ func loadDeploymentTemplate() (interface{}, error) {
 
 // struct for encoding a deployment parameter
 type deploymentParameter struct {
-	Value interface{} `json:"value"`
+	Value string `json:"value"`
 }
 
-func newDeploymentParameter(value interface{}) deploymentParameter {
+func newDeploymentParameter(value string) deploymentParameter {
 	return deploymentParameter{Value: value}
 }
 
 // struct for encoding deployment parameters
 type deploymentParameters struct {
-	Location            deploymentParameter `json:"location"`
-	TestId              deploymentParameter `json:"testId"`
-	Tag                 deploymentParameter `json:"tag"`
-	PublicIPAddressName deploymentParameter `json:"publicIPAddressName"`
-	ImagePath           deploymentParameter `json:"imagePath"`
-	AdminUsername       deploymentParameter `json:"adminUsername"`
-	AdminPublicKey      deploymentParameter `json:"adminPublicKey"`
+	NetworkInterfaceName     deploymentParameter `json:"networkInterfaceName"`
+	NetworkSecurityGroupName deploymentParameter `json:"networkSecurityGroupName"`
+	VirtualNetworkName       deploymentParameter `json:"virtualNetworkName"`
+	PublicIPAddressName      deploymentParameter `json:"publicIPAddressName"`
+	VirtualMachineName       deploymentParameter `json:"virtualMachineName"`
+	DiskName                 deploymentParameter `json:"diskName"`
+	ImageName                deploymentParameter `json:"imageName"`
+	Tag                      deploymentParameter `json:"tag"`
+	Location                 deploymentParameter `json:"location"`
+	ImagePath                deploymentParameter `json:"imagePath"`
+	AdminUsername            deploymentParameter `json:"adminUsername"`
+	AdminPublicKey           deploymentParameter `json:"adminPublicKey"`
 }

--- a/test/azure-deployment-template.json
+++ b/test/azure-deployment-template.json
@@ -2,10 +2,25 @@
   "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
   "parameters": {
-    "testId": {
+    "networkInterfaceName": {
+      "type": "string"
+    },
+    "networkSecurityGroupName": {
+      "type": "string"
+    },
+    "virtualNetworkName": {
       "type": "string"
     },
     "publicIPAddressName": {
+      "type": "string"
+    },
+    "virtualMachineName": {
+      "type": "string"
+    },
+    "diskName": {
+      "type": "string"
+    },
+    "imageName": {
       "type": "string"
     },
     "tag": {
@@ -25,26 +40,19 @@
     }
   },
   "variables": {
-    "subnetRef": "[concat(variables('vnetId'), '/subnets/default')]",
-    "networkInterfaceName": "[concat('iface-', parameters('testId'))]",
-    "networkSecurityGroupName": "[concat('nsg-', parameters('testId'))]",
-    "virtualNetworkName": "[concat('vnet-', parameters('testId'))]",
-    "publicIPAddressName": "[concat('ip-', parameters('testId'))]",
-    "virtualMachineName": "[concat('vm-', parameters('testId'))]",
-    "diskName": "[concat('disk-', parameters('testId'))]",
-    "imageName": "[concat('image-', parameters('testId'))]",
-    "nsgId": "[resourceId(resourceGroup().name, 'Microsoft.Network/networkSecurityGroups', variables('networkSecurityGroupName'))]",
-    "vnetId": "[resourceId(resourceGroup().name,'Microsoft.Network/virtualNetworks', variables('virtualNetworkName'))]"
+    "nsgId": "[resourceId(resourceGroup().name, 'Microsoft.Network/networkSecurityGroups', parameters('networkSecurityGroupName'))]",
+    "vnetId": "[resourceId(resourceGroup().name,'Microsoft.Network/virtualNetworks', parameters('virtualNetworkName'))]",
+    "subnetRef": "[concat(variables('vnetId'), '/subnets/default')]"
   },
   "resources": [
     {
-      "name": "[variables('networkInterfaceName')]",
+      "name": "[parameters('networkInterfaceName')]",
       "type": "Microsoft.Network/networkInterfaces",
       "apiVersion": "2019-07-01",
       "location": "[parameters('location')]",
       "dependsOn": [
-        "[concat('Microsoft.Network/networkSecurityGroups/', variables('networkSecurityGroupName'))]",
-        "[concat('Microsoft.Network/virtualNetworks/', variables('virtualNetworkName'))]",
+        "[concat('Microsoft.Network/networkSecurityGroups/', parameters('networkSecurityGroupName'))]",
+        "[concat('Microsoft.Network/virtualNetworks/', parameters('virtualNetworkName'))]",
         "[concat('Microsoft.Network/publicIpAddresses/', parameters('publicIPAddressName'))]"
       ],
       "properties": {
@@ -71,7 +79,7 @@
       }
     },
     {
-      "name": "[variables('networkSecurityGroupName')]",
+      "name": "[parameters('networkSecurityGroupName')]",
       "type": "Microsoft.Network/networkSecurityGroups",
       "apiVersion": "2019-02-01",
       "location": "[parameters('location')]",
@@ -97,7 +105,7 @@
       }
     },
     {
-      "name": "[variables('virtualNetworkName')]",
+      "name": "[parameters('virtualNetworkName')]",
       "type": "Microsoft.Network/virtualNetworks",
       "apiVersion": "2019-09-01",
       "location": "[parameters('location')]",
@@ -136,7 +144,7 @@
       }
     },
     {
-      "name": "[variables('imageName')]",
+      "name": "[parameters('imageName')]",
       "type": "Microsoft.Compute/images",
       "apiVersion": "2019-07-01",
       "location": "[parameters('location')]",
@@ -155,13 +163,13 @@
       }
     },
     {
-      "name": "[variables('virtualMachineName')]",
+      "name": "[parameters('virtualMachineName')]",
       "type": "Microsoft.Compute/virtualMachines",
       "apiVersion": "2019-07-01",
       "location": "[parameters('location')]",
       "dependsOn": [
-        "[concat('Microsoft.Network/networkInterfaces/', variables('networkInterfaceName'))]",
-        "[concat('Microsoft.Compute/images/', variables('imageName'))]"
+        "[concat('Microsoft.Network/networkInterfaces/', parameters('networkInterfaceName'))]",
+        "[concat('Microsoft.Compute/images/', parameters('imageName'))]"
       ],
       "properties": {
         "hardwareProfile": {
@@ -169,26 +177,26 @@
         },
         "storageProfile": {
           "imageReference": {
-            "id": "[resourceId(resourceGroup().name, 'Microsoft.Compute/images', variables('imageName'))]"
+            "id": "[resourceId(resourceGroup().name, 'Microsoft.Compute/images', parameters('imageName'))]"
           },
           "osDisk": {
             "caching": "ReadWrite",
             "managedDisk": {
               "storageAccountType": "Standard_LRS"
             },
-            "name": "[variables('diskName')]",
+            "name": "[parameters('diskName')]",
             "createOption": "FromImage"
           }
         },
         "networkProfile": {
           "networkInterfaces": [
             {
-              "id": "[resourceId('Microsoft.Network/networkInterfaces', variables('networkInterfaceName'))]"
+              "id": "[resourceId('Microsoft.Network/networkInterfaces', parameters('networkInterfaceName'))]"
             }
           ]
         },
         "osProfile": {
-          "computerName": "[variables('virtualMachineName')]",
+          "computerName": "[parameters('virtualMachineName')]",
           "adminUsername": "[parameters('adminUsername')]",
           "linuxConfiguration": {
             "disablePasswordAuthentication": true,

--- a/test/azure-deployment-template.json
+++ b/test/azure-deployment-template.json
@@ -23,9 +23,6 @@
     "imageName": {
       "type": "string"
     },
-    "tag": {
-      "type": "string"
-    },
     "location": {
       "type": "string"
     },
@@ -73,9 +70,6 @@
         "networkSecurityGroup": {
           "id": "[variables('nsgId')]"
         }
-      },
-      "tags": {
-        "osbuild-composer-image-test": "[parameters('tag')]"
       }
     },
     {
@@ -99,9 +93,6 @@
             }
           }
         ]
-      },
-      "tags": {
-        "osbuild-composer-image-test": "[parameters('tag')]"
       }
     },
     {
@@ -123,9 +114,6 @@
             }
           }
         ]
-      },
-      "tags": {
-        "osbuild-composer-image-test": "[parameters('tag')]"
       }
     },
     {
@@ -138,9 +126,6 @@
       },
       "sku": {
         "name": "Basic"
-      },
-      "tags": {
-        "osbuild-composer-image-test": "[parameters('tag')]"
       }
     },
     {
@@ -157,9 +142,6 @@
             "osState": "Generalized"
           }
         }
-      },
-      "tags": {
-        "osbuild-composer-image-test": "[parameters('tag')]"
       }
     },
     {
@@ -210,9 +192,6 @@
             }
           }
         }
-      },
-      "tags": {
-        "osbuild-composer-image-test": "[parameters('tag')]"
       }
     }
   ]


### PR DESCRIPTION
Previously, all resources were created with a certain tag. When the cleanup phase came, the Resources - List route\[1\] was used to get all resources with the tag. Then, they were deleted in the right order.

Sadly, the Resources - List API has issues with listing disks. Sometimes, it doesn't return the newly created disks for 15 minutes after they were created. As a result, the disks have been left behind quite often and our bill was higher than necessary.

This PR uses a different method - the Go code now knows all resource names, so it can delete all resources without listing them using the "broken" API route.

\[1\]: https://docs.microsoft.com/en-us/rest/api/resources/resources/list