### PR TITLE
weldr: make URL mandatory part of a new source

### DIFF
--- a/internal/weldr/api.go
+++ b/internal/weldr/api.go
@@ -599,6 +599,8 @@ func (api *API) sourceNewHandler(writer http.ResponseWriter, request *http.Reque
 			err = errors_package.New("'name' field is missing from request")
 		} else if len(source.GetType()) == 0 {
 			err = errors_package.New("'type' field is missing from request")
+		} else if len(source.SourceConfig().URL) == 0 {
+			err = errors_package.New("'url' field is missing from request")
 		}
 	}
 

--- a/internal/weldr/api_test.go
+++ b/internal/weldr/api_test.go
@@ -823,6 +823,9 @@ func TestSourcesNew(t *testing.T) {
 		// Bad JSON, missing quote after name
 		{"POST", "/api/v0/projects/source/new", `{"name: "fish","url": "https://download.opensuse.org/repositories/shells:/fish:/release:/3/Fedora_29/","type": "yum-baseurl","check_ssl": false,"check_gpg": false}`, http.StatusBadRequest, `{"errors": [{"id": "ProjectsError","msg": "Problem parsing POST body: invalid character 'f' after object key"}],"status":false}`},
 		{"POST", "/api/v0/projects/source/new", `{"name": "fish","url": "https://download.opensuse.org/repositories/shells:/fish:/release:/3/Fedora_29/","type": "yum-baseurl","check_ssl": false,"check_gpg": false}`, http.StatusOK, `{"status":true}`},
+		{"POST", "/api/v0/projects/source/new", `{"url": "https://download.opensuse.org/repositories/shells:/fish:/release:/3/Fedora_29/","type": "yum-baseurl","check_ssl": false,"check_gpg": false}`, http.StatusBadRequest, `{"errors": [{"id": "ProjectsError","msg": "Problem parsing POST body: 'name' field is missing from request"}],"status":false}`},
+		{"POST", "/api/v0/projects/source/new", `{"name": "fish", "type": "yum-baseurl","check_ssl": false,"check_gpg": false}`, http.StatusBadRequest, `{"errors": [{"id": "ProjectsError","msg": "Problem parsing POST body: 'url' field is missing from request"}],"status":false}`},
+		{"POST", "/api/v0/projects/source/new", `{"name": "fish", "url": "https://download.opensuse.org/repositories/shells:/fish:/release:/3/Fedora_29/","check_ssl": false,"check_gpg": false}`, http.StatusBadRequest, `{"errors": [{"id": "ProjectsError","msg": "Problem parsing POST body: 'type' field is missing from request"}],"status":false}`},
 	}
 
 	for _, c := range cases {


### PR DESCRIPTION
Sources without URL are useless. Make it mandatory.

Fixes: https://github.com/osbuild/osbuild-composer/issues/951