### PR TITLE
Add domain allowlist to remote worker and Koji APIs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -119,6 +119,7 @@ build:
 	go test -c -tags=integration -o osbuild-dnf-json-tests ./cmd/osbuild-dnf-json-tests/main_test.go
 	go test -c -tags=integration -o osbuild-image-tests ./cmd/osbuild-image-tests/
 	go test -c -tags=integration -o osbuild-composer-cloud-tests ./cmd/osbuild-composer-cloud-tests/main_test.go
+	go test -c -tags=integration -o osbuild-auth-tests ./cmd/osbuild-auth-tests/
 
 .PHONY: install
 install:

--- a/Makefile
+++ b/Makefile
@@ -137,28 +137,56 @@ install:
 	cp distribution/*.socket /etc/systemd/system/
 	systemctl daemon-reload
 
+CERT_DIR=/etc/osbuild-composer
+
 .PHONY: ca
 ca:
-ifneq (/etc/osbuild-composer/ca-key.pem/etc/osbuild-composer/ca-crt.pem,$(wildcard /etc/osbuild-composer/ca-key.pem)$(wildcard /etc/osbuild-composer/ca-crt.pem))
+ifneq (${CERT_DIR}/ca-key.pem${CERT_DIR}/ca-crt.pem,$(wildcard ${CERT_DIR}/ca-key.pem)$(wildcard ${CERT_DIR}/ca-crt.pem))
 	@echo CA key or certificate file is missing, generating a new pair...
-	- mkdir -p /etc/osbuild-composer
-	openssl req -new -nodes -x509 -days 365 -keyout /etc/osbuild-composer/ca-key.pem -out /etc/osbuild-composer/ca-crt.pem -subj "/CN=osbuild.org"
+	- mkdir -p ${CERT_DIR}
+	openssl req -new -nodes -x509 -days 365 -keyout ${CERT_DIR}/ca-key.pem -out ${CERT_DIR}/ca-crt.pem -subj "/CN=osbuild.org"
 else
 	@echo CA key and certificate files already exist, skipping...
 endif
 
 .PHONY: composer-key-pair
 composer-key-pair: ca
-	openssl genrsa -out /etc/osbuild-composer/composer-key.pem 2048
-	openssl req -new -sha256 -key /etc/osbuild-composer/composer-key.pem	-out /etc/osbuild-composer/composer-csr.pem -subj "/CN=localhost" # TODO: we need to generate certificates with another hostname
-	openssl x509 -req -in /etc/osbuild-composer/composer-csr.pem  -CA /etc/osbuild-composer/ca-crt.pem -CAkey /etc/osbuild-composer/ca-key.pem -CAcreateserial -out /etc/osbuild-composer/composer-crt.pem
-	chown _osbuild-composer:_osbuild-composer /etc/osbuild-composer/composer-key.pem /etc/osbuild-composer/composer-csr.pem /etc/osbuild-composer/composer-crt.pem
+	# generate a private key and a certificate request
+	openssl req -new -nodes \
+		-subj "/CN=localhost" \
+		-keyout ${CERT_DIR}/composer-key.pem \
+		-out ${CERT_DIR}/composer-csr.pem
+
+	# sign the certificate
+	openssl x509 -req \
+		-in ${CERT_DIR}/composer-csr.pem \
+		-CA ${CERT_DIR}/ca-crt.pem \
+		-CAkey ${CERT_DIR}/ca-key.pem \
+		-CAcreateserial \
+		-out ${CERT_DIR}/composer-crt.pem
+
+	# delete the request and set _osbuild-composer as the owner
+	rm ${CERT_DIR}/composer-csr.pem
+	chown _osbuild-composer:_osbuild-composer ${CERT_DIR}/composer-key.pem ${CERT_DIR}/composer-crt.pem
 
 .PHONY: worker-key-pair
 worker-key-pair: ca
-	openssl genrsa -out /etc/osbuild-composer/worker-key.pem 2048
-	openssl req -new -sha256 -key /etc/osbuild-composer/worker-key.pem	-out /etc/osbuild-composer/worker-csr.pem -subj "/CN=localhost"
-	openssl x509 -req -in /etc/osbuild-composer/worker-csr.pem  -CA /etc/osbuild-composer/ca-crt.pem -CAkey /etc/osbuild-composer/ca-key.pem -CAcreateserial -out /etc/osbuild-composer/worker-crt.pem
+	# generate a private key and a certificate request
+	openssl req -new -nodes \
+		-subj "/CN=localhost" \
+		-keyout ${CERT_DIR}/worker-key.pem \
+		-out ${CERT_DIR}/worker-csr.pem
+
+	# sign the certificate
+	openssl x509 -req \
+		-in ${CERT_DIR}/worker-csr.pem \
+		-CA ${CERT_DIR}/ca-crt.pem \
+		-CAkey ${CERT_DIR}/ca-key.pem \
+		-CAcreateserial \
+		-out ${CERT_DIR}/worker-crt.pem
+
+	# delete the request
+	rm /etc/osbuild-composer/worker-csr.pem
 
 
 #

--- a/cmd/osbuild-auth-tests/main_test.go
+++ b/cmd/osbuild-auth-tests/main_test.go
@@ -1,0 +1,250 @@
+// +build integration
+
+package main
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"os"
+	"os/exec"
+	"path"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type connectionConfig struct {
+	CACertFile     string
+	ClientKeyFile  string
+	ClientCertFile string
+}
+
+func createTLSConfig(config *connectionConfig) (*tls.Config, error) {
+	caCertPEM, err := ioutil.ReadFile(config.CACertFile)
+	if err != nil {
+		return nil, err
+	}
+
+	roots := x509.NewCertPool()
+	ok := roots.AppendCertsFromPEM(caCertPEM)
+	if !ok {
+		return nil, errors.New("failed to append root certificate")
+	}
+
+	cert, err := tls.LoadX509KeyPair(config.ClientCertFile, config.ClientKeyFile)
+	if err != nil {
+		return nil, err
+	}
+
+	return &tls.Config{
+		RootCAs:      roots,
+		Certificates: []tls.Certificate{cert},
+	}, nil
+}
+
+type certificateKeyPair struct {
+	baseDir string
+}
+
+func (ckp certificateKeyPair) remove() {
+	err := os.RemoveAll(ckp.baseDir)
+	if err != nil {
+		log.Printf("cannot delete the certificate key pair: %v", err)
+	}
+}
+
+func (ckp certificateKeyPair) certificate() string {
+	return path.Join(ckp.baseDir, "crt")
+}
+
+func (ckp certificateKeyPair) key() string {
+	return path.Join(ckp.baseDir, "key")
+}
+
+func newCertificateKeyPair(CA, CAkey, subj string) (*certificateKeyPair, error) {
+	dir, err := ioutil.TempDir("", "osbuild-auth-tests-")
+	if err != nil {
+		return nil, fmt.Errorf("cannot create a temporary directory for the certificate: %v", err)
+	}
+
+	ckp := certificateKeyPair{baseDir: dir}
+	certificateRequest := path.Join(dir, "csr")
+
+	cmd := exec.Command(
+		"openssl", "req", "-new", "-nodes",
+		"-subj", subj,
+		"-keyout", ckp.key(),
+		"-out", certificateRequest,
+	)
+
+	err = cmd.Run()
+	if err != nil {
+		return nil, fmt.Errorf("cannot generate a private key and a certificate request: %v", err)
+	}
+
+	defer os.Remove(certificateRequest)
+
+	cmd = exec.Command(
+		"openssl", "x509", "-req", "-CAcreateserial",
+		"-in", certificateRequest,
+		"-CA", CA,
+		"-CAkey", CAkey,
+		"-out", ckp.certificate(),
+	)
+	err = cmd.Run()
+	if err != nil {
+		return nil, fmt.Errorf("cannot sign the certificate: %v", err)
+	}
+
+	return &ckp, nil
+}
+
+func newSelfSignedCertificateKeyPair(subj string) (*certificateKeyPair, error) {
+	dir, err := ioutil.TempDir("", "osbuild-auth-tests-")
+	if err != nil {
+		return nil, fmt.Errorf("cannot create a temporary directory for the certificate: %v", err)
+	}
+
+	ckp := certificateKeyPair{baseDir: dir}
+
+	cmd := exec.Command(
+		"openssl", "req", "-nodes", "-x509",
+		"-subj", subj,
+		"-out", ckp.certificate(),
+		"-keyout", ckp.key(),
+	)
+	err = cmd.Run()
+	if err != nil {
+		return nil, fmt.Errorf("cannot generate a self-signed certificate: %v", err)
+	}
+
+	return &ckp, nil
+}
+
+func TestWorkerAPIAuth(t *testing.T) {
+	t.Run("certificate signed by a trusted CA", func(t *testing.T) {
+		cases := []struct {
+			caseDesc string
+			subj     string
+			success  bool
+		}{
+			{"valid CN 1", "/CN=worker.osbuild.org", true},
+			{"valid CN 2", "/CN=localhost", true},
+			{"invalid CN", "/CN=example.com", false},
+		}
+
+		for _, c := range cases {
+			t.Run(c.caseDesc, func(t *testing.T) {
+				ckp, err := newCertificateKeyPair("/etc/osbuild-composer/ca-crt.pem", "/etc/osbuild-composer/ca-key.pem", c.subj)
+				require.NoError(t, err)
+				defer ckp.remove()
+
+				testRoute(t, "https://localhost:8700/status", ckp, c.success)
+			})
+		}
+	})
+
+	t.Run("certificate signed by an untrusted CA", func(t *testing.T) {
+		// generate a new CA
+		ca, err := newSelfSignedCertificateKeyPair("/CN=osbuild.org")
+		require.NoError(t, err)
+		defer ca.remove()
+
+		// create a new certificate and signed it with the new CA
+		ckp, err := newCertificateKeyPair(ca.certificate(), ca.key(), "/CN=localhost")
+		require.NoError(t, err)
+		defer ckp.remove()
+
+		testRoute(t, "https://localhost:8700/status", ckp, false)
+	})
+
+	t.Run("self-signed certificate", func(t *testing.T) {
+		// generate a new self-signed certificate
+		ckp, err := newSelfSignedCertificateKeyPair("/CN=osbuild.org")
+		require.NoError(t, err)
+		defer ckp.remove()
+
+		testRoute(t, "https://localhost:8700/status", ckp, false)
+	})
+}
+
+func TestKojiAPIAuth(t *testing.T) {
+	t.Run("certificate signed by a trusted CA", func(t *testing.T) {
+		cases := []struct {
+			caseDesc string
+			subj     string
+			success  bool
+		}{
+			{"valid CN 1", "/CN=worker.osbuild.org", true},
+			{"valid CN 2", "/CN=localhost", true},
+			{"invalid CN", "/CN=example.com", false},
+		}
+
+		for _, c := range cases {
+			t.Run(c.caseDesc, func(t *testing.T) {
+				ckp, err := newCertificateKeyPair("/etc/osbuild-composer/ca-crt.pem", "/etc/osbuild-composer/ca-key.pem", c.subj)
+				require.NoError(t, err)
+				defer ckp.remove()
+
+				testRoute(t, "https://localhost/status", ckp, c.success)
+			})
+		}
+	})
+
+	t.Run("certificate signed by an untrusted CA", func(t *testing.T) {
+		// generate a new CA
+		ca, err := newSelfSignedCertificateKeyPair("/CN=osbuild.org")
+		require.NoError(t, err)
+		defer ca.remove()
+
+		// create a new certificate and signed it with the new CA
+		ckp, err := newCertificateKeyPair(ca.certificate(), ca.key(), "/CN=localhost")
+		require.NoError(t, err)
+		defer ckp.remove()
+
+		testRoute(t, "https://localhost/status", ckp, false)
+	})
+
+	t.Run("self-signed certificate", func(t *testing.T) {
+		// generate a new self-signed certificate
+		ckp, err := newSelfSignedCertificateKeyPair("/CN=osbuild.org")
+		require.NoError(t, err)
+		defer ckp.remove()
+
+		testRoute(t, "https://localhost/status", ckp, false)
+	})
+}
+
+func testRoute(t *testing.T, route string, ckp *certificateKeyPair, expectSuccess bool) {
+	tlsConfig, err := createTLSConfig(&connectionConfig{
+		CACertFile:     "/etc/osbuild-composer/ca-crt.pem",
+		ClientKeyFile:  ckp.key(),
+		ClientCertFile: ckp.certificate(),
+	})
+	require.NoError(t, err)
+
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.TLSClientConfig = tlsConfig
+	client := http.Client{Transport: transport}
+
+	response, err := client.Get(route)
+	if expectSuccess {
+		require.NoError(t, err)
+
+		var status struct {
+			Status string `json:"status"`
+		}
+		err := json.NewDecoder(response.Body).Decode(&status)
+		require.NoError(t, err)
+
+		require.Equal(t, "OK", status.Status)
+	} else {
+		require.Error(t, err)
+	}
+}

--- a/cmd/osbuild-composer/main.go
+++ b/cmd/osbuild-composer/main.go
@@ -72,11 +72,13 @@ func createTLSConfig(c *connectionConfig) (*tls.Config, error) {
 
 func main() {
 	var config struct {
-		KojiServers map[string]struct {
-			Kerberos *struct {
-				Principal string `toml:"principal"`
-				KeyTab    string `toml:"keytab"`
-			} `toml:"kerberos,omitempty"`
+		Koji *struct {
+			Servers map[string]struct {
+				Kerberos *struct {
+					Principal string `toml:"principal"`
+					KeyTab    string `toml:"keytab"`
+				} `toml:"kerberos,omitempty"`
+			} `toml:"servers"`
 		} `toml:"koji"`
 		Worker *struct {
 			AllowedDomains []string `toml:"allowed_domains"`
@@ -190,8 +192,11 @@ func main() {
 
 	// Optionally run Koji API
 	if kojiListeners, exists := listeners["osbuild-composer-koji.socket"]; exists {
+		if config.Koji == nil {
+			log.Fatal("koji not configured in the config file")
+		}
 		kojiServers := make(map[string]koji.GSSAPICredentials)
-		for server, creds := range config.KojiServers {
+		for server, creds := range config.Koji.Servers {
 			if creds.Kerberos == nil {
 				// For now we only support Kerberos authentication.
 				continue

--- a/cmd/osbuild-composer/main.go
+++ b/cmd/osbuild-composer/main.go
@@ -79,6 +79,7 @@ func main() {
 					KeyTab    string `toml:"keytab"`
 				} `toml:"kerberos,omitempty"`
 			} `toml:"servers"`
+			AllowedDomains []string `toml:"allowed_domains"`
 		} `toml:"koji"`
 		Worker *struct {
 			AllowedDomains []string `toml:"allowed_domains"`
@@ -213,6 +214,7 @@ func main() {
 			CACertFile:     "/etc/osbuild-composer/ca-crt.pem",
 			ServerKeyFile:  "/etc/osbuild-composer/composer-key.pem",
 			ServerCertFile: "/etc/osbuild-composer/composer-crt.pem",
+			AllowedDomains: config.Koji.AllowedDomains,
 		})
 		if err != nil {
 			log.Fatalf("TLS configuration cannot be created: " + err.Error())

--- a/cmd/osbuild-composer/main.go
+++ b/cmd/osbuild-composer/main.go
@@ -61,7 +61,9 @@ func createTLSConfig(c *connectionConfig) (*tls.Config, error) {
 		VerifyPeerCertificate: func(rawCerts [][]byte, verifiedChains [][]*x509.Certificate) error {
 			for _, chain := range verifiedChains {
 				for _, domain := range c.AllowedDomains {
-					return chain[0].VerifyHostname(domain)
+					if chain[0].VerifyHostname(domain) == nil {
+						return nil
+					}
 				}
 			}
 

--- a/golang-github-osbuild-composer.spec
+++ b/golang-github-osbuild-composer.spec
@@ -96,6 +96,7 @@ go test -c -tags=integration -ldflags="${TEST_LDFLAGS}" -o _bin/osbuild-tests %{
 go test -c -tags=integration -ldflags="${TEST_LDFLAGS}" -o _bin/osbuild-dnf-json-tests %{goipath}/cmd/osbuild-dnf-json-tests
 go test -c -tags=integration -ldflags="${TEST_LDFLAGS}" -o _bin/osbuild-weldr-tests %{goipath}/internal/client/
 go test -c -tags=integration -ldflags="${TEST_LDFLAGS}" -o _bin/osbuild-image-tests %{goipath}/cmd/osbuild-image-tests
+go test -c -tags=integration -ldflags="${TEST_LDFLAGS}" -o _bin/osbuild-auth-tests %{goipath}/cmd/osbuild-auth-tests
 
 %install
 install -m 0755 -vd                                         %{buildroot}%{_libexecdir}/osbuild-composer
@@ -119,6 +120,7 @@ install -m 0755 -vp _bin/osbuild-tests                      %{buildroot}%{_libex
 install -m 0755 -vp _bin/osbuild-weldr-tests                %{buildroot}%{_libexecdir}/tests/osbuild-composer/
 install -m 0755 -vp _bin/osbuild-dnf-json-tests             %{buildroot}%{_libexecdir}/tests/osbuild-composer/
 install -m 0755 -vp _bin/osbuild-image-tests                %{buildroot}%{_libexecdir}/tests/osbuild-composer/
+install -m 0755 -vp _bin/osbuild-auth-tests                %{buildroot}%{_libexecdir}/tests/osbuild-composer/
 install -m 0755 -vp tools/image-info                        %{buildroot}%{_libexecdir}/osbuild-composer/
 
 install -m 0755 -vd                                         %{buildroot}%{_datadir}/tests/osbuild-composer

--- a/internal/kojiapi/api/api.gen.go
+++ b/internal/kojiapi/api/api.gen.go
@@ -57,6 +57,11 @@ type Repository struct {
 	Gpgkey  string `json:"gpgkey"`
 }
 
+// Status defines model for Status.
+type Status struct {
+	Status string `json:"status"`
+}
+
 // PostComposeJSONBody defines parameters for PostCompose.
 type PostComposeJSONBody ComposeRequest
 
@@ -71,6 +76,9 @@ type ServerInterface interface {
 	// The status of a compose
 	// (GET /compose/{id})
 	GetComposeId(ctx echo.Context, id string) error
+	// status
+	// (GET /status)
+	GetStatus(ctx echo.Context) error
 }
 
 // ServerInterfaceWrapper converts echo contexts to parameters.
@@ -103,6 +111,15 @@ func (w *ServerInterfaceWrapper) GetComposeId(ctx echo.Context) error {
 	return err
 }
 
+// GetStatus converts echo context to params.
+func (w *ServerInterfaceWrapper) GetStatus(ctx echo.Context) error {
+	var err error
+
+	// Invoke the callback with all the unmarshalled arguments
+	err = w.Handler.GetStatus(ctx)
+	return err
+}
+
 // This is a simple interface which specifies echo.Route addition functions which
 // are present on both echo.Echo and echo.Group, since we want to allow using
 // either of them for path registration
@@ -127,5 +144,6 @@ func RegisterHandlers(router EchoRouter, si ServerInterface) {
 
 	router.POST("/compose", wrapper.PostCompose)
 	router.GET("/compose/:id", wrapper.GetComposeId)
+	router.GET("/status", wrapper.GetStatus)
 
 }

--- a/internal/kojiapi/api/openapi.yml
+++ b/internal/kojiapi/api/openapi.yml
@@ -7,6 +7,20 @@ info:
     name: Apache 2.0
     url: 'https://www.apache.org/licenses/LICENSE-2.0.html'
 paths:
+  /status:
+    get:
+      summary: status
+      tags: [ ]
+      responses:
+        '200':
+          description: OK
+          headers: { }
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Status'
+      operationId: GetStatus
+      description: Simple status handler to check whether the service is up.
   '/compose/{id}':
     get:
       summary: The status of a compose
@@ -70,6 +84,14 @@ paths:
                 type: string
 components:
   schemas:
+    Status:
+      required:
+        - status
+      properties:
+        status:
+          type: string
+          enum:
+            - OK
     ComposeStatus:
       required:
         - status

--- a/internal/kojiapi/server.go
+++ b/internal/kojiapi/server.go
@@ -247,6 +247,13 @@ func (h *apiHandlers) GetComposeId(ctx echo.Context, idstr string) error {
 	return ctx.JSON(http.StatusOK, response)
 }
 
+// GetStatus handles a /status GET request
+func (h *apiHandlers) GetStatus(ctx echo.Context) error {
+	return ctx.JSON(http.StatusOK, &api.Status{
+		Status: "OK",
+	})
+}
+
 // A simple echo.Binder(), which only accepts application/json, but is more
 // strict than echo's DefaultBinder. It does not handle binding query
 // parameters either.

--- a/osbuild-composer.spec
+++ b/osbuild-composer.spec
@@ -118,6 +118,7 @@ go test -c -tags=integration -ldflags="${TEST_LDFLAGS}" -o _bin/osbuild-dnf-json
 go test -c -tags=integration -ldflags="${TEST_LDFLAGS}" -o _bin/osbuild-weldr-tests %{goipath}/internal/client/
 go test -c -tags=integration -ldflags="${TEST_LDFLAGS}" -o _bin/osbuild-image-tests %{goipath}/cmd/osbuild-image-tests
 go test -c -tags=integration -ldflags="${TEST_LDFLAGS}" -o _bin/osbuild-composer-cloud-tests %{goipath}/cmd/osbuild-composer-cloud-tests
+go test -c -tags=integration -ldflags="${TEST_LDFLAGS}" -o _bin/osbuild-auth-tests %{goipath}/cmd/osbuild-auth-tests
 
 %endif
 
@@ -156,8 +157,9 @@ install -m 0755 -vp _bin/osbuild-tests                          %{buildroot}%{_l
 install -m 0755 -vp _bin/osbuild-weldr-tests                    %{buildroot}%{_libexecdir}/tests/osbuild-composer/
 install -m 0755 -vp _bin/osbuild-dnf-json-tests                 %{buildroot}%{_libexecdir}/tests/osbuild-composer/
 install -m 0755 -vp _bin/osbuild-image-tests                    %{buildroot}%{_libexecdir}/tests/osbuild-composer/
+install -m 0755 -vp _bin/osbuild-composer-cloud-tests           %{buildroot}%{_libexecdir}/tests/osbuild-composer/
+install -m 0755 -vp _bin/osbuild-auth-tests                     %{buildroot}%{_libexecdir}/tests/osbuild-composer/
 install -m 0755 -vp tools/image-info                            %{buildroot}%{_libexecdir}/osbuild-composer/
-install -m 0755 -vp _bin/osbuild-composer-cloud-tests       %{buildroot}%{_libexecdir}/tests/osbuild-composer/
 
 install -m 0755 -vd                                             %{buildroot}%{_datadir}/tests/osbuild-composer
 install -m 0644 -vp test/azure-deployment-template.json         %{buildroot}%{_datadir}/tests/osbuild-composer/

--- a/schutzbot/deploy.sh
+++ b/schutzbot/deploy.sh
@@ -76,11 +76,18 @@ if [[ -f "rhel-8-beta.json" ]]; then
     sudo cp rhel-8-beta.json /etc/osbuild-composer/repositories/
 fi
 
+greenprint "Copying custom composer config"
+# Remote worker needs this
+sudo mkdir -p /etc/osbuild-composer
+sudo cp test/image-tests/osbuild-composer.toml \
+    /etc/osbuild-composer/
+
 greenprint "Generating SSL certificates"
 sudo make composer-key-pair
 sudo make worker-key-pair
 
 greenprint "Starting services"
+sudo systemctl enable --now osbuild-remote-worker.socket
 sudo systemctl enable --now osbuild-composer.socket
 sudo systemctl enable --now osbuild-composer-koji.socket
 

--- a/schutzbot/run_base_tests.sh
+++ b/schutzbot/run_base_tests.sh
@@ -11,6 +11,7 @@ TEST_CASES=(
   "osbuild-weldr-tests"
   "osbuild-dnf-json-tests"
   "osbuild-tests"
+  "osbuild-auth-tests"
 )
 
 # Print out a nice test divider so we know when tests stop and start.

--- a/test/image-tests/koji.sh
+++ b/test/image-tests/koji.sh
@@ -35,10 +35,7 @@ fi
 greenprint "Starting containers"
 sudo ./internal/upload/koji/run-koji-container.sh start
 
-greenprint "Copying custom composer/worker config"
-sudo mkdir -p /etc/osbuild-composer
-sudo cp test/image-tests/osbuild-composer.toml \
-    /etc/osbuild-composer/
+greenprint "Copying custom worker config"
 sudo mkdir -p /etc/osbuild-worker
 sudo cp test/image-tests/osbuild-worker.toml \
     /etc/osbuild-worker/

--- a/test/image-tests/osbuild-composer.toml
+++ b/test/image-tests/osbuild-composer.toml
@@ -1,4 +1,4 @@
-[koji.localhost.kerberos]
+[koji.servers.localhost.kerberos]
 principal = "osbuild-krb@LOCAL"
 keytab = "/etc/osbuild-composer/client.keytab"
 

--- a/test/image-tests/osbuild-composer.toml
+++ b/test/image-tests/osbuild-composer.toml
@@ -1,5 +1,6 @@
 [koji]
 allowed_domains = [ "localhost", "worker.osbuild.org" ]
+ca = "/etc/osbuild-composer/ca-crt.pem"
 
 [koji.servers.localhost.kerberos]
 principal = "osbuild-krb@LOCAL"
@@ -7,3 +8,4 @@ keytab = "/etc/osbuild-composer/client.keytab"
 
 [worker]
 allowed_domains = [ "localhost", "worker.osbuild.org" ]
+ca = "/etc/osbuild-composer/ca-crt.pem"

--- a/test/image-tests/osbuild-composer.toml
+++ b/test/image-tests/osbuild-composer.toml
@@ -1,9 +1,9 @@
 [koji]
-allowed_domains = [ "localhost", "*.osbuild.org" ]
+allowed_domains = [ "localhost", "worker.osbuild.org" ]
 
 [koji.servers.localhost.kerberos]
 principal = "osbuild-krb@LOCAL"
 keytab = "/etc/osbuild-composer/client.keytab"
 
 [worker]
-allowed_domains = [ "localhost", "*.osbuild.org" ]
+allowed_domains = [ "localhost", "worker.osbuild.org" ]

--- a/test/image-tests/osbuild-composer.toml
+++ b/test/image-tests/osbuild-composer.toml
@@ -1,3 +1,6 @@
 [koji.localhost.kerberos]
 principal = "osbuild-krb@LOCAL"
 keytab = "/etc/osbuild-composer/client.keytab"
+
+[worker]
+allowed_domains = [ "localhost", "*.osbuild.org" ]

--- a/test/image-tests/osbuild-composer.toml
+++ b/test/image-tests/osbuild-composer.toml
@@ -1,3 +1,6 @@
+[koji]
+allowed_domains = [ "localhost", "*.osbuild.org" ]
+
 [koji.servers.localhost.kerberos]
 principal = "osbuild-krb@LOCAL"
 keytab = "/etc/osbuild-composer/client.keytab"


### PR DESCRIPTION
This PR adds:

- list of allowed domains for both Koji and remote worker APIs. After this change, the server accepts only certificates issued to pre-defined domains.
- tests for this.
- By default, koji and remote worker APIs now use the host's trusted CAs to validate client certificates.
  
  This is configurable in `osbuild-composer.toml` by `koji.ca` and `worker.ca` fields. These accept a path to a certificate that should be used to the validation instead of the default ones. If there's a need for using multiple certificates, it's possible to just append them to one file. (`cat cert1.pem cert2.pem > /etc/osbuild-composer/ca-crt.pem`)

What's still missing:

- wildcards for allowed domains (nice to have)
- SAN certificates for tests. Currently, only certificates with common names are used. This just requires a bit of tinkering with `openssl`.