### PR TITLE
test/ostree: use releng repo instead of nightly for rhel8.3

### DIFF
--- a/test/cmd/ostree.sh
+++ b/test/cmd/ostree.sh
@@ -26,7 +26,7 @@ case "${ID}-${VERSION_ID}" in
         IMAGE_TYPE=rhel-edge-commit
         OSTREE_REF="rhel/8/${ARCH}/edge"
         OS_VARIANT="rhel8-unknown"
-        BOOT_LOCATION="http://download.devel.redhat.com/rhel-8/nightly/RHEL-8/latest-RHEL-8.3/compose/BaseOS/x86_64/os/";;
+        BOOT_LOCATION="http://download.devel.redhat.com/rhel-8/rel-eng/RHEL-8/latest-RHEL-8.3/compose/BaseOS/x86_64/os/";;
     *) ;;
 esac
 


### PR DESCRIPTION
The previously used repo doesn't exist anymore making this test fail with:

Error validating install location: Could not find an installable distribution
at 'http://download.devel.redhat.com/rhel-8/nightly/RHEL-8/latest-RHEL-8.3/compose/BaseOS/x86_64/os/':
The URL could not be accessed, maybe you mistyped?

Let's switch to a releng repo that shouldn't be deleted.