### PR TITLE
cloudapi: add support for mirrorlist and metalink repos

### DIFF
--- a/internal/cloudapi/openapi.gen.go
+++ b/internal/cloudapi/openapi.gen.go
@@ -82,8 +82,10 @@ type ImageStatus struct {
 
 // Repository defines model for Repository.
 type Repository struct {
-	Baseurl string `json:"baseurl"`
-	Rhsm    bool   `json:"rhsm"`
+	Baseurl    *string `json:"baseurl,omitempty"`
+	Metalink   *string `json:"metalink,omitempty"`
+	Mirrorlist *string `json:"mirrorlist,omitempty"`
+	Rhsm       bool    `json:"rhsm"`
 }
 
 // Subscription defines model for Subscription.

--- a/internal/cloudapi/openapi.yml
+++ b/internal/cloudapi/openapi.yml
@@ -135,15 +135,22 @@ components:
     Repository:
       type: object
       required:
-        - baseurl
         - rhsm
       properties:
+        rhsm:
+          type: boolean
         baseurl:
           type: string
           format: url
           example: 'https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/'
-        rhsm:
-          type: boolean
+        mirrorlist:
+          type: string
+          format: url
+          example: 'https://mirrors.fedoraproject.org/mirrorlist?repo=fedora-33&arch=x86_64'
+        metalink:
+          type: string
+          format: url
+          example: 'https://mirrors.fedoraproject.org/metalink?repo=fedora-32&arch=x86_64'
     UploadRequest:
       type: object
       required:

--- a/internal/cloudapi/server.go
+++ b/internal/cloudapi/server.go
@@ -94,8 +94,18 @@ func (server *Server) Compose(w http.ResponseWriter, r *http.Request) {
 		}
 		repositories := make([]rpmmd.RepoConfig, len(ir.Repositories))
 		for j, repo := range ir.Repositories {
-			repositories[j].BaseURL = repo.Baseurl
 			repositories[j].RHSM = repo.Rhsm
+
+			if repo.Baseurl != nil {
+				repositories[j].BaseURL = *repo.Baseurl
+			} else if repo.Mirrorlist != nil {
+				repositories[j].MirrorList = *repo.Mirrorlist
+			} else if repo.Metalink != nil {
+				repositories[j].Metalink = *repo.Metalink
+			} else {
+				http.Error(w, "Must specify baseurl, mirrorlist, or metalink", http.StatusBadRequest)
+				return
+			}
 		}
 
 		var bp = blueprint.Blueprint{}


### PR DESCRIPTION
Previously, baseurl was required in openapi.yaml. In order to add support for metalink 
and mirrorlist repos as well, make all optional, since openapi does not support mutually 
exclusive parameters. Instead, enforce this logic in server.go, and if no repo has been 
specified, return a 400 bad request error.

