### PR TITLE
test: depend on rpms rather than installing them explicitly

### DIFF
--- a/golang-github-osbuild-composer.spec
+++ b/golang-github-osbuild-composer.spec
@@ -216,6 +216,37 @@ Requires:   composer-cli
 Requires:   createrepo_c
 Requires:   genisoimage
 Requires:   qemu-kvm-core
+Requires:   jq
+Requires:   unzip
+Requires:   container-selinux
+Requires:   dnsmasq
+Requires:   krb5-workstation
+Requires:   koji
+Requires:   podman
+Requires:   python3
+Requires:   sssd-krb5
+Requires:   libvirt-client libvirt-daemon
+Requires:   libvirt-daemon-config-network
+Requires:   libvirt-daemon-config-nwfilter
+Requires:   libvirt-daemon-driver-interface
+Requires:   libvirt-daemon-driver-network
+Requires:   libvirt-daemon-driver-nodedev
+Requires:   libvirt-daemon-driver-nwfilter
+Requires:   libvirt-daemon-driver-qemu
+Requires:   libvirt-daemon-driver-secret
+Requires:   libvirt-daemon-driver-storage
+Requires:   libvirt-daemon-driver-storage-disk
+Requires:   libvirt-daemon-kvm
+Requires:   qemu-img
+Requires:   qemu-kvm
+Requires:   virt-install
+Requires:   expect
+Requires:   python3-lxml
+Requires:   ansible
+Requires:   httpd
+%if 0%{?fedora}
+Requires:   podman-plugins
+%endif
 
 %description tests
 Integration tests to be run on a pristine-dedicated system to test the osbuild-composer package.

--- a/osbuild-composer.spec
+++ b/osbuild-composer.spec
@@ -292,6 +292,37 @@ Requires:   createrepo_c
 Requires:   genisoimage
 Requires:   qemu-kvm-core
 Requires:   systemd-container
+Requires:   jq
+Requires:   unzip
+Requires:   container-selinux
+Requires:   dnsmasq
+Requires:   krb5-workstation
+Requires:   koji
+Requires:   podman
+Requires:   python3
+Requires:   sssd-krb5
+Requires:   libvirt-client libvirt-daemon
+Requires:   libvirt-daemon-config-network
+Requires:   libvirt-daemon-config-nwfilter
+Requires:   libvirt-daemon-driver-interface
+Requires:   libvirt-daemon-driver-network
+Requires:   libvirt-daemon-driver-nodedev
+Requires:   libvirt-daemon-driver-nwfilter
+Requires:   libvirt-daemon-driver-qemu
+Requires:   libvirt-daemon-driver-secret
+Requires:   libvirt-daemon-driver-storage
+Requires:   libvirt-daemon-driver-storage-disk
+Requires:   libvirt-daemon-kvm
+Requires:   qemu-img
+Requires:   qemu-kvm
+Requires:   virt-install
+Requires:   expect
+Requires:   python3-lxml
+Requires:   ansible
+Requires:   httpd
+%if 0%{?fedora}
+Requires:   podman-plugins
+%endif
 %ifarch %{arm}
 Requires:   edk2-aarch64
 %endif

--- a/schutzbot/run_base_tests.sh
+++ b/schutzbot/run_base_tests.sh
@@ -37,9 +37,6 @@ run_test_case () {
     echo
 }
 
-# Ensure osbuild-composer-tests is installed.
-sudo dnf -y install osbuild-composer-tests
-
 # Change to the working directory.
 cd $WORKING_DIRECTORY
 

--- a/schutzbot/run_image_tests.sh
+++ b/schutzbot/run_image_tests.sh
@@ -74,11 +74,6 @@ run_test_case () {
     echo
 }
 
-# Ensure osbuild-composer-tests is installed.
-if ! rpm -qi osbuild-composer-tests > /dev/null 2>&1; then
-    sudo dnf -y install osbuild-composer-tests
-fi
-
 # Change to the working directory.
 cd $WORKING_DIRECTORY
 

