### PR TITLE
📜 mockbuild: Reduce log output

### DIFF
--- a/schutzbot/mockbuild.sh
+++ b/schutzbot/mockbuild.sh
@@ -88,7 +88,7 @@ fi
 
 # Compile RPMs in a mock chroot
 greenprint "🎁 Building RPMs with mock"
-sudo mock -v -r $MOCK_CONFIG --resultdir $REPO_DIR --with=tests \
+sudo mock -r $MOCK_CONFIG --resultdir $REPO_DIR --with=tests \
     rpmbuild/SRPMS/*.src.rpm osbuild/rpmbuild/SRPMS/*.src.rpm
 
 # Change the ownership of all of our repo files from root to our CI user.


### PR DESCRIPTION
Running mock with verbose enabled made sense a while back when we were
still unsure if things would work, but it's generating a ton of logs now
that eventually clogs Jenkins' disk.

Disable the verbose flag to reduce mock's log output.

Signed-off-by: Major Hayden <major@redhat.com>