### PR TITLE
distro/tests: use test case filename as test name

### DIFF
--- a/internal/distro/distro_test_common/distro_test_common.go
+++ b/internal/distro/distro_test_common/distro_test_common.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"path"
 	"path/filepath"
 	"testing"
 
@@ -63,7 +64,7 @@ func TestDistro_Manifest(t *testing.T, pipelinePath string, prefix string, distr
 				CheckGPG:   repo.CheckGPG,
 			}
 		}
-		t.Run(tt.ComposeRequest.ImageType, func(t *testing.T) {
+		t.Run(path.Base(fileName), func(t *testing.T) {
 			distros, err := distro.NewRegistry(distros...)
 			require.NoError(t, err)
 			d := distros.GetDistro(tt.ComposeRequest.Distro)


### PR DESCRIPTION
These tests used the image type as test name, which is ambiguous. Use
the file name for the test case instead.