### PR TITLE
spec: obsolete lorax-composer in Fedora 34

### DIFF
--- a/osbuild-composer.spec
+++ b/osbuild-composer.spec
@@ -67,6 +67,12 @@ Obsoletes: lorax-composer <= 29
 Conflicts: lorax-composer
 %endif
 
+# Remove when we stop releasing into Fedora 35
+%if 0%{?fedora} >= 34
+# lorax 34.3 is the first one without the composer subpackage
+Obsoletes: lorax-composer < 34.3
+%endif
+
 # remove in F34
 Obsoletes: golang-github-osbuild-composer < %{version}-%{release}
 Provides:  golang-github-osbuild-composer = %{version}-%{release}


### PR DESCRIPTION
Lorax-composer won't be shipped into Fedora 34. To upgrade users from it to osbuild-composer we need to obsolete it in our spec file.

Fixes RHBZ#1886405