### PR TITLE
🏠 Keep RHEL 8 image tests internal only

### DIFF
--- a/schutzbot/Jenkinsfile
+++ b/schutzbot/Jenkinsfile
@@ -273,7 +273,7 @@ pipeline {
                     }
                 }
                 stage('EL8.3 Image') {
-                    agent { label "rhel83cloudbase && x86_64" }
+                    agent { label "rhel83cloudbase && psi && x86_64" }
                     environment {
                         TEST_TYPE = "image"
                         AWS_CREDS = credentials('aws-credentials-osbuildci')


### PR DESCRIPTION
The image tests for RHEL 8 still download packages from a server that is only available inside the Red Hat network. 😢

Opened issue #902 for this.