### PR TITLE
tests/image: fix the selector

### DIFF
--- a/schutzbot/run_base_tests.sh
+++ b/schutzbot/run_base_tests.sh
@@ -54,8 +54,8 @@ echo "😃 Passed tests:" "${PASSED_TESTS[@]}"
 echo "☹ Failed tests:" "${FAILED_TESTS[@]}"
 test_divider
 
-# Exit with a failure if any tests failed.
-if [ ${#FAILED_TESTS[@]} -eq 0 ]; then
+# Exit with a failure if tests were executed and any of them failed.
+if [ ${#PASSED_TESTS[@]} -gt 0 ] && [ ${#FAILED_TESTS[@]} -eq 0 ]; then
     echo "🎉 All tests passed."
     exit 0
 else

--- a/schutzbot/run_image_tests.sh
+++ b/schutzbot/run_image_tests.sh
@@ -19,9 +19,9 @@ test_divider () {
 
 # Get a list of test cases.
 get_test_cases () {
-    TEST_CASE_SELECTOR="${ID}_${VERSION_ID%.*}-${ARCH}*.json"
+    TEST_CASE_SELECTOR="${ID}_${VERSION_ID%.*}-${ARCH}"
     pushd $IMAGE_TEST_CASES_PATH > /dev/null
-        ls "$TEST_CASE_SELECTOR"
+        ls "$TEST_CASE_SELECTOR"*.json
     popd > /dev/null
 }
 

--- a/schutzbot/run_image_tests.sh
+++ b/schutzbot/run_image_tests.sh
@@ -92,8 +92,8 @@ echo "😃 Passed tests: " "${PASSED_TESTS[@]}"
 echo "☹ Failed tests: " "${FAILED_TESTS[@]}"
 test_divider
 
-# Exit with a failure if any tests failed.
-if [ ${#FAILED_TESTS[@]} -eq 0 ]; then
+# Exit with a failure if tests were executed and any of them failed.
+if [ ${#PASSED_TESTS[@]} -gt 0 ] && [ ${#FAILED_TESTS[@]} -eq 0 ]; then
     echo "🎉 All tests passed."
     exit 0
 else

--- a/schutzbot/run_image_tests.sh
+++ b/schutzbot/run_image_tests.sh
@@ -62,7 +62,8 @@ run_test_case () {
 
     # Run the test and add the test name to the list of passed or failed
     # tests depending on the result.
-    if sudo "$TEST_CMD" 2>&1 | tee "${WORKSPACE}"/"${TEST_NAME}".log; then
+    # shellcheck disable=SC2086 # We need to pass multiple arguments here.
+    if sudo $TEST_CMD 2>&1 | tee "${WORKSPACE}"/"${TEST_NAME}".log; then
         PASSED_TESTS+=("$TEST_NAME")
     else
         FAILED_TESTS+=("$TEST_NAME")


### PR DESCRIPTION
**Currently, the image tests are not running!**

They're only reporting `ls: cannot access 'rhel_8-x86_64*.json': No such file or directory` and ending with success immediately. #1002 and #1003 tried (so far unsuccessfully) to fail the test if `ls` fails. This PR instead fixes the cause[1]. Nevertheless, we should still implement a better error handling if something like this ever happens again.

[1]Using a wildcard in quotes doesn't trigger shell expansion, therefore this PR moves the wildcard out of the quotes