### PR TITLE
crypt: add automatic darwin support

### DIFF
--- a/internal/crypt/crypt.go
+++ b/internal/crypt/crypt.go
@@ -6,6 +6,9 @@ import (
 	"strings"
 )
 
+// CryptSHA512 encrypts the given password with SHA512 and a random salt.
+//
+// Note that this function is not deterministic.
 func CryptSHA512(phrase string) (string, error) {
 	const SHA512SaltLength = 16
 
@@ -35,6 +38,13 @@ func genSalt(length int) (string, error) {
 	return string(b), nil
 }
 
+// PasswordIsCrypted returns true if the password appears to be an encrypted
+// one, according to a very simple heuristic.
+//
+// Any string starting with one of $2$, $6$ or $5$ is considered to be
+// encrypted. Any other string is consdirede to be unencrypted.
+//
+// This functionality is taken from pylorax.
 func PasswordIsCrypted(s string) bool {
 	// taken from lorax src: src/pylorax/api/compose.py:533
 	prefixes := [...]string{"$2b$", "$6$", "$5$"}

--- a/internal/crypt/crypt_impl.go
+++ b/internal/crypt/crypt_impl.go
@@ -1,4 +1,4 @@
-// +build !macos
+// +build !darwin
 
 // Copied from https://github.com/amoghe/go-crypt/blob/b3e291286513a0c993f7c4dd7060d327d2d56143/crypt_r.go
 // Original sources are under MIT license:

--- a/internal/crypt/crypt_impl_macos.go
+++ b/internal/crypt/crypt_impl_macos.go
@@ -1,8 +1,7 @@
-// +build macos
+// +build darwin
 
 package crypt
 
 func crypt(pass, salt string) (string, error) {
 	panic("You must not run osbuild-composer on macOS!")
-	return "", nil
 }

--- a/internal/crypt/crypt_test.go
+++ b/internal/crypt/crypt_test.go
@@ -1,10 +1,11 @@
-// +build !macos
+// +build !darwin
 
 package crypt
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func Test_crypt_PasswordIsCrypted(t *testing.T) {


### PR DESCRIPTION
Currently one would have to pass a `macos` flag explicitly to build on OSX, but if we replace `macos` with `darwin` this happens automatically.