### PR TITLE
drop the osbuild submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "osbuild"]
-	path = osbuild
-	url = https://github.com/osbuild/osbuild.git


### PR DESCRIPTION
64432c70 promised to remove it but this didn't actually happen. We don't use the submodule anymore so let's indeed drop it this time.