### PR TITLE
rhel8.3: restrict testing after branching

### DIFF
--- a/schutzbot/Jenkinsfile
+++ b/schutzbot/Jenkinsfile
@@ -40,38 +40,6 @@ pipeline {
 
             parallel {
 
-                stage('F31') {
-                    agent { label "f31cloudbase && x86_64" }
-                    environment {
-                        AWS_CREDS = credentials('aws-credentials-osbuildci')
-                    }
-                    steps {
-                        sh "schutzbot/ci_details.sh"
-                        retry(3) {
-                            sh "schutzbot/mockbuild.sh"
-                        }
-                        stash (
-                            includes: 'osbuild-mock.repo',
-                            name: 'fedora31'
-                        )
-                    }
-                }
-                stage('F32') {
-                    agent { label "f32cloudbase && x86_64" }
-                    environment {
-                        AWS_CREDS = credentials('aws-credentials-osbuildci')
-                    }
-                    steps {
-                        sh "schutzbot/ci_details.sh"
-                        retry(3) {
-                            sh "schutzbot/mockbuild.sh"
-                        }
-                        stash (
-                            includes: 'osbuild-mock.repo',
-                            name: 'fedora32'
-                        )
-                    }
-                }
                 stage('EL8') {
                     agent { label "rhel8cloudbase && x86_64" }
                     environment {
@@ -112,140 +80,6 @@ pipeline {
         stage("Testing 🍌") {
             parallel {
 
-                stage('F31 Base') {
-                    agent { label "f31cloudbase && x86_64" }
-                    environment { TEST_TYPE = "base" }
-                    steps {
-                        unstash 'fedora31'
-                        run_tests('base')
-                    }
-                    post {
-                        always {
-                            preserve_logs('fedora31-base')
-                        }
-                    }
-                }
-                stage('F31 Image') {
-                    agent { label "f31cloudbase && psi && x86_64" }
-                    environment {
-                        TEST_TYPE = "image"
-                        AWS_CREDS = credentials('aws-credentials-osbuildci')
-                        AZURE_CREDS = credentials('azure')
-                        OPENSTACK_CREDS = credentials("psi-openstack-creds")
-                        VCENTER_CREDS = credentials('vmware-vcenter-credentials')
-                    }
-                    steps {
-                        unstash 'fedora31'
-                        run_tests('image')
-                    }
-                    post {
-                        always {
-                            preserve_logs('fedora31-image')
-                        }
-                    }
-                }
-                stage('F31 Integration') {
-                    agent { label "f31cloudbase && x86_64" }
-                    environment {
-                        TEST_TYPE = "integration"
-                        AWS_CREDS = credentials('aws-credentials-osbuildci')
-                    }
-                    steps {
-                        unstash 'fedora31'
-                        run_tests('integration')
-                    }
-                    post {
-                        always {
-                            preserve_logs('fedora31-integration')
-                        }
-                    }
-                }
-
-                stage('F32 Base') {
-                    agent { label "f32cloudbase && x86_64" }
-                    environment { TEST_TYPE = "base" }
-                    steps {
-                        unstash 'fedora32'
-                        run_tests('base')
-                    }
-                    post {
-                        always {
-                            preserve_logs('fedora32-base')
-                        }
-                    }
-                }
-                stage('F32 Image') {
-                    agent { label "f32cloudbase && psi && x86_64" }
-                    environment {
-                        TEST_TYPE = "image"
-                        AWS_CREDS = credentials('aws-credentials-osbuildci')
-                        AZURE_CREDS = credentials('azure')
-                        OPENSTACK_CREDS = credentials("psi-openstack-creds")
-                        VCENTER_CREDS = credentials('vmware-vcenter-credentials')
-                    }
-                    steps {
-                        unstash 'fedora32'
-                        run_tests('image')
-                    }
-                    post {
-                        always {
-                            preserve_logs('fedora32-image')
-                        }
-                    }
-                }
-                stage('F32 Integration') {
-                    agent { label "f32cloudbase && x86_64" }
-                    environment {
-                        TEST_TYPE = "integration"
-                        AWS_CREDS = credentials('aws-credentials-osbuildci')
-                    }
-                    steps {
-                        unstash 'fedora32'
-                        run_tests('integration')
-                    }
-                    post {
-                        always {
-                            preserve_logs('fedora32-integration')
-                        }
-                    }
-                }
-
-                stage('EL8 Base') {
-                    agent { label "rhel8cloudbase && x86_64" }
-                    environment {
-                        TEST_TYPE = "base"
-                        RHN_REGISTRATION_SCRIPT = credentials('rhn-register-script-production')
-                    }
-                    steps {
-                        unstash 'rhel8cdn'
-                        run_tests('base')
-                    }
-                    post {
-                        always {
-                            preserve_logs('rhel8-base')
-                        }
-                    }
-                }
-                stage('EL8 Image') {
-                    agent { label "rhel8cloudbase && psi && x86_64" }
-                    environment {
-                        TEST_TYPE = "image"
-                        AWS_CREDS = credentials('aws-credentials-osbuildci')
-                        AZURE_CREDS = credentials('azure')
-                        OPENSTACK_CREDS = credentials("psi-openstack-creds")
-                        RHN_REGISTRATION_SCRIPT = credentials('rhn-register-script-production')
-                        VCENTER_CREDS = credentials('vmware-vcenter-credentials')
-                    }
-                    steps {
-                        unstash 'rhel8cdn'
-                        run_tests('image')
-                    }
-                    post {
-                        always {
-                            preserve_logs('rhel8-image')
-                        }
-                    }
-                }
                 stage('EL8 Integration') {
                     agent { label "rhel8cloudbase && x86_64" }
                     environment {
@@ -325,8 +159,8 @@ pipeline {
         success {
             node('schutzbot') {
                 script {
-                    if (env.BRANCH_NAME == 'master') {
-                        telegramSend "💚 CI passed for osbuild-composer master branch ${env.BUILD_URL}"
+                    if (env.BRANCH_NAME == 'rhel-8.3.0') {
+                        telegramSend "💚 CI passed for osbuild-composer ${env.BRANCH_NAME} branch ${env.BUILD_URL}"
                     }
                 }
             }
@@ -334,8 +168,8 @@ pipeline {
         unsuccessful {
             node('schutzbot') {
                 script {
-                    if (env.BRANCH_NAME == 'master') {
-                        telegramSend "💣 CI failed for osbuild-composer master branch ${env.BUILD_URL}"
+                    if (env.BRANCH_NAME == 'rhel-8.3.0') {
+                        telegramSend "💣 CI failed for osbuild-composer ${env.BRANCH_NAME} branch ${env.BUILD_URL}"
                     }
                 }
             }

--- a/schutzbot/mockbuild.sh
+++ b/schutzbot/mockbuild.sh
@@ -71,7 +71,11 @@ greenprint "📤 RPMS will be uploaded to: ${REPO_URL}"
 # Build source RPMs.
 greenprint "🔧 Building source RPMs."
 make srpm
-make -C osbuild srpm
+
+if [[ $VERSION_ID == 8.2 ]]; then
+    # osbuild does not exist in 8.2, so build from submodule
+    make -C osbuild srpm
+fi
 
 # Update the mock configs if we are on 8.3 beta.
 if [[ $VERSION_ID == 8.3 ]]; then
@@ -88,8 +92,13 @@ fi
 
 # Compile RPMs in a mock chroot
 greenprint "🎁 Building RPMs with mock"
-sudo mock -v -r $MOCK_CONFIG --resultdir $REPO_DIR --with=tests \
-    rpmbuild/SRPMS/*.src.rpm osbuild/rpmbuild/SRPMS/*.src.rpm
+if [[ $VERSION_ID == 8.2 ]]; then
+    sudo mock -v -r $MOCK_CONFIG --resultdir $REPO_DIR --with=tests \
+        rpmbuild/SRPMS/*.src.rpm osbuild/rpmbuild/SRPMS/*.src.rpm
+else
+    sudo mock -v -r $MOCK_CONFIG --resultdir $REPO_DIR --with=tests \
+        rpmbuild/SRPMS/*.src.rpm
+fi
 
 # Change the ownership of all of our repo files from root to our CI user.
 sudo chown -R $USER ${REPO_DIR%%/*}


### PR DESCRIPTION
This branch is where we will base any backports to RHEL8.3. Start off by restricting the testing to only test against the relevant distros.

We also make sure to test against osbuild that has landed in 8.3, rather than the submodule, when we can.