### PR TITLE
🦘 Skip checkout on prepare

### DIFF
--- a/schutzbot/Jenkinsfile
+++ b/schutzbot/Jenkinsfile
@@ -19,6 +19,11 @@ pipeline {
 
         stage("Prepare 🤔") {
             agent { label "schutzbot" }
+            options {
+                // Don't checkout the git repository here. It just clogs
+                // up the Jenkins disk space and does nothing for us.
+                skipDefaultCheckout()
+            }
             steps {
                 sh (
                     label: "Get environment variables",


### PR DESCRIPTION
Checking out the code from git during the prepare step is a waste of
time and disk space since we don't need the git repository cloned there.

Signed-off-by: Major Hayden <major@redhat.com>