### PR TITLE
🤹🏻‍♂️  Prepare for multi-arch support

### DIFF
--- a/schutzbot/Jenkinsfile
+++ b/schutzbot/Jenkinsfile
@@ -45,7 +45,7 @@ pipeline {
 
             parallel {
                 stage('Fedora 31') {
-                    agent { label "f31cloudbase" }
+                    agent { label "f31cloudbase && x86_64" }
                     environment {
                         AWS_CREDS = credentials('aws-credentials-osbuildci')
                     }
@@ -61,7 +61,7 @@ pipeline {
                     }
                 }
                 stage('Fedora 32') {
-                    agent { label "f32cloudbase" }
+                    agent { label "f32cloudbase && x86_64" }
                     environment {
                         AWS_CREDS = credentials('aws-credentials-osbuildci')
                     }
@@ -77,7 +77,7 @@ pipeline {
                     }
                 }
                 stage('RHEL 8 CDN') {
-                    agent { label "rhel8cloudbase" }
+                    agent { label "rhel8cloudbase && x86_64" }
                     environment {
                         AWS_CREDS = credentials('aws-credentials-osbuildci')
                         RHN_REGISTRATION_SCRIPT = credentials('rhn-register-script-production')
@@ -95,7 +95,7 @@ pipeline {
                 }
                 // NOTE(mhayden): RHEL 8.3 is only available in PSI for now.
                 stage('RHEL 8.3 Nightly') {
-                    agent { label "rhel83cloudbase" }
+                    agent { label "rhel83cloudbase && x86_64" }
                     environment {
                         AWS_CREDS = credentials('aws-credentials-osbuildci')
                         NIGHTLY_REPO = credentials('rhel8-nightly-repo')
@@ -120,7 +120,7 @@ pipeline {
 
             parallel {
                 stage('Fedora 31 base') {
-                    agent { label "f31cloudbase && psi" }
+                    agent { label "f31cloudbase && psi && x86_64" }
                     environment { TEST_TYPE = "base" }
                     steps {
                         unstash 'fedora31'
@@ -133,7 +133,7 @@ pipeline {
                     }
                 }
                 stage('Fedora 31 image') {
-                    agent { label "f31cloudbase && psi" }
+                    agent { label "f31cloudbase && psi && x86_64" }
                     environment {
                         TEST_TYPE = "image"
                         AWS_CREDS = credentials('aws-credentials-osbuildci')
@@ -149,7 +149,7 @@ pipeline {
                     }
                 }
                 stage('Fedora 31 integration') {
-                    agent { label "f31cloudbase && psi" }
+                    agent { label "f31cloudbase && psi && x86_64" }
                     environment {
                         TEST_TYPE = "integration"
                         AWS_CREDS = credentials('aws-credentials-osbuildci')
@@ -165,7 +165,7 @@ pipeline {
                     }
                 }
                 stage('Fedora 32 base') {
-                    agent { label "f32cloudbase && psi" }
+                    agent { label "f32cloudbase && psi && x86_64" }
                     environment { TEST_TYPE = "base" }
                     steps {
                         unstash 'fedora32'
@@ -178,7 +178,7 @@ pipeline {
                     }
                 }
                 stage('Fedora 32 image') {
-                    agent { label "f32cloudbase && psi" }
+                    agent { label "f32cloudbase && psi && x86_64" }
                     environment {
                         TEST_TYPE = "image"
                         AWS_CREDS = credentials('aws-credentials-osbuildci')
@@ -194,7 +194,7 @@ pipeline {
                     }
                 }
                 stage('Fedora 32 integration') {
-                    agent { label "f32cloudbase && psi" }
+                    agent { label "f32cloudbase && psi && x86_64" }
                     environment {
                         TEST_TYPE = "integration"
                         AWS_CREDS = credentials('aws-credentials-osbuildci')
@@ -210,7 +210,7 @@ pipeline {
                     }
                 }
                 stage('RHEL 8 CDN Base') {
-                    agent { label "rhel8cloudbase && psi" }
+                    agent { label "rhel8cloudbase && psi && x86_64" }
                     environment { TEST_TYPE = "base" }
                     steps {
                         unstash 'rhel8cdn'
@@ -223,7 +223,7 @@ pipeline {
                     }
                 }
                 stage('RHEL 8 CDN Image') {
-                    agent { label "rhel8cloudbase && psi" }
+                    agent { label "rhel8cloudbase && psi && x86_64" }
                     environment {
                         TEST_TYPE = "image"
                         AWS_CREDS = credentials('aws-credentials-osbuildci')
@@ -239,7 +239,7 @@ pipeline {
                     }
                 }
                 stage('RHEL 8 CDN integration') {
-                    agent { label "rhel8cloudbase && psi" }
+                    agent { label "rhel8cloudbase && psi && x86_64" }
                     environment {
                         TEST_TYPE = "integration"
                         AWS_CREDS = credentials('aws-credentials-osbuildci')
@@ -255,7 +255,7 @@ pipeline {
                     }
                 }
                 stage('RHEL 8.3 Base') {
-                    agent { label "rhel83cloudbase" }
+                    agent { label "rhel83cloudbase && x86_64" }
                     environment { TEST_TYPE = "base" }
                     steps {
                         unstash 'rhel83'
@@ -268,7 +268,7 @@ pipeline {
                     }
                 }
                 stage('RHEL 8.3 Image') {
-                    agent { label "rhel83cloudbase" }
+                    agent { label "rhel83cloudbase && x86_64" }
                     environment {
                         TEST_TYPE = "image"
                         AWS_CREDS = credentials('aws-credentials-osbuildci')
@@ -284,7 +284,7 @@ pipeline {
                     }
                 }
                 stage('RHEL 8.3 integration') {
-                    agent { label "rhel83cloudbase" }
+                    agent { label "rhel83cloudbase && x86_64" }
                     environment {
                         TEST_TYPE = "integration"
                         AWS_CREDS = credentials('aws-credentials-osbuildci')

--- a/schutzbot/ci_details.sh
+++ b/schutzbot/ci_details.sh
@@ -8,6 +8,8 @@ CPUS=$(nproc)
 MEM=$(free -m | grep -oP '\d+' | head -n 1)
 DISK=$(df --output=size -h / | sed '1d;s/[^0-9]//g')
 HOSTNAME=$(uname -n)
+ARCH=$(uname -m)
+KERNEL=$(uname -r)
 
 echo -e "\033[0;36m"
 cat << EOF
@@ -22,6 +24,8 @@ CI MACHINE SPECS
          CPUs: ${CPUS}
           RAM: ${MEM} GB
          DISK: ${DISK} GB
+         ARCH: ${ARCH}
+       KERNEL: ${KERNEL}
 
 ------------------------------------------------------------------------------
 EOF

--- a/schutzbot/mockbuild.sh
+++ b/schutzbot/mockbuild.sh
@@ -6,8 +6,9 @@ function greenprint {
   echo -e "\033[1;32m${1}\033[0m"
 }
 
-# Get OS details.
+# Get OS and architecture details.
 source /etc/os-release
+ARCH=$(uname -m)
 
 # Mock is only available in EPEL for RHEL.
 if [[ $ID == rhel ]] && ! rpm -q epel-release; then
@@ -53,10 +54,10 @@ REPO_BUCKET=osbuild-composer-repos
 MOCK_REPO_BASE_URL="http://osbuild-composer-repos.s3-website.us-east-2.amazonaws.com"
 
 # Directory to hold the RPMs temporarily before we upload them.
-REPO_DIR=repo/${JOB_NAME}/${POST_MERGE_SHA}/${ID}${VERSION_ID//./}
+REPO_DIR=repo/${JOB_NAME}/${POST_MERGE_SHA}/${ID}${VERSION_ID//./}_${ARCH}
 
 # Full URL to the RPM repository after they are uploaded.
-REPO_URL=${MOCK_REPO_BASE_URL}/${JOB_NAME}/${POST_MERGE_SHA}/${ID}${VERSION_ID//./}
+REPO_URL=${MOCK_REPO_BASE_URL}/${JOB_NAME}/${POST_MERGE_SHA}/${ID}${VERSION_ID//./}_${ARCH}
 
 # Print some data.
 greenprint "🧬 Using mock config: ${MOCK_CONFIG}"


### PR DESCRIPTION
As we embark on a CI journey to other architectures, we need to be
explicit about choosing the right architecture for each CI node.

This is a portion of the work required for #834.

Signed-off-by: Major Hayden <major@redhat.com>