### PR TITLE
🤷🏻‍♂️ Allow tests to run on AWS and PSI

### DIFF
--- a/schutzbot/Jenkinsfile
+++ b/schutzbot/Jenkinsfile
@@ -169,7 +169,7 @@ pipeline {
 
             parallel {
                 stage('Fedora 31 base') {
-                    agent { label "f31cloudbase && x86_64 && aws" }
+                    agent { label "f31cloudbase && x86_64" }
                     environment { TEST_TYPE = "base" }
                     steps {
                         unstash 'fedora31'
@@ -198,7 +198,7 @@ pipeline {
                     }
                 }
                 stage('Fedora 31 integration') {
-                    agent { label "f31cloudbase && x86_64 && aws" }
+                    agent { label "f31cloudbase && x86_64" }
                     environment {
                         TEST_TYPE = "integration"
                         AWS_CREDS = credentials('aws-credentials-osbuildci')
@@ -214,7 +214,7 @@ pipeline {
                     }
                 }
                 stage('Fedora 32 base') {
-                    agent { label "f32cloudbase && x86_64 && aws" }
+                    agent { label "f32cloudbase && x86_64" }
                     environment { TEST_TYPE = "base" }
                     steps {
                         unstash 'fedora32'
@@ -243,7 +243,7 @@ pipeline {
                     }
                 }
                 stage('Fedora 32 integration') {
-                    agent { label "f32cloudbase && x86_64 && aws" }
+                    agent { label "f32cloudbase && x86_64" }
                     environment {
                         TEST_TYPE = "integration"
                         AWS_CREDS = credentials('aws-credentials-osbuildci')
@@ -259,7 +259,7 @@ pipeline {
                     }
                 }
                 stage('RHEL 8 CDN Base') {
-                    agent { label "rhel8cloudbase && x86_64 && aws" }
+                    agent { label "rhel8cloudbase && x86_64" }
                     environment {
                         RHN_REGISTRATION_SCRIPT = credentials('rhn-register-script-production')
                         TEST_TYPE = "base"
@@ -291,7 +291,7 @@ pipeline {
                     }
                 }
                 stage('RHEL 8 CDN integration') {
-                    agent { label "rhel8cloudbase && x86_64 && aws" }
+                    agent { label "rhel8cloudbase && x86_64" }
                     environment {
                         TEST_TYPE = "integration"
                         AWS_CREDS = credentials('aws-credentials-osbuildci')


### PR DESCRIPTION
In #842, we verified that our tests run on AWS properly and we should
now let Jenkins decide where to run the tests since they work in both
places.

Remove the hardcoded AWS label and allow tests to run where they please.

Signed-off-by: Major Hayden <major@redhat.com>