### PR TITLE
spec: pull in systemd-nspawn

### DIFF
--- a/osbuild-composer.spec
+++ b/osbuild-composer.spec
@@ -247,6 +247,7 @@ Requires:   composer-cli
 Requires:   createrepo_c
 Requires:   genisoimage
 Requires:   qemu-kvm-core
+Requires:   systemd-container
 %ifarch %{arm}
 Requires:   edk2-aarch64
 %endif


### PR DESCRIPTION
The composer-tests use systemd-nspawn, so make sure the `*-tests` RPM
depends on `systemd-container`.

Right now this dependency is recursively fulfilled by the `osbuild`
RPM. However, this might change if we switch to `bubblewrap` as a
sandbox. Furthermore, we should not fulfill our dependencies
recursively, but list them directly.