### PR TITLE
distro/rhel84: remove rng-tools

### DIFF
--- a/internal/distro/rhel84/distro.go
+++ b/internal/distro/rhel84/distro.go
@@ -666,7 +666,7 @@ func New() distro.Distro {
 			"fwupd", "usbguard",
 			"bash-completion", "tmux",
 			"ima-evm-utils",
-			"audit", "rng-tools",
+			"audit",
 			"podman", "container-selinux", "skopeo", "criu",
 			"slirp4netns", "fuse-overlayfs",
 			"clevis", "clevis-dracut", "clevis-luks",
@@ -678,10 +678,11 @@ func New() distro.Distro {
 			"iwl5150-firmware", "iwl6000-firmware", "iwl6050-firmware", "iwl7260-firmware",
 		},
 		excludedPackages: []string{
+			"rng-tools",
 			"subscription-manager",
 		},
 		enabledServices: []string{
-			"NetworkManager.service", "firewalld.service", "rngd.service", "sshd.service",
+			"NetworkManager.service", "firewalld.service", "sshd.service",
 			"greenboot-grub2-set-counter", "greenboot-grub2-set-success", "greenboot-healthcheck",
 			"greenboot-rpm-ostree-grub2-check-fallback", "greenboot-status", "greenboot-task-runner",
 			"redboot-auto-reboot", "redboot-task-runner",
@@ -722,7 +723,7 @@ func New() distro.Distro {
 			"fwupd", "usbguard",
 			"bash-completion", "tmux",
 			"ima-evm-utils",
-			"audit", "rng-tools",
+			"audit",
 			"podman", "container-selinux", "skopeo", "criu",
 			"slirp4netns", "fuse-overlayfs",
 			"clevis", "clevis-dracut", "clevis-luks",
@@ -732,10 +733,11 @@ func New() distro.Distro {
 			"iwl7260-firmware",
 		},
 		excludedPackages: []string{
+			"rng-tools",
 			"subscription-manager",
 		},
 		enabledServices: []string{
-			"NetworkManager.service", "firewalld.service", "rngd.service", "sshd.service",
+			"NetworkManager.service", "firewalld.service", "sshd.service",
 			"greenboot-grub2-set-counter", "greenboot-grub2-set-success", "greenboot-healthcheck",
 			"greenboot-rpm-ostree-grub2-check-fallback", "greenboot-status", "greenboot-task-runner",
 			"redboot-auto-reboot", "redboot-task-runner",
@@ -765,7 +767,6 @@ func New() distro.Distro {
 			"NetworkManager",
 			"redhat-release",
 			"redhat-release-eula",
-			"rng-tools",
 			"rsync",
 			"selinux-policy-targeted",
 			"tar",
@@ -804,6 +805,7 @@ func New() distro.Distro {
 			"libertas-sd8787-firmware",
 			"libertas-usb8388-firmware",
 			"plymouth",
+			"rng-tools",
 
 			// TODO this cannot be removed, because the kernel (?)
 			// depends on it. The ec2 kickstart force-removes it.
@@ -851,7 +853,6 @@ func New() distro.Distro {
 			"subscription-manager-cockpit",
 			"redhat-release",
 			"redhat-release-eula",
-			"rng-tools",
 			"insights-client",
 			// TODO: rh-amazon-rhui-client
 		},
@@ -890,6 +891,7 @@ func New() distro.Distro {
 			"langpacks-en",
 			"fedora-release",
 			"fedora-repos",
+			"rng-tools",
 
 			// TODO setfiles failes because of usr/sbin/timedatex. Exlude until
 			// https://errata.devel.redhat.com/advisory/47339 lands
@@ -921,6 +923,7 @@ func New() distro.Distro {
 		},
 		excludedPackages: []string{
 			"dracut-config-rescue",
+			"rng-tools",
 		},
 		kernelOptions: "ro net.ifnames=0",
 		bootable:      true,
@@ -937,6 +940,9 @@ func New() distro.Distro {
 		packages: []string{
 			"policycoreutils",
 			"selinux-policy-targeted",
+		},
+		excludedPackages: []string{
+			"rng-tools",
 		},
 		bootable:      false,
 		kernelOptions: "ro net.ifnames=0",
@@ -967,6 +973,7 @@ func New() distro.Distro {
 		},
 		excludedPackages: []string{
 			"dracut-config-rescue",
+			"rng-tools",
 
 			// TODO setfiles failes because of usr/sbin/timedatex. Exlude until
 			// https://errata.devel.redhat.com/advisory/47339 lands
@@ -1000,6 +1007,7 @@ func New() distro.Distro {
 		},
 		excludedPackages: []string{
 			"dracut-config-rescue",
+			"rng-tools",
 
 			// TODO setfiles failes because of usr/sbin/timedatex. Exlude until
 			// https://errata.devel.redhat.com/advisory/47339 lands

--- a/internal/distro/rhel84/distro_test.go
+++ b/internal/distro/rhel84/distro_test.go
@@ -254,7 +254,6 @@ func TestImageType_BasePackages(t *testing.T) {
 				"NetworkManager",
 				"redhat-release",
 				"redhat-release-eula",
-				"rng-tools",
 				"rsync",
 				"selinux-policy-targeted",
 				"tar",
@@ -296,6 +295,7 @@ func TestImageType_BasePackages(t *testing.T) {
 				"libertas-sd8787-firmware",
 				"libertas-usb8388-firmware",
 				"plymouth",
+				"rng-tools",
 
 				// TODO this cannot be removed, because the kernel (?)
 				// depends on it. The ec2 kickstart force-removes it.
@@ -328,6 +328,7 @@ func TestImageType_BasePackages(t *testing.T) {
 			},
 			excludedPackages: []string{
 				"dracut-config-rescue",
+				"rng-tools",
 			},
 			bootable: true,
 		},

--- a/test/data/manifests/rhel_84-x86_64-ami-boot.json
+++ b/test/data/manifests/rhel_84-x86_64-ami-boot.json
@@ -730,9 +730,6 @@
           "sha256:9d2a2ef762444163e91c433c83ce91ef37acb2318ba168a81ac0dd4d65b834ef": {
             "url": "https://rpmrepo.osbuild.org/v1/psi/el8/el8-x86_64-baseos-8.4.0.n-20201010/Packages/subscription-manager-1.27.16-1.el8.x86_64.rpm"
           },
-          "sha256:9d9d1bdfba4cd852f90232ebe2c4247e7b3a88c4476578c820788a91d6838e55": {
-            "url": "https://rpmrepo.osbuild.org/v1/psi/el8/el8-x86_64-baseos-8.4.0.n-20201010/Packages/rng-tools-6.8-3.el8.x86_64.rpm"
-          },
           "sha256:9e08c0338eac83abf9a0118cb05fb646d4554c1b2513ab6801e9587aede40b28": {
             "url": "https://rpmrepo.osbuild.org/v1/psi/el8/el8-x86_64-appstream-8.4.0.n-20201010/Packages/python3-babel-2.5.1-5.el8.noarch.rpm"
           },
@@ -2839,9 +2836,6 @@
               },
               {
                 "checksum": "sha256:3bdf23bf017288b6de46967e083502d3a57dc6d2f760e4bcd74c23c5c999dd88"
-              },
-              {
-                "checksum": "sha256:9d9d1bdfba4cd852f90232ebe2c4247e7b3a88c4476578c820788a91d6838e55"
               },
               {
                 "checksum": "sha256:ad060f60303b6764e08657436147cc24cfc4bb1ccc1431796407ba005a7bcec0"
@@ -7940,15 +7934,6 @@
         "checksum": "sha256:3bdf23bf017288b6de46967e083502d3a57dc6d2f760e4bcd74c23c5c999dd88"
       },
       {
-        "name": "rng-tools",
-        "epoch": 0,
-        "version": "6.8",
-        "release": "3.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v1/psi/el8/el8-x86_64-baseos-8.4.0.n-20201010/Packages/rng-tools-6.8-3.el8.x86_64.rpm",
-        "checksum": "sha256:9d9d1bdfba4cd852f90232ebe2c4247e7b3a88c4476578c820788a91d6838e55"
-      },
-      {
         "name": "rootfiles",
         "epoch": 0,
         "version": "8.1",
@@ -8662,7 +8647,6 @@
       "nobody:x:65534:",
       "polkitd:x:996:",
       "render:x:998:",
-      "rngd:x:991:",
       "root:x:0:",
       "ssh_keys:x:995:",
       "sshd:x:74:",
@@ -9039,7 +9023,6 @@
       "readline-7.0-10.el8.x86_64",
       "redhat-release-8.4-0.5.el8.x86_64",
       "redhat-release-eula-8.4-0.5.el8.x86_64",
-      "rng-tools-6.8-3.el8.x86_64",
       "rootfiles-8.1-22.el8.noarch",
       "rpm-4.14.3-4.el8.x86_64",
       "rpm-build-libs-4.14.3-4.el8.x86_64",
@@ -9140,7 +9123,6 @@
       "nobody:x:65534:65534:Kernel Overflow User:/:/sbin/nologin",
       "operator:x:11:0:operator:/root:/sbin/nologin",
       "polkitd:x:998:996:User for polkitd:/:/sbin/nologin",
-      "rngd:x:994:991:Random Number Generator Daemon:/var/lib/rngd:/sbin/nologin",
       "root:x:0:0:root:/root:/bin/bash",
       "shutdown:x:6:0:shutdown:/sbin:/sbin/shutdown",
       "sshd:x:74:74:Privilege-separated SSH:/var/empty/sshd:/sbin/nologin",
@@ -9186,7 +9168,6 @@
       "remote-cryptsetup.target",
       "rhsm-facts.service",
       "rhsm.service",
-      "rngd-wake-threshold.service",
       "runlevel0.target",
       "runlevel6.target",
       "serial-getty@.service",
@@ -9226,7 +9207,6 @@
       "nis-domainname.service",
       "remote-fs.target",
       "rhsmcertd.service",
-      "rngd.service",
       "rsyslog.service",
       "selinux-autorelabel-mark.service",
       "sshd.service",

--- a/test/data/manifests/rhel_84-x86_64-openstack-boot.json
+++ b/test/data/manifests/rhel_84-x86_64-openstack-boot.json
@@ -828,9 +828,6 @@
           "sha256:9d2a2ef762444163e91c433c83ce91ef37acb2318ba168a81ac0dd4d65b834ef": {
             "url": "https://rpmrepo.osbuild.org/v1/psi/el8/el8-x86_64-baseos-8.4.0.n-20201010/Packages/subscription-manager-1.27.16-1.el8.x86_64.rpm"
           },
-          "sha256:9d9d1bdfba4cd852f90232ebe2c4247e7b3a88c4476578c820788a91d6838e55": {
-            "url": "https://rpmrepo.osbuild.org/v1/psi/el8/el8-x86_64-baseos-8.4.0.n-20201010/Packages/rng-tools-6.8-3.el8.x86_64.rpm"
-          },
           "sha256:9e08c0338eac83abf9a0118cb05fb646d4554c1b2513ab6801e9587aede40b28": {
             "url": "https://rpmrepo.osbuild.org/v1/psi/el8/el8-x86_64-appstream-8.4.0.n-20201010/Packages/python3-babel-2.5.1-5.el8.noarch.rpm"
           },
@@ -3045,9 +3042,6 @@
               },
               {
                 "checksum": "sha256:3bdf23bf017288b6de46967e083502d3a57dc6d2f760e4bcd74c23c5c999dd88"
-              },
-              {
-                "checksum": "sha256:9d9d1bdfba4cd852f90232ebe2c4247e7b3a88c4476578c820788a91d6838e55"
               },
               {
                 "checksum": "sha256:ad060f60303b6764e08657436147cc24cfc4bb1ccc1431796407ba005a7bcec0"
@@ -8423,15 +8417,6 @@
         "checksum": "sha256:3bdf23bf017288b6de46967e083502d3a57dc6d2f760e4bcd74c23c5c999dd88"
       },
       {
-        "name": "rng-tools",
-        "epoch": 0,
-        "version": "6.8",
-        "release": "3.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v1/psi/el8/el8-x86_64-baseos-8.4.0.n-20201010/Packages/rng-tools-6.8-3.el8.x86_64.rpm",
-        "checksum": "sha256:9d9d1bdfba4cd852f90232ebe2c4247e7b3a88c4476578c820788a91d6838e55"
-      },
-      {
         "name": "rootfiles",
         "epoch": 0,
         "version": "8.1",
@@ -9249,7 +9234,6 @@
       "polkitd:x:996:",
       "redhat:x:1000:",
       "render:x:998:",
-      "rngd:x:992:",
       "root:x:0:",
       "ssh_keys:x:995:",
       "sshd:x:74:",
@@ -9665,7 +9649,6 @@
       "readline-7.0-10.el8.x86_64",
       "redhat-release-8.4-0.5.el8.x86_64",
       "redhat-release-eula-8.4-0.5.el8.x86_64",
-      "rng-tools-6.8-3.el8.x86_64",
       "rootfiles-8.1-22.el8.noarch",
       "rpm-4.14.3-4.el8.x86_64",
       "rpm-build-libs-4.14.3-4.el8.x86_64",
@@ -9764,7 +9747,6 @@
       "operator:x:11:0:operator:/root:/sbin/nologin",
       "polkitd:x:998:996:User for polkitd:/:/sbin/nologin",
       "redhat:x:1000:1000::/home/redhat:/bin/bash",
-      "rngd:x:995:992:Random Number Generator Daemon:/var/lib/rngd:/sbin/nologin",
       "root:x:0:0:root:/root:/bin/bash",
       "shutdown:x:6:0:shutdown:/sbin:/sbin/shutdown",
       "sshd:x:74:74:Privilege-separated SSH:/var/empty/sshd:/sbin/nologin",
@@ -9813,7 +9795,6 @@
       "remote-cryptsetup.target",
       "rhsm-facts.service",
       "rhsm.service",
-      "rngd-wake-threshold.service",
       "runlevel0.target",
       "runlevel6.target",
       "serial-getty@.service",
@@ -9854,7 +9835,6 @@
       "nis-domainname.service",
       "remote-fs.target",
       "rhsmcertd.service",
-      "rngd.service",
       "rsyslog.service",
       "selinux-autorelabel-mark.service",
       "sshd.service",

--- a/test/data/manifests/rhel_84-x86_64-qcow2-boot.json
+++ b/test/data/manifests/rhel_84-x86_64-qcow2-boot.json
@@ -831,9 +831,6 @@
           "sha256:9d2a2ef762444163e91c433c83ce91ef37acb2318ba168a81ac0dd4d65b834ef": {
             "url": "https://rpmrepo.osbuild.org/v1/psi/el8/el8-x86_64-baseos-8.4.0.n-20201010/Packages/subscription-manager-1.27.16-1.el8.x86_64.rpm"
           },
-          "sha256:9d9d1bdfba4cd852f90232ebe2c4247e7b3a88c4476578c820788a91d6838e55": {
-            "url": "https://rpmrepo.osbuild.org/v1/psi/el8/el8-x86_64-baseos-8.4.0.n-20201010/Packages/rng-tools-6.8-3.el8.x86_64.rpm"
-          },
           "sha256:9e08c0338eac83abf9a0118cb05fb646d4554c1b2513ab6801e9587aede40b28": {
             "url": "https://rpmrepo.osbuild.org/v1/psi/el8/el8-x86_64-appstream-8.4.0.n-20201010/Packages/python3-babel-2.5.1-5.el8.noarch.rpm"
           },
@@ -3111,9 +3108,6 @@
               },
               {
                 "checksum": "sha256:9be187fd62ada3a61cb494a383b8a60fd6c705c93897a13051600dbbeb1d914f"
-              },
-              {
-                "checksum": "sha256:9d9d1bdfba4cd852f90232ebe2c4247e7b3a88c4476578c820788a91d6838e55"
               },
               {
                 "checksum": "sha256:ad060f60303b6764e08657436147cc24cfc4bb1ccc1431796407ba005a7bcec0"
@@ -8570,15 +8564,6 @@
         "checksum": "sha256:9be187fd62ada3a61cb494a383b8a60fd6c705c93897a13051600dbbeb1d914f"
       },
       {
-        "name": "rng-tools",
-        "epoch": 0,
-        "version": "6.8",
-        "release": "3.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v1/psi/el8/el8-x86_64-baseos-8.4.0.n-20201010/Packages/rng-tools-6.8-3.el8.x86_64.rpm",
-        "checksum": "sha256:9d9d1bdfba4cd852f90232ebe2c4247e7b3a88c4476578c820788a91d6838e55"
-      },
-      {
         "name": "rootfiles",
         "epoch": 0,
         "version": "8.1",
@@ -9583,7 +9568,6 @@
       "polkitd:x:996:",
       "redhat:x:1000:",
       "render:x:998:",
-      "rngd:x:988:",
       "root:x:0:",
       "rpc:x:32:",
       "rpcuser:x:29:",
@@ -10017,7 +10001,6 @@
       "redhat-release-eula-8.4-0.5.el8.x86_64",
       "rhn-client-tools-2.8.16-13.module+el8.1.0+3455+3ddf2832.x86_64",
       "rhsm-icons-1.27.16-1.el8.noarch",
-      "rng-tools-6.8-3.el8.x86_64",
       "rootfiles-8.1-22.el8.noarch",
       "rpcbind-1.2.5-7.el8.x86_64",
       "rpm-4.14.3-4.el8.x86_64",
@@ -10128,7 +10111,6 @@
       "operator:x:11:0:operator:/root:/sbin/nologin",
       "polkitd:x:998:996:User for polkitd:/:/sbin/nologin",
       "redhat:x:1000:1000::/home/redhat:/bin/bash",
-      "rngd:x:991:988:Random Number Generator Daemon:/var/lib/rngd:/sbin/nologin",
       "root:x:0:0:root:/root:/bin/bash",
       "rpc:x:32:32:Rpcbind Daemon:/var/lib/rpcbind:/sbin/nologin",
       "rpcuser:x:29:29:RPC Service User:/var/lib/nfs:/sbin/nologin",
@@ -10183,7 +10165,6 @@
       "remote-cryptsetup.target",
       "rhsm-facts.service",
       "rhsm.service",
-      "rngd-wake-threshold.service",
       "runlevel0.target",
       "runlevel6.target",
       "serial-getty@.service",
@@ -10225,7 +10206,6 @@
       "nis-domainname.service",
       "remote-fs.target",
       "rhsmcertd.service",
-      "rngd.service",
       "rpcbind.service",
       "rpcbind.socket",
       "rsyslog.service",

--- a/test/data/manifests/rhel_84-x86_64-qcow2-customize.json
+++ b/test/data/manifests/rhel_84-x86_64-qcow2-customize.json
@@ -883,9 +883,6 @@
           "sha256:9d2a2ef762444163e91c433c83ce91ef37acb2318ba168a81ac0dd4d65b834ef": {
             "url": "https://rpmrepo.osbuild.org/v1/psi/el8/el8-x86_64-baseos-8.4.0.n-20201010/Packages/subscription-manager-1.27.16-1.el8.x86_64.rpm"
           },
-          "sha256:9d9d1bdfba4cd852f90232ebe2c4247e7b3a88c4476578c820788a91d6838e55": {
-            "url": "https://rpmrepo.osbuild.org/v1/psi/el8/el8-x86_64-baseos-8.4.0.n-20201010/Packages/rng-tools-6.8-3.el8.x86_64.rpm"
-          },
           "sha256:9e08c0338eac83abf9a0118cb05fb646d4554c1b2513ab6801e9587aede40b28": {
             "url": "https://rpmrepo.osbuild.org/v1/psi/el8/el8-x86_64-appstream-8.4.0.n-20201010/Packages/python3-babel-2.5.1-5.el8.noarch.rpm"
           },
@@ -3163,9 +3160,6 @@
               },
               {
                 "checksum": "sha256:9be187fd62ada3a61cb494a383b8a60fd6c705c93897a13051600dbbeb1d914f"
-              },
-              {
-                "checksum": "sha256:9d9d1bdfba4cd852f90232ebe2c4247e7b3a88c4476578c820788a91d6838e55"
               },
               {
                 "checksum": "sha256:ad060f60303b6764e08657436147cc24cfc4bb1ccc1431796407ba005a7bcec0"
@@ -8680,15 +8674,6 @@
         "checksum": "sha256:9be187fd62ada3a61cb494a383b8a60fd6c705c93897a13051600dbbeb1d914f"
       },
       {
-        "name": "rng-tools",
-        "epoch": 0,
-        "version": "6.8",
-        "release": "3.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v1/psi/el8/el8-x86_64-baseos-8.4.0.n-20201010/Packages/rng-tools-6.8-3.el8.x86_64.rpm",
-        "checksum": "sha256:9d9d1bdfba4cd852f90232ebe2c4247e7b3a88c4476578c820788a91d6838e55"
-      },
-      {
         "name": "rootfiles",
         "epoch": 0,
         "version": "8.1",
@@ -9694,7 +9679,6 @@
       "nobody:x:65534:",
       "polkitd:x:996:",
       "render:x:998:",
-      "rngd:x:988:",
       "root:x:0:",
       "rpc:x:32:",
       "rpcuser:x:29:",
@@ -10129,7 +10113,6 @@
       "redhat-release-eula-8.4-0.5.el8.x86_64",
       "rhn-client-tools-2.8.16-13.module+el8.1.0+3455+3ddf2832.x86_64",
       "rhsm-icons-1.27.16-1.el8.noarch",
-      "rng-tools-6.8-3.el8.x86_64",
       "rootfiles-8.1-22.el8.noarch",
       "rpcbind-1.2.5-7.el8.x86_64",
       "rpm-4.14.3-4.el8.x86_64",
@@ -10239,7 +10222,6 @@
       "nobody:x:65534:65534:Kernel Overflow User:/:/sbin/nologin",
       "operator:x:11:0:operator:/root:/sbin/nologin",
       "polkitd:x:998:996:User for polkitd:/:/sbin/nologin",
-      "rngd:x:991:988:Random Number Generator Daemon:/var/lib/rngd:/sbin/nologin",
       "root:x:0:0:root:/root:/bin/bash",
       "rpc:x:32:32:Rpcbind Daemon:/var/lib/rpcbind:/sbin/nologin",
       "rpcuser:x:29:29:RPC Service User:/var/lib/nfs:/sbin/nologin",
@@ -10297,7 +10279,6 @@
       "remote-cryptsetup.target",
       "rhsm-facts.service",
       "rhsm.service",
-      "rngd-wake-threshold.service",
       "runlevel0.target",
       "runlevel6.target",
       "serial-getty@.service",
@@ -10338,7 +10319,6 @@
       "nis-domainname.service",
       "remote-fs.target",
       "rhsmcertd.service",
-      "rngd.service",
       "rpcbind.service",
       "rpcbind.socket",
       "rsyslog.service",

--- a/test/data/manifests/rhel_84-x86_64-vhd-boot.json
+++ b/test/data/manifests/rhel_84-x86_64-vhd-boot.json
@@ -816,9 +816,6 @@
           "sha256:9d2a2ef762444163e91c433c83ce91ef37acb2318ba168a81ac0dd4d65b834ef": {
             "url": "https://rpmrepo.osbuild.org/v1/psi/el8/el8-x86_64-baseos-8.4.0.n-20201010/Packages/subscription-manager-1.27.16-1.el8.x86_64.rpm"
           },
-          "sha256:9d9d1bdfba4cd852f90232ebe2c4247e7b3a88c4476578c820788a91d6838e55": {
-            "url": "https://rpmrepo.osbuild.org/v1/psi/el8/el8-x86_64-baseos-8.4.0.n-20201010/Packages/rng-tools-6.8-3.el8.x86_64.rpm"
-          },
           "sha256:9e08c0338eac83abf9a0118cb05fb646d4554c1b2513ab6801e9587aede40b28": {
             "url": "https://rpmrepo.osbuild.org/v1/psi/el8/el8-x86_64-appstream-8.4.0.n-20201010/Packages/python3-babel-2.5.1-5.el8.noarch.rpm"
           },
@@ -3024,9 +3021,6 @@
               },
               {
                 "checksum": "sha256:3bdf23bf017288b6de46967e083502d3a57dc6d2f760e4bcd74c23c5c999dd88"
-              },
-              {
-                "checksum": "sha256:9d9d1bdfba4cd852f90232ebe2c4247e7b3a88c4476578c820788a91d6838e55"
               },
               {
                 "checksum": "sha256:ad060f60303b6764e08657436147cc24cfc4bb1ccc1431796407ba005a7bcec0"
@@ -8406,15 +8400,6 @@
         "checksum": "sha256:3bdf23bf017288b6de46967e083502d3a57dc6d2f760e4bcd74c23c5c999dd88"
       },
       {
-        "name": "rng-tools",
-        "epoch": 0,
-        "version": "6.8",
-        "release": "3.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v1/psi/el8/el8-x86_64-baseos-8.4.0.n-20201010/Packages/rng-tools-6.8-3.el8.x86_64.rpm",
-        "checksum": "sha256:9d9d1bdfba4cd852f90232ebe2c4247e7b3a88c4476578c820788a91d6838e55"
-      },
-      {
         "name": "rootfiles",
         "epoch": 0,
         "version": "8.1",
@@ -9161,7 +9146,6 @@
       "polkitd:x:995:",
       "redhat:x:1000:",
       "render:x:998:",
-      "rngd:x:991:",
       "root:x:0:",
       "ssh_keys:x:996:",
       "sshd:x:74:",
@@ -9572,7 +9556,6 @@
       "readline-7.0-10.el8.x86_64",
       "redhat-release-8.4-0.5.el8.x86_64",
       "redhat-release-eula-8.4-0.5.el8.x86_64",
-      "rng-tools-6.8-3.el8.x86_64",
       "rootfiles-8.1-22.el8.noarch",
       "rpm-4.14.3-4.el8.x86_64",
       "rpm-build-libs-4.14.3-4.el8.x86_64",
@@ -9671,7 +9654,6 @@
       "operator:x:11:0:operator:/root:/sbin/nologin",
       "polkitd:x:998:995:User for polkitd:/:/sbin/nologin",
       "redhat:x:1000:1000::/home/redhat:/bin/bash",
-      "rngd:x:994:991:Random Number Generator Daemon:/var/lib/rngd:/sbin/nologin",
       "root:x:0:0:root:/root:/bin/bash",
       "shutdown:x:6:0:shutdown:/sbin:/sbin/shutdown",
       "sshd:x:74:74:Privilege-separated SSH:/var/empty/sshd:/sbin/nologin",
@@ -9721,7 +9703,6 @@
       "remote-cryptsetup.target",
       "rhsm-facts.service",
       "rhsm.service",
-      "rngd-wake-threshold.service",
       "runlevel0.target",
       "runlevel6.target",
       "serial-getty@.service",
@@ -9763,7 +9744,6 @@
       "nis-domainname.service",
       "remote-fs.target",
       "rhsmcertd.service",
-      "rngd.service",
       "rsyslog.service",
       "selinux-autorelabel-mark.service",
       "sshd.service",

--- a/test/data/manifests/rhel_84-x86_64-vmdk-boot.json
+++ b/test/data/manifests/rhel_84-x86_64-vmdk-boot.json
@@ -786,9 +786,6 @@
           "sha256:9d2a2ef762444163e91c433c83ce91ef37acb2318ba168a81ac0dd4d65b834ef": {
             "url": "https://rpmrepo.osbuild.org/v1/psi/el8/el8-x86_64-baseos-8.4.0.n-20201010/Packages/subscription-manager-1.27.16-1.el8.x86_64.rpm"
           },
-          "sha256:9d9d1bdfba4cd852f90232ebe2c4247e7b3a88c4476578c820788a91d6838e55": {
-            "url": "https://rpmrepo.osbuild.org/v1/psi/el8/el8-x86_64-baseos-8.4.0.n-20201010/Packages/rng-tools-6.8-3.el8.x86_64.rpm"
-          },
           "sha256:9e70cafe666de95febf05bcee7d3be9a2c5cb9bb3d361d81b2d72bde8a5e20c7": {
             "url": "https://rpmrepo.osbuild.org/v1/psi/el8/el8-x86_64-appstream-8.4.0.n-20201010/Packages/python36-3.6.8-2.module+el8.1.0+3334+5cb623d7.x86_64.rpm"
           },
@@ -2913,9 +2910,6 @@
               },
               {
                 "checksum": "sha256:3bdf23bf017288b6de46967e083502d3a57dc6d2f760e4bcd74c23c5c999dd88"
-              },
-              {
-                "checksum": "sha256:9d9d1bdfba4cd852f90232ebe2c4247e7b3a88c4476578c820788a91d6838e55"
               },
               {
                 "checksum": "sha256:ad060f60303b6764e08657436147cc24cfc4bb1ccc1431796407ba005a7bcec0"
@@ -8123,15 +8117,6 @@
         "checksum": "sha256:3bdf23bf017288b6de46967e083502d3a57dc6d2f760e4bcd74c23c5c999dd88"
       },
       {
-        "name": "rng-tools",
-        "epoch": 0,
-        "version": "6.8",
-        "release": "3.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v1/psi/el8/el8-x86_64-baseos-8.4.0.n-20201010/Packages/rng-tools-6.8-3.el8.x86_64.rpm",
-        "checksum": "sha256:9d9d1bdfba4cd852f90232ebe2c4247e7b3a88c4476578c820788a91d6838e55"
-      },
-      {
         "name": "rootfiles",
         "epoch": 0,
         "version": "8.1",
@@ -8797,7 +8782,6 @@
       "polkitd:x:996:",
       "redhat:x:1000:",
       "render:x:998:",
-      "rngd:x:991:",
       "root:x:0:",
       "ssh_keys:x:995:",
       "sshd:x:74:",
@@ -9181,7 +9165,6 @@
       "readline-7.0-10.el8.x86_64",
       "redhat-release-8.4-0.5.el8.x86_64",
       "redhat-release-eula-8.4-0.5.el8.x86_64",
-      "rng-tools-6.8-3.el8.x86_64",
       "rootfiles-8.1-22.el8.noarch",
       "rpm-4.14.3-4.el8.x86_64",
       "rpm-build-libs-4.14.3-4.el8.x86_64",
@@ -9283,7 +9266,6 @@
       "operator:x:11:0:operator:/root:/sbin/nologin",
       "polkitd:x:998:996:User for polkitd:/:/sbin/nologin",
       "redhat:x:1000:1000::/home/redhat:/bin/bash",
-      "rngd:x:994:991:Random Number Generator Daemon:/var/lib/rngd:/sbin/nologin",
       "root:x:0:0:root:/root:/bin/bash",
       "shutdown:x:6:0:shutdown:/sbin:/sbin/shutdown",
       "sshd:x:74:74:Privilege-separated SSH:/var/empty/sshd:/sbin/nologin",
@@ -9332,7 +9314,6 @@
       "remote-cryptsetup.target",
       "rhsm-facts.service",
       "rhsm.service",
-      "rngd-wake-threshold.service",
       "run-vmblock\\x2dfuse.mount",
       "runlevel0.target",
       "runlevel6.target",
@@ -9371,7 +9352,6 @@
       "nis-domainname.service",
       "remote-fs.target",
       "rhsmcertd.service",
-      "rngd.service",
       "rsyslog.service",
       "selinux-autorelabel-mark.service",
       "sshd.service",


### PR DESCRIPTION
rng-tools is no longer included as a package in the RHEL 8.4 image. This package is both removed from being an included package and also specifically declared as excluded. The test manifests are updated.

I am unsure why rng-tools needs to be explicitly declared as excluded. But, when I just removed it from the included packages list, it was still getting added to the manifest. I tried running `dnf repoquery --whatdepends` to see what might be pulling it in but that didn't reveal anything. If anyone has thoughts on this I'd appreciate the info.
