### PR TITLE
Run base tests partially in AWS (2nd version)

### DIFF
--- a/cmd/osbuild-base-test-runner/main.go
+++ b/cmd/osbuild-base-test-runner/main.go
@@ -171,6 +171,8 @@ func runTestOverSSH(address, privateKey, testCommand string) int {
 	// Get details about the machine
 	err := runSSHCommand(address, privateKey, "cat /etc/os-release")
 	panicErr(err)
+	err = runSSHCommand(address, privateKey, "df -h")
+	panicErr(err)
 
 	// Prepare the socket for forwarding because it is not owned by the redhat user
 	err = runSSHCommand(address, privateKey, "sudo chmod go+rw /run/weldr/api.socket")

--- a/cmd/osbuild-base-test-runner/main.go
+++ b/cmd/osbuild-base-test-runner/main.go
@@ -1,0 +1,225 @@
+// +build integration
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+
+	"github.com/osbuild/osbuild-composer/internal/boot"
+)
+
+type timeoutError struct{}
+
+func (*timeoutError) Error() string { return "Timeout exceeded" }
+
+// GenerateCIArtifactName generates a new identifier for CI artifacts which is based
+// on environment variables specified by Jenkins
+// note: in case of migration to sth else like Github Actions, change it to whatever variables GH Action provides
+func GenerateCIArtifactName(prefix string) (string, error) {
+	distroCode := os.Getenv("DISTRO_CODE")
+	changeId := os.Getenv("CHANGE_ID")
+	buildId := os.Getenv("BUILD_ID")
+	if changeId == "" || buildId == "" || distroCode == "" {
+		return "", fmt.Errorf("The environment variables must specify CHANGE_ID, BUILD_ID, and DISTRO_CODE")
+	}
+
+	return fmt.Sprintf("%s%s-%s-%s", prefix, distroCode, changeId, buildId), nil
+}
+
+// sshDisableHostChecking disables host (=remote machine) key checking
+// because the key of the fresh VM in AWS is not in the list of known_hosts.
+// The function also uses an empty known_hosts file by setting it to /dev/null.
+func sshDisableHostChecking() []string {
+	return []string{
+		"-o", "StrictHostKeyChecking=no",
+		"-o", "UserKnownHostsFile=/dev/null",
+	}
+}
+
+func runLocalCommand(name string, args ...string) {
+	cmd := exec.Command(name, args...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		fmt.Println("Error: ", err)
+	}
+}
+
+func runSSHCommand(address, privateKey, command string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	cmdName := "ssh"
+	cmdArgs := []string{
+		"-i", privateKey,
+	}
+	cmdArgs = append(cmdArgs, sshDisableHostChecking()...)
+	cmdArgs = append(cmdArgs, "redhat@"+address, command)
+
+	var cmd *exec.Cmd = exec.CommandContext(ctx, cmdName, cmdArgs...)
+
+	output, err := cmd.Output()
+
+	if ctx.Err() == context.DeadlineExceeded {
+		return &timeoutError{}
+	}
+
+	if err != nil {
+		if exitError, ok := err.(*exec.ExitError); ok {
+			if exitError.ExitCode() == 255 {
+				return &timeoutError{}
+			}
+		} else {
+			return fmt.Errorf("ssh command failed from unknown reason: %#v", err)
+		}
+	}
+	outputString := strings.TrimSpace(string(output))
+	fmt.Println(outputString)
+
+	return nil
+}
+
+// testSSHOnce tries to test the running image using ssh once
+// It returns timeoutError if ssh command returns 255, if it runs for more
+// that 10 seconds or if systemd-is-running returns starting.
+// It returns nil if systemd-is-running returns running or degraded.
+// It can also return other errors in other error cases.
+func testSSHOnce(address string, privateKey string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	cmdName := "ssh"
+	cmdArgs := []string{
+		"-i", privateKey,
+	}
+	cmdArgs = append(cmdArgs, sshDisableHostChecking()...)
+	cmdArgs = append(cmdArgs, "redhat@"+address, "systemctl --wait is-system-running")
+
+	var cmd *exec.Cmd = exec.CommandContext(ctx, cmdName, cmdArgs...)
+
+	output, err := cmd.Output()
+
+	if ctx.Err() == context.DeadlineExceeded {
+		return &timeoutError{}
+	}
+
+	if err != nil {
+		if exitError, ok := err.(*exec.ExitError); ok {
+			if exitError.ExitCode() == 255 {
+				return &timeoutError{}
+			}
+		} else {
+			return fmt.Errorf("ssh command failed from unknown reason: %#v", err)
+		}
+	}
+
+	outputString := strings.TrimSpace(string(output))
+	switch outputString {
+	case "running":
+		fmt.Println("ssh test passed")
+		return nil
+	case "degraded":
+		fmt.Println("ssh test passed, but the system is degraded")
+		return nil
+	case "starting":
+		return &timeoutError{}
+	default:
+		return fmt.Errorf("ssh test failed, system status is: %s", outputString)
+	}
+}
+
+// testSSH tests the running image using ssh.
+// It tries 20 attempts before giving up. If a major error occurs, it might
+// return earlier.
+func testSSH(address string, privateKey string) {
+	const attempts = 20
+	for i := 0; i < attempts; i++ {
+		err := testSSHOnce(address, privateKey)
+		if err == nil {
+			// pass the test
+			return
+		}
+
+		// if any other error than the timeout one happened, fail the test immediately
+		if _, ok := err.(*timeoutError); !ok {
+			panic(err)
+		}
+
+		time.Sleep(10 * time.Second)
+	}
+
+	panic(fmt.Sprintf("ssh test failure, %d attempts were made", attempts))
+}
+
+func main() {
+	fmt.Println("Getting AWS credentials")
+	creds, err := boot.GetAWSCredentialsFromEnv()
+	if err != nil {
+		panic("AWS credentials unavailable")
+	}
+	if creds == nil {
+		panic("Empty AWS credentials")
+	}
+<<<<<<< HEAD
+=======
+
+	// Get environment variables defining the name of CI artifacts
+>>>>>>> 1fc50d4... amend introduce
+	fmt.Println("Getting change and build IDs")
+	changeId := os.Getenv("CHANGE_ID")
+	buildId := os.Getenv("BUILD_ID")
+	if changeId == "" || buildId == "" {
+		panic("The environment variables must specify CHANGE_ID and BUILD_ID")
+	}
+	imageName := fmt.Sprintf("osbuild-composer-base-test-%s-%s", changeId, buildId)
+<<<<<<< HEAD
+	fmt.Println("Getting the EC2 image description")
+=======
+
+	securityGroupName, err := GenerateCIArtifactName("osbuild-image-tests-security-group-")
+	if err != nil {
+		panic(err)
+	}
+
+>>>>>>> 1fc50d4... amend introduce
+	e, err := boot.NewEC2(creds)
+	if err != nil {
+		panic("Failed to obtain credentials for EC2")
+	}
+	imageDesc, err := boot.DescribeEC2Image(e, imageName)
+	if err != nil {
+		panic("Failed to describe EC2 image")
+	}
+	// delete the image after the test is over
+	defer func() {
+		err = boot.DeregisterEC2Image(e, imageDesc)
+		if err != nil {
+			fmt.Println("Cannot delete the ec2 image, resources could have been leaked")
+		}
+	}()
+	fmt.Println("Booting the image")
+	// boot the uploaded image and try to connect to it
+	err = boot.WithSSHKeyPair(func(privateKey, publicKey string) error {
+		return boot.WithBootedImageInEC2(e, securityGroupName, imageDesc, publicKey, func(address string) error {
+			testSSH(address, privateKey)
+			err = runSSHCommand(address, privateKey, "cat /etc/os-release")
+			if err != nil {
+				panic(err)
+			}
+			err = runSSHCommand(address, privateKey, "sudo chmod go+rw /run/weldr/api.socket")
+			if err != nil {
+				panic(err)
+			}
+			runLocalCommand("sudo", "mkdir", "/run/weldr")
+			runLocalCommand("sudo", "ssh", "-o", "StrictHostKeyChecking=no", "-o", "UserKnownHostsFile=/dev/null", "-i", privateKey, "-fN", "-L", "/run/weldr/api.socket:/run/weldr/api.socket", fmt.Sprintf("redhat@%s", address))
+			fmt.Println("Running test: ", os.Args[1])
+			runLocalCommand(os.Args[1])
+			return nil
+		})
+	})
+}

