### PR TITLE
awsupload: Add description to snapshots

### DIFF
--- a/internal/upload/awsupload/awsupload.go
+++ b/internal/upload/awsupload/awsupload.go
@@ -1,6 +1,7 @@
 package awsupload
 
 import (
+	"fmt"
 	"log"
 	"os"
 	"time"
@@ -115,8 +116,10 @@ func WaitUntilImportSnapshotTaskCompletedWithContext(c *ec2.EC2, ctx aws.Context
 
 func (a *AWS) Register(name, bucket, key string) (*string, error) {
 	log.Printf("[AWS] 📥 Importing snapshot from image: %s/%s", bucket, key)
+	snapshotDescription := fmt.Sprintf("Image Builder AWS Import of %s", name)
 	importTaskOutput, err := a.importer.ImportSnapshot(
 		&ec2.ImportSnapshotInput{
+			Description: aws.String(snapshotDescription),
 			DiskContainer: &ec2.SnapshotDiskContainer{
 				UserBucket: &ec2.UserBucket{
 					S3Bucket: aws.String(bucket),

--- a/internal/upload/awsupload/awsupload.go
+++ b/internal/upload/awsupload/awsupload.go
@@ -132,7 +132,7 @@ func (a *AWS) Register(name, bucket, key string) (*string, error) {
 		return nil, err
 	}
 
-	log.Printf("[AWS] ⏱ Waiting for snapshot to finish importing: %s", *importTaskOutput.ImportTaskId)
+	log.Printf("[AWS] 🚚 Waiting for snapshot to finish importing: %s", *importTaskOutput.ImportTaskId)
 	err = WaitUntilImportSnapshotTaskCompleted(
 		a.importer,
 		&ec2.DescribeImportSnapshotTasksInput{

--- a/internal/upload/awsupload/awsupload.go
+++ b/internal/upload/awsupload/awsupload.go
@@ -167,6 +167,24 @@ func (a *AWS) Register(name, bucket, key string) (*string, error) {
 	}
 
 	snapshotID := importOutput.ImportSnapshotTasks[0].SnapshotTaskDetail.SnapshotId
+
+	// Tag the snapshot with the image name.
+	req, _ := a.importer.CreateTagsRequest(
+		&ec2.CreateTagsInput{
+			Resources: []*string{snapshotID},
+			Tags: []*ec2.Tag{
+				{
+					Key:   aws.String("Name"),
+					Value: aws.String(name),
+				},
+			},
+		},
+	)
+	err = req.Send()
+	if err != nil {
+		return nil, err
+	}
+
 	log.Printf("[AWS] 📋 Registering AMI from imported snapshot: %s", *snapshotID)
 	registerOutput, err := a.importer.RegisterImage(
 		&ec2.RegisterImageInput{

--- a/internal/upload/awsupload/awsupload.go
+++ b/internal/upload/awsupload/awsupload.go
@@ -114,6 +114,9 @@ func WaitUntilImportSnapshotTaskCompletedWithContext(c *ec2.EC2, ctx aws.Context
 	return w.WaitWithContext(ctx)
 }
 
+// Register is a function that imports a snapshot, waits for the snapshot to
+// fully import, tags the snapshot, cleans up the image in S3, and registers
+// an AMI in AWS.
 func (a *AWS) Register(name, bucket, key string) (*string, error) {
 	log.Printf("[AWS] 📥 Importing snapshot from image: %s/%s", bucket, key)
 	snapshotDescription := fmt.Sprintf("Image Builder AWS Import of %s", name)


### PR DESCRIPTION
Make it easier to tell which snapshot goes with each AMI by labeling
them with a description.

Signed-off-by: Major Hayden <major@redhat.com>