### PR TITLE
 .github: switch to ubuntu-20.04

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   lint:
     name: "🛃 Checks"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
 
       - name: Set up Go 1.13
@@ -55,7 +55,7 @@ jobs:
 
   shellcheck:
     name: "🐚 Shellcheck"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
     - name: Run ShellCheck
@@ -67,7 +67,7 @@ jobs:
 
   rpmlint:
     name: "📦 RPMlint"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     container: registry.fedoraproject.org/fedora:33
     steps:
       - name: Install dependencies


### PR DESCRIPTION
As the team obsessed with immutable test dependencies, how could we use the ubuntu-latest VM which can change at any time?

Speaking of changes to ubuntu-latest... It will soon be updated from ubuntu 18.04 to 20.04 \[1\].

This commit switches our testing pipeline to use ubuntu-20.04 to:

1) make our test dependencies immutable (or at least slightly more immutable)
2) make us prepared for the ubuntu-latest changes.

\[1\]: actions/virtual-environments#1816