### PR TITLE
distro: enable cloud-init services for openstack and qcow2 images for fedora

### DIFF
--- a/internal/distro/fedora31/distro.go
+++ b/internal/distro/fedora31/distro.go
@@ -242,6 +242,12 @@ func New() *Fedora31 {
 			"gobject-introspection",
 			"plymouth",
 		},
+		enabledServices: []string{
+			"cloud-init.service",
+			"cloud-config.service",
+			"cloud-final.service",
+			"cloud-init-local.service",
+		},
 		kernelOptions: "ro biosdevname=0 net.ifnames=0",
 		bootable:      true,
 		defaultSize:   2 * GigaByte,
@@ -268,6 +274,12 @@ func New() *Fedora31 {
 		},
 		excludedPackages: []string{
 			"dracut-config-rescue",
+		},
+		enabledServices: []string{
+			"cloud-init.service",
+			"cloud-config.service",
+			"cloud-final.service",
+			"cloud-init-local.service",
 		},
 		kernelOptions: "ro biosdevname=0 net.ifnames=0",
 		bootable:      true,

--- a/internal/distro/fedora32/distro.go
+++ b/internal/distro/fedora32/distro.go
@@ -626,6 +626,12 @@ func New() distro.Distro {
 			"gobject-introspection",
 			"plymouth",
 		},
+		enabledServices: []string{
+			"cloud-init.service",
+			"cloud-config.service",
+			"cloud-final.service",
+			"cloud-init-local.service",
+		},
 		kernelOptions: "ro biosdevname=0 net.ifnames=0",
 		bootable:      true,
 		defaultSize:   2 * GigaByte,
@@ -652,6 +658,12 @@ func New() distro.Distro {
 		},
 		excludedPackages: []string{
 			"dracut-config-rescue",
+		},
+		enabledServices: []string{
+			"cloud-init.service",
+			"cloud-config.service",
+			"cloud-final.service",
+			"cloud-init-local.service",
 		},
 		kernelOptions: "ro biosdevname=0 net.ifnames=0",
 		bootable:      true,

