### PR TITLE
🔐 Add OpenStack credentials for image tests

### DIFF
--- a/schutzbot/Jenkinsfile
+++ b/schutzbot/Jenkinsfile
@@ -127,6 +127,7 @@ pipeline {
                         TEST_TYPE = "image"
                         AWS_CREDS = credentials('aws-credentials-osbuildci')
                         AZURE_CREDS = credentials('azure')
+                        OPENSTACK_CREDS = credentials("psi-openstack-clouds-yaml")
                     }
                     steps {
                         unstash 'fedora31'
@@ -174,6 +175,7 @@ pipeline {
                         TEST_TYPE = "image"
                         AWS_CREDS = credentials('aws-credentials-osbuildci')
                         AZURE_CREDS = credentials('azure')
+                        OPENSTACK_CREDS = credentials("psi-openstack-clouds-yaml")
                     }
                     steps {
                         unstash 'fedora32'
@@ -224,6 +226,7 @@ pipeline {
                         TEST_TYPE = "image"
                         AWS_CREDS = credentials('aws-credentials-osbuildci')
                         AZURE_CREDS = credentials('azure')
+                        OPENSTACK_CREDS = credentials("psi-openstack-clouds-yaml")
                         RHN_REGISTRATION_SCRIPT = credentials('rhn-register-script-production')
                     }
                     steps {
@@ -273,6 +276,7 @@ pipeline {
                         TEST_TYPE = "image"
                         AWS_CREDS = credentials('aws-credentials-osbuildci')
                         AZURE_CREDS = credentials('azure')
+                        OPENSTACK_CREDS = credentials("psi-openstack-clouds-yaml")
                     }
                     steps {
                         unstash 'rhel83'

--- a/schutzbot/run_image_tests.sh
+++ b/schutzbot/run_image_tests.sh
@@ -75,6 +75,10 @@ if ! rpm -qi osbuild-composer-tests > /dev/null 2>&1; then
     sudo dnf -y install osbuild-composer-tests
 fi
 
+# Prepare the OpenStack login credentials.
+mkdir -p ~/.config/openstack
+cp $OPENSTACK_CREDS ~/.config/openstack/clouds.yaml
+
 # Change to the working directory.
 cd $WORKING_DIRECTORY
 


### PR DESCRIPTION
We want to deliver images directly to OpenStack during the CI tests.
Ensure the credentials are available during those tests and move them to
the proper location to be read by OpenStack tools and SDKs.

This helps with #876.

Signed-off-by: Major Hayden <major@redhat.com>