### PR TITLE
make: put all binaries into bin directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,15 +1,4 @@
 __pycache__
 
-/osbuild-composer
-/osbuild-worker
-/osbuild-weldr-tests
-/osbuild-pipeline
-/osbuild-upload-azure
-/osbuild-upload-aws
-/osbuild-dnf-json-tests
-/osbuild-composer-cli-tests
-/osbuild-weldr-tests
-/osbuild-composer-cloud
-/osbuild-composer-cloud-tests
-
+/bin
 /rpmbuild

--- a/Makefile
+++ b/Makefile
@@ -108,25 +108,26 @@ man: $(MANPAGES_TROFF)
 
 .PHONY: build
 build:
-	go build -o osbuild-composer ./cmd/osbuild-composer/
-	go build -o osbuild-composer-cloud ./cmd/osbuild-composer-cloud/
-	go build -o osbuild-worker ./cmd/osbuild-worker/
-	go build -o osbuild-pipeline ./cmd/osbuild-pipeline/
-	go build -o osbuild-upload-azure ./cmd/osbuild-upload-azure/
-	go build -o osbuild-upload-aws ./cmd/osbuild-upload-aws/
-	go test -c -tags=integration -o osbuild-composer-cli-tests ./cmd/osbuild-composer-cli-tests/main_test.go
-	go test -c -tags=integration -o osbuild-weldr-tests ./internal/client/
-	go test -c -tags=integration -o osbuild-dnf-json-tests ./cmd/osbuild-dnf-json-tests/main_test.go
-	go test -c -tags=integration -o osbuild-image-tests ./cmd/osbuild-image-tests/
-	go test -c -tags=integration -o osbuild-composer-cloud-tests ./cmd/osbuild-composer-cloud-tests/main_test.go
-	go test -c -tags=integration -o osbuild-auth-tests ./cmd/osbuild-auth-tests/
+	- mkdir bin
+	go build -o bin/osbuild-composer ./cmd/osbuild-composer/
+	go build -o bin/osbuild-composer-cloud ./cmd/osbuild-composer-cloud/
+	go build -o bin/osbuild-worker ./cmd/osbuild-worker/
+	go build -o bin/osbuild-pipeline ./cmd/osbuild-pipeline/
+	go build -o bin/osbuild-upload-azure ./cmd/osbuild-upload-azure/
+	go build -o bin/osbuild-upload-aws ./cmd/osbuild-upload-aws/
+	go test -c -tags=integration -o bin/osbuild-composer-cli-tests ./cmd/osbuild-composer-cli-tests/main_test.go
+	go test -c -tags=integration -o bin/osbuild-weldr-tests ./internal/client/
+	go test -c -tags=integration -o bin/osbuild-dnf-json-tests ./cmd/osbuild-dnf-json-tests/main_test.go
+	go test -c -tags=integration -o bin/osbuild-image-tests ./cmd/osbuild-image-tests/
+	go test -c -tags=integration -o bin/osbuild-composer-cloud-tests ./cmd/osbuild-composer-cloud-tests/main_test.go
+	go test -c -tags=integration -o bin/osbuild-auth-tests ./cmd/osbuild-auth-tests/
 
 .PHONY: install
 install:
 	- mkdir -p /usr/libexec/osbuild-composer
-	cp osbuild-composer /usr/libexec/osbuild-composer/
-	cp osbuild-worker /usr/libexec/osbuild-composer/
-	cp osbuild-composer-cloud /usr/libexec/osbuild-composer/
+	cp bin/osbuild-composer /usr/libexec/osbuild-composer/
+	cp bin/osbuild-worker /usr/libexec/osbuild-composer/
+	cp bin/osbuild-composer-cloud /usr/libexec/osbuild-composer/
 	cp dnf-json /usr/libexec/osbuild-composer/
 	- mkdir -p /usr/share/osbuild-composer/repositories
 	cp repositories/* /usr/share/osbuild-composer/repositories


### PR DESCRIPTION
Currently, we have osbuild-image-tests binary committed in the master branch. IMHO the root cause is that we don't have it in .gitignore. Actually, I think that it is pretty hard to keep .gitignore in sync with the build target.

This commit solves the situation by putting all the built binaries into bin directory and adding this directory into .gitignore. This way, it's much harder to actually commit a new Go binary into the repository.

This commit doesn't remove the binary as #1017 already does that.

We don't want to merge this before #1017