### PR TITLE
dnf-json: don't initialize dnf plugins

### DIFF
--- a/dnf-json
+++ b/dnf-json
@@ -56,9 +56,6 @@ def create_base(repos, module_platform_id, persistdir, cachedir, arch):
     # downloading metadata (when depsolving) and downloading packages.
     base.conf.fastestmirror = True
 
-    # Initialize all plugins (including fastestmirror).
-    base.init_plugins()
-
     # Try another mirror if it takes longer than 5 seconds to connect.
     base.conf.timeout = 5
 


### PR DESCRIPTION
acf91a4 enabled fastestmirror but also calls `base.init_plugins()` to
initialize dnf plugins. This is not necessary and not what we want
conceptually.

Not necessary, because `fastestmirror` is a dnf built-in (it was a
plugin during yum-times [1]). The same patch sets the `fastestmirror`
option as well. Thus, this patch does not revert functionality.

Not what we want, because we're using dnf more as a library, explicitly
passing all options. Plugins depend on additional host configuration,
which we'd like to avoid pulling in. In particular, the
subscription-manager plugin tries reading certificates in `/etc/pki`,
which are not readable by the `osbuild-composer` user. This leads to
these errors in the journal:

    [ERROR] dnf-json:54297:MainThread @logutil.py:194 -
      [Errno 13] Permission denied: '/var/log/rhsm/rhsm.log' -
      Further logging output will be written to stderr
    [ERROR] dnf-json:54297:MainThread @identity.py:156 -
      Reload of consumer identity cert /etc/pki/consumer/cert.pem
      raised an exception with msg:
      [Errno 13] Permission denied: '/etc/pki/consumer/key.pem'

These errors are not fatal, but could confuse people when inspecting
logs to find unrelated problems. This patch makes them disappear.

[1] https://fedoraproject.org/wiki/Yum_to_DNF_Cheatsheet