### PR TITLE
🐣 Use RHEL 8.3 beta content from CDN

### DIFF
--- a/schutzbot/Jenkinsfile
+++ b/schutzbot/Jenkinsfile
@@ -88,8 +88,7 @@ pipeline {
                     agent { label "rhel83cloudbase && x86_64" }
                     environment {
                         AWS_CREDS = credentials('aws-credentials-osbuildci')
-                        NIGHTLY_REPO = credentials('rhel8-nightly-repo')
-                        NIGHTLY_MOCK_TEMPLATE = credentials('rhel8-nightly-mock-template')
+                        RHN_REGISTRATION_SCRIPT = credentials('rhn-register-script-production-beta')
                     }
                     steps {
                         sh "schutzbot/ci_details.sh"
@@ -259,7 +258,10 @@ pipeline {
 
                 stage('EL8.3 Base') {
                     agent { label "rhel83cloudbase && x86_64" }
-                    environment { TEST_TYPE = "base" }
+                    environment {
+                        TEST_TYPE = "base"
+                        RHN_REGISTRATION_SCRIPT = credentials('rhn-register-script-production-beta')
+                    }
                     steps {
                         unstash 'rhel83'
                         run_tests('base')
@@ -277,6 +279,7 @@ pipeline {
                         AWS_CREDS = credentials('aws-credentials-osbuildci')
                         AZURE_CREDS = credentials('azure')
                         OPENSTACK_CREDS = credentials("psi-openstack-clouds-yaml")
+                        RHN_REGISTRATION_SCRIPT = credentials('rhn-register-script-production-beta')
                     }
                     steps {
                         unstash 'rhel83'
@@ -293,6 +296,7 @@ pipeline {
                     environment {
                         TEST_TYPE = "integration"
                         AWS_CREDS = credentials('aws-credentials-osbuildci')
+                        RHN_REGISTRATION_SCRIPT = credentials('rhn-register-script-production-beta')
                     }
                     steps {
                         unstash 'rhel83'


### PR DESCRIPTION
Remove the nightly repos from the RHEL 8.3 jobs and replace them with CDN registration for beta content.

Signed-off-by: Major Hayden <major@redhat.com>