### PR TITLE
schutzbot/run_cloud_cleaner: pass BRANCH_NAME instead of CHANGE_ID

### DIFF
--- a/schutzbot/run_cloud_cleaner.sh
+++ b/schutzbot/run_cloud_cleaner.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -euo pipefail
 
-CLEANER_CMD="env $(cat "$AZURE_CREDS") CHANGE_ID=$CHANGE_ID BUILD_ID=$BUILD_ID DISTRO_CODE=$DISTRO_CODE /usr/libexec/osbuild-composer/cloud-cleaner"
+CLEANER_CMD="env $(cat "$AZURE_CREDS") BRANCH_NAME=$BRANCH_NAME BUILD_ID=$BUILD_ID DISTRO_CODE=$DISTRO_CODE /usr/libexec/osbuild-composer/cloud-cleaner"
 
 echo "🧹 Running the cloud cleaner"
 $CLEANER_CMD


### PR DESCRIPTION
`CHANGE_ID` bug strikes for the 3rd time :-/. Hope this is the last one. Recursive grep does not show any other usage:
```
$ rg CHANGE_ID
$
```