### PR TITLE
Add friendly message for logs on running build

### DIFF
--- a/internal/weldr/api.go
+++ b/internal/weldr/api.go
@@ -2479,7 +2479,7 @@ func (api *API) composeLogHandler(writer http.ResponseWriter, request *http.Requ
 	}
 
 	if composeStatus.State == common.CRunning {
-		fmt.Fprintf(writer, "Running...\n")
+		fmt.Fprintf(writer, "Build %s is still running.\n", uuidString)
 		return
 	}
 

--- a/internal/weldr/api_test.go
+++ b/internal/weldr/api_test.go
@@ -722,7 +722,7 @@ func TestComposeLog(t *testing.T) {
 		ExpectedResponse string
 	}{
 		{rpmmd_mock.BaseFixture, "GET", "/api/v0/compose/log/30000000-0000-0000-0000-000000000000", http.StatusOK, `{"status":false,"errors":[{"id":"BuildInWrongState","msg":"Build 30000000-0000-0000-0000-000000000000 has not started yet. No logs to view."}]}` + "\n"},
-		{rpmmd_mock.BaseFixture, "GET", "/api/v0/compose/log/30000000-0000-0000-0000-000000000001", http.StatusOK, `Running...` + "\n"},
+		{rpmmd_mock.BaseFixture, "GET", "/api/v0/compose/log/30000000-0000-0000-0000-000000000001", http.StatusOK, `Build 30000000-0000-0000-0000-000000000001 is still running.` + "\n"},
 		{rpmmd_mock.BaseFixture, "GET", "/api/v0/compose/log/30000000-0000-0000-0000-000000000002", http.StatusOK, `The compose result is empty.` + "\n"},
 		{rpmmd_mock.BaseFixture, "GET", "/api/v1/compose/log/30000000-0000-0000-0000-000000000002", http.StatusOK, `The compose result is empty.` + "\n"},
 		{rpmmd_mock.BaseFixture, "GET", "/api/v1/compose/log/30000000-0000-0000-0000", http.StatusBadRequest, `{"status":false,"errors":[{"id":"UnknownUUID","msg":"30000000-0000-0000-0000 is not a valid build uuid"}]}` + "\n"},


### PR DESCRIPTION
Improve the message returned by osbuild-composer when a user asks for
logs of a compose that is still running.

Signed-off-by: Major Hayden <major@redhat.com>