### PR TITLE
test/integration: delete composes after we're done

### DIFF
--- a/test/cases/aws.sh
+++ b/test/cases/aws.sh
@@ -270,6 +270,9 @@ $AWS_CMD ec2 terminate-instances --instance-id "${INSTANCE_ID}"
 $AWS_CMD ec2 deregister-image --image-id "${AMI_IMAGE_ID}"
 $AWS_CMD ec2 delete-snapshot --snapshot-id "${SNAPSHOT_ID}"
 
+# Also delete the compose so we don't run out of disk space
+sudo composer-cli compose delete "${COMPOSE_ID}" > /dev/null
+
 # Use the return code of the smoke test to determine if we passed or failed.
 # On rhel continue with the cloudapi test
 if [[ $RESULTS == 1 ]]; then

--- a/test/cases/qemu.sh
+++ b/test/cases/qemu.sh
@@ -301,6 +301,9 @@ else
 fi
 sudo rm -f "$LIBVIRT_IMAGE_PATH" $CLOUD_INIT_PATH
 
+# Also delete the compose so we don't run out of disk space
+sudo composer-cli compose delete "${COMPOSE_ID}" > /dev/null
+
 # Use the return code of the smoke test to determine if we passed or failed.
 if [[ $RESULTS == 1 ]]; then
   greenprint "💚 Success"


### PR DESCRIPTION
The integration tests are leaving the composes (which include images) in osbuild-composer. This can lead to exhausting the disk space we have available on our tiny testing machines. This commit adds a removal of the composes after each integration test is finished. This issue is not present in koji.sh and api.sh as they use different osbuild-composer APIs that don't use the artifact feature.

This issue occurred when I worked on enabling the Fedora 33 tests, see:

https://osbuildci.cloud.paas.psi.redhat.com/blue/organizations/jenkins/osbuild%2Fosbuild-composer/detail/PR-1014/23/pipeline