### PR TITLE
mockbuild: Fix path to latest repo

### DIFF
--- a/schutzbot/mockbuild.sh
+++ b/schutzbot/mockbuild.sh
@@ -58,7 +58,7 @@ REPO_DIR=repo/${JOB_NAME}/${POST_MERGE_SHA}/${ID}${VERSION_ID//./}_${ARCH}
 
 # Maintain a directory for the master branch that always contains the latest
 # RPM packages.
-REPO_DIR_LATEST=repo/${JOB_NAME}/latest/${ID}${VERSION_ID//./}_${ARCH}
+REPO_DIR_LATEST=repo/${JOB_NAME}/latest
 
 # Full URL to the RPM repository after they are uploaded.
 REPO_URL=${MOCK_REPO_BASE_URL}/${JOB_NAME}/${POST_MERGE_SHA}/${ID}${VERSION_ID//./}_${ARCH}


### PR DESCRIPTION
Using `cp` to copy the repo content caused the last part of the path to
be duplicated:

* Current: `master/latest/rhel82_x86_64/rhel82_x86_64/repodata/repomd.xml`
* Desired: `master/latest/rhel82_x86_64/repodata/repomd.xml`

Remove the VERSION_ID/ARCH from the destination to remove the duplicated
path.

Signed-off-by: Major Hayden <major@redhat.com>