### PR TITLE
Start osbuild-composer-koji.socket only if installed

### DIFF
--- a/schutzbot/deploy.sh
+++ b/schutzbot/deploy.sh
@@ -89,7 +89,10 @@ sudo make worker-key-pair
 greenprint "Starting services"
 sudo systemctl enable --now osbuild-remote-worker.socket
 sudo systemctl enable --now osbuild-composer.socket
-sudo systemctl enable --now osbuild-composer-koji.socket
+
+if rpm -q osbuild-composer-koji; then
+    sudo systemctl enable --now osbuild-composer-koji.socket
+fi
 
 if [[ $ID == rhel ]]; then
     greenprint "Starting cloud socket"


### PR DESCRIPTION
Tom says this shouldn't be started unconditionally because most
of the tests don't need it. In fact it isn't even available in
RHEL trees.