--- a/test/cases/fedora_31-aarch64-openstack-boot.json
+++ b/test/cases/fedora_31-aarch64-openstack-boot.json
@@ -4129,6 +4129,17 @@
           }
         },
         {
+          "name": "org.osbuild.systemd",
+          "options": {
+            "enabled_services": [
+              "cloud-init.service",
+              "cloud-config.service",
+              "cloud-final.service",
+              "cloud-init-local.service"
+            ]
+          }
+        },
+        {
           "name": "org.osbuild.selinux",
           "options": {
             "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/cases/fedora_31-aarch64-qcow2-boot.json
+++ b/test/cases/fedora_31-aarch64-qcow2-boot.json
@@ -4010,6 +4010,17 @@
           }
         },
         {
+          "name": "org.osbuild.systemd",
+          "options": {
+            "enabled_services": [
+              "cloud-init.service",
+              "cloud-config.service",
+              "cloud-final.service",
+              "cloud-init-local.service"
+            ]
+          }
+        },
+        {
           "name": "org.osbuild.selinux",
           "options": {
             "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/cases/fedora_31-x86_64-openstack-boot.json
+++ b/test/cases/fedora_31-x86_64-openstack-boot.json
@@ -4140,6 +4140,17 @@
           }
         },
         {
+          "name": "org.osbuild.systemd",
+          "options": {
+            "enabled_services": [
+              "cloud-init.service",
+              "cloud-config.service",
+              "cloud-final.service",
+              "cloud-init-local.service"
+            ]
+          }
+        },
+        {
           "name": "org.osbuild.selinux",
           "options": {
             "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
@@ -11688,10 +11699,6 @@
       "arp-ethers.service",
       "chrony-dnssrv@.timer",
       "chrony-wait.service",
-      "cloud-config.service",
-      "cloud-final.service",
-      "cloud-init-local.service",
-      "cloud-init.service",
       "console-getty.service",
       "debug-shell.service",
       "exit.target",
@@ -11735,6 +11742,10 @@
       "auditd.service",
       "autovt@.service",
       "chronyd.service",
+      "cloud-config.service",
+      "cloud-final.service",
+      "cloud-init-local.service",
+      "cloud-init.service",
       "ctrl-alt-del.target",
       "dbus-broker.service",
       "dbus-org.fedoraproject.FirewallD1.service",

--- a/test/cases/fedora_31-x86_64-qcow2-boot.json
+++ b/test/cases/fedora_31-x86_64-qcow2-boot.json
@@ -4070,6 +4070,17 @@
           }
         },
         {
+          "name": "org.osbuild.systemd",
+          "options": {
+            "enabled_services": [
+              "cloud-init.service",
+              "cloud-config.service",
+              "cloud-final.service",
+              "cloud-init-local.service"
+            ]
+          }
+        },
+        {
           "name": "org.osbuild.selinux",
           "options": {
             "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
@@ -11507,10 +11518,6 @@
       "arp-ethers.service",
       "chrony-dnssrv@.timer",
       "chrony-wait.service",
-      "cloud-config.service",
-      "cloud-final.service",
-      "cloud-init-local.service",
-      "cloud-init.service",
       "console-getty.service",
       "debug-shell.service",
       "exit.target",
@@ -11553,6 +11560,10 @@
       "auditd.service",
       "autovt@.service",
       "chronyd.service",
+      "cloud-config.service",
+      "cloud-final.service",
+      "cloud-init-local.service",
+      "cloud-init.service",
       "ctrl-alt-del.target",
       "dbus-broker.service",
       "dbus-org.freedesktop.nm-dispatcher.service",

--- a/test/cases/fedora_31-x86_64-qcow2-customize.json
+++ b/test/cases/fedora_31-x86_64-qcow2-customize.json
@@ -4172,6 +4172,10 @@
           "name": "org.osbuild.systemd",
           "options": {
             "enabled_services": [
+              "cloud-init.service",
+              "cloud-config.service",
+              "cloud-final.service",
+              "cloud-init-local.service",
               "sshd.socket"
             ],
             "disabled_services": [
@@ -11621,10 +11625,6 @@
       "arp-ethers.service",
       "chrony-dnssrv@.timer",
       "chrony-wait.service",
-      "cloud-config.service",
-      "cloud-final.service",
-      "cloud-init-local.service",
-      "cloud-init.service",
       "console-getty.service",
       "debug-shell.service",
       "exit.target",
@@ -11666,6 +11666,10 @@
       "auditd.service",
       "autovt@.service",
       "chronyd.service",
+      "cloud-config.service",
+      "cloud-final.service",
+      "cloud-init-local.service",
+      "cloud-init.service",
       "ctrl-alt-del.target",
       "dbus-broker.service",
       "dbus-org.freedesktop.nm-dispatcher.service",

--- a/test/cases/fedora_32-aarch64-openstack-boot.json
+++ b/test/cases/fedora_32-aarch64-openstack-boot.json
@@ -3591,6 +3591,17 @@
           }
         },
         {
+          "name": "org.osbuild.systemd",
+          "options": {
+            "enabled_services": [
+              "cloud-init.service",
+              "cloud-config.service",
+              "cloud-final.service",
+              "cloud-init-local.service"
+            ]
+          }
+        },
+        {
           "name": "org.osbuild.selinux",
           "options": {
             "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/cases/fedora_32-aarch64-qcow2-boot.json
+++ b/test/cases/fedora_32-aarch64-qcow2-boot.json
@@ -3381,6 +3381,17 @@
           }
         },
         {
+          "name": "org.osbuild.systemd",
+          "options": {
+            "enabled_services": [
+              "cloud-init.service",
+              "cloud-config.service",
+              "cloud-final.service",
+              "cloud-init-local.service"
+            ]
+          }
+        },
+        {
           "name": "org.osbuild.selinux",
           "options": {
             "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/cases/fedora_32-x86_64-openstack-boot.json
+++ b/test/cases/fedora_32-x86_64-openstack-boot.json
@@ -3558,6 +3558,17 @@
           }
         },
         {
+          "name": "org.osbuild.systemd",
+          "options": {
+            "enabled_services": [
+              "cloud-init.service",
+              "cloud-config.service",
+              "cloud-final.service",
+              "cloud-init-local.service"
+            ]
+          }
+        },
+        {
           "name": "org.osbuild.selinux",
           "options": {
             "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
@@ -9950,10 +9961,6 @@
       "arp-ethers.service",
       "chrony-dnssrv@.timer",
       "chrony-wait.service",
-      "cloud-config.service",
-      "cloud-final.service",
-      "cloud-init-local.service",
-      "cloud-init.service",
       "console-getty.service",
       "debug-shell.service",
       "exit.target",
@@ -9996,6 +10003,10 @@
       "auditd.service",
       "autovt@.service",
       "chronyd.service",
+      "cloud-config.service",
+      "cloud-final.service",
+      "cloud-init-local.service",
+      "cloud-init.service",
       "ctrl-alt-del.target",
       "dbus-broker.service",
       "dbus-org.fedoraproject.FirewallD1.service",

--- a/test/cases/fedora_32-x86_64-qcow2-boot.json
+++ b/test/cases/fedora_32-x86_64-qcow2-boot.json
@@ -3397,6 +3397,17 @@
           }
         },
         {
+          "name": "org.osbuild.systemd",
+          "options": {
+            "enabled_services": [
+              "cloud-init.service",
+              "cloud-config.service",
+              "cloud-final.service",
+              "cloud-init-local.service"
+            ]
+          }
+        },
+        {
           "name": "org.osbuild.selinux",
           "options": {
             "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
@@ -9535,10 +9546,6 @@
       "arp-ethers.service",
       "chrony-dnssrv@.timer",
       "chrony-wait.service",
-      "cloud-config.service",
-      "cloud-final.service",
-      "cloud-init-local.service",
-      "cloud-init.service",
       "console-getty.service",
       "console-login-helper-messages-issuegen.service",
       "console-login-helper-messages-motdgen.service",
@@ -9582,6 +9589,10 @@
       "auditd.service",
       "autovt@.service",
       "chronyd.service",
+      "cloud-config.service",
+      "cloud-final.service",
+      "cloud-init-local.service",
+      "cloud-init.service",
       "ctrl-alt-del.target",
       "dbus-broker.service",
       "dbus-org.freedesktop.nm-dispatcher.service",

--- a/test/cases/fedora_32-x86_64-qcow2-customize.json
+++ b/test/cases/fedora_32-x86_64-qcow2-customize.json
@@ -3499,6 +3499,10 @@
           "name": "org.osbuild.systemd",
           "options": {
             "enabled_services": [
+              "cloud-init.service",
+              "cloud-config.service",
+              "cloud-final.service",
+              "cloud-init-local.service",
               "sshd.socket"
             ],
             "disabled_services": [
@@ -9649,10 +9653,6 @@
       "arp-ethers.service",
       "chrony-dnssrv@.timer",
       "chrony-wait.service",
-      "cloud-config.service",
-      "cloud-final.service",
-      "cloud-init-local.service",
-      "cloud-init.service",
       "console-getty.service",
       "console-login-helper-messages-issuegen.service",
       "console-login-helper-messages-motdgen.service",
@@ -9695,6 +9695,10 @@
       "auditd.service",
       "autovt@.service",
       "chronyd.service",
+      "cloud-config.service",
+      "cloud-final.service",
+      "cloud-init-local.service",
+      "cloud-init.service",
       "ctrl-alt-del.target",
       "dbus-broker.service",
       "dbus-org.freedesktop.nm-dispatcher.service",


### PR DESCRIPTION

Previously, cloud-init was installed on qcow and openstack images but was not enabled, preventing a user from logging in to these images. Cloud-init and cloud-config services are enabled in fedora 31 and fedora 32. The image tests have been updated to reflect these changes.