### PR TITLE
base_tests.sh: make the test self-contained

### DIFF
--- a/schutzbot/Jenkinsfile
+++ b/schutzbot/Jenkinsfile
@@ -351,6 +351,8 @@ void preserve_logs(test_slug) {
 
     // Make a directory for the log files and move the logs there.
     sh "mkdir ${test_slug} && mv *.log *.jpg ${test_slug}/ || true"
+    // The workspace directory is not used everywhere, tests use temporary directory under /tmp/logs.
+    sh "mkdir -p ${test_slug} && find /tmp/logs/ -name '*.log' -exec mv {} ${test_slug}/ \\; || true"
 
     // Artifact the logs.
     archiveArtifacts (

--- a/test/cases/base_tests.sh
+++ b/test/cases/base_tests.sh
@@ -3,6 +3,8 @@ set -euo pipefail
 
 WORKING_DIRECTORY=/usr/libexec/osbuild-composer
 TESTS_PATH=/usr/libexec/osbuild-composer-test
+mkdir --parents /tmp/logs
+LOGS_DIRECTORY=$(mktemp --directory --tmpdir=/tmp/logs)
 
 PASSED_TESTS=()
 FAILED_TESTS=()
@@ -27,7 +29,7 @@ run_test_case () {
     echo "🏃🏻 Running test: ${TEST_NAME}"
     test_divider
 
-    if sudo "${1}" -test.v | tee "${WORKSPACE}"/"${TEST_NAME}".log; then
+    if sudo "${1}" -test.v | tee "${LOGS_DIRECTORY}"/"${TEST_NAME}".log; then
         PASSED_TESTS+=("$TEST_NAME")
     else
         FAILED_TESTS+=("$TEST_NAME")


### PR DESCRIPTION
We claim to have self-contained test cases, but the base_tests.sh script
still requires the WORKSPACE environment variable to be set outside of
the script, which is what Jenkins does.

This patch introduces a default value, which makes it possible to use
the script outside of Jenkins.
