### PR TITLE
image-info: various cleanups and use loop devices instead of nbd

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,4 +23,4 @@ script:
   - sudo sh -c 'mkdir /etc/rpm; echo "%_dbpath /var/lib/rpm" > /etc/rpm/macros'
   - export GO111MODULE=on
   - go test -c -tags 'travis integration' -o osbuild-image-tests ./cmd/osbuild-image-tests
-  - travis_wait 30 sudo ./osbuild-image-tests -test.v test/cases/${TRAVIS_JOB_NAME}*-x86_64-vhd-boot.json
+  - sudo ./osbuild-image-tests -test.v test/cases/${TRAVIS_JOB_NAME}*-x86_64-vhd-boot.json

--- a/cmd/osbuild-image-tests/constants/constants-travis.go
+++ b/cmd/osbuild-image-tests/constants/constants-travis.go
@@ -2,7 +2,10 @@
 
 package constants
 
-import "os/exec"
+import (
+	"os"
+	"os/exec"
+)
 
 func GetOsbuildCommand(store, outputDirectory string) *exec.Cmd {
 	cmd := exec.Command(
@@ -15,6 +18,15 @@ func GetOsbuildCommand(store, outputDirectory string) *exec.Cmd {
 		"-",
 	)
 	cmd.Dir = "osbuild"
+	return cmd
+}
+
+func GetImageInfoCommand(imagePath string) *exec.Cmd {
+	cmd := exec.Command(
+		"tools/image-info",
+		imagePath,
+	)
+	cmd.Env = append(os.Environ(), "PYTHONPATH=osbuild")
 	return cmd
 }
 

--- a/cmd/osbuild-image-tests/constants/constants.go
+++ b/cmd/osbuild-image-tests/constants/constants.go
@@ -14,6 +14,13 @@ func GetOsbuildCommand(store, outputDirectory string) *exec.Cmd {
 	)
 }
 
