### PR TITLE
schutzbot/mockbuild: test against osbuild in target release by default

### DIFF
--- a/schutzbot/mockbuild.sh
+++ b/schutzbot/mockbuild.sh
@@ -71,7 +71,11 @@ greenprint "📤 RPMS will be uploaded to: ${REPO_URL}"
 # Build source RPMs.
 greenprint "🔧 Building source RPMs."
 make srpm
-make -C osbuild srpm
+
+if [[ $VERSION_ID == 8.2 ]]; then
+    # osbuild does not exist in 8.2, so build from submodule
+    make -C osbuild srpm
+fi
 
 # Update the mock configs if we are on 8.3 beta.
 if [[ $VERSION_ID == 8.3 ]]; then
@@ -88,8 +92,13 @@ fi
 
 # Compile RPMs in a mock chroot
 greenprint "🎁 Building RPMs with mock"
-sudo mock -v -r $MOCK_CONFIG --resultdir $REPO_DIR --with=tests \
-    rpmbuild/SRPMS/*.src.rpm osbuild/rpmbuild/SRPMS/*.src.rpm
+if [[ $VERSION_ID == 8.2 ]]; then
+    sudo mock -v -r $MOCK_CONFIG --resultdir $REPO_DIR --with=tests \
+        rpmbuild/SRPMS/*.src.rpm osbuild/rpmbuild/SRPMS/*.src.rpm
+else
+    sudo mock -v -r $MOCK_CONFIG --resultdir $REPO_DIR --with=tests \
+        rpmbuild/SRPMS/*.src.rpm
+fi
 
 # Change the ownership of all of our repo files from root to our CI user.
 sudo chown -R $USER ${REPO_DIR%%/*}


### PR DESCRIPTION
*Just trying to rebase this patch on top of current master*

To make sure we test against what we will release with, osbuild from the
target distro.

The only exception is in RHEL8.2, where we are not actually releasing
into the distro, but want to test against it anyway. In this case, build
osbuild from the submodule.

Signed-off-by: Tom Gundersen <teg@jklm.no>