### PR TITLE
tools/deploy-qemu: add macOS support 

### DIFF
--- a/tools/deploy-qemu
+++ b/tools/deploy-qemu
@@ -29,13 +29,15 @@ function cleanup() {
 }
 trap cleanup EXIT
 
+mkdir "$workdir/cidata"
+
 if [ -d "$userdata" ]; then
-  "$scriptdir/gen-user-data" "$userdata" > "$workdir/user-data"
+  "$scriptdir/gen-user-data" "$userdata" > "$workdir/cidata/user-data"
 else
-  cp "$userdata" "$workdir/user-data"
+  cp "$userdata" "$workdir/cidata/user-data"
 fi
 
-echo -e "instance-id: nocloud\nlocal-hostname: vm\n" > "$workdir/meta-data"
+echo -e "instance-id: nocloud\nlocal-hostname: vm\n" > "$workdir/cidata/meta-data"
 
 genisoimage \
   -input-charset utf-8 \
@@ -45,8 +47,8 @@ genisoimage \
   -rock \
   -quiet \
   -graft-points \
-  "$workdir/user-data" \
-  "$workdir/meta-data"
+  "$workdir/cidata/user-data" \
+  "$workdir/cidata/meta-data"
 
 qemu-system-x86_64 \
   -enable-kvm \

--- a/tools/deploy-qemu
+++ b/tools/deploy-qemu
@@ -12,6 +12,8 @@
 # USERDATA -- A cloud-init user-data config file, or a directory of
 #             configuration as accepted by the `gen-user-data` tool.
 #
+# In addition, if the QEMU_EXTRA_ARGS environment variable is defined, it adds
+# its content as additional arguments to qemu.
 
 set -euo pipefail
 
@@ -23,6 +25,7 @@ fi
 scriptdir=$(dirname "$0")
 image=$1
 userdata=$2
+read -ra qemu_extra_args <<< "${QEMU_EXTRA_ARGS:-}"
 workdir=$(mktemp -d "$scriptdir/qemu-tmp-XXXXXX")
 function cleanup() {
   rm -rf "$workdir"
@@ -67,4 +70,4 @@ qemu-system-x86_64 \
   -net nic,model=virtio \
   -net user,hostfwd=tcp::2222-:22,hostfwd=tcp::4430-:443 \
   -cdrom "$workdir/cloudinit.iso" \
-  "$image"
+  "${qemu_extra_args[@]}" "$image"

--- a/tools/deploy-qemu
+++ b/tools/deploy-qemu
@@ -1,4 +1,4 @@
-#!/usr/bin/bash
+#!/bin/bash
 
 #
 # deploy-qemu IMAGE USERDATA
@@ -39,19 +39,28 @@ fi
 
 echo -e "instance-id: nocloud\nlocal-hostname: vm\n" > "$workdir/cidata/meta-data"
 
-genisoimage \
-  -input-charset utf-8 \
-  -output "$workdir/cloudinit.iso" \
-  -volid cidata \
-  -joliet \
-  -rock \
-  -quiet \
-  -graft-points \
-  "$workdir/cidata/user-data" \
-  "$workdir/cidata/meta-data"
+case $(uname -s) in
+  "Linux")
+    genisoimage \
+      -input-charset utf-8 \
+      -output "$workdir/cloudinit.iso" \
+      -volid cidata \
+      -joliet \
+      -rock \
+      -quiet \
+      -graft-points \
+      "$workdir/cidata/user-data" \
+      "$workdir/cidata/meta-data"
+    ;;
+
+  "Darwin")
+    # conviently uses the last component of source as volumeid, which has to be cidata
+    hdiutil makehybrid -iso -joliet -o "$workdir/cloudinit.iso" "$workdir/cidata"
+    ;;
+esac
 
 qemu-system-x86_64 \
-  -enable-kvm \
+  -M accel=kvm:hvf \
   -m 1024 \
   -snapshot \
   -cpu host \

--- a/tools/gen-user-data
+++ b/tools/gen-user-data
@@ -20,17 +20,15 @@ The configuration directory may contain:
                    to this directore (`files/etc/hosts` → `/etc/hosts`). Its
                    permissions are copied over, but the owner will always be
                    root:root. Empty directories are ignored.
-
-The `python3-pyyaml` package is required to run this tool.
 """
 
 
 import argparse
 import base64
+import json
 import os
 import stat
 import sys
-import yaml
 
 
 def octal_mode_string(mode):
@@ -48,11 +46,7 @@ def main():
     p.add_argument("configdir", metavar="CONFIGDIR", help="input directory")
     args = p.parse_args()
 
-    try:
-        with open(f"{args.configdir}/user-data.yml") as f:
-            userdata = yaml.load(f, Loader=yaml.SafeLoader)
-    except FileNotFoundError:
-        userdata = {}
+    write_files = []
 
     filesdir = f"{args.configdir}/files"
     for directory, dirs, files in os.walk(filesdir, followlinks=True):
@@ -60,15 +54,18 @@ def main():
             path = f"{directory}/{name}"
             with open(path, "rb") as f:
                 content = base64.b64encode(f.read()).decode("utf-8")
-            userdata.setdefault("write_files", []).append({
+            write_files.append({
                 "path": "/" + os.path.relpath(path, filesdir),
                 "encoding": "b64",
                 "content": content,
                 "permissions": octal_mode_string(os.lstat(path).st_mode)
             })
 
-    sys.stdout.write("#cloud-config\n")
-    yaml.dump(userdata, sys.stdout, Dumper=yaml.SafeDumper)
+    with open(f"{args.configdir}/user-data.yml") as f:
+        sys.stdout.write(f.read())
+    sys.stdout.write("write_files: ")
+    json.dump(write_files, sys.stdout)
+    sys.stdout.write("\n")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Also, add a `QEMU_EXTRA_ARGS` environment variable for people to set arguments from their `bashrc` (or similar) that better suit their workflow.