### PR TITLE
koji/test: use our quay mirror of the postgres container

### DIFF
--- a/tools/run-koji-container.sh
+++ b/tools/run-koji-container.sh
@@ -57,7 +57,7 @@ koji_start() {
     -e POSTGRES_USER=koji \
     -e POSTGRES_PASSWORD=kojipass \
     -e POSTGRES_DB=koji \
-    docker.io/library/postgres:12-alpine
+    quay.io/osbuild/postgres:v1
 
   ${CONTAINER_RUNTIME} run -d --name org.osbuild.koji.kdc \
     --network org.osbuild.koji \


### PR DESCRIPTION
docker.io has recently introduced a rate limiting on container pulls causing the koji test to fail quite often.

To fix this issue, I created our own postgres mirror\[1\]. This commit switches the Koji test to use it. Note that this change bumps the postgres version from 12 to 13.

\[1\]: https://github.com/osbuild/containers/commit/7db3c6802ebe434129dfc5cd37e7dced329cfe88