--- a/test/cmd/aws.sh
+++ b/test/cmd/aws.sh
@@ -24,16 +24,9 @@ if [[ $ID == rhel ]]; then
     sudo rm -f /usr/lib/python3.6/site-packages/composer/cli/compose.pyc
 fi
 
-# We need jq for parsing composer-cli output.
-if ! hash jq; then
-    greenprint "Installing jq"
-    sudo dnf -qy install jq
-fi
-
 # We need awscli to talk to AWS.
 if ! hash aws; then
     greenprint "Installing awscli"
-    sudo dnf -y install unzip
     pushd /tmp
         curl -Ls --retry 5 --output awscliv2.zip \
             https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip

--- a/test/cmd/koji.sh
+++ b/test/cmd/koji.sh
@@ -18,22 +18,10 @@ if [[ $ID == rhel ]] && ! rpm -q epel-release; then
     sudo rpm -Uvh /tmp/epel.rpm
 fi
 
-greenprint "Installing required packages"
-sudo dnf -y install \
-    container-selinux \
-    dnsmasq \
-    krb5-workstation \
-    koji \
-    podman \
-    python3 \
-    sssd-krb5
-
 greenprint "Adding podman dnsname plugin"
 if [[ $ID == rhel ]]; then
   sudo cp /usr/share/tests/osbuild-composer/vendor/87-podman-bridge.conflist /etc/cni/net.d/
   sudo cp /usr/share/tests/osbuild-composer/vendor/dnsname /usr/libexec/cni/
-else
-  sudo dnf -y install podman-plugins
 fi
 
 greenprint "Starting containers"

--- a/test/cmd/ostree.sh
+++ b/test/cmd/ostree.sh
@@ -44,17 +44,6 @@ if [[ $ID == rhel ]] && ! rpm -q epel-release; then
     sudo rpm -Uvh /tmp/epel.rpm
 fi
 
-# Install required packages.
-greenprint "📦 Installing required packages"
-sudo dnf -y install jq libvirt-client libvirt-daemon \
-    libvirt-daemon-config-network libvirt-daemon-config-nwfilter \
-    libvirt-daemon-driver-interface libvirt-daemon-driver-network \
-    libvirt-daemon-driver-nodedev libvirt-daemon-driver-nwfilter \
-    libvirt-daemon-driver-qemu libvirt-daemon-driver-secret \
-    libvirt-daemon-driver-storage libvirt-daemon-driver-storage-disk \
-    libvirt-daemon-kvm qemu-img qemu-kvm virt-install expect \
-    python3-lxml ansible httpd
-
 # Start libvirtd and test it.
 greenprint "🚀 Starting libvirt daemon"
 sudo systemctl start libvirtd

--- a/test/cmd/qemu.sh
+++ b/test/cmd/qemu.sh
@@ -36,16 +36,6 @@ function greenprint {
     echo -e "\033[1;32m${1}\033[0m"
 }
 
-# Install required packages.
-greenprint "📦 Installing required packages"
-sudo dnf -y install jq libvirt-client libvirt-daemon \
-    libvirt-daemon-config-network libvirt-daemon-config-nwfilter \
-    libvirt-daemon-driver-interface libvirt-daemon-driver-network \
-    libvirt-daemon-driver-nodedev libvirt-daemon-driver-nwfilter \
-    libvirt-daemon-driver-qemu libvirt-daemon-driver-secret \
-    libvirt-daemon-driver-storage libvirt-daemon-driver-storage-disk \
-    libvirt-daemon-kvm qemu-img qemu-kvm virt-install
-
 # Start libvirtd and test it.
 greenprint "🚀 Starting libvirt daemon"
 sudo systemctl start libvirtd


### PR DESCRIPTION
The -test subpackage should depend on all that it needs, and we should
never need to install anything explicitly from the test scripts.

Signed-off-by: Tom Gundersen <teg@jklm.no>