### PR TITLE
mockbuild: make repository URLs more predictable

### DIFF
--- a/schutzbot/mockbuild.sh
+++ b/schutzbot/mockbuild.sh
@@ -43,7 +43,7 @@ MOCK_REPO_BASE_URL="http://osbuild-composer-repos.s3-website.us-east-2.amazonaws
 
 # Relative path of the repository – used for constructing both the local and
 # remote paths below, so that they're consistent.
-REPO_PATH=${JOB_NAME}/${COMMIT}/${ID}${VERSION_ID//./}_${ARCH}
+REPO_PATH=osbuild-composer/${ID}-${VERSION_ID}/${ARCH}/${COMMIT}
 
 # Directory to hold the RPMs temporarily before we upload them.
 REPO_DIR=repo/${REPO_PATH}
@@ -86,7 +86,7 @@ popd
 greenprint "📜 Generating dnf repository file"
 tee osbuild-mock.repo << EOF
 [osbuild-mock]
-name=osbuild mock ${JOB_NAME}-${COMMIT} ${ID}${VERSION_ID//./}
+name=osbuild mock ${COMMIT}
 baseurl=${REPO_URL}
 enabled=1
 gpgcheck=0

--- a/schutzbot/mockbuild.sh
+++ b/schutzbot/mockbuild.sh
@@ -47,10 +47,6 @@ MOCK_REPO_BASE_URL="http://osbuild-composer-repos.s3-website.us-east-2.amazonaws
 # Directory to hold the RPMs temporarily before we upload them.
 REPO_DIR=repo/${JOB_NAME}/${COMMIT}/${ID}${VERSION_ID//./}_${ARCH}
 
-# Maintain a directory for the master branch that always contains the latest
-# RPM packages.
-REPO_DIR_LATEST=repo/${JOB_NAME}/latest
-
 # Full URL to the RPM repository after they are uploaded.
 REPO_URL=${MOCK_REPO_BASE_URL}/${JOB_NAME}/${COMMIT}/${ID}${VERSION_ID//./}_${ARCH}
 
@@ -79,14 +75,6 @@ mv "${REPO_DIR}"/*.log "$WORKSPACE"
 # Create a repo of the built RPMs.
 greenprint "⛓️ Creating dnf repository"
 createrepo_c "${REPO_DIR}"
-
-# Copy the current build to the latest directory.
-mkdir -p "$REPO_DIR_LATEST"
-cp -arv "${REPO_DIR}"/ "${REPO_DIR_LATEST}"/
-
-# Remove the previous latest build for this branch.
-# Don't fail if the path is missing.
-s3cmd --recursive rm "s3://${REPO_BUCKET}/${JOB_NAME}/latest/${ID}${VERSION_ID//./}_${ARCH}" || true
 
 # Upload repository to S3.
 greenprint "☁ Uploading RPMs to S3"

--- a/schutzbot/mockbuild.sh
+++ b/schutzbot/mockbuild.sh
@@ -35,11 +35,8 @@ WORKSPACE=${WORKSPACE:-$(pwd)}
 # Mock configuration file to use for building RPMs.
 MOCK_CONFIG="${ID}-${VERSION_ID%.*}-$(uname -m)"
 
-# Jenkins takes the proposed PR and merges it onto master. Although this
-# creates a new SHA (which is slightly confusing), it ensures that the code
-# merges properly against master and it tests the code against the latest
-# commit in master, which is certainly good.
-POST_MERGE_SHA=$(git rev-parse --short HEAD)
+# The commit this script operates on.
+COMMIT=$(git rev-parse --short HEAD)
 
 # Bucket in S3 where our artifacts are uploaded
 REPO_BUCKET=osbuild-composer-repos
@@ -48,18 +45,18 @@ REPO_BUCKET=osbuild-composer-repos
 MOCK_REPO_BASE_URL="http://osbuild-composer-repos.s3-website.us-east-2.amazonaws.com"
 
 # Directory to hold the RPMs temporarily before we upload them.
-REPO_DIR=repo/${JOB_NAME}/${POST_MERGE_SHA}/${ID}${VERSION_ID//./}_${ARCH}
+REPO_DIR=repo/${JOB_NAME}/${COMMIT}/${ID}${VERSION_ID//./}_${ARCH}
 
 # Maintain a directory for the master branch that always contains the latest
 # RPM packages.
 REPO_DIR_LATEST=repo/${JOB_NAME}/latest
 
 # Full URL to the RPM repository after they are uploaded.
-REPO_URL=${MOCK_REPO_BASE_URL}/${JOB_NAME}/${POST_MERGE_SHA}/${ID}${VERSION_ID//./}_${ARCH}
+REPO_URL=${MOCK_REPO_BASE_URL}/${JOB_NAME}/${COMMIT}/${ID}${VERSION_ID//./}_${ARCH}
 
 # Print some data.
 greenprint "🧬 Using mock config: ${MOCK_CONFIG}"
-greenprint "📦 Post merge SHA: ${POST_MERGE_SHA}"
+greenprint "📦 SHA: ${COMMIT}"
 greenprint "📤 RPMS will be uploaded to: ${REPO_URL}"
 
 # Build source RPMs.
@@ -101,7 +98,7 @@ popd
 greenprint "📜 Generating dnf repository file"
 tee osbuild-mock.repo << EOF
 [osbuild-mock]
-name=osbuild mock ${JOB_NAME}-${POST_MERGE_SHA} ${ID}${VERSION_ID//./}
+name=osbuild mock ${JOB_NAME}-${COMMIT} ${ID}${VERSION_ID//./}
 baseurl=${REPO_URL}
 enabled=1
 gpgcheck=0

--- a/schutzbot/mockbuild.sh
+++ b/schutzbot/mockbuild.sh
@@ -41,11 +41,15 @@ REPO_BUCKET=osbuild-composer-repos
 # Public URL for the S3 bucket with our artifacts.
 MOCK_REPO_BASE_URL="http://osbuild-composer-repos.s3-website.us-east-2.amazonaws.com"
 
+# Relative path of the repository – used for constructing both the local and
+# remote paths below, so that they're consistent.
+REPO_PATH=${JOB_NAME}/${COMMIT}/${ID}${VERSION_ID//./}_${ARCH}
+
 # Directory to hold the RPMs temporarily before we upload them.
-REPO_DIR=repo/${JOB_NAME}/${COMMIT}/${ID}${VERSION_ID//./}_${ARCH}
+REPO_DIR=repo/${REPO_PATH}
 
 # Full URL to the RPM repository after they are uploaded.
-REPO_URL=${MOCK_REPO_BASE_URL}/${JOB_NAME}/${COMMIT}/${ID}${VERSION_ID//./}_${ARCH}
+REPO_URL=${MOCK_REPO_BASE_URL}/${REPO_PATH}
 
 # Print some data.
 greenprint "🧬 Using mock config: ${MOCK_CONFIG}"

--- a/schutzbot/mockbuild.sh
+++ b/schutzbot/mockbuild.sh
@@ -33,7 +33,7 @@ sudo dnf -y install createrepo_c make mock rpm-build s3cmd
 MOCK_CONFIG="${ID}-${VERSION_ID%.*}-$(uname -m)"
 
 # The commit this script operates on.
-COMMIT=$(git rev-parse --short HEAD)
+COMMIT=$(git rev-parse HEAD)
 
 # Bucket in S3 where our artifacts are uploaded
 REPO_BUCKET=osbuild-composer-repos

--- a/schutzbot/mockbuild.sh
+++ b/schutzbot/mockbuild.sh
@@ -68,9 +68,8 @@ sudo mock -r "$MOCK_CONFIG" --resultdir "$REPO_DIR" --with=tests \
 # Change the ownership of all of our repo files from root to our CI user.
 sudo chown -R "$USER" "${REPO_DIR%%/*}"
 
-# Move the logs out of the way.
-greenprint "🧹 Retaining logs from mock build"
-mv "${REPO_DIR}"/*.log "$WORKSPACE"
+greenprint "🧹 Remove logs from mock build"
+rm "${REPO_DIR}"/*.log
 
 # Create a repo of the built RPMs.
 greenprint "⛓️ Creating dnf repository"

--- a/schutzbot/mockbuild.sh
+++ b/schutzbot/mockbuild.sh
@@ -29,9 +29,6 @@ fi
 greenprint "📦 Installing mock requirements"
 sudo dnf -y install createrepo_c make mock rpm-build s3cmd
 
-# Jenkins sets a workspace variable as the root of its working directory.
-WORKSPACE=${WORKSPACE:-$(pwd)}
-
 # Mock configuration file to use for building RPMs.
 MOCK_CONFIG="${ID}-${VERSION_ID%.*}-$(uname -m)"
 


### PR DESCRIPTION
Please see individual commits. The main point is to make it easier to use the resulting URLs, without having to look at the log of a previous Jenkins run.