### PR TITLE
schutzbot: don't copy dnf repo file between stages

### DIFF
--- a/schutzbot/Jenkinsfile
+++ b/schutzbot/Jenkinsfile
@@ -51,10 +51,6 @@ pipeline {
                         retry(3) {
                             sh "schutzbot/mockbuild.sh"
                         }
-                        stash (
-                            includes: 'osbuild-mock.repo',
-                            name: 'fedora32'
-                        )
                     }
                 }
                 stage('F33') {
@@ -68,10 +64,6 @@ pipeline {
                         retry(3) {
                             sh "schutzbot/mockbuild.sh"
                         }
-                        stash (
-                            includes: 'osbuild-mock.repo',
-                            name: 'fedora33'
-                        )
                     }
                 }
                 stage('EL8') {
@@ -86,10 +78,6 @@ pipeline {
                         retry(3) {
                             sh "schutzbot/mockbuild.sh"
                         }
-                        stash (
-                            includes: 'osbuild-mock.repo',
-                            name: 'rhel8cdn'
-                        )
                     }
                 }
             }
@@ -102,7 +90,6 @@ pipeline {
                     agent { label "f32cloudbase && x86_64 && aws" }
                     environment { TEST_TYPE = "base" }
                     steps {
-                        unstash 'fedora32'
                         run_tests('base')
                     }
                     post {
@@ -123,7 +110,6 @@ pipeline {
                         DISTRO_CODE = "fedora32"
                     }
                     steps {
-                        unstash 'fedora32'
                         run_tests('image')
                     }
                     post {
@@ -144,7 +130,6 @@ pipeline {
                         AWS_IMAGE_TEST_CREDS = credentials('aws-credentials-osbuild-image-test')
                     }
                     steps {
-                        unstash 'fedora32'
                         run_tests('integration')
                     }
                     post {
@@ -156,7 +141,6 @@ pipeline {
                 stage('F32 OSTree') {
                     agent { label "f32cloudbase && psi && x86_64" }
                     steps {
-                        unstash 'fedora32'
                         run_tests('ostree')
                     }
                     post {
@@ -169,7 +153,6 @@ pipeline {
                     agent { label "f33cloudbase && x86_64 && aws" }
                     environment { TEST_TYPE = "base" }
                     steps {
-                        unstash 'fedora33'
                         run_tests('base')
                     }
                     post {
@@ -190,7 +173,6 @@ pipeline {
                         DISTRO_CODE = "fedora33"
                     }
                     steps {
-                        unstash 'fedora33'
                         run_tests('image')
                     }
                     post {
@@ -207,7 +189,6 @@ pipeline {
                         AWS_IMAGE_TEST_CREDS = credentials('aws-credentials-osbuild-image-test')
                     }
                     steps {
-                        unstash 'fedora33'
                         run_tests('integration')
                     }
                     post {
@@ -219,7 +200,6 @@ pipeline {
                 stage('F33 OSTree') {
                     agent { label "f33cloudbase && psi && x86_64" }
                     steps {
-                        unstash 'fedora33'
                         run_tests('ostree')
                     }
                     post {
@@ -235,7 +215,6 @@ pipeline {
                         RHN_REGISTRATION_SCRIPT = credentials('rhn-register-script-production')
                     }
                     steps {
-                        unstash 'rhel8cdn'
                         run_tests('base')
                     }
                     post {
@@ -257,7 +236,6 @@ pipeline {
                         DISTRO_CODE = "rhel8"
                     }
                     steps {
-                        unstash 'rhel8cdn'
                         run_tests('image')
                     }
                     post {
@@ -279,7 +257,6 @@ pipeline {
                         RHN_REGISTRATION_SCRIPT = credentials('rhn-register-script-production')
                     }
                     steps {
-                        unstash 'rhel8cdn'
                         run_tests('integration')
                     }
                     post {
@@ -291,7 +268,6 @@ pipeline {
                 stage('EL8 OSTree') {
                     agent { label "rhel8cloudbase && psi && x86_64" }
                     steps {
-                        unstash 'rhel8cdn'
                         run_tests('ostree')
                     }
                     post {

--- a/schutzbot/mockbuild.sh
+++ b/schutzbot/mockbuild.sh
@@ -10,25 +10,6 @@ function greenprint {
 source /etc/os-release
 ARCH=$(uname -m)
 
-# Mock and s3cmd is only available in EPEL for RHEL.
-if [[ $ID == rhel ]] && ! rpm -q epel-release; then
-    greenprint "📦 Setting up EPEL repository"
-    curl -Ls --retry 5 --output /tmp/epel.rpm \
-        https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
-    sudo rpm -Uvh /tmp/epel.rpm
-fi
-
-# Register RHEL if we are provided with a registration script.
-if [[ -n "${RHN_REGISTRATION_SCRIPT:-}" ]] && ! sudo subscription-manager status; then
-    greenprint "🪙 Registering RHEL instance"
-    sudo chmod +x "$RHN_REGISTRATION_SCRIPT"
-    sudo "$RHN_REGISTRATION_SCRIPT"
-fi
-
-# Install requirements for building RPMs in mock.
-greenprint "📦 Installing mock requirements"
-sudo dnf -y install createrepo_c make mock rpm-build s3cmd
-
 # Mock configuration file to use for building RPMs.
 MOCK_CONFIG="${ID}-${VERSION_ID%.*}-$(uname -m)"
 
@@ -56,6 +37,26 @@ if curl --silent --fail --head --output /dev/null "${REPO_URL}/repodata/repomd.x
   greenprint "🎁 Repository already exists. Exiting."
   exit 0
 fi
+
+# Mock and s3cmd is only available in EPEL for RHEL.
+if [[ $ID == rhel ]] && ! rpm -q epel-release; then
+    greenprint "📦 Setting up EPEL repository"
+    curl -Ls --retry 5 --output /tmp/epel.rpm \
+        https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
+    sudo rpm -Uvh /tmp/epel.rpm
+fi
+
+# Register RHEL if we are provided with a registration script.
+if [[ -n "${RHN_REGISTRATION_SCRIPT:-}" ]] && ! sudo subscription-manager status; then
+    greenprint "🪙 Registering RHEL instance"
+    sudo chmod +x "$RHN_REGISTRATION_SCRIPT"
+    sudo "$RHN_REGISTRATION_SCRIPT"
+fi
+
+# Install requirements for building RPMs in mock.
+greenprint "📦 Installing mock requirements"
+sudo dnf -y install createrepo_c make mock rpm-build s3cmd
+
 
 # Print some data.
 greenprint "🧬 Using mock config: ${MOCK_CONFIG}"

--- a/schutzbot/mockbuild.sh
+++ b/schutzbot/mockbuild.sh
@@ -81,15 +81,3 @@ greenprint "☁ Uploading RPMs to S3"
 pushd repo
     s3cmd --acl-public sync . s3://${REPO_BUCKET}/
 popd
-
-# Create a repository file.
-greenprint "📜 Generating dnf repository file"
-tee osbuild-mock.repo << EOF
-[osbuild-mock]
-name=osbuild mock ${COMMIT}
-baseurl=${REPO_URL}
-enabled=1
-gpgcheck=0
-# Default dnf repo priority is 99. Lower number means higher priority.
-priority=5
-EOF

--- a/schutzbot/mockbuild.sh
+++ b/schutzbot/mockbuild.sh
@@ -51,6 +51,12 @@ REPO_DIR=repo/${REPO_PATH}
 # Full URL to the RPM repository after they are uploaded.
 REPO_URL=${MOCK_REPO_BASE_URL}/${REPO_PATH}
 
+# Don't rerun the build if it already exists
+if curl --silent --fail --head --output /dev/null "${REPO_URL}/repodata/repomd.xml"; then
+  greenprint "🎁 Repository already exists. Exiting."
+  exit 0
+fi
+
 # Print some data.
 greenprint "🧬 Using mock config: ${MOCK_CONFIG}"
 greenprint "📦 SHA: ${COMMIT}"


### PR DESCRIPTION
Now that the repository URLs are predictable, don't use Jenkins' stash
feature to pass the repo file between stages.

Instead, simply create the repo file where it is needed, in deploy.sh.