### PR TITLE
spec: generate packageinfo files for composer and worker

### DIFF
--- a/osbuild-composer.spec
+++ b/osbuild-composer.spec
@@ -101,6 +101,24 @@ sed -i "s$// +build kolo_xmlrpc_oldapi$// +build !kolo_xmlrpc_oldapi$" internal/
 sed -i "s$// +build !kolo_xmlrpc_oldapi$// +build kolo_xmlrpc_oldapi$" internal/upload/koji/xmlrpc-response.go
 %endif
 
+# create the packageinfo files for composer and worker
+tee osbuild-composer-packageinfo.json << EOF
+{
+  "name": "%{name}",
+  "version": "%{version}",
+  "release": "%{release}",
+  "arch": "%{_arch}"
+}
+EOF
+tee osbuild-worker-packageinfo.json << EOF
+{
+  "name": "%{name}-worker",
+  "version": "%{version}",
+  "release": "%{release}",
+  "arch": "%{_arch}"
+}
+EOF
+
 %build
 %if 0%{?rhel}
 GO_BUILD_PATH=$PWD/_build
@@ -147,8 +165,13 @@ install -m 0755 -vp _bin/osbuild-composer                       %{buildroot}%{_l
 install -m 0755 -vp _bin/osbuild-worker                         %{buildroot}%{_libexecdir}/osbuild-composer/
 install -m 0755 -vp dnf-json                                    %{buildroot}%{_libexecdir}/osbuild-composer/
 
+install -m 0755 -vd                                             %{buildroot}%{_datadir}/osbuild-composer
+install -m 0644 -vp osbuild-composer-packageinfo.json           %{buildroot}%{_datadir}/osbuild-composer/packageinfo.json
 install -m 0755 -vd                                             %{buildroot}%{_datadir}/osbuild-composer/repositories
 install -m 0644 -vp repositories/*                              %{buildroot}%{_datadir}/osbuild-composer/repositories/
+
+install -m 0755 -vd                                             %{buildroot}%{_datadir}/osbuild-worker
+install -m 0644 -vp osbuild-worker-packageinfo.json             %{buildroot}%{_datadir}/osbuild-worker/packageinfo.json
 
 install -m 0755 -vd                                             %{buildroot}%{_unitdir}
 install -m 0644 -vp distribution/osbuild-composer.service       %{buildroot}%{_unitdir}/
@@ -271,6 +294,7 @@ The worker for osbuild-composer
 
 %files worker
 %{_libexecdir}/osbuild-composer/osbuild-worker
+%{_datadir}/osbuild-worker/
 %{_unitdir}/osbuild-worker@.service
 %{_unitdir}/osbuild-remote-worker@.service
 


### PR DESCRIPTION
For Koji builds, it would be nice to know the version of osbuild-composer and worker that was used to build the image.

This commit explores the approach of putting the information about the package version in two json files:

```
/usr/share/osbuild-composer/packageinfo.json
/usr/share/osbuild-worker/packageinfo.json
```

For now, I chose to have separate NVRA fields in the files. From my test run:

```
$ cat /usr/share/osbuild-composer/packageinfo.json 
{
  "name": "osbuild-composer",
  "version": "22",
  "release": "1.20201023git820a330.fc33",
  "arch": "x86_64"
}
$ cat /usr/share/osbuild-worker/packageinfo.json 
{
  "name": "osbuild-composer-worker",
  "version": "22",
  "release": "1.20201023git820a330.fc33",
  "arch": "x86_64"
}
```

The other approach is to query rpm database for this information but this changes `osbuild-composer` dependant on `rpm`, that is something that we probably don't want.

I'm open to all suggestions!

We will need something similar in `osbuild` (composer needs to know its version), so I'm asking for a review and suggestions also from @gicmo and @dvdhrm because it would nice to do this the same way in both packages.