### PR TITLE
distro/rhel84: use the org.osbuild.rhel84 runner

### DIFF
--- a/internal/distro/rhel84/distro.go
+++ b/internal/distro/rhel84/distro.go
@@ -229,8 +229,7 @@ func sources(packages []rpmmd.PackageSpec) *osbuild.Sources {
 
 func (t *imageType) pipeline(c *blueprint.Customizations, options distro.ImageOptions, repos []rpmmd.RepoConfig, packageSpecs, buildPackageSpecs []rpmmd.PackageSpec) (*osbuild.Pipeline, error) {
 	p := &osbuild.Pipeline{}
-	// TODO add osbuild rhel84 runner
-	p.SetBuild(t.buildPipeline(repos, *t.arch, buildPackageSpecs), "org.osbuild.rhel83")
+	p.SetBuild(t.buildPipeline(repos, *t.arch, buildPackageSpecs), "org.osbuild.rhel84")
 
 	if t.arch.Name() == "s390x" {
 		p.AddStage(osbuild.NewKernelCmdlineStage(&osbuild.KernelCmdlineStageOptions{

--- a/test/data/manifests/rhel_84-x86_64-ami-boot.json
+++ b/test/data/manifests/rhel_84-x86_64-ami-boot.json
@@ -1884,7 +1884,7 @@
             }
           ]
         },
-        "runner": "org.osbuild.rhel83"
+        "runner": "org.osbuild.rhel84"
       },
       "stages": [
         {

--- a/test/data/manifests/rhel_84-x86_64-openstack-boot.json
+++ b/test/data/manifests/rhel_84-x86_64-openstack-boot.json
@@ -2012,7 +2012,7 @@
             }
           ]
         },
-        "runner": "org.osbuild.rhel83"
+        "runner": "org.osbuild.rhel84"
       },
       "stages": [
         {

--- a/test/data/manifests/rhel_84-x86_64-qcow2-boot.json
+++ b/test/data/manifests/rhel_84-x86_64-qcow2-boot.json
@@ -2072,7 +2072,7 @@
             }
           ]
         },
-        "runner": "org.osbuild.rhel83"
+        "runner": "org.osbuild.rhel84"
       },
       "stages": [
         {

--- a/test/data/manifests/rhel_84-x86_64-qcow2-customize.json
+++ b/test/data/manifests/rhel_84-x86_64-qcow2-customize.json
@@ -2124,7 +2124,7 @@
             }
           ]
         },
-        "runner": "org.osbuild.rhel83"
+        "runner": "org.osbuild.rhel84"
       },
       "stages": [
         {

--- a/test/data/manifests/rhel_84-x86_64-vhd-boot.json
+++ b/test/data/manifests/rhel_84-x86_64-vhd-boot.json
@@ -1985,7 +1985,7 @@
             }
           ]
         },
-        "runner": "org.osbuild.rhel83"
+        "runner": "org.osbuild.rhel84"
       },
       "stages": [
         {

--- a/test/data/manifests/rhel_84-x86_64-vmdk-boot.json
+++ b/test/data/manifests/rhel_84-x86_64-vmdk-boot.json
@@ -1919,7 +1919,7 @@
             }
           ]
         },
-        "runner": "org.osbuild.rhel83"
+        "runner": "org.osbuild.rhel84"
       },
       "stages": [
         {


### PR DESCRIPTION
The RHEL 8.4 specific runner was introduced in osbuild 22, released on the 8th of October 2020. It should by now be in relevant Fedora releases and RHEL 8.4.