### PR TITLE
spec: fix the osbuild dependency

### DIFF
--- a/osbuild-composer.spec
+++ b/osbuild-composer.spec
@@ -56,8 +56,6 @@ BuildRequires:  golang(github.com/vmware/govmomi)
 
 Requires: %{name}-worker = %{version}-%{release}
 Requires: systemd
-Requires: osbuild >= 23
-Requires: osbuild-ostree >= 23
 Requires: qemu-img
 
 Provides: weldr
@@ -261,7 +259,8 @@ cd $PWD/_build/src/%{goipath}
 %package worker
 Summary:    The worker for osbuild-composer
 Requires:   systemd
-Requires:   osbuild
+Requires:   osbuild >= 23
+Requires:   osbuild-ostree >= 23
 
 # remove in F34
 Obsoletes: golang-github-osbuild-composer-worker < %{version}-%{release}


### PR DESCRIPTION
osbuild-composer doesn't actually require osbuild. osbuild-composer-worker does. Let's remove the dependency from osbuild-composer and depend on the right version of osbuild in the worker.