### PR TITLE
Add ability to run reverse dependency tests, and run one for koji-osbuild

### DIFF
--- a/Schutzfile
+++ b/Schutzfile
@@ -1,8 +1,20 @@
 {
+  "fedora-32": {
+    "dependants": {
+      "koji-osbuild": {
+        "commit": "c282b9b1f087fc58cf96f2d1322e90bb4e75bae7"
+      }
+    }
+  },
   "rhel-8.3": {
     "dependencies": {
       "osbuild": {
         "commit": "5aee7b9fa724575daa010a55cad0558fbb7b9ad1"
+      }
+    },
+    "dependants": {
+      "koji-osbuild": {
+        "commit": "c282b9b1f087fc58cf96f2d1322e90bb4e75bae7"
       }
     }
   }

--- a/schutzbot/Jenkinsfile
+++ b/schutzbot/Jenkinsfile
@@ -164,6 +164,17 @@ pipeline {
                         }
                     }
                 }
+                stage('F32: koji-osbuild') {
+                    agent { label "f32cloudbase && x86_64 && aws" }
+                    steps {
+                        run_project_tests('koji-osbuild', 'integration.sh')
+                    }
+                    post {
+                        always {
+                            preserve_logs('fedora32-revdep-koji-osbuild')
+                        }
+                    }
+                }
                 stage('F33 Base') {
                     agent { label "f33cloudbase && x86_64 && aws" }
                     environment { TEST_TYPE = "base" }
@@ -288,6 +299,17 @@ pipeline {
                     post {
                         always {
                             preserve_logs('rhel8-ostree')
+                        }
+                    }
+                }
+                stage('EL8: koji-osbuild') {
+                    agent { label "rhel8cloudbase && psi && x86_64" }
+                    steps {
+                        run_project_tests('koji-osbuild', 'integration.sh')
+                    }
+                    post {
+                        always {
+                            preserve_logs('rhel8-revdep-koji-osbuild')
                         }
                     }
                 }
@@ -466,7 +488,14 @@ void run_tests(test_type, boot_type) {
             script: "/usr/libexec/tests/osbuild-composer/api.sh"
         )
     }
+}
 
+// Similar to run_tests, but with a more general signature: allows setting the
+// project whose -tests package to install, and the name of the test to execute
+void run_project_tests(project, test) {
+    sh "schutzbot/ci_details.sh"
+    sh "schutzbot/deploy.sh ${project}"
+    sh "/usr/libexec/tests/${project}/${test}"
 }
 
 // Move logs to a unique location and tell Jenkins to capture them on success

--- a/schutzbot/deploy.sh
+++ b/schutzbot/deploy.sh
@@ -1,6 +1,14 @@
 #!/bin/bash
 set -euxo pipefail
 
+# The project whose -tests package is installed.
+#
+# If it is osbuild-composer (the default), it is pulled from the same
+# repository as the osbuild-composer under test. For all other projects, the
+# "dependants" key in Schutzfile is consulted to determine the repository to
+# pull the -test package from.
+PROJECT=${1:-osbuild-composer}
+
 # Colorful output.
 function greenprint {
     echo -e "\033[1;32m${1}\033[0m"
@@ -64,12 +72,17 @@ if [[ "${OSBUILD_GIT_COMMIT}" != "null" ]]; then
   setup_repo osbuild "${OSBUILD_GIT_COMMIT}" 10
 fi
 
+if [[ "$PROJECT" != "osbuild-composer" ]]; then
+  PROJECT_COMMIT=$(jq -r ".[\"${ID}-${VERSION_ID}\"].dependants[\"${PROJECT}\"].commit" Schutzfile)
+  setup_repo "${PROJECT}" "${PROJECT_COMMIT}" 10
+fi
+
 if [[ $ID == rhel ]]; then
     greenprint "Setting up EPEL repository"
     # we need this for ansible and koji
     sudo dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
 fi
 
-greenprint "Installing the Image Builder packages"
+greenprint "Installing test packages for ${PROJECT}"
 # Note: installing only -tests to catch missing dependencies
-retry sudo dnf -y install osbuild-composer-tests
+retry sudo dnf -y install "${PROJECT}-tests"


### PR DESCRIPTION
Now that koji-osbuild pushes rpms for (most) commits in the same format as osbuild and osbuild-composer, it is trivial to add reverse dependency tests for it. 🎈