--- a/cmd/osbuild-base-test-runner/main.go
+++ b/cmd/osbuild-base-test-runner/main.go
@@ -224,6 +224,7 @@ func runTest(e *ec2.EC2, imageName, securityGroupName string) int {
 		fmt.Printf("[AWS] 📋 Registering AMI from imported snapshot: %s", *sid)
 		imgId, err := awsupload.RegisterEC2Snapshot(e, sid, imageName)
 		panicErr(err)
+		imageDesc = new(boot.ImageDescription)
 		imageDesc.Id = imgId
 		imageDesc.SnapshotId = sid
 	}

--- a/internal/boot/aws.go
+++ b/internal/boot/aws.go
@@ -151,17 +151,17 @@ func DescribeEC2Image(e *ec2.EC2, imageName string) (*imageDescription, error) {
 	}, nil
 }
 
-func DeregisterEC2Image(e *ec2.EC2, imageDesc *imageDescription) error {
+func DeregisterEC2Image(e *ec2.EC2, amiId *string) error {
 	_, err := e.DeregisterImage(&ec2.DeregisterImageInput{
-		ImageId: imageDesc.Id,
+		ImageId: amiId,
 	})
 
 	return err
 }
 
-func DeleteEC2Snapshot(e *ec2.EC2, imageDesc *imageDescription) error {
+func DeleteEC2Snapshot(e *ec2.EC2, snapshotId *string) error {
 	_, err := e.DeleteSnapshot(&ec2.DeleteSnapshotInput{
-		SnapshotId: imageDesc.SnapshotId,
+		SnapshotId: snapshotId,
 	})
 
 	return err
@@ -172,14 +172,14 @@ func DeleteEC2Image(e *ec2.EC2, imageDesc *imageDescription) error {
 	var retErr error
 
 	// firstly, deregister the image
-	err := DeregisterEC2Image(e, imageDesc)
+	err := DeregisterEC2Image(e, imageDesc.Id)
 
 	if err != nil {
 		retErr = wrapErrorf(retErr, "cannot deregister the image: %#v", err)
 	}
 
 	// now it's possible to delete the snapshot
-	err = DeleteEC2Snapshot(e, imageDesc)
+	err = DeleteEC2Snapshot(e, imageDesc.SnapshotId)
 
 	if err != nil {
 		retErr = wrapErrorf(retErr, "cannot delete the snapshot: %#v", err)

--- a/internal/boot/aws.go
+++ b/internal/boot/aws.go
@@ -167,6 +167,9 @@ func DescribeEC2Image(e *ec2.EC2, imageName string) (*imageDescription, error) {
 	if err != nil {
 		return nil, fmt.Errorf("cannot describe the image: %#v", err)
 	}
+	if len(imageDescriptions.Images) == 0 {
+		return nil, fmt.Errorf("no images found")
+	}
 	imageId := imageDescriptions.Images[0].ImageId
 	snapshotId := imageDescriptions.Images[0].BlockDeviceMappings[0].Ebs.SnapshotId
 

--- a/internal/boot/aws.go
+++ b/internal/boot/aws.go
@@ -151,23 +151,35 @@ func DescribeEC2Image(e *ec2.EC2, imageName string) (*imageDescription, error) {
 	}, nil
 }
 
+func DeregisterEC2Image(e *ec2.EC2, imageDesc *imageDescription) error {
+	_, err := e.DeregisterImage(&ec2.DeregisterImageInput{
+		ImageId: imageDesc.Id,
+	})
+
+	return err
+}
+
+func DeleteEC2Snapshot(e *ec2.EC2, imageDesc *imageDescription) error {
+	_, err := e.DeleteSnapshot(&ec2.DeleteSnapshotInput{
+		SnapshotId: imageDesc.SnapshotId,
+	})
+
+	return err
+}
+
 // DeleteEC2Image deletes the specified image and its associated snapshot
 func DeleteEC2Image(e *ec2.EC2, imageDesc *imageDescription) error {
 	var retErr error
 
 	// firstly, deregister the image
-	_, err := e.DeregisterImage(&ec2.DeregisterImageInput{
-		ImageId: imageDesc.Id,
-	})
+	err := DeregisterEC2Image(e, imageDesc)
 
 	if err != nil {
 		retErr = wrapErrorf(retErr, "cannot deregister the image: %#v", err)
 	}
 
 	// now it's possible to delete the snapshot
-	_, err = e.DeleteSnapshot(&ec2.DeleteSnapshotInput{
-		SnapshotId: imageDesc.SnapshotId,
-	})
+	err = DeleteEC2Snapshot(e, imageDesc)
 
 	if err != nil {
 		retErr = wrapErrorf(retErr, "cannot delete the snapshot: %#v", err)

--- a/internal/boot/aws.go
+++ b/internal/boot/aws.go
@@ -119,7 +119,7 @@ func NewEC2(c *awsCredentials) (*ec2.EC2, error) {
 	return ec2.New(sess), nil
 }
 
-type imageDescription struct {
+type ImageDescription struct {
 	Id         *string
 	SnapshotId *string
 	// this doesn't support multiple snapshots per one image,
@@ -153,7 +153,7 @@ func DescribeEC2Snapshot(e *ec2.EC2, snapshotName string) (*string, error) {
 
 // DescribeEC2Image searches for EC2 image by its name and returns
 // its id and snapshot id
-func DescribeEC2Image(e *ec2.EC2, imageName string) (*imageDescription, error) {
+func DescribeEC2Image(e *ec2.EC2, imageName string) (*ImageDescription, error) {
 	imageDescriptions, err := e.DescribeImages(&ec2.DescribeImagesInput{
 		Filters: []*ec2.Filter{
 			{
@@ -173,7 +173,7 @@ func DescribeEC2Image(e *ec2.EC2, imageName string) (*imageDescription, error) {
 	imageId := imageDescriptions.Images[0].ImageId
 	snapshotId := imageDescriptions.Images[0].BlockDeviceMappings[0].Ebs.SnapshotId
 
-	return &imageDescription{
+	return &ImageDescription{
 		Id:         imageId,
 		SnapshotId: snapshotId,
 	}, nil
@@ -196,7 +196,7 @@ func DeleteEC2Snapshot(e *ec2.EC2, snapshotId *string) error {
 }
 
 // DeleteEC2Image deletes the specified image and its associated snapshot
-func DeleteEC2Image(e *ec2.EC2, imageDesc *imageDescription) error {
+func DeleteEC2Image(e *ec2.EC2, imageDesc *ImageDescription) error {
 	var retErr error
 
 	// firstly, deregister the image
@@ -218,7 +218,7 @@ func DeleteEC2Image(e *ec2.EC2, imageDesc *imageDescription) error {
 
 // WithBootedImageInEC2 runs the function f in the context of booted
 // image in AWS EC2
-func WithBootedImageInEC2(e *ec2.EC2, securityGroupName string, imageDesc *imageDescription, publicKey string, f func(address string) error) (retErr error) {
+func WithBootedImageInEC2(e *ec2.EC2, securityGroupName string, imageDesc *ImageDescription, publicKey string, f func(address string) error) (retErr error) {
 	// generate user data with given public key
 	userData, err := CreateUserData(publicKey)
 	if err != nil {

--- a/internal/boot/aws.go
+++ b/internal/boot/aws.go
@@ -126,6 +126,31 @@ type imageDescription struct {
 	// because this feature is not supported in composer
 }
 
+func DescribeEC2Snapshot(e *ec2.EC2, snapshotName string) (*string, error) {
+	input := &ec2.DescribeSnapshotsInput{
+		Filters: []*ec2.Filter{
+			{
+				Name: aws.String("tag:Name"),
+				Values: []*string{
+					aws.String(snapshotName),
+				},
+			},
+		},
+	}
+
+	result, err := e.DescribeSnapshots(input)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(result.Snapshots) != 1 {
+		return nil, fmt.Errorf("The list of snapshots does not contain exactly one element! This must not happen, check what is going on in AWS and fix it!")
+	}
+
+	snapshotId := result.Snapshots[0].SnapshotId
+	return snapshotId, nil
+}
+
 // DescribeEC2Image searches for EC2 image by its name and returns
 // its id and snapshot id
 func DescribeEC2Image(e *ec2.EC2, imageName string) (*imageDescription, error) {

--- a/osbuild-composer.spec
+++ b/osbuild-composer.spec
@@ -117,6 +117,7 @@ go test -c -tags=integration -ldflags="${TEST_LDFLAGS}" -o _bin/osbuild-dnf-json
 go test -c -tags=integration -ldflags="${TEST_LDFLAGS}" -o _bin/osbuild-weldr-tests %{goipath}/internal/client/
 go test -c -tags=integration -ldflags="${TEST_LDFLAGS}" -o _bin/osbuild-image-tests %{goipath}/cmd/osbuild-image-tests
 go test -c -tags=integration -ldflags="${TEST_LDFLAGS}" -o _bin/osbuild-composer-koji-tests %{goipath}/cmd/osbuild-composer-koji-tests
+go build -tags=integration -ldflags="${TEST_LDFLAGS}" -o _bin/osbuild-base-test-runner %{goipath}/cmd/osbuild-base-test-runner
 
 %endif
 
@@ -150,6 +151,7 @@ install -m 0755 -vp _bin/osbuild-weldr-tests                    %{buildroot}%{_l
 install -m 0755 -vp _bin/osbuild-dnf-json-tests                 %{buildroot}%{_libexecdir}/tests/osbuild-composer/
 install -m 0755 -vp _bin/osbuild-image-tests                    %{buildroot}%{_libexecdir}/tests/osbuild-composer/
 install -m 0755 -vp _bin/osbuild-composer-koji-tests            %{buildroot}%{_libexecdir}/tests/osbuild-composer/
+install -m 0755 -vp _bin/osbuild-base-test-runner               %{buildroot}%{_libexecdir}/tests/osbuild-composer/
 install -m 0755 -vp tools/image-info                            %{buildroot}%{_libexecdir}/osbuild-composer/
 
 install -m 0755 -vd                                             %{buildroot}%{_datadir}/tests/osbuild-composer

--- a/schutzbot/Jenkinsfile
+++ b/schutzbot/Jenkinsfile
@@ -117,6 +117,7 @@ pipeline {
             agent { label "f32cloudbase && x86_64 && aws" }
             environment {
                 AWS_CREDS = credentials('aws-credentials-osbuildci')
+                DISTRO_CODE = "fedora32"
             }
             steps {
                 unstash 'fedora32'
@@ -540,7 +541,7 @@ pipeline {
             }
         }
     }
-}
+
 
 //TODO: send messages via Email too
 // TODO: how do we make the contents of COMPOSE_ID available as env.COMPOSE_ID
@@ -560,6 +561,7 @@ pipeline {
             }
         }
     }
+}
 
 // Run a script to create a target VM and upload it to AWS so that it
 // can be used in base tests

--- a/schutzbot/Jenkinsfile
+++ b/schutzbot/Jenkinsfile
@@ -200,6 +200,7 @@ pipeline {
                     agent { label "f32cloudbase && x86_64 && aws" }
                     environment {
                         AWS_CREDS = credentials('aws-credentials-osbuildci')
+                        DISTRO_CODE = "fedora32"
                     }
                     steps {
                         unstash 'fedora32'

--- a/schutzbot/Jenkinsfile
+++ b/schutzbot/Jenkinsfile
@@ -70,6 +70,10 @@ pipeline {
                             includes: 'osbuild-mock.repo',
                             name: 'fedora32'
                         )
+			stash (
+                            includes: 'osbuild-mock.toml',
+                            name: 'fedora32toml'
+                        )
                     }
                 }
                 stage('EL8') {
@@ -105,6 +109,23 @@ pipeline {
                             name: 'rhel83'
                         )
                     }
+                }
+            }
+        }
+
+        stage("Creating target images 🎯") {
+            agent { label "f32cloudbase && x86_64 && aws" }
+            environment {
+                AWS_CREDS = credentials('aws-credentials-osbuildci')
+            }
+            steps {
+                unstash 'fedora32'
+                unstash 'fedora32toml'
+                create_target_image()
+            }
+            post {
+                always {
+                    preserve_logs('fedora32-create-target-image')
                 }
             }
         }
@@ -172,6 +193,32 @@ pipeline {
                     post {
                         always {
                             preserve_logs('fedora32-base')
+                        }
+                    }
+                }
+                stage("F32 Base with target VM") {
+                    agent { label "f32cloudbase && x86_64 && aws" }
+                    environment {
+                        AWS_CREDS = credentials('aws-credentials-osbuildci')
+                    }
+                    steps {
+                        unstash 'fedora32'
+                        sh (
+                            label: "Get environment variables",
+                            script: "env | sort"
+                        )
+                        sh (
+                            label: "Get CI machine details",
+                            script: "schutzbot/ci_details.sh"
+                        )
+                        sh (
+                            label: "Run target machine",
+                            script: "test/base-tests/run.sh"
+                        )
+                    }
+                    post {
+                        always {
+                            preserve_logs('fedora32-create-target-image')
                         }
                     }
                 }
@@ -492,6 +539,7 @@ pipeline {
             }
         }
     }
+}
 
 //TODO: send messages via Email too
 // TODO: how do we make the contents of COMPOSE_ID available as env.COMPOSE_ID
@@ -511,6 +559,31 @@ pipeline {
             }
         }
     }
+
+// Run a script to create a target VM and upload it to AWS so that it
+// can be used in base tests
+void create_target_image() {
+    sh (
+        label: "Get environment variables",
+        script: "env | sort"
+    )
+
+    // Get CI machine details.
+    sh (
+        label: "Get CI machine details",
+        script: "schutzbot/ci_details.sh"
+    )
+
+    // Deploy the Image Builder packages and services.
+    sh (
+        label: "Deploy",
+        script: "schutzbot/deploy.sh"
+    )
+
+    sh (
+        label: "Create target VM and upload it to AWS",
+        script: "test/base-tests/upload-to-aws.sh"
+    )
 }
 
 // Set up a function to hold the steps needed to run the tests so we don't

--- a/schutzbot/mockbuild.sh
+++ b/schutzbot/mockbuild.sh
@@ -127,3 +127,15 @@ gpgcheck=0
 # Default dnf repo priority is 99. Lower number means higher priority.
 priority=5
 EOF
+
+# Create a osbuild-composer "sources" file
+greenprint "📜 Generating osbuild-composer \"sources\" file"
+tee osbuild-mock.toml << EOF
+id="osbuild-mock"
+name="osbuild-mock"
+type="yum-baseurl"
+url="${REPO_URL}"
+enabled="1"
+gpgcheck="0"
+priority="5"
+EOF

--- a/test/base-tests/run.sh
+++ b/test/base-tests/run.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+set -euox pipefail
+
+CHECKOUT_DIRECTORY="${PWD}"
+WORKING_DIRECTORY=/usr/libexec/osbuild-composer
+TESTS_PATH=/usr/libexec/tests/osbuild-composer
+
+PASSED_TESTS=()
+FAILED_TESTS=()
+
+TEST_RUNNER=/usr/libexec/tests/osbuild-composer/osbuild-base-test-runner
+
+function retry {
+    local count=0
+    local retries=5
+    until "$@"; do
+        exit=$?
+        count=$(($count + 1))
+        if [[ $count -lt $retries ]]; then
+            echo "Retrying command..."
+            sleep 1
+        else
+            echo "Command failed after ${retries} retries. Giving up."
+            return $exit
+        fi
+    done
+    return 0
+}
+
+# Get OS details.
+source /etc/os-release
+
+# Register RHEL if we are provided with a registration script.
+if [[ -n "${RHN_REGISTRATION_SCRIPT:-}" ]] && ! sudo subscription-manager status; then
+    sudo chmod +x $RHN_REGISTRATION_SCRIPT
+    sudo $RHN_REGISTRATION_SCRIPT
+fi
+
+# Restart systemd to work around some Fedora issues in cloud images.
+sudo systemctl restart systemd-journald
+
+# Remove Fedora's modular repositories to speed up dnf.
+sudo rm -f /etc/yum.repos.d/fedora*modular*
+
+# Enable fastestmirror and disable weak dependency installation to speed up
+# dnf operations.
+echo -e "fastestmirror=1\ninstall_weak_deps=0" | sudo tee -a /etc/dnf/dnf.conf
+
+# Ensure we are using the latest dnf since early revisions of Fedora 31 had
+# some dnf repo priority bugs like BZ 1733582.
+# NOTE(mhayden): We can exclude kernel updates here to save time with dracut
+# and module updates. The system will not be rebooted in CI anyway, so a
+# kernel update is not needed.
+if [[ $ID == fedora ]]; then
+    sudo dnf -y upgrade --exclude kernel --exclude kernel-core
+fi
+
+# Add osbuild team ssh keys.
+cat schutzbot/team_ssh_keys.txt | tee -a ~/.ssh/authorized_keys > /dev/null
+
+# Set up a dnf repository for the RPMs we built via mock.
+sudo cp osbuild-mock.repo /etc/yum.repos.d/osbuild-mock.repo
+sudo dnf repository-packages osbuild-mock list
+
+# Ensure osbuild-composer-tests is installed.
+retry sudo dnf -y install osbuild-composer-tests
+
+ls -l /usr/libexec/tests/osbuild-composer
+
+# Change to the working directory.
+cd $WORKING_DIRECTORY
+
+# Run
+sudo --preserve-env $TEST_RUNNER /usr/libexec/tests/osbuild-composer/osbuild-weldr-tests

--- a/test/base-tests/run.sh
+++ b/test/base-tests/run.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -euox pipefail
+set -euo pipefail
 
 WORKING_DIRECTORY="/usr/libexec/osbuild-composer"
 TEST_RUNNER="/usr/libexec/tests/osbuild-composer/osbuild-base-test-runner"

--- a/test/base-tests/run.sh
+++ b/test/base-tests/run.sh
@@ -72,3 +72,5 @@ cd $WORKING_DIRECTORY
 
 # Run
 sudo --preserve-env $TEST_RUNNER /usr/libexec/tests/osbuild-composer/osbuild-weldr-tests
+sudo --preserve-env $TEST_RUNNER /usr/libexec/tests/osbuild-composer/osbuild-tests
+sudo --preserve-env $TEST_RUNNER -cleanup

--- a/test/base-tests/upload-to-aws.sh
+++ b/test/base-tests/upload-to-aws.sh
@@ -1,0 +1,151 @@
+#!/bin/bash
+set -xeuo pipefail
+
+source /etc/os-release
+
+# Fedora 31's composer-cli doesn't support doing image uploads.
+if [[ $ID == fedora ]] && [[ $VERSION_ID == 31 ]]; then
+    echo "Fedora 31 does not support image uploads with composer-cli."
+    exit 0
+fi
+
+# Colorful output.
+function greenprint {
+    echo -e "\033[1;32m${1}\033[0m"
+}
+
+# Apply lorax patch to work around pytoml issues in RHEL 8.x.
+# See BZ 1843704 or https://github.com/weldr/lorax/pull/1030 for more details.
+if [[ $ID == rhel ]]; then
+    sudo sed -r -i 's#toml.load\(args\[3\]\)#toml.load(open(args[3]))#' \
+        /usr/lib/python3.6/site-packages/composer/cli/compose.py
+    sudo rm -f /usr/lib/python3.6/site-packages/composer/cli/compose.pyc
+fi
+
+# We need jq for parsing composer-cli output.
+if ! hash jq; then
+    greenprint "Installing jq"
+    sudo dnf -qy install jq
+fi
+
+TEST_ID="${CHANGE_ID}-${BUILD_ID}"
+IMAGE_KEY=osbuild-composer-base-test-${TEST_ID}
+
+# Jenkins sets WORKSPACE to the job workspace, but if this script runs
+# outside of Jenkins, we can set up a temporary directory instead.
+if [[ ${WORKSPACE:-empty} == empty ]]; then
+    WORKSPACE=$(mktemp -d)
+fi
+
+# Set up temporary files.
+TEMPDIR=$(mktemp -d)
+AWS_CONFIG=${TEMPDIR}/aws.toml
+BLUEPRINT_FILE=${TEMPDIR}/blueprint.toml
+BLUEPRINT_NAME=targetimage
+COMPOSE_START=${TEMPDIR}/compose-start-${IMAGE_KEY}.json
+COMPOSE_INFO=${TEMPDIR}/compose-info-${IMAGE_KEY}.json
+
+# Get the compose log.
+get_compose_log () {
+    COMPOSE_ID=$1
+    LOG_FILE=${WORKSPACE}/osbuild-${ID}-${VERSION_ID}-aws.log
+
+    # Download the logs.
+    sudo composer-cli compose log $COMPOSE_ID | tee $LOG_FILE > /dev/null
+}
+
+# Get the compose metadata.
+get_compose_metadata () {
+    COMPOSE_ID=$1
+    METADATA_FILE=${WORKSPACE}/osbuild-${ID}-${VERSION_ID}-aws.json
+
+    # Download the metadata.
+    sudo composer-cli compose metadata $COMPOSE_ID > /dev/null
+
+    # Find the tarball and extract it.
+    TARBALL=$(basename $(find . -maxdepth 1 -type f -name "*-metadata.tar"))
+    tar -xf $TARBALL
+    rm -f $TARBALL
+
+    # Move the JSON file into place.
+    cat ${COMPOSE_ID}.json | jq -M '.' | tee $METADATA_FILE > /dev/null
+}
+
+# Write an AWS TOML file
+tee $AWS_CONFIG > /dev/null << EOF
+provider = "aws"
+
+[settings]
+accessKeyID = "${AWS_ACCESS_KEY_ID}"
+secretAccessKey = "${AWS_SECRET_ACCESS_KEY}"
+bucket = "${AWS_BUCKET}"
+region = "${AWS_REGION}"
+key = "${IMAGE_KEY}"
+EOF
+
+# Write a basic blueprint for our image.
+tee $BLUEPRINT_FILE << EOF
+name = "${BLUEPRINT_NAME}"
+description = "A base system with bash"
+version = "0.0.1"
+
+[[packages]]
+name = "bash"
+
+[[packages]]
+name = "osbuild-composer"
+
+[customizations.services]
+enabled = ["sshd", "cloud-init", "cloud-init-local", "cloud-config", "cloud-final", "osbuild-composer.socket"]
+EOF
+
+# Add osbuild-mock repo as a source to osbuild-composer
+greenprint "📋 Adding sources"
+sudo composer-cli sources add osbuild-mock.toml
+
+sudo composer-cli sources list
+sudo composer-cli sources info osbuild-mock
+
+# Prepare the blueprint for the compose.
+greenprint "📋 Preparing blueprint"
+cat $BLUEPRINT_FILE
+sudo composer-cli -j blueprints push $BLUEPRINT_FILE
+greenprint "📋 Depsolving blueprint"
+sudo composer-cli -j blueprints depsolve $BLUEPRINT_NAME
+
+# Get worker unit file so we can watch the journal.
+WORKER_UNIT=$(sudo systemctl list-units | egrep -o "osbuild.*worker.*\.service")
+sudo journalctl -af -n 1 -u ${WORKER_UNIT} &
+
+# Start the compose and upload to AWS.
+greenprint "🚀 Starting compose"
+sudo composer-cli --json compose start $BLUEPRINT_NAME ami $IMAGE_KEY $AWS_CONFIG | tee $COMPOSE_START
+COMPOSE_ID=$(jq -r '.build_id' $COMPOSE_START)
+
+# Wait for the compose to finish.
+greenprint "⏱ Waiting for compose to finish: ${COMPOSE_ID}"
+while true; do
+    sudo composer-cli --json compose info ${COMPOSE_ID} | tee $COMPOSE_INFO > /dev/null
+    COMPOSE_STATUS=$(jq -r '.queue_status' $COMPOSE_INFO)
+
+    # Is the compose finished?
+    if [[ $COMPOSE_STATUS != RUNNING ]] && [[ $COMPOSE_STATUS != WAITING ]]; then
+        break
+    fi
+
+    # Wait 30 seconds and try again.
+    sleep 30
+done
+
+# Capture the compose logs from osbuild.
+greenprint "💬 Getting compose log and metadata"
+get_compose_log $COMPOSE_ID
+get_compose_metadata $COMPOSE_ID
+
+# Did the compose finish with success?
+if [[ $COMPOSE_STATUS != FINISHED ]]; then
+    echo "Something went wrong with the compose. 😢"
+    exit 1
+fi
+
+exit 0

--- a/test/base-tests/upload-to-aws.sh
+++ b/test/base-tests/upload-to-aws.sh
@@ -80,11 +80,8 @@ EOF
 # Write a basic blueprint for our image.
 tee "${BLUEPRINT_FILE}" << EOF
 name = "${BLUEPRINT_NAME}"
-description = "A base system with bash"
+description = "A base system with osbuild-composer"
 version = "0.0.1"
-
-[[packages]]
-name = "bash"
 
 [[packages]]
 name = "osbuild-composer"

--- a/test/base-tests/upload-to-aws.sh
+++ b/test/base-tests/upload-to-aws.sh
@@ -102,7 +102,7 @@ greenprint "📋 Preparing blueprint"
 cat "${BLUEPRINT_FILE}"
 sudo composer-cli -j blueprints push "${BLUEPRINT_FILE}"
 greenprint "📋 Depsolving blueprint"
-sudo composer-cli -j blueprints depsolve "${BLUEPRINT_FILE}"
+sudo composer-cli -j blueprints depsolve "${BLUEPRINT_NAME}"
 
 # Get worker unit file so we can watch the journal.
 WORKER_UNIT=$(sudo systemctl list-units | egrep -o "osbuild.*worker.*\.service")

--- a/test/base-tests/upload-to-aws.sh
+++ b/test/base-tests/upload-to-aws.sh
@@ -22,8 +22,8 @@ if ! hash jq; then
     sudo dnf -qy install jq
 fi
 
-TEST_ID="${CHANGE_ID}-${BUILD_ID}"
-IMAGE_KEY=osbuild-composer-base-test-${TEST_ID}
+TEST_ID="${DISTRO_CODE}-${BRANCH_NAME}-${BUILD_ID}"
+IMAGE_KEY="osbuild-composer-base-test-${TEST_ID}"
 
 # Jenkins sets WORKSPACE to the job workspace, but if this script runs
 # outside of Jenkins, we can set up a temporary directory instead.


### PR DESCRIPTION
This PR introduces an alternative version of running base tests for Fedora 32.  The idea is to create a "target" image (that is a pristine image with only osbuild-composer installed) which will run in AWS and the Weldr API socket will be forwarded over SSH to the machine where test binaries (from the -tests RPM subpackage) are running.

Because we already have code for cloud upload and spawning EC2 VMs, this PR contains a lot of refactoring in order to use as much existing code as possible and introduce as little new code as possible.

How it works:
 1. The mock build stage now creates "sources" file alongside the "repo" file
 2. A new stage "Creating target images 🎯" is introduced to run osbuild-composer and create the target image. The cloud upload functionality is used to upload the image directly to EC2.
 3. A new stage "F32 Base with target VM" is introduced to run a newly created binary `cmd/osbuild-base-test-runner` which takes the snapshot/image in EC2 boots it and runs a test against it. At the end of the run, the image is deregistered. This is repeated for every test specified in the `test/base-tests/run.sh` script. At the end of the script a "cleanup" code is invoked which will clean all remaining artifacts from AWS.