### PR TITLE
Add tools/deploy-openstack

### DIFF
--- a/DEPLOYING.md
+++ b/DEPLOYING.md
@@ -1,0 +1,53 @@
+# Deploying osbuild-composer
+
+*osbuild-composer* has currently has to be deployed in a virtual machine. The
+[tools](./tools) subdirectory contains various scripts (those starting with
+`deploy-`) to deploy it into cloud-init-enabled environemnts. These scripts all
+take the form:
+
+    $ ./tools/deploy-<target> <config> <userdata>
+
+`<config>` depends on the target (see below). `<userdata>` is either a
+cloud-init [cloud-config file][cloud-config], or a directory containing
+this configuration, as documented by [./tools/gen-user-data][gen-user-data].
+
+[gen-user-data]: ./tools/gen-user-data
+[cloud-config]: https://cloudinit.readthedocs.io/en/latest/topics/format.html#cloud-config-data
+
+
+## Target: QEMU
+
+`tools/deploy-qemu` takes as `<config>` the path to a qcow2 image and starts a
+ephemeral virtual machine using qemu. The qcow2 file is not changed and all
+changes to the virtual machine are lost after stopping qemu.
+
+Two ports are forwarded to the host via qemu's [user networking][qemu-network]:
+22 → 2222 and 443 → 4430.
+
+See [HACKING.md][./HACKING.md] for how to use this target for running
+integration tests locally.
+
+[qemu-network]: https://wiki.qemu.org/Documentation/Networking#User_Networking_.28SLIRP.29
+
+
+## Target: OpenStack
+
+`tools/deploy-openstack` uses the `openstack` tool (from `python3-openstack`)
+to deploy a machine in an OpenStack cluster. It expects that an [OpenStack RC
+file][openstackrc] was sourced into the running shell:
+
+    . openstackrc.sh
+
+`<config>` has to be a JSON-file containing configuration about what kind of
+machine to create. For example:
+
+```json
+{
+  "name": "composer-instance",
+  "image": "fedora-32-x86_64",
+  "flavor": "m1.small",
+  "network": "my-network-id"
+}
+```
+
+[openstackrc]: https://docs.openstack.org/newton/admin-guide/common/cli-set-environment-variables-using-openstack-rc.html

--- a/HACKING.md
+++ b/HACKING.md
@@ -31,7 +31,7 @@ mimick what is run on *osbuild-composer*'s continuous integration
 infrastructure, i.e., installing `osbuild-composer-tests` and starting the
 service.
 
-The virtual machine uses qemu's user mode networking [1], forwarding port 22 to
+The virtual machine uses qemu's [user networking][1], forwarding port 22 to
 the host's 2222 and 443 to 4430. You can log into the running machine with
 
     ssh admin@localhost -p 2222

--- a/tools/deploy-openstack
+++ b/tools/deploy-openstack
@@ -1,0 +1,70 @@
+#!/usr/bin/bash
+
+#
+# deploy-openstack IMAGE USERDATA
+#
+# Starts an openstack instance, injecting configuration via cloud-init. It
+# assumes that an openstackrc file has been sourced into the environment.
+#
+# CONFIG   -- A JSON file containing configuration for an openstack deployment,
+#             containing "image", "flavor", "network" (same as openstack server
+#             create arguments), and "extra-args".
+#
+# USERDATA -- A cloud-init user-data config file, or a directory of
+#             configuration as accepted by the `gen-user-data` tool.
+#
+
+set -euo pipefail
+
+if [[ "$#" != 2 ]]; then
+  echo "usage: $0 CONFIG USERDATA"
+  exit 1
+fi
+
+scriptdir=$(dirname "$0")
+config=$1
+userdata=$2
+
+# Verify that an openstackrc file has been sourced. This will fail when the
+# variables do not exist.
+printenv OS_PROJECT_NAME OS_USERNAME > /dev/null
+
+workdir=$(mktemp -d "$scriptdir/qemu-tmp-XXXXXX")
+function cleanup() {
+  rm -rf "$workdir"
+}
+trap cleanup EXIT
+
+if [ -d "$userdata" ]; then
+  "$scriptdir/gen-user-data" "$userdata" > "$workdir/user-data"
+else
+  cp "$userdata" "$workdir/user-data"
+fi
+
+name=$(jq -r '.name // ""' "$config")
+image=$(jq -r '.image // ""' "$config")
+flavor=$(jq -r '.flavor // ""' "$config")
+network=$(jq -r '.network // ""' "$config")
+extra_args=$(jq -r '.extra_args // ""' "$config")
+
+if [[ -z "$name" || -z "$image" || -z "$flavor" ]]; then
+  echo "at least 'name', 'image', and 'flavor' must be set in $config"
+  exit 1
+fi
+
+if openstack server show "$name" 2>/dev/null >/dev/null; then
+  echo "server '$name' already exists - delete it with"
+  echo ""
+  echo "    openstack server stop $name"
+  echo "    openstack server delete $name"
+  exit 1
+fi
+
+openstack server create \
+  --wait \
+  --image "$image" \
+  --flavor "$flavor" \
+  --user-data "$workdir/user-data" \
+  ${network:+--network "$network"} \
+  ${extra_args:+$extra_args} \
+  "$name"


### PR DESCRIPTION
Similar to deploy-qemu, but deploys into an OpenStack cluster. It uses
the same logic for user-data.

No downstream testing is necessary for this commit, as it doesn't change *osbuild-composer* itself.