### PR TITLE
schutzbot: don't skip image test for fedora iot commit

### DIFF
--- a/schutzbot/run_image_tests.sh
+++ b/schutzbot/run_image_tests.sh
@@ -84,12 +84,6 @@ cd $WORKING_DIRECTORY
 
 # Run each test case.
 for TEST_CASE in $(get_test_cases); do
-    # The fedora_32-x86_64-fedora_iot_commit-boot test has some bugs that
-    # still need to be worked out.  See this bug for details:
-    # https://github.com/osbuild/osbuild-composer/issues/798
-    if [[ $TEST_CASE == *fedora_iot_commit* ]]; then
-        continue
-    fi
     run_test_case $IMAGE_TEST_CASE_RUNNER $TEST_CASE
 done
 

--- a/test/cases/fedora_32-x86_64-fedora_iot_commit-boot.json
+++ b/test/cases/fedora_32-x86_64-fedora_iot_commit-boot.json
@@ -10214,7 +10214,7 @@
     "ostree": {
       "refs": {
         "fedora/32/x86_64/iot": {
-          "inputhash": "4879988213fbac55953e12b6268dc7fce3fc20b28d9112958665c98a546c1820"
+          "inputhash": "e7a265e665ce2765c90c1a51ba187202e8b77b4e0aadddfc545189171cb9c31f"
         }
       },
       "repo": {


### PR DESCRIPTION
The SELinux bug has been fixed so there is no need to skip it.