### PR TITLE
tests: Change boot type to openstack. Refs #876

### DIFF
--- a/schutzbot/Jenkinsfile
+++ b/schutzbot/Jenkinsfile
@@ -131,7 +131,7 @@ pipeline {
                         TEST_TYPE = "image"
                         AWS_CREDS = credentials('aws-credentials-osbuildci')
                         AZURE_CREDS = credentials('azure')
-                        OPENSTACK_CREDS = credentials("psi-openstack-clouds-yaml")
+                        OPENSTACK_CREDS = credentials("psi-openstack-creds")
                     }
                     steps {
                         unstash 'fedora31'
@@ -179,7 +179,7 @@ pipeline {
                         TEST_TYPE = "image"
                         AWS_CREDS = credentials('aws-credentials-osbuildci')
                         AZURE_CREDS = credentials('azure')
-                        OPENSTACK_CREDS = credentials("psi-openstack-clouds-yaml")
+                        OPENSTACK_CREDS = credentials("psi-openstack-creds")
                     }
                     steps {
                         unstash 'fedora32'
@@ -230,7 +230,7 @@ pipeline {
                         TEST_TYPE = "image"
                         AWS_CREDS = credentials('aws-credentials-osbuildci')
                         AZURE_CREDS = credentials('azure')
-                        OPENSTACK_CREDS = credentials("psi-openstack-clouds-yaml")
+                        OPENSTACK_CREDS = credentials("psi-openstack-creds")
                         RHN_REGISTRATION_SCRIPT = credentials('rhn-register-script-production')
                     }
                     steps {
@@ -283,7 +283,7 @@ pipeline {
                         TEST_TYPE = "image"
                         AWS_CREDS = credentials('aws-credentials-osbuildci')
                         AZURE_CREDS = credentials('azure')
-                        OPENSTACK_CREDS = credentials("psi-openstack-clouds-yaml")
+                        OPENSTACK_CREDS = credentials("psi-openstack-creds")
                         RHN_REGISTRATION_SCRIPT = credentials('rhn-register-script-production-beta')
                     }
                     steps {

--- a/schutzbot/run_image_tests.sh
+++ b/schutzbot/run_image_tests.sh
@@ -56,7 +56,8 @@ run_test_case () {
     # support aarch64), therefore the following line sets AZURE_CREDS to
     # /dev/null if the variable is undefined.
     AZURE_CREDS=${AZURE_CREDS-/dev/null}
-    TEST_CMD="env $(cat $AZURE_CREDS) $TEST_RUNNER -test.v ${IMAGE_TEST_CASES_PATH}/${TEST_CASE_FILENAME}"
+    OPENSTACK_CREDS=${OPENSTACK_CREDS-/dev/null}
+    TEST_CMD="env $(cat $AZURE_CREDS $OPENSTACK_CREDS) $TEST_RUNNER -test.v ${IMAGE_TEST_CASES_PATH}/${TEST_CASE_FILENAME}"
 
     # Run the test and add the test name to the list of passed or failed
     # tests depending on the result.
@@ -74,10 +75,6 @@ run_test_case () {
 if ! rpm -qi osbuild-composer-tests > /dev/null 2>&1; then
     sudo dnf -y install osbuild-composer-tests
 fi
-
-# Prepare the OpenStack login credentials.
-mkdir -p ~/.config/openstack
-cp $OPENSTACK_CREDS ~/.config/openstack/clouds.yaml
 
 # Change to the working directory.
 cd $WORKING_DIRECTORY

--- a/test/README.md
+++ b/test/README.md
@@ -89,6 +89,17 @@ it uploads the image to Azure, boots it and tries to ssh into it.
    the *Access control (IAM)* section under the newly created resource group.
    Here, add the new application with the *Developer* role.
 
+### Setting up OpenStack upload tests
+
+The following environment variables are required
+
+- `OS_AUTH_URL`
+- `OS_USERNAME`
+- `OS_PASSWORD`
+- `OS_PROJECT_ID`
+- `OS_DOMAIN_NAME`
+
+
 ## Notes on asserts and comparing expected values
 
 When comparing for expected values in test functions you should use the

--- a/test/cases/fedora_31-x86_64-openstack-boot.json
+++ b/test/cases/fedora_31-x86_64-openstack-boot.json
@@ -1,6 +1,6 @@
 {
   "boot": {
-    "type": "qemu"
+    "type": "openstack"
   },
   "compose-request": {
     "distro": "fedora-31",

--- a/test/cases/fedora_32-x86_64-openstack-boot.json
+++ b/test/cases/fedora_32-x86_64-openstack-boot.json
@@ -1,6 +1,6 @@
 {
   "boot": {
-    "type": "qemu"
+    "type": "openstack"
   },
   "compose-request": {
     "distro": "fedora-32",

--- a/test/cases/rhel_8-x86_64-openstack-boot.json
+++ b/test/cases/rhel_8-x86_64-openstack-boot.json
@@ -1,6 +1,6 @@
 {
   "boot": {
-    "type": "qemu"
+    "type": "openstack"
   },
   "compose-request": {
     "distro": "rhel-8",

--- a/tools/test-case-generators/format-request-map.json
+++ b/tools/test-case-generators/format-request-map.json
@@ -34,7 +34,7 @@
   },
   "openstack": {
     "boot": {
-      "type": "qemu"
+      "type": "openstack"
     },
     "compose-request": {
       "distro": "",


### PR DESCRIPTION
this will cause the images to be uploaded and booted in our OpenStack cluster.

Note: this change is only for x86_64, not added to the aarch64 files.