### PR TITLE
dnf-json: Sort depsolve pkg list

### DIFF
--- a/dnf-json
+++ b/dnf-json
@@ -199,5 +199,5 @@ with tempfile.TemporaryDirectory() as persistdir:
             })
         json.dump({
             "checksums": repo_checksums(base),
-            "dependencies": dependencies
+            "dependencies": sorted(dependencies, key=lambda x: x['name'])
         }, sys.stdout)


### PR DESCRIPTION
Running `composer-cli blueprints depsolve` gives an unordered list of
packages and this can make it difficult to figure out if your desired
package is in the list.

Sort the list of depsolved packages by the name of the package when
returning it from dnf-json.

Signed-off-by: Major Hayden <major@redhat.com>