### PR TITLE
⛅ Allow base/integration tests to run in PSI + AWS

### DIFF
--- a/schutzbot/Jenkinsfile
+++ b/schutzbot/Jenkinsfile
@@ -169,7 +169,7 @@ pipeline {
 
             parallel {
                 stage('Fedora 31 base') {
-                    agent { label "f31cloudbase && psi && x86_64" }
+                    agent { label "f31cloudbase && x86_64 && aws" }
                     environment { TEST_TYPE = "base" }
                     steps {
                         unstash 'fedora31'
@@ -198,7 +198,7 @@ pipeline {
                     }
                 }
                 stage('Fedora 31 integration') {
-                    agent { label "f31cloudbase && psi && x86_64" }
+                    agent { label "f31cloudbase && x86_64 && aws" }
                     environment {
                         TEST_TYPE = "integration"
                         AWS_CREDS = credentials('aws-credentials-osbuildci')
@@ -214,7 +214,7 @@ pipeline {
                     }
                 }
                 stage('Fedora 32 base') {
-                    agent { label "f32cloudbase && psi && x86_64" }
+                    agent { label "f32cloudbase && x86_64 && aws" }
                     environment { TEST_TYPE = "base" }
                     steps {
                         unstash 'fedora32'
@@ -243,7 +243,7 @@ pipeline {
                     }
                 }
                 stage('Fedora 32 integration') {
-                    agent { label "f32cloudbase && psi && x86_64" }
+                    agent { label "f32cloudbase && x86_64 && aws" }
                     environment {
                         TEST_TYPE = "integration"
                         AWS_CREDS = credentials('aws-credentials-osbuildci')
@@ -259,8 +259,11 @@ pipeline {
                     }
                 }
                 stage('RHEL 8 CDN Base') {
-                    agent { label "rhel8cloudbase && psi && x86_64" }
-                    environment { TEST_TYPE = "base" }
+                    agent { label "rhel8cloudbase && x86_64 && aws" }
+                    environment {
+                        RHN_REGISTRATION_SCRIPT = credentials('rhn-register-script-production')
+                        TEST_TYPE = "base"
+                    }
                     steps {
                         unstash 'rhel8cdn'
                         run_tests('base')
@@ -288,10 +291,11 @@ pipeline {
                     }
                 }
                 stage('RHEL 8 CDN integration') {
-                    agent { label "rhel8cloudbase && psi && x86_64" }
+                    agent { label "rhel8cloudbase && x86_64 && aws" }
                     environment {
                         TEST_TYPE = "integration"
                         AWS_CREDS = credentials('aws-credentials-osbuildci')
+                        RHN_REGISTRATION_SCRIPT = credentials('rhn-register-script-production')
                     }
                     steps {
                         unstash 'rhel8cdn'

--- a/schutzbot/deploy.sh
+++ b/schutzbot/deploy.sh
@@ -21,6 +21,12 @@ function retry {
 # Get OS details.
 source /etc/os-release
 
+# Register RHEL if we are provided with a registration script.
+if [[ -n "${RHN_REGISTRATION_SCRIPT:-}" ]] && ! sudo subscription-manager status; then
+    sudo chmod +x $RHN_REGISTRATION_SCRIPT
+    sudo $RHN_REGISTRATION_SCRIPT
+fi
+
 # Restart systemd to work around some Fedora issues in cloud images.
 sudo systemctl restart systemd-journald
 

--- a/schutzbot/mockbuild.sh
+++ b/schutzbot/mockbuild.sh
@@ -72,14 +72,14 @@ make -C osbuild srpm
 # Fix RHEL 8 mock template for non-subscribed images.
 if [[ "${ID}${VERSION_ID//./}" == rhel83 ]]; then
     greenprint "📋 Updating RHEL 8 mock template for unsubscribed image"
-    sudo mv $NIGHTLY_MOCK_TEMPLATE /etc/mock/templates/rhel-8.tpl
+    sudo cp $NIGHTLY_MOCK_TEMPLATE /etc/mock/templates/rhel-8.tpl
     cat $NIGHTLY_REPO | sudo tee -a /etc/mock/templates/rhel-8.tpl > /dev/null
     echo '"""' | sudo tee -a /etc/mock/templates/rhel-8.tpl > /dev/null
 fi
 
 # Compile RPMs in a mock chroot
 greenprint "🎁 Building RPMs with mock"
-sudo mock -r $MOCK_CONFIG --resultdir $REPO_DIR --with=tests \
+sudo mock -v -r $MOCK_CONFIG --resultdir $REPO_DIR --with=tests \
     rpmbuild/SRPMS/*.src.rpm osbuild/rpmbuild/SRPMS/*.src.rpm
 sudo chown -R $USER ${REPO_DIR}
 

--- a/schutzbot/mockbuild.sh
+++ b/schutzbot/mockbuild.sh
@@ -19,7 +19,7 @@ if [[ $ID == rhel ]] && ! rpm -q epel-release; then
 fi
 
 # Register RHEL if we are provided with a registration script.
-if [[ -n "${RHN_REGISTRATION_SCRIPT:-}" ]]; then
+if [[ -n "${RHN_REGISTRATION_SCRIPT:-}" ]] && ! sudo subscription-manager status; then
     greenprint "🪙 Registering RHEL instance"
     sudo chmod +x $RHN_REGISTRATION_SCRIPT
     sudo $RHN_REGISTRATION_SCRIPT

--- a/test/cloud-init/network-config
+++ b/test/cloud-init/network-config
@@ -1,0 +1,14 @@
+network:
+  version: 2
+  renderer: NetworkManager
+  ethernets:
+    eth0:
+      dhcpv4: false
+      dhcpv6: false
+      addresses:
+        - 192.168.122.50/24
+      gateway4: 192.168.122.1
+      nameservers:
+        addresses:
+          - 1.1.1.1
+          - 8.8.8.8


### PR DESCRIPTION
Make it easier to handle PSI outages or those times when PSI is overloaded with jobs by allowing base and integration tests to run on PSI OpenStack and AWS.

Also increase the reliability and speed of the integration tests that are booted locally by using a static IP address configuration. Keep checking for the smoke test file repeatedly without messing around with ssh key scanning. This helps when ssh comes up on an instance and then goes back down again.

Fixes #844.
Fixes #847.