### PR TITLE
api/koji: return pending status until all jobs are finished

### DIFF
--- a/internal/kojiapi/server.go
+++ b/internal/kojiapi/server.go
@@ -224,6 +224,10 @@ func composeStatusFromJobStatus(js *worker.JobStatus, initResult *worker.KojiIni
 		return "failure"
 	}
 
+	if js.Finished.IsZero() {
+		return "pending"
+	}
+
 	if initResult.KojiError != "" {
 		return "failure"
 	}
@@ -235,10 +239,6 @@ func composeStatusFromJobStatus(js *worker.JobStatus, initResult *worker.KojiIni
 		if buildResult.KojiError != "" {
 			return "failure"
 		}
-	}
-
-	if js.Finished.IsZero() {
-		return "pending"
 	}
 
 	if result.KojiError == "" {

--- a/internal/kojiapi/server.go
+++ b/internal/kojiapi/server.go
@@ -241,11 +241,11 @@ func composeStatusFromJobStatus(js *worker.JobStatus, initResult *worker.KojiIni
 		}
 	}
 
-	if result.KojiError == "" {
-		return "success"
+	if result.KojiError != "" {
+		return "failure"
 	}
 
-	return "failure"
+	return "success"
 }
 
 func imageStatusFromJobStatus(js *worker.JobStatus, initResult *worker.KojiInitJobResult, buildResult *worker.OSBuildKojiJobResult) string {


### PR DESCRIPTION
Previously, the compose status returned failure as soon as possible. koji-osbuild considers the job as done when its status == failure and proceeds with uploading the logs to koji and marking the job as failed. However, not all osbuild-composer jobs might be done at this point so the logs might be incomplete making the debugging hard.

This commit changes the behaviour: Now, the compose status is pending until ALL jobs belonging to it are finished.