### PR TITLE
{koji,worker}/server: log errors returned from handlers

### DIFF
--- a/internal/kojiapi/server.go
+++ b/internal/kojiapi/server.go
@@ -46,6 +46,12 @@ func (s *Server) Handler(path string) http.Handler {
 	e.Binder = binder{}
 	e.StdLogger = s.logger
 
+	// log errors returned from handlers
+	e.HTTPErrorHandler = func(err error, c echo.Context) {
+		log.Println(c.Path(), c.QueryParams().Encode(), err.Error())
+		e.DefaultHTTPErrorHandler(err, c)
+	}
+
 	api.RegisterHandlers(e.Group(path), &apiHandlers{s})
 
 	return e

--- a/internal/worker/server.go
+++ b/internal/worker/server.go
@@ -62,6 +62,12 @@ func (s *Server) Handler() http.Handler {
 	e.Binder = binder{}
 	e.StdLogger = s.logger
 
+	// log errors returned from handlers
+	e.HTTPErrorHandler = func(err error, c echo.Context) {
+		log.Println(c.Path(), c.QueryParams().Encode(), err.Error())
+		e.DefaultHTTPErrorHandler(err, c)
+	}
+
 	handler := apiHandlers{
 		server: s,
 	}


### PR DESCRIPTION
Previously, we had no clue what errors were caught by the default echo's error handler. Thus, in the case of an error, we were basically blind. Let's log all errors so we can investigate them later.