### PR TITLE
weldr: Fix out of range index for missing toml blueprint freeze

### DIFF
--- a/internal/weldr/api.go
+++ b/internal/weldr/api.go
@@ -1246,7 +1246,12 @@ func (api *API) blueprintsFreezeHandler(writer http.ResponseWriter, request *htt
 		// lorax concatenates multiple blueprints with `\n\n` here,
 		// which is never useful. Deviate by only returning the first
 		// blueprint.
-		if len(blueprints) > 1 {
+		if len(blueprints) == 0 {
+			// lorax-composer just outputs an empty string if there were no blueprints
+			writer.WriteHeader(http.StatusOK)
+			fmt.Fprintf(writer, "")
+			return
+		} else if len(blueprints) > 1 {
 			errors := responseError{
 				ID:  "HTTPError",
 				Msg: "toml format only supported when requesting one blueprint",

--- a/internal/weldr/api_test.go
+++ b/internal/weldr/api_test.go
@@ -351,6 +351,7 @@ func TestBlueprintsFreeze(t *testing.T) {
 			ExpectedTOML   string
 		}{
 			{rpmmd_mock.BaseFixture, "/api/v0/blueprints/freeze/test?format=toml", http.StatusOK, "name=\"test\"\n description=\"Test\"\n version=\"0.0.1\"\n groups = []\n [[packages]]\n name=\"dep-package1\"\n version=\"1.33-2.fc30.x86_64\"\n [[packages]]\n name=\"dep-package3\"\n version=\"7:3.0.3-1.fc30.x86_64\"\n [[modules]]\n name=\"dep-package2\"\n version=\"2.9-1.fc30.x86_64\""},
+			{rpmmd_mock.BaseFixture, "/api/v0/blueprints/freeze/missing?format=toml", http.StatusOK, ""},
 		}
 
 		for _, c := range cases {


### PR DESCRIPTION
The API was crashing if the freeze request was called on a non-existent
blueprint. This changes it to return an empty string, matching
lorax-composer's behavior (since the output is toml it shouldn't return
json).