### PR TITLE
worker API: introduce job types and architecture

### DIFF
--- a/cmd/osbuild-composer/main.go
+++ b/cmd/osbuild-composer/main.go
@@ -152,7 +152,21 @@ func main() {
 		log.Fatalf("cannot create queue directory: %v", err)
 	}
 
-	jobs, err := fsjobqueue.New(queueDir, []string{"osbuild"})
+	// construct job types of the form osbuild:{arch} for all arches
+	jobTypes := []string{"osbuild"}
+	jobTypesMap := map[string]bool{}
+	for _, name := range distros.List() {
+		d := distros.GetDistro(name)
+		for _, arch := range d.ListArches() {
+			jt := "osbuild:" + arch
+			if !jobTypesMap[jt] {
+				jobTypesMap[jt] = true
+				jobTypes = append(jobTypes, jt)
+			}
+		}
+	}
+
+	jobs, err := fsjobqueue.New(queueDir, jobTypes)
 	if err != nil {
 		log.Fatalf("cannot create jobqueue: %v", err)
 	}

--- a/internal/cloudapi/server.go
+++ b/internal/cloudapi/server.go
@@ -69,6 +69,7 @@ func (server *Server) Compose(w http.ResponseWriter, r *http.Request) {
 
 	type imageRequest struct {
 		manifest distro.Manifest
+		arch     string
 	}
 	imageRequests := make([]imageRequest, len(request.ImageRequests))
 	var targets []*target.Target
@@ -128,6 +129,7 @@ func (server *Server) Compose(w http.ResponseWriter, r *http.Request) {
 		}
 
 		imageRequests[i].manifest = manifest
+		imageRequests[i].arch = arch.Name()
 
 		if len(ir.UploadRequests) != 1 {
 			http.Error(w, "Only compose requests with a single upload target are currently supported", http.StatusBadRequest)
@@ -179,7 +181,7 @@ func (server *Server) Compose(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	id, err := server.workers.Enqueue(ir.manifest, targets)
+	id, err := server.workers.Enqueue(ir.arch, ir.manifest, targets)
 	if err != nil {
 		http.Error(w, "Failed to enqueue manifest", http.StatusInternalServerError)
 		return

--- a/internal/kojiapi/server.go
+++ b/internal/kojiapi/server.go
@@ -92,6 +92,7 @@ func (h *apiHandlers) PostCompose(ctx echo.Context) error {
 
 	type imageRequest struct {
 		manifest distro.Manifest
+		arch     string
 		filename string
 	}
 	imageRequests := make([]imageRequest, len(request.ImageRequests))
@@ -132,6 +133,7 @@ func (h *apiHandlers) PostCompose(ctx echo.Context) error {
 		}
 
 		imageRequests[i].manifest = manifest
+		imageRequests[i].arch = arch.Name()
 		imageRequests[i].filename = imageType.Filename()
 	}
 
@@ -167,7 +169,7 @@ func (h *apiHandlers) PostCompose(ctx echo.Context) error {
 		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Could not initialize build with koji: %v", err))
 	}
 
-	id, err := h.server.workers.Enqueue(ir.manifest, []*target.Target{
+	id, err := h.server.workers.Enqueue(ir.arch, ir.manifest, []*target.Target{
 		target.NewKojiTarget(&target.KojiTargetOptions{
 			BuildID:         uint64(buildInfo.BuildID),
 			TaskID:          uint64(request.Koji.TaskId),

--- a/internal/weldr/api.go
+++ b/internal/weldr/api.go
@@ -1825,7 +1825,7 @@ func (api *API) composeHandler(writer http.ResponseWriter, request *http.Request
 	} else {
 		var jobId uuid.UUID
 
-		jobId, err = api.workers.Enqueue(manifest, targets)
+		jobId, err = api.workers.Enqueue(api.arch.Name(), manifest, targets)
 		if err == nil {
 			err = api.store.PushCompose(composeID, manifest, imageType, bp, size, targets, jobId)
 		}

--- a/internal/worker/api/api.gen.go
+++ b/internal/worker/api/api.gen.go
@@ -16,7 +16,9 @@ type Error struct {
 }
 
 // RequestJobJSONBody defines parameters for RequestJob.
-type RequestJobJSONBody map[string]interface{}
+type RequestJobJSONBody struct {
+	Types []string `json:"types"`
+}
 
 // UpdateJobJSONBody defines parameters for UpdateJob.
 type UpdateJobJSONBody struct {

--- a/internal/worker/api/api.gen.go
+++ b/internal/worker/api/api.gen.go
@@ -17,6 +17,7 @@ type Error struct {
 
 // RequestJobJSONBody defines parameters for RequestJob.
 type RequestJobJSONBody struct {
+	Arch  string   `json:"arch"`
 	Types []string `json:"types"`
 }
 

--- a/internal/worker/api/openapi.yml
+++ b/internal/worker/api/openapi.yml
@@ -49,19 +49,20 @@ paths:
                 type: object
                 additionalProperties: false
                 properties:
-                  manifest: {}
-                  targets:
-                    type: array
-                    items: {}
+                  id:
+                    type: string
+                    format: uuid
                   location:
                     type: string
                   artifact_location:
                     type: string
-                  id:
+                  type:
                     type: string
-                    format: uuid
+                    enum:
+                      - osbuild
+                  args: {}
                 required:
-                  - manifest
+                  - type
                   - location
                   - id
         4XX:

--- a/internal/worker/api/openapi.yml
+++ b/internal/worker/api/openapi.yml
@@ -83,6 +83,15 @@ paths:
             schema:
               type: object
               additionalProperties: false
+              properties:
+                types:
+                  type: array
+                  items:
+                    type: string
+                    enum:
+                      - osbuild
+              required:
+                - types
         description: ''
       description: Requests a job. This operation blocks until a job is available.
     parameters: []

--- a/internal/worker/api/openapi.yml
+++ b/internal/worker/api/openapi.yml
@@ -90,8 +90,11 @@ paths:
                     type: string
                     enum:
                       - osbuild
+                arch:
+                  type: string
               required:
                 - types
+                - arch
         description: ''
       description: Requests a job. This operation blocks until a job is available.
     parameters: []

--- a/internal/worker/client.go
+++ b/internal/worker/client.go
@@ -84,6 +84,7 @@ func (c *Client) RequestJob() (Job, error) {
 	var buf bytes.Buffer
 	err = json.NewEncoder(&buf).Encode(api.RequestJobJSONRequestBody{
 		Types: []string{"osbuild"},
+		Arch:  common.CurrentArch(),
 	})
 	if err != nil {
 		panic(err)

--- a/internal/worker/client.go
+++ b/internal/worker/client.go
@@ -82,7 +82,9 @@ func (c *Client) RequestJob() (Job, error) {
 	}
 
 	var buf bytes.Buffer
-	err = json.NewEncoder(&buf).Encode(api.RequestJobJSONRequestBody{})
+	err = json.NewEncoder(&buf).Encode(api.RequestJobJSONRequestBody{
+		Types: []string{"osbuild"},
+	})
 	if err != nil {
 		panic(err)
 	}

--- a/internal/worker/json.go
+++ b/internal/worker/json.go
@@ -1,6 +1,8 @@
 package worker
 
 import (
+	"encoding/json"
+
 	"github.com/google/uuid"
 	"github.com/osbuild/osbuild-composer/internal/common"
 	"github.com/osbuild/osbuild-composer/internal/distro"
@@ -30,11 +32,11 @@ type statusResponse struct {
 }
 
 type requestJobResponse struct {
-	Id               uuid.UUID        `json:"id"`
-	Manifest         distro.Manifest  `json:"manifest"`
-	Targets          []*target.Target `json:"targets,omitempty"`
-	Location         string           `json:"location"`
-	ArtifactLocation string           `json:"artifact_location"`
+	Id               uuid.UUID       `json:"id"`
+	Location         string          `json:"location"`
+	ArtifactLocation string          `json:"artifact_location"`
+	Type             string          `json:"type"`
+	Args             json.RawMessage `json:"args,omitempty"`
 }
 
 type getJobResponse struct {

--- a/internal/worker/server.go
+++ b/internal/worker/server.go
@@ -169,7 +169,7 @@ func (s *Server) DeleteArtifacts(id uuid.UUID) error {
 	return os.RemoveAll(path.Join(s.artifactsDir, id.String()))
 }
 
-func (s *Server) RequestJob(ctx context.Context) (uuid.UUID, uuid.UUID, *OSBuildJob, error) {
+func (s *Server) RequestOSBuildJob(ctx context.Context) (uuid.UUID, uuid.UUID, *OSBuildJob, error) {
 	token := uuid.New()
 
 	var args OSBuildJob
@@ -259,7 +259,7 @@ func (h *apiHandlers) RequestJob(ctx echo.Context) error {
 		return echo.NewHTTPError(http.StatusBadRequest, "invalid job types")
 	}
 
-	token, jobId, jobArgs, err := h.server.RequestJob(ctx.Request().Context())
+	token, jobId, jobArgs, err := h.server.RequestOSBuildJob(ctx.Request().Context())
 	if err != nil {
 		return err
 	}

--- a/internal/worker/server.go
+++ b/internal/worker/server.go
@@ -260,12 +260,17 @@ func (h *apiHandlers) RequestJob(ctx echo.Context) error {
 		return err
 	}
 
+	serializedArgs, err := json.Marshal(jobArgs)
+	if err != nil {
+		return err
+	}
+
 	return ctx.JSON(http.StatusCreated, requestJobResponse{
 		Id:               jobId,
-		Manifest:         jobArgs.Manifest,
-		Targets:          jobArgs.Targets,
 		Location:         fmt.Sprintf("/jobs/%v", token),
 		ArtifactLocation: fmt.Sprintf("/jobs/%v/artifacts/", token),
+		Type:             "osbuild",
+		Args:             serializedArgs,
 	})
 }
 

--- a/internal/worker/server.go
+++ b/internal/worker/server.go
@@ -249,10 +249,14 @@ func (h *apiHandlers) GetStatus(ctx echo.Context) error {
 }
 
 func (h *apiHandlers) RequestJob(ctx echo.Context) error {
-	var body struct{}
+	var body api.RequestJobJSONRequestBody
 	err := ctx.Bind(&body)
 	if err != nil {
 		return err
+	}
+
+	if len(body.Types) != 1 || body.Types[0] != "osbuild" {
+		return echo.NewHTTPError(http.StatusBadRequest, "invalid job types")
 	}
 
 	token, jobId, jobArgs, err := h.server.RequestJob(ctx.Request().Context())

--- a/internal/worker/server_test.go
+++ b/internal/worker/server_test.go
@@ -64,10 +64,10 @@ func TestCreate(t *testing.T) {
 	}
 	server := worker.NewServer(nil, testjobqueue.New(), "")
 
-	_, err = server.Enqueue(manifest, nil)
+	_, err = server.Enqueue(arch.Name(), manifest, nil)
 	require.NoError(t, err)
 
-	test.TestRoute(t, server, false, "POST", "/jobs", `{"types":["osbuild"]}`, http.StatusCreated,
+	test.TestRoute(t, server, false, "POST", "/jobs", `{"types":["osbuild"],"arch":"x86_64"}`, http.StatusCreated,
 		`{"type":"osbuild","args":{"manifest":{"pipeline":{},"sources":{}}}}`, "id", "location", "artifact_location")
 }
 
@@ -87,10 +87,10 @@ func TestCancel(t *testing.T) {
 	}
 	server := worker.NewServer(nil, testjobqueue.New(), "")
 
-	jobId, err := server.Enqueue(manifest, nil)
+	jobId, err := server.Enqueue(arch.Name(), manifest, nil)
 	require.NoError(t, err)
 
-	token, j, _, err := server.RequestOSBuildJob(context.Background())
+	token, j, _, err := server.RequestOSBuildJob(context.Background(), arch.Name())
 	require.NoError(t, err)
 	require.Equal(t, jobId, j)
 

--- a/internal/worker/server_test.go
+++ b/internal/worker/server_test.go
@@ -68,7 +68,7 @@ func TestCreate(t *testing.T) {
 	require.NoError(t, err)
 
 	test.TestRoute(t, server, false, "POST", "/jobs", `{}`, http.StatusCreated,
-		`{"manifest":{"sources":{},"pipeline":{}}}`, "id", "location", "artifact_location")
+		`{"type":"osbuild","args":{"manifest":{"pipeline":{},"sources":{}}}}`, "id", "location", "artifact_location")
 }
 
 func TestCancel(t *testing.T) {

--- a/internal/worker/server_test.go
+++ b/internal/worker/server_test.go
@@ -90,7 +90,7 @@ func TestCancel(t *testing.T) {
 	jobId, err := server.Enqueue(manifest, nil)
 	require.NoError(t, err)
 
-	token, j, _, err := server.RequestJob(context.Background())
+	token, j, _, err := server.RequestOSBuildJob(context.Background())
 	require.NoError(t, err)
 	require.Equal(t, jobId, j)
 

--- a/internal/worker/server_test.go
+++ b/internal/worker/server_test.go
@@ -67,7 +67,7 @@ func TestCreate(t *testing.T) {
 	_, err = server.Enqueue(manifest, nil)
 	require.NoError(t, err)
 
-	test.TestRoute(t, server, false, "POST", "/jobs", `{}`, http.StatusCreated,
+	test.TestRoute(t, server, false, "POST", "/jobs", `{"types":["osbuild"]}`, http.StatusCreated,
 		`{"type":"osbuild","args":{"manifest":{"pipeline":{},"sources":{}}}}`, "id", "location", "artifact_location")
 }
 


### PR DESCRIPTION
This is an effort to future-proof the worker API. It removes the assumption that all jobs are osbuild jobs and requires a worker to pass both the jobs it can handle and the architecture it runs on. 