### PR TITLE
schutzbot: add uploading to Azure

### DIFF
--- a/schutzbot/Jenkinsfile
+++ b/schutzbot/Jenkinsfile
@@ -70,6 +70,7 @@ pipeline {
                             environment {
                                 TEST_TYPE = "image"
                                 AWS_CREDS = credentials('aws-credentials-osbuildci')
+                                AZURE_CREDS = credentials('azure')
                             }
                             steps {
                                 unstash 'fedora31'
@@ -190,6 +191,7 @@ pipeline {
                             environment {
                                 TEST_TYPE = "image"
                                 AWS_CREDS = credentials('aws-credentials-osbuildci')
+                                AZURE_CREDS = credentials('azure')
                             }
                             steps {
                                 unstash 'fedora32'
@@ -314,6 +316,7 @@ pipeline {
                             environment {
                                 TEST_TYPE = "image"
                                 AWS_CREDS = credentials('aws-credentials-osbuildci')
+                                AZURE_CREDS = credentials('azure')
                                 RHN_REGISTRATION_SCRIPT = credentials('rhn-register-script-production')
                             }
                             steps {
@@ -442,6 +445,7 @@ pipeline {
                             environment {
                                 TEST_TYPE = "image"
                                 AWS_CREDS = credentials('aws-credentials-osbuildci')
+                                AZURE_CREDS = credentials('azure')
                             }
                             steps {
                                 unstash 'rhel83'

--- a/schutzbot/run_image_tests.sh
+++ b/schutzbot/run_image_tests.sh
@@ -36,8 +36,27 @@ run_test_case () {
     echo "🏃🏻 Running test: ${TEST_NAME}"
     test_divider
 
-    # Set up the testing command.
-    TEST_CMD="$TEST_RUNNER -test.v ${IMAGE_TEST_CASES_PATH}/${TEST_CASE_FILENAME}"
+    # Set up the testing command with Azure secrets in the environment.
+    #
+    # This works by having a text file stored in Jenkins credentials.
+    # In Jenkinsfile, the following line assigns the path to this secret file
+    # to an environment variable called AZURE_CREDS:
+    # AZURE_CREDS = credentials('azure')
+    #
+    # The file is in the following format:
+    # KEY1=VALUE1
+    # KEY2=VALUE2
+    #
+    # Using `env $(cat $AZURE_CREDS)` we can take all the key-value pairs and
+    # save them as environment variables.
+    # Read test/README.md to see all required environment variables for Azure
+    # uploads
+    #
+    # AZURE_CREDS might not be defined in all cases (e.g. Azure doesn't
+    # support aarch64), therefore the following line sets AZURE_CREDS to
+    # /dev/null if the variable is undefined.
+    AZURE_CREDS=${AZURE_CREDS-/dev/null}
+    TEST_CMD="env $(cat $AZURE_CREDS) $TEST_RUNNER -test.v ${IMAGE_TEST_CASES_PATH}/${TEST_CASE_FILENAME}"
 
     # Run the test and add the test name to the list of passed or failed
     # tests depending on the result.


### PR DESCRIPTION
Support for uploading was already in, it's just needed to pass the right environment variables.

We should probably add an integration test for this but this is good enough for now and it allows us to get rid of Travis.