### PR TITLE
⛈  Use AWS more often for testing

### DIFF
--- a/schutzbot/Jenkinsfile
+++ b/schutzbot/Jenkinsfile
@@ -41,7 +41,7 @@ pipeline {
             parallel {
 
                 stage('F31') {
-                    agent { label "f31cloudbase && x86_64" }
+                    agent { label "f31cloudbase && x86_64 && aws" }
                     environment {
                         AWS_CREDS = credentials('aws-credentials-osbuildci')
                     }
@@ -57,7 +57,7 @@ pipeline {
                     }
                 }
                 stage('F32') {
-                    agent { label "f32cloudbase && x86_64" }
+                    agent { label "f32cloudbase && x86_64 && aws" }
                     environment {
                         AWS_CREDS = credentials('aws-credentials-osbuildci')
                     }
@@ -73,7 +73,7 @@ pipeline {
                     }
                 }
                 stage('EL8') {
-                    agent { label "rhel8cloudbase && x86_64" }
+                    agent { label "rhel8cloudbase && x86_64 && aws" }
                     environment {
                         AWS_CREDS = credentials('aws-credentials-osbuildci')
                         RHN_REGISTRATION_SCRIPT = credentials('rhn-register-script-production')
@@ -90,7 +90,7 @@ pipeline {
                     }
                 }
                 stage('EL8.3') {
-                    agent { label "rhel83cloudbase && x86_64" }
+                    agent { label "rhel83cloudbase && x86_64 && aws" }
                     environment {
                         AWS_CREDS = credentials('aws-credentials-osbuildci')
                         RHN_REGISTRATION_SCRIPT = credentials('rhn-register-script-production-beta')
@@ -113,7 +113,7 @@ pipeline {
             parallel {
 
                 stage('F31 Base') {
-                    agent { label "f31cloudbase && x86_64" }
+                    agent { label "f31cloudbase && x86_64 && aws" }
                     environment { TEST_TYPE = "base" }
                     steps {
                         unstash 'fedora31'
@@ -145,7 +145,7 @@ pipeline {
                     }
                 }
                 stage('F31 Integration') {
-                    agent { label "f31cloudbase && x86_64" }
+                    agent { label "f31cloudbase && x86_64 && aws" }
                     environment {
                         TEST_TYPE = "integration"
                         AWS_CREDS = credentials('aws-credentials-osbuildci')
@@ -162,7 +162,7 @@ pipeline {
                 }
 
                 stage('F32 Base') {
-                    agent { label "f32cloudbase && x86_64" }
+                    agent { label "f32cloudbase && x86_64 && aws" }
                     environment { TEST_TYPE = "base" }
                     steps {
                         unstash 'fedora32'
@@ -194,7 +194,7 @@ pipeline {
                     }
                 }
                 stage('F32 Integration') {
-                    agent { label "f32cloudbase && x86_64" }
+                    agent { label "f32cloudbase && x86_64 && aws" }
                     environment {
                         TEST_TYPE = "integration"
                         AWS_CREDS = credentials('aws-credentials-osbuildci')
@@ -211,7 +211,7 @@ pipeline {
                 }
 
                 stage('EL8 Base') {
-                    agent { label "rhel8cloudbase && x86_64" }
+                    agent { label "rhel8cloudbase && x86_64 && aws" }
                     environment {
                         TEST_TYPE = "base"
                         RHN_REGISTRATION_SCRIPT = credentials('rhn-register-script-production')
@@ -247,7 +247,7 @@ pipeline {
                     }
                 }
                 stage('EL8 Integration') {
-                    agent { label "rhel8cloudbase && x86_64" }
+                    agent { label "rhel8cloudbase && x86_64 && aws" }
                     environment {
                         TEST_TYPE = "integration"
                         AWS_CREDS = credentials('aws-credentials-osbuildci')
@@ -265,7 +265,7 @@ pipeline {
                 }
 
                 stage('EL8.3 Base') {
-                    agent { label "rhel83cloudbase && x86_64" }
+                    agent { label "rhel83cloudbase && x86_64 && aws" }
                     environment {
                         TEST_TYPE = "base"
                         RHN_REGISTRATION_SCRIPT = credentials('rhn-register-script-production-beta')
@@ -301,7 +301,7 @@ pipeline {
                     }
                 }
                 stage('EL8.3 Integration') {
-                    agent { label "rhel83cloudbase && x86_64" }
+                    agent { label "rhel83cloudbase && x86_64 && aws" }
                     environment {
                         TEST_TYPE = "integration"
                         AWS_CREDS = credentials('aws-credentials-osbuildci')


### PR DESCRIPTION
Now that we've reduced how much of our PSI quota we are using so the
OpenStack boot tests will work, we need to use AWS for jobs more often.
This should allow test runs to complete a little sooner by freeing up
PSI resources for the jobs that are only able to run there.

Signed-off-by: Major Hayden <major@redhat.com>