### PR TITLE
tests: move the epel dependencies to provisioning

### DIFF
--- a/Schutzfile
+++ b/Schutzfile
@@ -14,7 +14,10 @@
     },
     "dependants": {
       "koji-osbuild": {
-        "commit": "4fdc457745e1147475ea3ac1e3b073e592d7b174"
+        "commit": "4fdc457745e1147475ea3ac1e3b073e592d7b174",
+        "pre_install_packages": [
+          "https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm"
+        ]
       }
     }
   }

--- a/osbuild-composer.spec
+++ b/osbuild-composer.spec
@@ -306,7 +306,6 @@ Requires:   unzip
 Requires:   container-selinux
 Requires:   dnsmasq
 Requires:   krb5-workstation
-Requires:   koji
 Requires:   podman
 Requires:   python3
 Requires:   sssd-krb5
@@ -327,11 +326,15 @@ Requires:   qemu-kvm
 Requires:   virt-install
 Requires:   expect
 Requires:   python3-lxml
-Requires:   ansible
 Requires:   httpd
 Requires:   openssl
 %if 0%{?fedora}
 Requires:   podman-plugins
+# koji and ansible are not in RHEL repositories. Depending on them breaks RHEL
+# gating (see OSCI-1541). The test script must enable EPEL and install those
+# packages manually.
+Requires:   koji
+Requires:   ansible
 %endif
 %ifarch %{arm}
 Requires:   edk2-aarch64

--- a/schutzbot/deploy.sh
+++ b/schutzbot/deploy.sh
@@ -75,6 +75,15 @@ fi
 if [[ "$PROJECT" != "osbuild-composer" ]]; then
   PROJECT_COMMIT=$(jq -r ".[\"${ID}-${VERSION_ID}\"].dependants[\"${PROJECT}\"].commit" Schutzfile)
   setup_repo "${PROJECT}" "${PROJECT_COMMIT}" 10
+
+  # Get a list of packages needed to be preinstalled before "${PROJECT}-tests".
+  # Useful mainly for EPEL.
+  PRE_INSTALL_PACKAGES=$(jq -r ".[\"${ID}-${VERSION_ID}\"].dependants[\"${PROJECT}\"].pre_install_packages[]?" Schutzfile)
+
+  if [ "${PRE_INSTALL_PACKAGES}" ]; then
+    # shellcheck disable=SC2086 # We need to pass multiple arguments here.
+    sudo dnf -y install ${PRE_INSTALL_PACKAGES}
+  fi
 fi
 
 if [[ $ID == rhel ]]; then

--- a/schutzbot/deploy.sh
+++ b/schutzbot/deploy.sh
@@ -86,12 +86,6 @@ if [[ "$PROJECT" != "osbuild-composer" ]]; then
   fi
 fi
 
-if [[ $ID == rhel ]]; then
-    greenprint "Setting up EPEL repository"
-    # we need this for ansible and koji
-    sudo dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
-fi
-
 greenprint "Installing test packages for ${PROJECT}"
 # Note: installing only -tests to catch missing dependencies
 retry sudo dnf -y install "${PROJECT}-tests"

--- a/tools/provision.sh
+++ b/tools/provision.sh
@@ -3,6 +3,14 @@ set -euxo pipefail
 
 source /etc/os-release
 
+# koji and ansible are not in RHEL repositories. Depending on them in the spec
+# file breaks RHEL gating (see OSCI-1541). Therefore, we need to enable epel
+# and install koji and ansible here.
+if [[ $ID == rhel ]]; then
+    sudo dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
+    sudo dnf install -y koji ansible
+fi
+
 sudo mkdir -p /etc/osbuild-composer
 sudo cp -a /usr/share/tests/osbuild-composer/composer/*.toml \
     /etc/osbuild-composer/


### PR DESCRIPTION
koji and ansible are not in RHEL repositories. Depending on them breaks RHEL gating (see OSCI-1541): It tries to build a custom image with -tests package in it but in the build environment there's no EPEL.

This commit makes the RPM independent from EPEL. However, we still need koji and ansible, so the provision script now enables EPEL and installs the packages from there. This is not nice but we have to live with that until OSCI-1541 is solved.