### PR TITLE
Fix osbuild-composer in ELN

### DIFF
--- a/osbuild-composer.spec
+++ b/osbuild-composer.spec
@@ -30,6 +30,7 @@ Source0:        %{gosource}
 
 BuildRequires:  %{?go_compiler:compiler(go-compiler)}%{!?go_compiler:golang}
 BuildRequires:  systemd
+BuildRequires:  krb5-devel
 %if 0%{?fedora}
 BuildRequires:  systemd-rpm-macros
 BuildRequires:  git
@@ -51,7 +52,6 @@ BuildRequires:  golang(github.com/gophercloud/gophercloud)
 BuildRequires:  golang(github.com/stretchr/testify/assert)
 BuildRequires:  golang(github.com/ubccr/kerby)
 BuildRequires:  golang(github.com/vmware/govmomi)
-BuildRequires:  krb5-devel
 %endif
 
 Requires: %{name}-worker = %{version}-%{release}

--- a/osbuild-composer.spec
+++ b/osbuild-composer.spec
@@ -207,6 +207,8 @@ install -m 0755 -vp test/data/vendor/dnsname                    %{buildroot}%{_d
 %if 0%{?rhel}
 export GOFLAGS=-mod=vendor
 export GOPATH=$PWD/_build:%{gopath}
+# cd inside GOPATH, otherwise go with GO111MODULE=off ignores vendor directory
+cd $PWD/_build/src/%{goipath}
 %gotest ./...
 %else
 %gocheck


### PR DESCRIPTION
See individual commits.

I would introduce a test building our package in ELN using `mock` but `mock` with ELN target seems to be currently broken. I already asked for help in fedora devel channel.

There's at least a manual ELN scratch build: https://koji.fedoraproject.org/koji/taskinfo?taskID=53369289

Fixes rhbz#1884383