### PR TITLE
image-tests: don't use random names for CI artifacts

### DIFF
--- a/internal/boot/aws.go
+++ b/internal/boot/aws.go
@@ -178,7 +178,7 @@ func DeleteEC2Image(e *ec2.EC2, imageDesc *imageDescription) error {
 
 // WithBootedImageInEC2 runs the function f in the context of booted
 // image in AWS EC2
-func WithBootedImageInEC2(e *ec2.EC2, imageDesc *imageDescription, publicKey string, f func(address string) error) (retErr error) {
+func WithBootedImageInEC2(e *ec2.EC2, securityGroupName string, imageDesc *imageDescription, publicKey string, f func(address string) error) (retErr error) {
 	// generate user data with given public key
 	userData, err := CreateUserData(publicKey)
 	if err != nil {
@@ -187,12 +187,6 @@ func WithBootedImageInEC2(e *ec2.EC2, imageDesc *imageDescription, publicKey str
 
 	// Security group must be now generated, because by default
 	// all traffic to EC2 instance is filtered.
-
-	securityGroupName, err := GenerateRandomString("osbuild-image-tests-security-group-")
-	if err != nil {
-		return fmt.Errorf("cannot generate a random name for the image: %#v", err)
-	}
-
 	// Firstly create a security group
 	securityGroup, err := e.CreateSecurityGroup(&ec2.CreateSecurityGroupInput{
 		GroupName:   aws.String(securityGroupName),

--- a/internal/boot/helpers.go
+++ b/internal/boot/helpers.go
@@ -7,8 +7,6 @@ import (
 	"os"
 	"syscall"
 	"time"
-
-	"github.com/google/uuid"
 )
 
 // durationMin returns the smaller of two given durations
@@ -51,15 +49,4 @@ func killProcessCleanly(process *os.Process, timeout time.Duration) error {
 	}
 
 	return process.Kill()
-}
-
-// GenerateRandomString generates a new random string with specified prefix.
-// The random part is based on UUID.
-func GenerateRandomString(prefix string) (string, error) {
-	id, err := uuid.NewRandom()
-	if err != nil {
-		return "", err
-	}
-
-	return prefix + id.String(), nil
 }

--- a/schutzbot/Jenkinsfile
+++ b/schutzbot/Jenkinsfile
@@ -133,6 +133,7 @@ pipeline {
                         AZURE_CREDS = credentials('azure')
                         OPENSTACK_CREDS = credentials("psi-openstack-creds")
                         VCENTER_CREDS = credentials('vmware-vcenter-credentials')
+                        DISTRO_CODE = "fedora31"
                     }
                     steps {
                         unstash 'fedora31'
@@ -182,6 +183,7 @@ pipeline {
                         AZURE_CREDS = credentials('azure')
                         OPENSTACK_CREDS = credentials("psi-openstack-creds")
                         VCENTER_CREDS = credentials('vmware-vcenter-credentials')
+                        DISTRO_CODE = "fedora32"
                     }
                     steps {
                         unstash 'fedora32'
@@ -246,6 +248,7 @@ pipeline {
                         OPENSTACK_CREDS = credentials("psi-openstack-creds")
                         RHN_REGISTRATION_SCRIPT = credentials('rhn-register-script-production')
                         VCENTER_CREDS = credentials('vmware-vcenter-credentials')
+                        DISTRO_CODE = "rhel8"
                     }
                     steps {
                         unstash 'rhel8cdn'
@@ -300,6 +303,7 @@ pipeline {
                         OPENSTACK_CREDS = credentials("psi-openstack-creds")
                         RHN_REGISTRATION_SCRIPT = credentials('rhn-register-script-production-beta')
                         VCENTER_CREDS = credentials('vmware-vcenter-credentials')
+                        DISTRO_CODE = "rhel83"
                     }
                     steps {
                         unstash 'rhel83'

--- a/schutzbot/run_image_tests.sh
+++ b/schutzbot/run_image_tests.sh
@@ -58,7 +58,7 @@ run_test_case () {
     AZURE_CREDS=${AZURE_CREDS-/dev/null}
     OPENSTACK_CREDS=${OPENSTACK_CREDS-/dev/null}
     VCENTER_CREDS=${VCENTER_CREDS-/dev/null}
-    TEST_CMD="env $(cat $AZURE_CREDS $OPENSTACK_CREDS $VCENTER_CREDS) $TEST_RUNNER -test.v ${IMAGE_TEST_CASES_PATH}/${TEST_CASE_FILENAME}"
+    TEST_CMD="env $(cat $AZURE_CREDS $OPENSTACK_CREDS $VCENTER_CREDS) CHANGE_ID=$CHANGE_ID BUILD_ID=$BUILD_ID DISTRO_CODE=$DISTRO_CODE $TEST_RUNNER -test.v ${IMAGE_TEST_CASES_PATH}/${TEST_CASE_FILENAME}"
 
     # Run the test and add the test name to the list of passed or failed
     # tests depending on the result.


### PR DESCRIPTION
When using random names for artifacts like AWS snapshots, or Azure
images, it becomes hard to clean them up in case of CI failure. See this
issue for more details:
https://github.com/osbuild/osbuild-composer/issues/942

This PR introduces predictable names so that we can easily determine
which artifact belongs to which PR and therefore we can decide to wipe
all resources that are not needed any more.