### PR TITLE
🔃 Retry mock build up to 3 times

### DIFF
--- a/schutzbot/Jenkinsfile
+++ b/schutzbot/Jenkinsfile
@@ -42,7 +42,9 @@ pipeline {
                     }
                     steps {
                         sh "schutzbot/ci_details.sh"
-                        sh "schutzbot/mockbuild.sh"
+                        retry(3) {
+                            sh "schutzbot/mockbuild.sh"
+                        }
                         stash (
                             includes: 'osbuild-mock.repo',
                             name: 'fedora31'
@@ -56,7 +58,9 @@ pipeline {
                     }
                     steps {
                         sh "schutzbot/ci_details.sh"
-                        sh "schutzbot/mockbuild.sh"
+                        retry(3) {
+                            sh "schutzbot/mockbuild.sh"
+                        }
                         stash (
                             includes: 'osbuild-mock.repo',
                             name: 'fedora32'
@@ -70,7 +74,9 @@ pipeline {
                     }
                     steps {
                         sh "schutzbot/ci_details.sh"
-                        sh "schutzbot/mockbuild.sh"
+                        retry(3) {
+                            sh "schutzbot/mockbuild.sh"
+                        }
                         stash (
                             includes: 'osbuild-mock.repo',
                             name: 'rhel8cdn'
@@ -85,7 +91,9 @@ pipeline {
                     }
                     steps {
                         sh "schutzbot/ci_details.sh"
-                        sh "schutzbot/mockbuild.sh"
+                        retry(3) {
+                            sh "schutzbot/mockbuild.sh"
+                        }
                         stash (
                             includes: 'osbuild-mock.repo',
                             name: 'rhel83'


### PR DESCRIPTION
Sometimes dnf has issues downloading RPMs or downloading the repo XML
and this breaks the mock build. Try to run the mock builds three times
before giving up.

Signed-off-by: Major Hayden <major@redhat.com>