### PR TITLE
test: don't install epel in test cases

### DIFF
--- a/test/cases/koji.sh
+++ b/test/cases/koji.sh
@@ -14,13 +14,6 @@ function greenprint {
 # Provision the software under tet.
 /usr/libexec/osbuild-composer-test/provision.sh
 
-if [[ $ID == rhel ]] && ! rpm -q epel-release; then
-    greenprint "📦 Setting up EPEL repository"
-    curl -Ls --retry 5 --output /tmp/epel.rpm \
-        https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
-    sudo rpm -Uvh /tmp/epel.rpm
-fi
-
 greenprint "Adding podman dnsname plugin"
 if [[ $ID == rhel ]]; then
   sudo cp /usr/share/tests/osbuild-composer/vendor/87-podman-bridge.conflist /etc/cni/net.d/

--- a/test/cases/ostree.sh
+++ b/test/cases/ostree.sh
@@ -33,14 +33,6 @@ function greenprint {
     echo -e "\033[1;32m${1}\033[0m"
 }
 
-# Mock is only available in EPEL for RHEL.
-if [[ $ID == rhel ]] && ! rpm -q epel-release; then
-    greenprint "📦 Setting up EPEL repository"
-    curl -Ls --retry 5 --output /tmp/epel.rpm \
-        https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
-    sudo rpm -Uvh /tmp/epel.rpm
-fi
-
 # Start libvirtd and test it.
 greenprint "🚀 Starting libvirt daemon"
 sudo systemctl start libvirtd


### PR DESCRIPTION
We don't install any packages in test cases anymore, therefore we don't need to install EPEL there.

A slightly different explanation:
osbuild-composer-tests depends on packages from EPEL on RHEL. Therefore, you cannot run the test cases without EPEL installed. Therefore, there's no point in installing EPEL there.