### PR TITLE
💣 Notify via telegram on master CI failure

### DIFF
--- a/schutzbot/Jenkinsfile
+++ b/schutzbot/Jenkinsfile
@@ -303,6 +303,18 @@ pipeline {
             }
         }
     }
+
+    post {
+        success {
+            when { branch 'master' }
+            telegramSend "💚 CI passed for osbuild-composer master branch!. ${env.BUILD_URL}"
+        }
+        unsuccessful {
+            when { branch 'master' }
+            telegramSend "💣 CI failed for osbuild-composer master branch! ${env.BUILD_URL}"
+        }
+    }
+
 }
 
 // Set up a function to hold the steps needed to run the tests so we don't


### PR DESCRIPTION
We've come a long way and we need to triage failures that occur during
CI for the master branch. This will help us find problems with CI as
well as find other issues that could show up in a customer environment.

Also, let's send a happy notification when everything goes well. 💚

🧹 Remove the YAML files from the old Ansible tests since they are no longer needed.