### PR TITLE
Add Install section to remote worker unit file

### DIFF
--- a/distribution/osbuild-remote-worker@.service
+++ b/distribution/osbuild-remote-worker@.service
@@ -13,3 +13,6 @@ IOSchedulingClass=idle
 CacheDirectory=osbuild-worker
 # systemd >= 240 sets this, but osbuild-worker runs on earlier versions
 Environment="CACHE_DIRECTORY=/var/cache/osbuild-worker"
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Although the obuild-remote-worker@.service unit can be started, it can't
be enabled at boot time since the `Install` section is missing in the
unit file.

Add a small `[Install]` section with the same `WantedBy` as
osbuild-composr.service.

Fixes #924.

Signed-off-by: Major Hayden <major@redhat.com>