### PR TITLE
⏱  Extend golangci-lint timeout to 5m0s

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -41,7 +41,7 @@ jobs:
         run: curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b $(go env GOPATH)/bin v1.23.7
 
       - name: Run golangci-lint
-        run: $(go env GOPATH)/bin/golangci-lint run
+        run: $(go env GOPATH)/bin/golangci-lint run --timeout 5m0s
 
       - name: Run unit tests
         run: go test -v -race -covermode=atomic -coverprofile=coverage.txt -coverpkg=./... ./...


### PR DESCRIPTION
For reasons unknown, golangci-lint's default 1m0s timeout is *slightly*
too short for CI runs occasionally. Extend it to 5 minutes to ensure the
job always has enough time to run.

Signed-off-by: Major Hayden <major@redhat.com>