### PR TITLE
spec: do not conflict with lorax-composer

### DIFF
--- a/osbuild-composer.spec
+++ b/osbuild-composer.spec
@@ -55,7 +55,7 @@ Requires: osbuild-ostree >= 17
 Provides: weldr
 
 %if 0%{?rhel}
-Obsoletes: lorax-composer <= 28
+Obsoletes: lorax-composer <= 29
 Conflicts: lorax-composer
 %endif
 


### PR DESCRIPTION
Conflicting makes upgrades fail, obsoletes is sufficient.

Signed-off-by: Tom Gundersen <teg@jklm.no>