### PR TITLE
azuretest: Refactor clean up code to separate functions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.13
 require (
 	github.com/Azure/azure-sdk-for-go v41.3.0+incompatible
 	github.com/Azure/azure-storage-blob-go v0.8.0
-	github.com/Azure/go-autorest/autorest v0.10.0 // indirect
+	github.com/Azure/go-autorest/autorest v0.10.0
 	github.com/Azure/go-autorest/autorest/azure/auth v0.4.2
 	github.com/Azure/go-autorest/autorest/to v0.3.0 // indirect
 	github.com/Azure/go-autorest/autorest/validation v0.2.0 // indirect

--- a/internal/boot/azuretest/deployment.go
+++ b/internal/boot/azuretest/deployment.go
@@ -41,7 +41,7 @@ func newDeploymentParameter(value string) deploymentParameter {
 }
 
 // struct for encoding deployment parameters
-type deploymentParameters struct {
+type DeploymentParameters struct {
 	NetworkInterfaceName     deploymentParameter `json:"networkInterfaceName"`
 	NetworkSecurityGroupName deploymentParameter `json:"networkSecurityGroupName"`
 	VirtualNetworkName       deploymentParameter `json:"virtualNetworkName"`


### PR DESCRIPTION
In order to run the clean up in a separate binary it is necessary to
refactor the clean up code away from the context manager.