+func GetImageInfoCommand(imagePath string) *exec.Cmd {
+	return exec.Command(
+		"/usr/libexec/osbuild-composer/image-info",
+		imagePath,
+	)
+}
+
 var TestPaths = struct {
 	ImageInfo               string
 	PrivateKey              string

--- a/cmd/osbuild-image-tests/main_test.go
+++ b/cmd/osbuild-image-tests/main_test.go
@@ -84,7 +84,7 @@ func testImageInfo(t *testing.T, imagePath string, rawImageInfoExpected []byte) 
 	err := json.Unmarshal(rawImageInfoExpected, &imageInfoExpected)
 	require.NoErrorf(t, err, "cannot decode expected image info: %#v", err)
 
-	cmd := exec.Command(constants.TestPaths.ImageInfo, imagePath)
+	cmd := constants.GetImageInfoCommand(imagePath)
 	cmd.Stderr = os.Stderr
 	reader, writer := io.Pipe()
 	cmd.Stdout = writer

--- a/tools/image-info
+++ b/tools/image-info
@@ -215,6 +215,14 @@ def read_firewall_zone(tree):
     return r
 
 
+def read_fstab(tree):
+    result = []
+    with contextlib.suppress(FileNotFoundError):
+        with open(f"{tree}/etc/fstab") as f:
+            result = sorted([line.split() for line in f if line and not line.startswith("#")])
+    return result
+
+
 def append_filesystem(report, tree, *, is_ostree=False):
     if os.path.exists(f"{tree}/etc/os-release"):
         report["packages"] = rpm_packages(tree, is_ostree)
@@ -237,9 +245,9 @@ def append_filesystem(report, tree, *, is_ostree=False):
         with contextlib.suppress(FileNotFoundError):
             report["firewall-enabled"] = read_firewall_zone(tree)
 
-        with contextlib.suppress(FileNotFoundError):
-            with open(f"{tree}/etc/fstab") as f:
-                report["fstab"] = sorted([line.split() for line in f.read().split("\n") if line and not line.startswith("#")])
+        fstab = read_fstab(tree)
+        if fstab:
+            report["fstab"] = fstab
 
         with open(f"{tree}/etc/passwd") as f:
             report["passwd"] = sorted(f.read().strip().split("\n"))

--- a/tools/image-info
+++ b/tools/image-info
@@ -227,27 +227,19 @@ def append_filesystem(report, tree, *, is_ostree=False):
         report["services-enabled"] = read_services(tree, "enabled")
         report["services-disabled"] = read_services(tree, "disabled")
 
-        try:
+        with contextlib.suppress(FileNotFoundError):
             with open(f"{tree}/etc/hostname") as f:
                 report["hostname"] = f.read().strip()
-        except FileNotFoundError:
-            pass
 
-        try:
+        with contextlib.suppress(FileNotFoundError):
             report["timezone"] = os.path.basename(os.readlink(f"{tree}/etc/localtime"))
-        except FileNotFoundError:
-            pass
 
-        try:
+        with contextlib.suppress(FileNotFoundError):
             report["firewall-enabled"] = read_firewall_zone(tree)
-        except FileNotFoundError:
-            pass
 
-        try:
+        with contextlib.suppress(FileNotFoundError):
             with open(f"{tree}/etc/fstab") as f:
                 report["fstab"] = sorted([line.split() for line in f.read().split("\n") if line and not line.startswith("#")])
-        except FileNotFoundError:
-            pass
 
         with open(f"{tree}/etc/passwd") as f:
             report["passwd"] = sorted(f.read().strip().split("\n"))
@@ -264,11 +256,9 @@ def append_filesystem(report, tree, *, is_ostree=False):
 
         if os.path.exists(f"{tree}/boot") and len(os.listdir(f"{tree}/boot")) > 0:
             assert "bootmenu" not in report
-            try:
+            with contextlib.suppress(FileNotFoundError):
                 with open(f"{tree}/boot/grub2/grubenv") as f:
                     report["boot-environment"] = parse_environment_vars(f.read())
-            except FileNotFoundError:
-                pass
             report["bootmenu"] = read_boot_entries(f"{tree}/boot")
 
     elif len(glob.glob(f"{tree}/vmlinuz-*")) > 0:

--- a/tools/image-info
+++ b/tools/image-info
@@ -143,8 +143,13 @@ def read_image_format(device):
 
 
 def read_partition(device, partition):
-    blkid = subprocess_check_output(["blkid", "--output", "export", device],
-                                   parse_environment_vars)
+    res = subprocess.run(["blkid", "--output", "export", device],
+                         check=False, encoding="utf-8",
+                         stdout=subprocess.PIPE)
+    if res.returncode == 0:
+        blkid = parse_environment_vars(res.stdout)
+    else:
+        blkid = {}
 
     partition["label"] = blkid.get("LABEL") # doesn't exist for mbr
     partition["uuid"] = blkid.get("UUID")

--- a/tools/image-info
+++ b/tools/image-info
@@ -171,6 +171,7 @@ def read_partition_table(device):
     ptable = sfdisk["partitiontable"]
     assert ptable["unit"] == "sectors"
     is_dos = ptable["label"] == "dos"
+    ssize = ptable.get("sectorsize", 512)
 
     for i, p in enumerate(ptable["partitions"]):
 
@@ -187,8 +188,8 @@ def read_partition_table(device):
         partitions.append({
             "bootable": p.get("bootable", False),
             "type": p["type"],
-            "start": p["start"] * 512,
-            "size": p["size"] * 512,
+            "start": p["start"] * ssize,
+            "size": p["size"] * ssize,
             "partuuid": partuuid
         })
 

--- a/tools/image-info
+++ b/tools/image-info
@@ -396,6 +396,37 @@ def analyse_tarball(path):
         return analyse_directory(tree)
 
 
+def is_compressed(path):
+    _, encoding = mimetypes.guess_type(path)
+    return encoding in ["xz", "gzip", "bzip2"]
+
+
+def analyse_compressed(path):
+    _, encoding = mimetypes.guess_type(path)
+
+    if encoding == "xz":
+        command = ["unxz", "--force"]
+    elif encoding == "gzip":
+        command = ["gunzip", "--force"]
+    elif encoding == "bzip2":
+        command = ["bunzip2", "--force"]
+    else:
+        raise ValueError(f"Unsupported compression: {encoding}")
+
+    with tempfile.TemporaryDirectory(dir="/var/tmp") as tmpdir:
+        subprocess.run(["cp", "--reflink=auto", "-a", path, tmpdir],
+                       check=True)
+
+        files = os.listdir(tmpdir)
+        archive = os.path.join(tmpdir, files[0])
+        subprocess.run(command + [archive], check=True)
+
+        files = os.listdir(tmpdir)
+        assert len(files) == 1
+        image = os.path.join(tmpdir, files[0])
+        return analyse_image(image)
+
+
 def main():
     parser = argparse.ArgumentParser(description="Inspect an image")
     parser.add_argument("target", metavar="TARGET",
@@ -409,6 +440,8 @@ def main():
         report = analyse_directory(target)
     elif is_tarball(target):
         report = analyse_tarball(target)
+    elif is_compressed(target):
+        report = analyse_compressed(target)
     else:
         report = analyse_image(target)
 

--- a/tools/image-info
+++ b/tools/image-info
@@ -398,7 +398,9 @@ def analyse_tarball(path):
 
 def main():
     parser = argparse.ArgumentParser(description="Inspect an image")
-    parser.add_argument("target",  help="The file or directory to analyse")
+    parser.add_argument("target", metavar="TARGET",
+                        help="The file or directory to analyse",
+                        type=os.path.abspath)
 
     args = parser.parse_args()
     target = args.target

--- a/tools/image-info
+++ b/tools/image-info
@@ -288,9 +288,10 @@ def find_esp(partitions):
 def analyse_image(image):
     subprocess.run(["modprobe", "nbd"], check=True)
 
-    report = {}
+    imgfmt = read_image_format(image)
+    report = {"image-format": imgfmt}
+
     with nbd_connect(image) as device:
-        report["image-format"] = read_image_format(image)
         report["bootloader"] = read_bootloader_type(device)
         report["partition-table"], report["partition-table-id"], report["partitions"] = read_partition_table(device)
 

--- a/tools/image-info
+++ b/tools/image-info
@@ -2,6 +2,7 @@
 
 import argparse
 import contextlib
+import errno
 import functools
 import glob
 import mimetypes
@@ -11,6 +12,8 @@ import subprocess
 import sys
 import tempfile
 import xml.etree.ElementTree
+
+from osbuild import loop
 
 
 def run_ostree(*args, _input=None, _check=True, **kwargs):
@@ -25,17 +28,51 @@ def run_ostree(*args, _input=None, _check=True, **kwargs):
 
 
 @contextlib.contextmanager
-def nbd_connect(image):
-    for device in glob.glob("/dev/nbd*"):
-        r = subprocess.run(["qemu-nbd", "--connect", device, "--read-only", image], check=False).returncode
-        if r == 0:
-            try:
-                yield device
-            finally:
-                subprocess.run(["qemu-nbd", "--disconnect", device], check=True, stdout=subprocess.DEVNULL)
-            break
-    else:
-        raise RuntimeError("no free network block device")
+def loop_create_device(ctl, fd, offset=None, sizelimit=None):
+    while True:
+        lo = loop.Loop(ctl.get_unbound())
+        try:
+            lo.set_fd(fd)
+        except OSError as e:
+            lo.close()
+            if e.errno == errno.EBUSY:
+                continue
+            raise e
+        try:
+            lo.set_status(offset=offset, sizelimit=sizelimit, autoclear=True)
+        except BlockingIOError:
+            lo.clear_fd()
+            lo.close()
+            continue
+        break
+    try:
+        yield lo
+    finally:
+        lo.close()
+
+
+@contextlib.contextmanager
+def loop_open(ctl, image, *, offset=None, size=None):
+    with open(image, "rb") as f:
+        fd = f.fileno()
+        with loop_create_device(ctl, fd, offset=offset, sizelimit=size) as lo:
+            yield os.path.join("/dev", lo.devname)
+
+
+@contextlib.contextmanager
+def open_image(ctl, image, fmt):
+    with tempfile.TemporaryDirectory() as tmp:
+        if fmt != "raw":
+            target = os.path.join(tmp, "image.raw")
+            subprocess.run(["qemu-img", "convert", "-O", "raw", image, target],
+                           check=True)
+        else:
+            target = image
+
+        size = os.stat(target).st_size
+
+        with loop_open(ctl, target, offset=0, size=size) as dev:
+            yield target, dev
 
 
 @contextlib.contextmanager
@@ -105,18 +142,14 @@ def read_image_format(device):
     return qemu["format"]
 
 
-def read_partition(device, bootable, typ=None, start=0, size=0):
-   blkid = subprocess_check_output(["blkid", "--output", "export", device], parse_environment_vars)
-   return {
-       "label": blkid.get("LABEL"), # doesn't exist for mbr
-       "type": typ,
-       "uuid": blkid.get("UUID"),
-       "partuuid": blkid.get("PARTUUID"),
-       "fstype": blkid.get("TYPE"),
-       "bootable": bootable,
-       "start": start,
-       "size": size
-   }
+def read_partition(device, partition):
+    blkid = subprocess_check_output(["blkid", "--output", "export", device],
+                                   parse_environment_vars)
+
+    partition["label"] = blkid.get("LABEL") # doesn't exist for mbr
+    partition["uuid"] = blkid.get("UUID")
+    partition["fstype"] = blkid.get("TYPE")
+    return partition
 
 
 def read_partition_table(device):
@@ -132,8 +165,28 @@ def read_partition_table(device):
 
     ptable = sfdisk["partitiontable"]
     assert ptable["unit"] == "sectors"
-    for p in ptable["partitions"]:
-        partitions.append(read_partition(p["node"], p.get("bootable", False), p["type"], p["start"] * 512, p["size"] * 512))
+    is_dos = ptable["label"] == "dos"
+
+    for i, p in enumerate(ptable["partitions"]):
+
+        partuuid = p.get("uuid")
+        if not partuuid and is_dos:
+            # For dos/mbr partition layouts the partition uuid
+            # is generated. Normally this would be done by
+            # udev+blkid, when the partition table is scanned.
+            # 'sfdisk' prefixes the partition id with '0x' but
+            # 'blkid' does not; remove it to mimic 'blkid'
+            table_id = ptable['id'][2:]
+            partuuid = "%.33s-%02x" % (table_id, i+1)
+
+        partitions.append({
+            "bootable": p.get("bootable", False),
+            "type": p["type"],
+            "start": p["start"] * 512,
+            "size": p["size"] * 512,
+            "partuuid": partuuid
+        })
+
     info["partition-table"] = ptable["label"]
     info["partition-table-id"] = ptable["id"]
 
@@ -289,33 +342,43 @@ def find_esp(partitions):
     return None, 0
 
 
-def append_partitions(report, device):
-    esp, esp_id = find_esp(report["partitions"])
+def append_partitions(report, device, loctl):
+    partitions = report["partitions"]
+    esp, esp_id = find_esp(partitions)
 
-    for n, part in enumerate(report["partitions"]):
-        if not part["fstype"]:
-            continue
+    with contextlib.ExitStack() as cm:
 
-        with mount(device + f"p{n + 1}") as tree:
-            if esp and os.path.exists(f"{tree}/boot/efi"):
-                with mount_at(device + f"p{esp_id + 1}", f"{tree}/boot/efi", options=['umask=077']):
+        devices = {}
+        for n, part in enumerate(partitions):
+            start, size = part["start"], part["size"]
+            dev = cm.enter_context(loop_open(loctl, device, offset=start, size=size))
+            devices[n] = dev
+            read_partition(dev, part)
+
+        for n, part in enumerate(partitions):
+            if not part["fstype"]:
+                continue
+
+            with mount(devices[n]) as tree:
+                if esp and os.path.exists(f"{tree}/boot/efi"):
+                    with mount_at(devices[esp_id], f"{tree}/boot/efi", options=['umask=077']):
+                        append_filesystem(report, tree)
+                else:
                     append_filesystem(report, tree)
-            else:
-                append_filesystem(report, tree)
 
 
 def analyse_image(image):
-    subprocess.run(["modprobe", "nbd"], check=True)
+    loctl = loop.LoopControl()
 
     imgfmt = read_image_format(image)
     report = {"image-format": imgfmt}
 
-    with nbd_connect(image) as device:
+    with open_image(loctl, image, imgfmt) as (_, device):
         report["bootloader"] = read_bootloader_type(device)
         report.update(read_partition_table(device))
 
         if report["partition-table"]:
-            append_partitions(report, device)
+            append_partitions(report, device, loctl)
         else:
             with mount(device) as tree:
                 append_filesystem(report, tree)

--- a/tools/image-info
+++ b/tools/image-info
@@ -293,15 +293,17 @@ def find_esp(partitions):
 
 def append_partitions(report, device):
     esp, esp_id = find_esp(report["partitions"])
-    n_partitions = len(report["partitions"])
-    for n in range(n_partitions):
-        if report["partitions"][n]["fstype"]:
-            with mount(device + f"p{n + 1}") as tree:
-                if esp and os.path.exists(f"{tree}/boot/efi"):
-                    with mount_at(device + f"p{esp_id + 1}", f"{tree}/boot/efi", options=['umask=077']):
-                        append_filesystem(report, tree)
-                else:
+
+    for n, part in enumerate(report["partitions"]):
+        if not part["fstype"]:
+            continue
+
+        with mount(device + f"p{n + 1}") as tree:
+            if esp and os.path.exists(f"{tree}/boot/efi"):
+                with mount_at(device + f"p{esp_id + 1}", f"{tree}/boot/efi", options=['umask=077']):
                     append_filesystem(report, tree)
+            else:
+                append_filesystem(report, tree)
 
 
 def analyse_image(image):

--- a/tools/image-info
+++ b/tools/image-info
@@ -105,7 +105,7 @@ def read_image_format(device):
     return qemu["format"]
 
 
-def read_partition(device, bootable, typ=None, start=0, size=0, type=None):
+def read_partition(device, bootable, typ=None, start=0, size=0):
    blkid = subprocess_check_output(["blkid", "--output", "export", device], parse_environment_vars)
    return {
        "label": blkid.get("LABEL"), # doesn't exist for mbr

--- a/tools/image-info
+++ b/tools/image-info
@@ -121,17 +121,23 @@ def read_partition(device, bootable, typ=None, start=0, size=0):
 
 def read_partition_table(device):
     partitions = []
+    info = {"partition-table": None,
+            "partition-table-id": None,
+            "partitions": partitions}
     try:
         sfdisk = subprocess_check_output(["sfdisk", "--json", device], json.loads)
     except subprocess.CalledProcessError:
         partitions.append(read_partition(device, False))
-        return None, None, partitions
-    else:
-        ptable = sfdisk["partitiontable"]
-        assert ptable["unit"] == "sectors"
-        for p in ptable["partitions"]:
-            partitions.append(read_partition(p["node"], p.get("bootable", False), p["type"], p["start"] * 512, p["size"] * 512))
-        return ptable["label"], ptable["id"], partitions
+        return info
+
+    ptable = sfdisk["partitiontable"]
+    assert ptable["unit"] == "sectors"
+    for p in ptable["partitions"]:
+        partitions.append(read_partition(p["node"], p.get("bootable", False), p["type"], p["start"] * 512, p["size"] * 512))
+    info["partition-table"] = ptable["label"]
+    info["partition-table-id"] = ptable["id"]
+
+    return info
 
 
 def read_bootloader_type(device):
@@ -293,7 +299,7 @@ def analyse_image(image):
 
     with nbd_connect(image) as device:
         report["bootloader"] = read_bootloader_type(device)
-        report["partition-table"], report["partition-table-id"], report["partitions"] = read_partition_table(device)
+        report.update(read_partition_table(device))
 
         if report["partition-table"]:
             esp, esp_id = find_esp(report["partitions"])

--- a/tools/image-info
+++ b/tools/image-info
@@ -291,6 +291,19 @@ def find_esp(partitions):
     return None, 0
 
 
+def append_partitions(report, device):
+    esp, esp_id = find_esp(report["partitions"])
+    n_partitions = len(report["partitions"])
+    for n in range(n_partitions):
+        if report["partitions"][n]["fstype"]:
+            with mount(device + f"p{n + 1}") as tree:
+                if esp and os.path.exists(f"{tree}/boot/efi"):
+                    with mount_at(device + f"p{esp_id + 1}", f"{tree}/boot/efi", options=['umask=077']):
+                        append_filesystem(report, tree)
+                else:
+                    append_filesystem(report, tree)
+
+
 def analyse_image(image):
     subprocess.run(["modprobe", "nbd"], check=True)
 
@@ -302,16 +315,7 @@ def analyse_image(image):
         report.update(read_partition_table(device))
 
         if report["partition-table"]:
-            esp, esp_id = find_esp(report["partitions"])
-            n_partitions = len(report["partitions"])
-            for n in range(n_partitions):
-                if report["partitions"][n]["fstype"]:
-                    with mount(device + f"p{n + 1}") as tree:
-                        if esp and os.path.exists(f"{tree}/boot/efi"):
-                            with mount_at(device + f"p{esp_id + 1}", f"{tree}/boot/efi", options=['umask=077']):
-                                append_filesystem(report, tree)
-                        else:
-                            append_filesystem(report, tree)
+            append_partitions(report, device)
         else:
             with mount(device) as tree:
                 append_filesystem(report, tree)


### PR DESCRIPTION
I am preparing to remove the usage of `nbd` from `image-info` but wanted to give the code a bit of a cleanup before I started doing that. See the individual commit messages for details.