### PR TITLE
distro/rhel8*: change the default size of qcow2 to 10 GiB

### DIFF
--- a/internal/distro/rhel84/distro.go
+++ b/internal/distro/rhel84/distro.go
@@ -898,7 +898,7 @@ func New() distro.Distro {
 		},
 		kernelOptions: "ro console=ttyS0 console=ttyS0,115200n8 no_timer_check net.ifnames=0 crashkernel=auto",
 		bootable:      true,
-		defaultSize:   4 * GigaByte,
+		defaultSize:   10 * GigaByte,
 		assembler: func(options distro.ImageOptions, arch distro.Arch) *osbuild.Assembler {
 			return qemuAssembler("qcow2", "disk.qcow2", options, arch)
 		},

--- a/test/data/manifests/rhel_84-x86_64-qcow2-boot.json
+++ b/test/data/manifests/rhel_84-x86_64-qcow2-boot.json
@@ -3496,7 +3496,7 @@
           },
           "format": "qcow2",
           "filename": "disk.qcow2",
-          "size": 4294967296,
+          "size": 10737418240,
           "ptuuid": "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
           "pttype": "gpt",
           "partitions": [
@@ -10105,7 +10105,7 @@
         "fstype": "xfs",
         "label": "root",
         "partuuid": "6264D520-3FB9-423F-8AB8-7A0A8E3D3562",
-        "size": 4187995648,
+        "size": 10630446592,
         "start": 106954752,
         "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
         "uuid": "efe8afea-c0a8-45dc-8e6e-499279f6fa5d"

--- a/test/data/manifests/rhel_84-x86_64-qcow2-customize.json
+++ b/test/data/manifests/rhel_84-x86_64-qcow2-customize.json
@@ -3606,7 +3606,7 @@
           },
           "format": "qcow2",
           "filename": "disk.qcow2",
-          "size": 4294967296,
+          "size": 10737418240,
           "ptuuid": "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
           "pttype": "gpt",
           "partitions": [
@@ -10217,7 +10217,7 @@
         "fstype": "xfs",
         "label": "root",
         "partuuid": "6264D520-3FB9-423F-8AB8-7A0A8E3D3562",
-        "size": 4187995648,
+        "size": 10630446592,
         "start": 106954752,
         "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
         "uuid": "efe8afea-c0a8-45dc-8e6e-499279f6fa5d"


### PR DESCRIPTION
The default size of RHEL 8 qcow2 images is 10 GiB, let's align our default.

Related: rhbz#1846087