### PR TITLE
tests: Make run_image_tests.sh fail on ls errors. Fix #1002

### DIFF
--- a/schutzbot/run_base_tests.sh
+++ b/schutzbot/run_base_tests.sh
@@ -53,8 +53,8 @@ echo "😃 Passed tests:" "${PASSED_TESTS[@]}"
 echo "☹ Failed tests:" "${FAILED_TESTS[@]}"
 test_divider
 
-# Exit with a failure if any tests failed.
-if [ ${#FAILED_TESTS[@]} -eq 0 ]; then
+# Exit with a failure if tests were executed and any of them failed.
+if [ ${#PASSED_TESTS[@]} -gt 0 ] && [ ${#FAILED_TESTS[@]} -eq 0 ]; then
     echo "🎉 All tests passed."
     exit 0
 else

--- a/schutzbot/run_image_tests.sh
+++ b/schutzbot/run_image_tests.sh
@@ -91,8 +91,8 @@ echo "😃 Passed tests: " "${PASSED_TESTS[@]}"
 echo "☹ Failed tests: " "${FAILED_TESTS[@]}"
 test_divider
 
-# Exit with a failure if any tests failed.
-if [ ${#FAILED_TESTS[@]} -eq 0 ]; then
+# Exit with a failure if tests were executed and any of them failed.
+if [ ${#PASSED_TESTS[@]} -gt 0 ] && [ ${#FAILED_TESTS[@]} -eq 0 ]; then
     echo "🎉 All tests passed."
     exit 0
 else


### PR DESCRIPTION
man set says:

... The shell does not exit if the command that fails is part
of  the  command list  immediately  following a while or until
keyword ...

It doesn't say anything about `for` but it looks like it's the
same.