### PR TITLE
Do not obsolete lorax-composer

### DIFF
--- a/osbuild-composer.spec
+++ b/osbuild-composer.spec
@@ -55,7 +55,6 @@ Requires: osbuild-ostree >= 17
 Provides: weldr
 
 %if 0%{?rhel}
-Obsoletes: lorax-composer <= 29
 Conflicts: lorax-composer
 %endif
 


### PR DESCRIPTION
Doing this makes it impossible to install lorax-composer when you want
it, which breaks testing in lorax as well as causes problems for users
who specifically want to install it.

Resolves: rhbz#1858051