### PR TITLE
Allow osbuild-composer to run without Weldr API

### DIFF
--- a/cmd/osbuild-composer/composer.go
+++ b/cmd/osbuild-composer/composer.go
@@ -156,6 +156,15 @@ func (c *Composer) InitRemoteWorkers(cert, key string, l net.Listener) error {
 //
 // Running without the weldr API is currently not supported.
 func (c *Composer) Start() error {
+	// sanity checks
+	if c.localWorkerListener == nil && c.workerListener == nil {
+		log.Fatal("neither the local worker socket nor the remote worker socket is enabled, osbuild-composer is useless without workers")
+	}
+
+	if c.apiListener == nil && c.weldrListener == nil {
+		log.Fatal("neither the weldr API socket nor the composer API socket is enabled, osbuild-composer is useless without one of these APIs enabled")
+	}
+
 	if c.localWorkerListener != nil {
 		go func() {
 			err := c.workers.Serve(c.localWorkerListener)

--- a/cmd/osbuild-composer/main.go
+++ b/cmd/osbuild-composer/main.go
@@ -65,16 +65,22 @@ func main() {
 	}
 
 	if l, exists := listeners["osbuild-composer.socket"]; exists {
-		if len(l) != 2 {
-			log.Fatalf("Expected two listeners in osbuild-composer.socket, but found %d", len(l))
+		if len(l) != 1 {
+			log.Fatal("The osbuild-composer.socket unit is misconfigured. It should contain only one socket.")
 		}
 
-		err = composer.InitWeldr(repositoryConfigs, l[0], l[1])
+		err = composer.InitWeldr(repositoryConfigs, l[0])
 		if err != nil {
 			log.Fatalf("Error initializing weldr API: %v", err)
 		}
-	} else {
-		log.Fatalf("osbuild-composer.socket doesn't exist")
+	}
+
+	if l, exists := listeners["osbuild-local-worker.socket"]; exists {
+		if len(l) != 1 {
+			log.Fatal("The osbuild-local-worker.socket unit is misconfigured. It should contain only one socket.")
+		}
+
+		composer.InitLocalWorker(l[0])
 	}
 
 	if l, exists := listeners["osbuild-composer-api.socket"]; exists {

--- a/distribution/osbuild-composer.service
+++ b/distribution/osbuild-composer.service
@@ -1,7 +1,10 @@
 [Unit]
 Description=OSBuild Composer
 After=multi-user.target
-Requires=osbuild-composer.socket
+
+# Weldr API needs a local worker by default.
+# Run `systemctl mask osbuild-worker@1.service`
+# to disable it.
 Wants=osbuild-worker@1.service
 
 [Service]

--- a/distribution/osbuild-composer.socket
+++ b/distribution/osbuild-composer.socket
@@ -3,7 +3,6 @@ Description=OSBuild Composer Weldr API socket
 
 [Socket]
 ListenStream=/run/weldr/api.socket
-ListenStream=/run/osbuild-composer/job.socket
 SocketGroup=weldr
 SocketMode=660
 

--- a/distribution/osbuild-composer.socket
+++ b/distribution/osbuild-composer.socket
@@ -1,5 +1,5 @@
 [Unit]
-Description=OSBuild Composer API sockets
+Description=OSBuild Composer Weldr API socket
 
 [Socket]
 ListenStream=/run/weldr/api.socket

--- a/distribution/osbuild-local-worker.socket
+++ b/distribution/osbuild-local-worker.socket
@@ -1,0 +1,9 @@
+[Unit]
+Description=OSBuild local worker API socket
+
+[Socket]
+Service=osbuild-composer.service
+ListenStream=/run/osbuild-composer/job.socket
+
+[Install]
+WantedBy=sockets.target

--- a/distribution/osbuild-remote-worker.socket
+++ b/distribution/osbuild-remote-worker.socket
@@ -1,5 +1,5 @@
 [Unit]
-Description=OSBuild Composer API sockets
+Description=OSBuild remote worker API socket
 
 [Socket]
 Service=osbuild-composer.service

--- a/distribution/osbuild-worker@.service
+++ b/distribution/osbuild-worker@.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=OSBuild Composer Worker (%i)
-Requires=osbuild-composer.socket
-After=multi-user.target osbuild-composer.socket
+Requires=osbuild-local-worker.socket
+After=multi-user.target osbuild-local-worker.socket
 
 [Service]
 Type=simple

--- a/osbuild-composer.spec
+++ b/osbuild-composer.spec
@@ -245,6 +245,7 @@ cd $PWD/_build/src/%{goipath}
 %{_unitdir}/osbuild-composer.service
 %{_unitdir}/osbuild-composer.socket
 %{_unitdir}/osbuild-composer-api.socket
+%{_unitdir}/osbuild-local-worker.socket
 %{_unitdir}/osbuild-remote-worker.socket
 %{_sysusersdir}/osbuild-composer.conf
 

--- a/osbuild-composer.spec
+++ b/osbuild-composer.spec
@@ -153,15 +153,7 @@ install -m 0755 -vd                                             %{buildroot}%{_d
 install -m 0644 -vp repositories/*                              %{buildroot}%{_datadir}/osbuild-composer/repositories/
 
 install -m 0755 -vd                                             %{buildroot}%{_unitdir}
-install -m 0644 -vp distribution/osbuild-composer.service       %{buildroot}%{_unitdir}/
-install -m 0644 -vp distribution/osbuild-composer.socket        %{buildroot}%{_unitdir}/
-install -m 0644 -vp distribution/osbuild-remote-worker.socket   %{buildroot}%{_unitdir}/
-install -m 0644 -vp distribution/osbuild-remote-worker@.service %{buildroot}%{_unitdir}/
-install -m 0644 -vp distribution/osbuild-worker@.service        %{buildroot}%{_unitdir}/
-install -m 0644 -vp distribution/osbuild-composer-api.socket    %{buildroot}%{_unitdir}/
-install -m 0755 -vd                                             %{buildroot}%{_unitdir}
-install -m 0644 -vp distribution/osbuild-composer.{service,socket} %{buildroot}%{_unitdir}/
-install -m 0644 -vp distribution/osbuild-*worker*.{service,socket} %{buildroot}%{_unitdir}/
+install -m 0644 -vp distribution/*.{service,socket}             %{buildroot}%{_unitdir}/
 
 install -m 0755 -vd                                             %{buildroot}%{_sysusersdir}
 install -m 0644 -vp distribution/osbuild-composer.conf          %{buildroot}%{_sysusersdir}/


### PR DESCRIPTION
I think we should be able to ditch the local worker altogether. This is the first step. See the individual comments for details.