### PR TITLE
🛃 Ensure the correct packages are installed

### DIFF
--- a/schutzbot/deploy.sh
+++ b/schutzbot/deploy.sh
@@ -31,6 +31,10 @@ sudo rm -f /etc/yum.repos.d/fedora*modular*
 # dnf operations.
 echo -e "fastestmirror=1\ninstall_weak_deps=0" | sudo tee -a /etc/dnf/dnf.conf
 
+# Ensure we are using the latest dnf since early revisions of Fedora 31 had
+# some dnf repo priority bugs like BZ 1733582.
+sudo dnf -y upgrade
+
 # Add osbuild team ssh keys.
 cat schutzbot/team_ssh_keys.txt | tee -a ~/.ssh/authorized_keys > /dev/null
 

--- a/schutzbot/mockbuild.sh
+++ b/schutzbot/mockbuild.sh
@@ -10,7 +10,7 @@ function greenprint {
 source /etc/os-release
 
 # Mock is only available in EPEL for RHEL.
-if [[ $ID == rhel ]]; then
+if [[ $ID == rhel ]] && ! rpm -q epel-release; then
     greenprint "📦 Setting up EPEL repository"
     curl -Ls --retry 5 --output /tmp/epel.rpm \
         https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm


### PR DESCRIPTION
Some dnf bugs existed in early releases of Fedora 31 + 32 around
repository priorities being ignored (like BZ 1733582. Ensure that we are
running the latest version of dnf before we try to install from the mock
build repo (which has a much higher priority than Fedora's default
repos).

Also, check to see if EPEL is installed already before installing it
again.

Fixes #824. 🥰

Signed-off-by: Major Hayden <major@redhat.com>