### PR TITLE
25

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,30 @@
 # OSBuild Composer - Operating System Image Composition Services
 
+## CHANGES WITH 25:
+
+  * Composer now supports RHEL 8.4! Big thanks to Jacob Kozol!
+    If you want to build RHEL 8.4 using Composer API or Composer API for
+    Koji, remember to pass "rhel-84" as a distribution name.
+
+  * Composer can now be started without Weldr API. If you need it, start
+    `osbuild-composer.socket` before `osbuild-composer.service` is started.
+    Note that cockpit-composer starts `osbuild-composer.socket` so this change
+    is backward compatible.
+    
+  * When Koji call failed, both osbuild-composer and osbuild-worker errored.
+    This is now fixed.
+    
+  * The dependency on osbuild in the spec file is now moved to the worker
+    subpackage. This was a mistake that could cause the worker to use
+    an incompatible version of osbuild.
+    
+  * As always, testing got some upgrades. This time, mostly in the way
+    we build our testing RPMs.
+
+Contributions from: Jacob Kozol, Lars Karlitski, Ondřej Budai, Tom Gundersen
+
+— Liberec, 2020-11-19
+
 ## CHANGES WITH 24:
 
   * Composer now internally supports multi-build composes. A big part of the

--- a/osbuild-composer.spec
+++ b/osbuild-composer.spec
@@ -4,7 +4,7 @@
 
 %global goipath         github.com/osbuild/osbuild-composer
 
-Version:        24
+Version:        25
 
 %gometa
 


### PR DESCRIPTION
  * Composer now supports RHEL 8.4! Big thanks to Jacob Kozol!
    If you want to build RHEL 8.4 using Composer API or Composer API for
    Koji, remember to pass "rhel-84" as a distribution name.

  * Composer can now be started without Weldr API. If you need it, start
    `osbuild-composer.socket` before `osbuild-composer.service` is started.
    Note that cockpit-composer starts `osbuild-composer.socket` so this change
    is backward compatible.

  * When Koji call failed, both osbuild-composer and osbuild-worker errored.
    This is now fixed.

  * The dependency on osbuild in the spec file is now moved to the worker
    subpackage. This was a mistake that could cause the worker to use
    an incompatible version of osbuild.

  * As always, testing got some upgrades. This time, mostly in the way
    we build our testing RPMs.