### PR TITLE
worker: support returning returning images as StreamOptimized

### DIFF
--- a/golang-github-osbuild-composer.spec
+++ b/golang-github-osbuild-composer.spec
@@ -47,6 +47,7 @@ Requires: %{name}-worker = %{version}-%{release}
 Requires: systemd
 Requires: osbuild >= 18
 Requires: osbuild-ostree >= 18
+Requires: qemu-img
 
 Provides: osbuild-composer
 Provides: weldr

--- a/internal/target/local_target.go
+++ b/internal/target/local_target.go
@@ -3,9 +3,10 @@ package target
 import "github.com/google/uuid"
 
 type LocalTargetOptions struct {
-	ComposeId    uuid.UUID `json:"compose_id"`
-	ImageBuildId int       `json:"image_build_id"`
-	Filename     string    `json:"filename"`
+	ComposeId       uuid.UUID `json:"compose_id"`
+	ImageBuildId    int       `json:"image_build_id"`
+	Filename        string    `json:"filename"`
+	StreamOptimized bool      `json:"stream_optimized"` // return image as stream optimized
 }
 
 func (LocalTargetOptions) isTargetOptions() {}

--- a/internal/weldr/api.go
+++ b/internal/weldr/api.go
@@ -1753,9 +1753,10 @@ func (api *API) composeHandler(writer http.ResponseWriter, request *http.Request
 
 	targets = append(targets, target.NewLocalTarget(
 		&target.LocalTargetOptions{
-			ComposeId:    composeID,
-			ImageBuildId: 0,
-			Filename:     imageType.Filename(),
+			ComposeId:       composeID,
+			ImageBuildId:    0,
+			Filename:        imageType.Filename(),
+			StreamOptimized: imageType.Name() == "vmdk", // TODO: move conversion to osbuild
 		},
 	))
 

--- a/osbuild-composer.spec
+++ b/osbuild-composer.spec
@@ -51,6 +51,7 @@ Requires: %{name}-worker = %{version}-%{release}
 Requires: systemd
 Requires: osbuild >= 18
 Requires: osbuild-ostree >= 18
+Requires: qemu-img
 
 Provides: weldr
 


### PR DESCRIPTION
vCenter requires images to be uploaded as vmdk StreamOptimized. Lorax
always produced images on this format, so we should make sure to do the
same for our VMWare images.

Allow LocalTarget to request the images produced by osbuild be converted
to be streamOptimized before saving in composer, and hook the weldr API
up to enable this option for vmdk images.

Ideally this should simply be an option in osbuild, but that would
require some more work, which we will not manage in time for RHEL8.3.
Therefore do this minimal fix.

Note that that means the images produced by our manifests (including in
our image-test test cases) are not on the format that the weldr API
returns, so the tests we run on them would also, for now, need to
convert before uploading to vCenter.

Signed-off-by: Tom Gundersen <teg@jklm.no>