### PR TITLE
generate-test-cases: stop and fail when osbuild fails

### DIFF
--- a/tools/test-case-generators/generate-test-cases
+++ b/tools/test-case-generators/generate-test-cases
@@ -31,6 +31,8 @@ def run_osbuild(manifest, store, output):
                             input=json.dumps(manifest))
         except:
             print(log.read())
+            raise
+
 
 class TestCaseGenerator:
     '''

--- a/tools/test-case-generators/generate-test-cases
+++ b/tools/test-case-generators/generate-test-cases
@@ -7,12 +7,13 @@ import os
 import sys
 import tempfile
 
+
 def get_subprocess_stdout(*args, **kwargs):
     sp = subprocess.run(*args, **kwargs, stdout=subprocess.PIPE)
     if sp.returncode != 0:
         sys.stderr.write(sp.stdout)
         sys.exit(1)
-    
+
     return sp.stdout
 
 
@@ -199,6 +200,7 @@ def main(distro, arch, image_types, keep_image_info, store, output):
         }
         generate_test_case("customize", distro, arch, "qcow2", test_case_request, keep_image_info, store, output)
     return
+
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description="Generate test cases")


### PR DESCRIPTION
generate-test-cases ignored osbuild failing before.