### PR TITLE
schutzbot: add required env variable to 8.4 integration test

### DIFF
--- a/schutzbot/Jenkinsfile
+++ b/schutzbot/Jenkinsfile
@@ -359,6 +359,7 @@ pipeline {
                     environment {
                         TEST_TYPE = "integration"
                         AWS_CREDS = credentials('aws-credentials-osbuildci')
+                        AWS_API_TEST_SHARE_ACCOUNT = credentials('aws-credentials-share-account')
                         AWS_IMAGE_TEST_CREDS = credentials('aws-credentials-osbuild-image-test')
                     }
                     steps {


### PR DESCRIPTION
22c9f6a introduced a new environment variable to api.sh,
AWS_API_TEST_SHARE_ACCOUNT, but only set it in the RHEL 8 tests.

Seems like the corresponding branch was not rebased to a version which
already had those 8.4 tests:

    https://github.com/osbuild/osbuild-composer/pull/1098
