### PR TITLE
Fix spec file and introduce rpmlint

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -64,3 +64,19 @@ jobs:
         ignore: vendor # We don't want to fix the code in vendored dependencies
       env:
         SHELLCHECK_OPTS: -e SC1091 -e SC2002 # don't check /etc/os-release sourcing and allow useless cats to live inside our codebase
+
+  rpmlint:
+    name: "📦 RPMlint"
+    runs-on: ubuntu-latest
+    container: registry.fedoraproject.org/fedora:33
+    steps:
+      - name: Install dependencies
+        run: sudo dnf install -y rpmlint rpm-build make git-core
+
+      - uses: actions/checkout@v2
+
+      - name: Create SRPM
+        run: make srpm
+
+      - name: Run rpmlint
+        run: rpmlint rpmbuild/SRPMS/*

--- a/Makefile
+++ b/Makefile
@@ -201,7 +201,7 @@ worker-key-pair: ca
 # ./rpmbuild, using rpmbuild's usual directory structure.
 #
 
-RPM_SPECFILE=rpmbuild/SPECS/osbuild-composer-$(COMMIT).spec
+RPM_SPECFILE=rpmbuild/SPECS/osbuild-composer.spec
 RPM_TARBALL=rpmbuild/SOURCES/osbuild-composer-$(COMMIT).tar.gz
 
 $(RPM_SPECFILE):

--- a/osbuild-composer.spec
+++ b/osbuild-composer.spec
@@ -348,4 +348,8 @@ Integration tests to be run on a pristine-dedicated system to test the osbuild-c
 %endif
 
 %changelog
-# the changelog is distribution-specific, therefore it doesn't make sense to have it upstream
+# the changelog is distribution-specific, therefore there's just one entry
+# to make rpmlint happy.
+
+* Wed Sep 11 2019 Image Builder team <osbuilders@redhat.com> - 0-1
+- On this day, this project was born.

--- a/osbuild-composer.spec
+++ b/osbuild-composer.spec
@@ -78,7 +78,7 @@ Obsoletes: golang-github-osbuild-composer < %{version}-%{release}
 Provides:  golang-github-osbuild-composer = %{version}-%{release}
 
 # remove when F34 is EOL
-Obsoletes: osbuild-composer-koji
+Obsoletes: osbuild-composer-koji <= 23
 
 %description
 %{common_description}


### PR DESCRIPTION
#1070 introduced an `rpmlint` error. This PR fixes it. Also, it fixes a couple of other minor issues and introduces a new Github workflow that runs `rpmlint` against our upstream spec file. This should solve the issue with `rpmlint` errors once and forever.

Fixes #1076 