### PR TITLE
Add an owner to a job and allow workers to filter jobs by owners

### DIFF
--- a/cmd/osbuild-worker/main.go
+++ b/cmd/osbuild-worker/main.go
@@ -151,11 +151,11 @@ func main() {
 	}
 
 	jobImpls := map[string]JobImplementation{
-		"osbuild": &OSBuildJobImpl{
+		"osbuild:" + common.CurrentArch(): &OSBuildJobImpl{
 			Store:       store,
 			KojiServers: kojiServers,
 		},
-		"osbuild-koji": &OSBuildKojiJobImpl{
+		"osbuild-koji:" + common.CurrentArch(): &OSBuildKojiJobImpl{
 			Store:       store,
 			KojiServers: kojiServers,
 		},
@@ -174,7 +174,7 @@ func main() {
 
 	for {
 		fmt.Println("Waiting for a new job...")
-		job, err := client.RequestJob(acceptedJobTypes, common.CurrentArch())
+		job, err := client.RequestJob(acceptedJobTypes)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/cmd/osbuild-worker/main.go
+++ b/cmd/osbuild-worker/main.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/BurntSushi/toml"
 
+	"github.com/osbuild/osbuild-composer/internal/common"
 	"github.com/osbuild/osbuild-composer/internal/upload/koji"
 	"github.com/osbuild/osbuild-composer/internal/worker"
 )
@@ -173,7 +174,7 @@ func main() {
 
 	for {
 		fmt.Println("Waiting for a new job...")
-		job, err := client.RequestJob(acceptedJobTypes)
+		job, err := client.RequestJob(acceptedJobTypes, common.CurrentArch())
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/cmd/osbuild-worker/main.go
+++ b/cmd/osbuild-worker/main.go
@@ -84,6 +84,7 @@ func main() {
 				KeyTab    string `toml:"keytab"`
 			} `toml:"kerberos,omitempty"`
 		} `toml:"koji"`
+		AcceptedJobOwners []string `toml:"accepted_job_owners,omitempty"`
 	}
 	var unix bool
 	flag.BoolVar(&unix, "unix", false, "Interpret 'address' as a path to a unix domain socket instead of a network address")
@@ -174,7 +175,7 @@ func main() {
 
 	for {
 		fmt.Println("Waiting for a new job...")
-		job, err := client.RequestJob(acceptedJobTypes)
+		job, err := client.RequestJob(acceptedJobTypes, config.AcceptedJobOwners)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/cmd/osbuild-worker/main.go
+++ b/cmd/osbuild-worker/main.go
@@ -114,6 +114,10 @@ func main() {
 		log.Fatalf("Could not load config file '%s': %v", configFile, err)
 	}
 
+	if len(config.AcceptedJobOwners) == 0 {
+		config.AcceptedJobOwners = []string{"_weldr"}
+	}
+
 	cacheDirectory, ok := os.LookupEnv("CACHE_DIRECTORY")
 	if !ok {
 		log.Fatal("CACHE_DIRECTORY is not set. Is the service file missing CacheDirectory=?")

--- a/internal/cloudapi/server.go
+++ b/internal/cloudapi/server.go
@@ -188,7 +188,7 @@ func (server *Server) Compose(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	id, err := server.workers.EnqueueOSBuild(ir.arch, &worker.OSBuildJob{
+	id, err := server.workers.EnqueueOSBuild(ir.arch, "", &worker.OSBuildJob{
 		Manifest: ir.manifest,
 		Targets:  targets,
 	})

--- a/internal/jobqueue/jobqueue.go
+++ b/internal/jobqueue/jobqueue.go
@@ -23,25 +23,24 @@ import (
 
 // JobQueue is an interface to a simple job queue. It is safe for concurrent use.
 type JobQueue interface {
-	// Enqueues a job.
+	// Enqueues a job to queue with a certain `queueName`.
 	//
-	// `args` must be JSON-serializable and fit the given `jobType`, i.e., a worker
-	// that is running that job must know the format of `args`.
+	// `args` must be JSON-serializable.
 	//
 	// All dependencies must already exist, but the job isn't run until all of them
 	// have finished.
 	//
 	// Returns the id of the new job, or an error.
-	Enqueue(jobType string, args interface{}, dependencies []uuid.UUID) (uuid.UUID, error)
+	Enqueue(queueName string, args interface{}, dependencies []uuid.UUID) (uuid.UUID, error)
 
 	// Dequeues a job, blocking until one is available.
 	//
-	// Waits until a job with a type of any of `jobTypes` is available, or `ctx` is
+	// Waits until a job is available in any of queues with `queueNames`, or `ctx` is
 	// canceled.
 	//
-	// Returns the job's id, dependencies, type, and arguments, or an error. Arguments
-	// can be unmarshaled to the type given in Enqueue().
-	Dequeue(ctx context.Context, jobTypes []string) (uuid.UUID, []uuid.UUID, string, json.RawMessage, error)
+	// Returns the job's id, dependencies, name of the queue in which the job was queued
+	// and its arguments given in `Enqueue()`, or an error.
+	Dequeue(ctx context.Context, queueNames []string) (uuid.UUID, []uuid.UUID, string, json.RawMessage, error)
 
 	// Mark the job with `id` as finished. `result` must fit the associated
 	// job type and must be serializable to JSON.

--- a/internal/kojiapi/server.go
+++ b/internal/kojiapi/server.go
@@ -132,7 +132,7 @@ func (h *apiHandlers) PostCompose(ctx echo.Context) error {
 		)
 	}
 
-	initID, err := h.server.workers.EnqueueKojiInit(&worker.KojiInitJob{
+	initID, err := h.server.workers.EnqueueKojiInit("", &worker.KojiInitJob{
 		Server:  request.Koji.Server,
 		Name:    request.Name,
 		Version: request.Version,
@@ -145,7 +145,7 @@ func (h *apiHandlers) PostCompose(ctx echo.Context) error {
 
 	var buildIDs []uuid.UUID
 	for i, ir := range imageRequests {
-		id, err := h.server.workers.EnqueueOSBuildKoji(ir.arch, &worker.OSBuildKojiJob{
+		id, err := h.server.workers.EnqueueOSBuildKoji(ir.arch, "", &worker.OSBuildKojiJob{
 			Manifest:      ir.manifest,
 			ImageName:     ir.filename,
 			KojiServer:    request.Koji.Server,
@@ -159,7 +159,7 @@ func (h *apiHandlers) PostCompose(ctx echo.Context) error {
 		buildIDs = append(buildIDs, id)
 	}
 
-	id, err := h.server.workers.EnqueueKojiFinalize(&worker.KojiFinalizeJob{
+	id, err := h.server.workers.EnqueueKojiFinalize("", &worker.KojiFinalizeJob{
 		Server:        request.Koji.Server,
 		Name:          request.Name,
 		Version:       request.Version,

--- a/internal/kojiapi/server_test.go
+++ b/internal/kojiapi/server_test.go
@@ -239,7 +239,7 @@ func TestCompose(t *testing.T) {
 		wg.Add(1)
 
 		go func(t *testing.T, result worker.KojiInitJobResult) {
-			token, _, jobType, rawJob, _, err := workerServer.RequestJob(context.Background(), "x86_64", []string{"koji-init"})
+			token, _, jobType, rawJob, _, err := workerServer.RequestJob(context.Background(), []string{"koji-init"})
 			require.NoError(t, err)
 			require.Equal(t, "koji-init", jobType)
 
@@ -290,9 +290,9 @@ func TestCompose(t *testing.T) {
 		}`, c.composeReplyCode, c.composeReply, "id")
 		wg.Wait()
 
-		token, _, jobType, rawJob, _, err := workerServer.RequestJob(context.Background(), "x86_64", []string{"osbuild-koji"})
+		token, _, jobType, rawJob, _, err := workerServer.RequestJob(context.Background(), []string{"osbuild-koji:x86_64"})
 		require.NoError(t, err)
-		require.Equal(t, "osbuild-koji", jobType)
+		require.Equal(t, "osbuild-koji:x86_64", jobType)
 
 		var osbuildJob worker.OSBuildKojiJob
 		err = json.Unmarshal(rawJob, &osbuildJob)
@@ -305,9 +305,9 @@ func TestCompose(t *testing.T) {
 		require.NoError(t, err)
 		test.TestRoute(t, workerHandler, false, "PATCH", fmt.Sprintf("/api/worker/v1/jobs/%v", token), string(buildJobResult), http.StatusOK, `{}`)
 
-		token, _, jobType, rawJob, _, err = workerServer.RequestJob(context.Background(), "x86_64", []string{"osbuild-koji"})
+		token, _, jobType, rawJob, _, err = workerServer.RequestJob(context.Background(), []string{"osbuild-koji:x86_64"})
 		require.NoError(t, err)
-		require.Equal(t, "osbuild-koji", jobType)
+		require.Equal(t, "osbuild-koji:x86_64", jobType)
 
 		err = json.Unmarshal(rawJob, &osbuildJob)
 		require.NoError(t, err)
@@ -327,7 +327,7 @@ func TestCompose(t *testing.T) {
 			}
 		}`, http.StatusOK, `{}`)
 
-		token, finalizeID, jobType, rawJob, _, err := workerServer.RequestJob(context.Background(), "x86_64", []string{"koji-finalize"})
+		token, finalizeID, jobType, rawJob, _, err := workerServer.RequestJob(context.Background(), []string{"koji-finalize"})
 		require.NoError(t, err)
 		require.Equal(t, "koji-finalize", jobType)
 

--- a/internal/kojiapi/server_test.go
+++ b/internal/kojiapi/server_test.go
@@ -239,7 +239,7 @@ func TestCompose(t *testing.T) {
 		wg.Add(1)
 
 		go func(t *testing.T, result worker.KojiInitJobResult) {
-			token, _, jobType, rawJob, _, err := workerServer.RequestJob(context.Background(), []string{"koji-init"})
+			token, _, jobType, rawJob, _, err := workerServer.RequestJob(context.Background(), []string{"koji-init"}, []string{})
 			require.NoError(t, err)
 			require.Equal(t, "koji-init", jobType)
 
@@ -290,7 +290,7 @@ func TestCompose(t *testing.T) {
 		}`, c.composeReplyCode, c.composeReply, "id")
 		wg.Wait()
 
-		token, _, jobType, rawJob, _, err := workerServer.RequestJob(context.Background(), []string{"osbuild-koji:x86_64"})
+		token, _, jobType, rawJob, _, err := workerServer.RequestJob(context.Background(), []string{"osbuild-koji:x86_64"}, []string{})
 		require.NoError(t, err)
 		require.Equal(t, "osbuild-koji:x86_64", jobType)
 
@@ -305,7 +305,7 @@ func TestCompose(t *testing.T) {
 		require.NoError(t, err)
 		test.TestRoute(t, workerHandler, false, "PATCH", fmt.Sprintf("/api/worker/v1/jobs/%v", token), string(buildJobResult), http.StatusOK, `{}`)
 
-		token, _, jobType, rawJob, _, err = workerServer.RequestJob(context.Background(), []string{"osbuild-koji:x86_64"})
+		token, _, jobType, rawJob, _, err = workerServer.RequestJob(context.Background(), []string{"osbuild-koji:x86_64"}, []string{})
 		require.NoError(t, err)
 		require.Equal(t, "osbuild-koji:x86_64", jobType)
 
@@ -327,7 +327,7 @@ func TestCompose(t *testing.T) {
 			}
 		}`, http.StatusOK, `{}`)
 
-		token, finalizeID, jobType, rawJob, _, err := workerServer.RequestJob(context.Background(), []string{"koji-finalize"})
+		token, finalizeID, jobType, rawJob, _, err := workerServer.RequestJob(context.Background(), []string{"koji-finalize"}, []string{})
 		require.NoError(t, err)
 		require.Equal(t, "koji-finalize", jobType)
 

--- a/internal/weldr/api.go
+++ b/internal/weldr/api.go
@@ -1866,7 +1866,7 @@ func (api *API) composeHandler(writer http.ResponseWriter, request *http.Request
 	} else {
 		var jobId uuid.UUID
 
-		jobId, err = api.workers.EnqueueOSBuild(api.arch.Name(), &worker.OSBuildJob{
+		jobId, err = api.workers.EnqueueOSBuild(api.arch.Name(), "", &worker.OSBuildJob{
 			Manifest:        manifest,
 			Targets:         targets,
 			ImageName:       imageType.Filename(),

--- a/internal/weldr/api.go
+++ b/internal/weldr/api.go
@@ -1866,7 +1866,7 @@ func (api *API) composeHandler(writer http.ResponseWriter, request *http.Request
 	} else {
 		var jobId uuid.UUID
 
-		jobId, err = api.workers.EnqueueOSBuild(api.arch.Name(), "", &worker.OSBuildJob{
+		jobId, err = api.workers.EnqueueOSBuild(api.arch.Name(), "_weldr", &worker.OSBuildJob{
 			Manifest:        manifest,
 			Targets:         targets,
 			ImageName:       imageType.Filename(),

--- a/internal/worker/api/api.gen.go
+++ b/internal/worker/api/api.gen.go
@@ -21,8 +21,12 @@ type RequestJobJSONBody struct {
 	// Deprecated. The architecture is now part of the job type.
 	// If this field is set, its value will be appended to osbuild and osbuild-koji job types with a leading colon to maintain backwards compatibility. Example:
 	// `types = [osbuild, osbuild-koji, koji-init], arch = aarch64` results into: `types = [osbuild:aarch64, osbuild-koji:aarch64, koji-init]`
-	Arch  string   `json:"arch"`
-	Types []string `json:"types"`
+	Arch string `json:"arch"`
+
+	// Denotes by which owners the worker accepts jobs. Jobs without an owner can be assigned to an arbitrary worker, this is used only for backward compatibility.
+	// If left empty, the worker can get jobs from arbitrary owners. This is important for keeping backward compatibility.
+	Owners *[]string `json:"owners,omitempty"`
+	Types  []string  `json:"types"`
 }
 
 // UpdateJobJSONBody defines parameters for UpdateJob.

--- a/internal/worker/api/api.gen.go
+++ b/internal/worker/api/api.gen.go
@@ -17,6 +17,10 @@ type Error struct {
 
 // RequestJobJSONBody defines parameters for RequestJob.
 type RequestJobJSONBody struct {
+
+	// Deprecated. The architecture is now part of the job type.
+	// If this field is set, its value will be appended to osbuild and osbuild-koji job types with a leading colon to maintain backwards compatibility. Example:
+	// `types = [osbuild, osbuild-koji, koji-init], arch = aarch64` results into: `types = [osbuild:aarch64, osbuild-koji:aarch64, koji-init]`
 	Arch  string   `json:"arch"`
 	Types []string `json:"types"`
 }

--- a/internal/worker/api/openapi.yml
+++ b/internal/worker/api/openapi.yml
@@ -106,6 +106,16 @@ paths:
 
                     `types = [osbuild, osbuild-koji, koji-init], arch = aarch64` results into:
                     `types = [osbuild:aarch64, osbuild-koji:aarch64, koji-init]`
+                owners:
+                  type: array
+                  items:
+                    type: string
+                  description: >
+                    Denotes by which owners the worker accepts jobs. Jobs without an owner can be assigned to
+                    an arbitrary worker, this is used only for backward compatibility.
+
+                    If left empty, the worker can get jobs from arbitrary owners. This is important for keeping
+                    backward compatibility.
               required:
                 - types
                 - arch

--- a/internal/worker/api/openapi.yml
+++ b/internal/worker/api/openapi.yml
@@ -97,6 +97,15 @@ paths:
                       - osbuild
                 arch:
                   type: string
+                  deprecated: true
+                  description: >
+                    Deprecated. The architecture is now part of the job type.
+
+                    If this field is set, its value will be appended to osbuild and osbuild-koji job types with
+                    a leading colon to maintain backwards compatibility. Example:
+
+                    `types = [osbuild, osbuild-koji, koji-init], arch = aarch64` results into:
+                    `types = [osbuild:aarch64, osbuild-koji:aarch64, koji-init]`
               required:
                 - types
                 - arch

--- a/internal/worker/client.go
+++ b/internal/worker/client.go
@@ -12,7 +12,7 @@ import (
 	"net/url"
 
 	"github.com/google/uuid"
-	"github.com/osbuild/osbuild-composer/internal/common"
+
 	"github.com/osbuild/osbuild-composer/internal/worker/api"
 )
 
@@ -84,7 +84,7 @@ func NewClientUnix(path string) *Client {
 	return &Client{server, requester}
 }
 
-func (c *Client) RequestJob(types []string) (Job, error) {
+func (c *Client) RequestJob(types []string, arch string) (Job, error) {
 	url, err := c.server.Parse("jobs")
 	if err != nil {
 		// This only happens when "jobs" cannot be parsed.
@@ -94,7 +94,7 @@ func (c *Client) RequestJob(types []string) (Job, error) {
 	var buf bytes.Buffer
 	err = json.NewEncoder(&buf).Encode(api.RequestJobJSONRequestBody{
 		Types: types,
-		Arch:  common.CurrentArch(),
+		Arch:  arch,
 	})
 	if err != nil {
 		panic(err)

--- a/internal/worker/client.go
+++ b/internal/worker/client.go
@@ -84,7 +84,7 @@ func NewClientUnix(path string) *Client {
 	return &Client{server, requester}
 }
 
-func (c *Client) RequestJob(types []string) (Job, error) {
+func (c *Client) RequestJob(types []string, owners []string) (Job, error) {
 	url, err := c.server.Parse("jobs")
 	if err != nil {
 		// This only happens when "jobs" cannot be parsed.
@@ -93,7 +93,8 @@ func (c *Client) RequestJob(types []string) (Job, error) {
 
 	var buf bytes.Buffer
 	err = json.NewEncoder(&buf).Encode(api.RequestJobJSONRequestBody{
-		Types: types,
+		Types:  types,
+		Owners: &owners,
 	})
 	if err != nil {
 		panic(err)

--- a/internal/worker/client.go
+++ b/internal/worker/client.go
@@ -84,7 +84,7 @@ func NewClientUnix(path string) *Client {
 	return &Client{server, requester}
 }
 
-func (c *Client) RequestJob(types []string, arch string) (Job, error) {
+func (c *Client) RequestJob(types []string) (Job, error) {
 	url, err := c.server.Parse("jobs")
 	if err != nil {
 		// This only happens when "jobs" cannot be parsed.
@@ -94,7 +94,6 @@ func (c *Client) RequestJob(types []string, arch string) (Job, error) {
 	var buf bytes.Buffer
 	err = json.NewEncoder(&buf).Encode(api.RequestJobJSONRequestBody{
 		Types: types,
-		Arch:  arch,
 	})
 	if err != nil {
 		panic(err)

--- a/internal/worker/server.go
+++ b/internal/worker/server.go
@@ -72,23 +72,23 @@ func (s *Server) Handler() http.Handler {
 	return e
 }
 
-func (s *Server) EnqueueOSBuild(arch string, job *OSBuildJob) (uuid.UUID, error) {
-	queueName := toQueueName("osbuild:"+arch, "")
+func (s *Server) EnqueueOSBuild(arch string, owner string, job *OSBuildJob) (uuid.UUID, error) {
+	queueName := toQueueName("osbuild:"+arch, owner)
 	return s.jobs.Enqueue(queueName, job, nil)
 }
 
-func (s *Server) EnqueueOSBuildKoji(arch string, job *OSBuildKojiJob, initID uuid.UUID) (uuid.UUID, error) {
-	queueName := toQueueName("osbuild-koji:"+arch, "")
+func (s *Server) EnqueueOSBuildKoji(arch string, owner string, job *OSBuildKojiJob, initID uuid.UUID) (uuid.UUID, error) {
+	queueName := toQueueName("osbuild-koji:"+arch, owner)
 	return s.jobs.Enqueue(queueName, job, []uuid.UUID{initID})
 }
 
-func (s *Server) EnqueueKojiInit(job *KojiInitJob) (uuid.UUID, error) {
-	queueName := toQueueName("koji-init", "")
+func (s *Server) EnqueueKojiInit(owner string, job *KojiInitJob) (uuid.UUID, error) {
+	queueName := toQueueName("koji-init", owner)
 	return s.jobs.Enqueue(queueName, job, nil)
 }
 
-func (s *Server) EnqueueKojiFinalize(job *KojiFinalizeJob, initID uuid.UUID, buildIDs []uuid.UUID) (uuid.UUID, error) {
-	queueName := toQueueName("koji-finalize", "")
+func (s *Server) EnqueueKojiFinalize(owner string, job *KojiFinalizeJob, initID uuid.UUID, buildIDs []uuid.UUID) (uuid.UUID, error) {
+	queueName := toQueueName("koji-finalize", owner)
 	return s.jobs.Enqueue(queueName, job, append([]uuid.UUID{initID}, buildIDs...))
 }
 

--- a/internal/worker/server_internal_test.go
+++ b/internal/worker/server_internal_test.go
@@ -1,0 +1,72 @@
+package worker
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestToQueueName(t *testing.T) {
+	cases := []struct {
+		Name      string
+		JobType   string
+		QueueName string
+	}{
+		{
+			Name:      "only a job type",
+			JobType:   "osbuild:x86_64",
+			QueueName: "osbuild:x86_64",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.Name, func(t *testing.T) {
+			require.Equal(t, c.QueueName, toQueueName(c.JobType))
+		})
+	}
+}
+
+func TestFromQueueName(t *testing.T) {
+	cases := []struct {
+		Name      string
+		QueueName string
+		JobType   string
+	}{
+		{
+			Name:      "only a job type",
+			QueueName: "osbuild:x86_64",
+			JobType:   "osbuild:x86_64",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.Name, func(t *testing.T) {
+			actualJobType, err := fromQueueName(c.QueueName)
+			require.NoError(t, err)
+			require.Equal(t, c.JobType, actualJobType)
+		})
+	}
+}
+
+// Test that jobRestrictions == fromQueueName(toQueueName(jobRestrictions))
+// holds true.
+func TestToQueueNameAndBack(t *testing.T) {
+	cases := []struct {
+		Name    string
+		JobType string
+	}{
+		{
+			Name:    "only a job type",
+			JobType: "osbuild:x86_64",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.Name, func(t *testing.T) {
+			queueName := toQueueName(c.JobType)
+			actualJobType, err := fromQueueName(queueName)
+			require.NoError(t, err)
+			require.Equal(t, c.JobType, actualJobType)
+		})
+	}
+}

--- a/internal/worker/server_internal_test.go
+++ b/internal/worker/server_internal_test.go
@@ -10,40 +10,91 @@ func TestToQueueName(t *testing.T) {
 	cases := []struct {
 		Name      string
 		JobType   string
+		JobOwner  string
 		QueueName string
 	}{
 		{
 			Name:      "only a job type",
 			JobType:   "osbuild:x86_64",
+			JobOwner:  "",
 			QueueName: "osbuild:x86_64",
+		},
+		{
+			Name:      "job type and job owner",
+			JobType:   "osbuild:x86_64",
+			JobOwner:  "ostrich",
+			QueueName: "osbuild:x86_64?owner=ostrich",
+		},
+		{
+			Name:      "job type and weird job owner",
+			JobType:   "osbuild:x86_64",
+			JobOwner:  "bird?kingfisher",
+			QueueName: "osbuild:x86_64?owner=bird%3Fkingfisher",
 		},
 	}
 
 	for _, c := range cases {
 		t.Run(c.Name, func(t *testing.T) {
-			require.Equal(t, c.QueueName, toQueueName(c.JobType))
+			require.Equal(t, c.QueueName, toQueueName(c.JobType, c.JobOwner))
 		})
 	}
 }
 
 func TestFromQueueName(t *testing.T) {
 	cases := []struct {
-		Name      string
-		QueueName string
-		JobType   string
+		Name          string
+		QueueName     string
+		JobType       string
+		JobOwner      string
+		expectedError bool
 	}{
 		{
-			Name:      "only a job type",
-			QueueName: "osbuild:x86_64",
-			JobType:   "osbuild:x86_64",
+			Name:          "only a job type",
+			QueueName:     "osbuild:x86_64",
+			JobType:       "osbuild:x86_64",
+			JobOwner:      "",
+			expectedError: false,
+		},
+		{
+			Name:          "job type and job owner",
+			QueueName:     "osbuild:x86_64?owner=ostrich",
+			JobType:       "osbuild:x86_64",
+			JobOwner:      "ostrich",
+			expectedError: false,
+		},
+		{
+			Name:          "job type and weird job owner",
+			QueueName:     "osbuild:x86_64?owner=bird%3Fkingfisher",
+			JobType:       "osbuild:x86_64",
+			JobOwner:      "bird?kingfisher",
+			expectedError: false,
+		},
+		{
+			Name:          "non existing parameter",
+			QueueName:     "osbuild:x86_64?bird=emu",
+			JobType:       "",
+			JobOwner:      "",
+			expectedError: true,
+		},
+		{
+			Name:          "non unescapable parameter value",
+			QueueName:     "osbuild:x86_64?owner=bird%3vulture",
+			JobType:       "",
+			JobOwner:      "",
+			expectedError: true,
 		},
 	}
 
 	for _, c := range cases {
 		t.Run(c.Name, func(t *testing.T) {
-			actualJobType, err := fromQueueName(c.QueueName)
-			require.NoError(t, err)
+			actualJobType, actualJobOwner, err := fromQueueName(c.QueueName)
+			if c.expectedError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
 			require.Equal(t, c.JobType, actualJobType)
+			require.Equal(t, c.JobOwner, actualJobOwner)
 		})
 	}
 }
@@ -52,21 +103,34 @@ func TestFromQueueName(t *testing.T) {
 // holds true.
 func TestToQueueNameAndBack(t *testing.T) {
 	cases := []struct {
-		Name    string
-		JobType string
+		Name     string
+		JobType  string
+		JobOwner string
 	}{
 		{
-			Name:    "only a job type",
-			JobType: "osbuild:x86_64",
+			Name:     "only a job type",
+			JobType:  "osbuild:x86_64",
+			JobOwner: "",
+		},
+		{
+			Name:     "job type and job owner",
+			JobType:  "osbuild:x86_64",
+			JobOwner: "ostrich",
+		},
+		{
+			Name:     "job type and weird job owner",
+			JobType:  "osbuild:x86_64",
+			JobOwner: "bird?kingfisher",
 		},
 	}
 
 	for _, c := range cases {
 		t.Run(c.Name, func(t *testing.T) {
-			queueName := toQueueName(c.JobType)
-			actualJobType, err := fromQueueName(queueName)
+			queueName := toQueueName(c.JobType, c.JobOwner)
+			actualJobType, actualJobOwner, err := fromQueueName(queueName)
 			require.NoError(t, err)
 			require.Equal(t, c.JobType, actualJobType)
+			require.Equal(t, c.JobOwner, actualJobOwner)
 		})
 	}
 }

--- a/internal/worker/server_test.go
+++ b/internal/worker/server_test.go
@@ -67,7 +67,7 @@ func TestCreate(t *testing.T) {
 	server := worker.NewServer(nil, testjobqueue.New(), "")
 	handler := server.Handler()
 
-	_, err = server.EnqueueOSBuild(arch.Name(), &worker.OSBuildJob{Manifest: manifest})
+	_, err = server.EnqueueOSBuild(arch.Name(), "", &worker.OSBuildJob{Manifest: manifest})
 	require.NoError(t, err)
 
 	test.TestRoute(t, handler, false, "POST", "/api/worker/v1/jobs", `{"types":["osbuild"],"arch":"x86_64"}`, http.StatusCreated,
@@ -91,7 +91,7 @@ func TestCancel(t *testing.T) {
 	server := worker.NewServer(nil, testjobqueue.New(), "")
 	handler := server.Handler()
 
-	jobId, err := server.EnqueueOSBuild(arch.Name(), &worker.OSBuildJob{Manifest: manifest})
+	jobId, err := server.EnqueueOSBuild(arch.Name(), "", &worker.OSBuildJob{Manifest: manifest})
 	require.NoError(t, err)
 
 	token, j, typ, args, dynamicArgs, err := server.RequestJob(context.Background(), []string{"osbuild" + ":" + arch.Name()}, []string{})
@@ -128,7 +128,7 @@ func TestUpdate(t *testing.T) {
 	server := worker.NewServer(nil, testjobqueue.New(), "")
 	handler := server.Handler()
 
-	jobId, err := server.EnqueueOSBuild(arch.Name(), &worker.OSBuildJob{Manifest: manifest})
+	jobId, err := server.EnqueueOSBuild(arch.Name(), "", &worker.OSBuildJob{Manifest: manifest})
 	require.NoError(t, err)
 
 	token, j, typ, args, dynamicArgs, err := server.RequestJob(context.Background(), []string{"osbuild" + ":" + arch.Name()}, []string{})
@@ -159,7 +159,7 @@ func TestUpload(t *testing.T) {
 	server := worker.NewServer(nil, testjobqueue.New(), "")
 	handler := server.Handler()
 
-	jobID, err := server.EnqueueOSBuild(arch.Name(), &worker.OSBuildJob{Manifest: manifest})
+	jobID, err := server.EnqueueOSBuild(arch.Name(), "", &worker.OSBuildJob{Manifest: manifest})
 	require.NoError(t, err)
 
 	token, j, typ, args, dynamicArgs, err := server.RequestJob(context.Background(), []string{"osbuild" + ":" + arch.Name()}, []string{})

--- a/internal/worker/server_test.go
+++ b/internal/worker/server_test.go
@@ -94,7 +94,7 @@ func TestCancel(t *testing.T) {
 	jobId, err := server.EnqueueOSBuild(arch.Name(), &worker.OSBuildJob{Manifest: manifest})
 	require.NoError(t, err)
 
-	token, j, typ, args, dynamicArgs, err := server.RequestJob(context.Background(), []string{"osbuild" + ":" + arch.Name()})
+	token, j, typ, args, dynamicArgs, err := server.RequestJob(context.Background(), []string{"osbuild" + ":" + arch.Name()}, []string{})
 	require.NoError(t, err)
 	require.Equal(t, jobId, j)
 	require.Equal(t, "osbuild:x86_64", typ)
@@ -131,7 +131,7 @@ func TestUpdate(t *testing.T) {
 	jobId, err := server.EnqueueOSBuild(arch.Name(), &worker.OSBuildJob{Manifest: manifest})
 	require.NoError(t, err)
 
-	token, j, typ, args, dynamicArgs, err := server.RequestJob(context.Background(), []string{"osbuild" + ":" + arch.Name()})
+	token, j, typ, args, dynamicArgs, err := server.RequestJob(context.Background(), []string{"osbuild" + ":" + arch.Name()}, []string{})
 	require.NoError(t, err)
 	require.Equal(t, jobId, j)
 	require.Equal(t, "osbuild:x86_64", typ)
@@ -162,7 +162,7 @@ func TestUpload(t *testing.T) {
 	jobID, err := server.EnqueueOSBuild(arch.Name(), &worker.OSBuildJob{Manifest: manifest})
 	require.NoError(t, err)
 
-	token, j, typ, args, dynamicArgs, err := server.RequestJob(context.Background(), []string{"osbuild" + ":" + arch.Name()})
+	token, j, typ, args, dynamicArgs, err := server.RequestJob(context.Background(), []string{"osbuild" + ":" + arch.Name()}, []string{})
 	require.NoError(t, err)
 	require.Equal(t, jobID, j)
 	require.Equal(t, "osbuild:x86_64", typ)

--- a/internal/worker/server_test.go
+++ b/internal/worker/server_test.go
@@ -94,10 +94,10 @@ func TestCancel(t *testing.T) {
 	jobId, err := server.EnqueueOSBuild(arch.Name(), &worker.OSBuildJob{Manifest: manifest})
 	require.NoError(t, err)
 
-	token, j, typ, args, dynamicArgs, err := server.RequestJob(context.Background(), arch.Name(), []string{"osbuild"})
+	token, j, typ, args, dynamicArgs, err := server.RequestJob(context.Background(), []string{"osbuild" + ":" + arch.Name()})
 	require.NoError(t, err)
 	require.Equal(t, jobId, j)
-	require.Equal(t, "osbuild", typ)
+	require.Equal(t, "osbuild:x86_64", typ)
 	require.NotNil(t, args)
 	require.Nil(t, dynamicArgs)
 
@@ -131,10 +131,10 @@ func TestUpdate(t *testing.T) {
 	jobId, err := server.EnqueueOSBuild(arch.Name(), &worker.OSBuildJob{Manifest: manifest})
 	require.NoError(t, err)
 
-	token, j, typ, args, dynamicArgs, err := server.RequestJob(context.Background(), arch.Name(), []string{"osbuild"})
+	token, j, typ, args, dynamicArgs, err := server.RequestJob(context.Background(), []string{"osbuild" + ":" + arch.Name()})
 	require.NoError(t, err)
 	require.Equal(t, jobId, j)
-	require.Equal(t, "osbuild", typ)
+	require.Equal(t, "osbuild:x86_64", typ)
 	require.NotNil(t, args)
 	require.Nil(t, dynamicArgs)
 
@@ -162,10 +162,10 @@ func TestUpload(t *testing.T) {
 	jobID, err := server.EnqueueOSBuild(arch.Name(), &worker.OSBuildJob{Manifest: manifest})
 	require.NoError(t, err)
 
-	token, j, typ, args, dynamicArgs, err := server.RequestJob(context.Background(), arch.Name(), []string{"osbuild"})
+	token, j, typ, args, dynamicArgs, err := server.RequestJob(context.Background(), []string{"osbuild" + ":" + arch.Name()})
 	require.NoError(t, err)
 	require.Equal(t, jobID, j)
-	require.Equal(t, "osbuild", typ)
+	require.Equal(t, "osbuild:x86_64", typ)
 	require.NotNil(t, args)
 	require.Nil(t, dynamicArgs)
 


### PR DESCRIPTION
This PR needs some tests but the basic gist is ready to be reviewed. It consists of several parts:

1) `arch` is merged in the job type.
2) Job queue no longer works with the concept of a job type, it instead uses a queue name. Queue name can be constructed from a job type and vice versa.
3) Jobs now have a owner. Queue names are now constructed in a backward compatible way from a job type and an owner. The inverse function now also has the support for job owners.
4) The worker can now accept jobs only from a pre-selected set of owners (configurable).
5) Jobs created by Koji and Cloud APIs have now owners based on the SAN field of the certificate that was used to create the job.
6) Jobs created by Weldr API have now _weldr owner. Unconfigured workers fall back to jobs owned by _weldr.