### PR TITLE
distro/rhel84: disable rhsmcertd.service

### DIFF
--- a/internal/distro/rhel84/distro.go
+++ b/internal/distro/rhel84/distro.go
@@ -287,7 +287,7 @@ func (t *imageType) pipeline(c *blueprint.Customizations, options distro.ImageOp
 		p.AddStage(osbuild.NewUsersStage(options))
 	}
 
-	if services := c.GetServices(); services != nil || t.enabledServices != nil {
+	if services := c.GetServices(); services != nil || t.enabledServices != nil || t.disabledServices != nil {
 		p.AddStage(osbuild.NewSystemdStage(t.systemdStageOptions(t.enabledServices, t.disabledServices, services, t.defaultTarget)))
 	}
 
@@ -686,6 +686,9 @@ func New() distro.Distro {
 			"greenboot-rpm-ostree-grub2-check-fallback", "greenboot-status", "greenboot-task-runner",
 			"redboot-auto-reboot", "redboot-task-runner",
 		},
+		disabledServices: []string{
+			"rhsmcertd.service",
+		},
 		rpmOstree: true,
 		assembler: func(options distro.ImageOptions, arch distro.Arch) *osbuild.Assembler {
 			return ostreeCommitAssembler(options, arch)
@@ -739,6 +742,9 @@ func New() distro.Distro {
 			"greenboot-grub2-set-counter", "greenboot-grub2-set-success", "greenboot-healthcheck",
 			"greenboot-rpm-ostree-grub2-check-fallback", "greenboot-status", "greenboot-task-runner",
 			"redboot-auto-reboot", "redboot-task-runner",
+		},
+		disabledServices: []string{
+			"rhsmcertd.service",
 		},
 		rpmOstree: true,
 		assembler: func(options distro.ImageOptions, arch distro.Arch) *osbuild.Assembler {
@@ -812,6 +818,9 @@ func New() distro.Distro {
 			// TODO setfiles failes because of usr/sbin/timedatex. Exlude until
 			// https://errata.devel.redhat.com/advisory/47339 lands
 			"timedatex",
+		},
+		disabledServices: []string{
+			"rhsmcertd.service",
 		},
 		defaultTarget: "multi-user.target",
 		kernelOptions: "ro console=ttyS0,115200n8 console=tty0 net.ifnames=0 rd.blacklist=nouveau nvme_core.io_timeout=4294967295 crashkernel=auto",
@@ -895,6 +904,9 @@ func New() distro.Distro {
 			// https://errata.devel.redhat.com/advisory/47339 lands
 			"timedatex",
 		},
+		disabledServices: []string{
+			"rhsmcertd.service",
+		},
 		kernelOptions: "ro console=ttyS0 console=ttyS0,115200n8 no_timer_check net.ifnames=0 crashkernel=auto",
 		bootable:      true,
 		defaultSize:   10 * GigaByte,
@@ -922,6 +934,9 @@ func New() distro.Distro {
 		excludedPackages: []string{
 			"dracut-config-rescue",
 		},
+		disabledServices: []string{
+			"rhsmcertd.service",
+		},
 		kernelOptions: "ro net.ifnames=0",
 		bootable:      true,
 		defaultSize:   4 * GigaByte,
@@ -937,6 +952,9 @@ func New() distro.Distro {
 		packages: []string{
 			"policycoreutils",
 			"selinux-policy-targeted",
+		},
+		disabledServices: []string{
+			"rhsmcertd.service",
 		},
 		bootable:      false,
 		kernelOptions: "ro net.ifnames=0",
@@ -976,6 +994,9 @@ func New() distro.Distro {
 			"sshd",
 			"waagent",
 		},
+		disabledServices: []string{
+			"rhsmcertd.service",
+		},
 		defaultTarget: "multi-user.target",
 		kernelOptions: "ro biosdevname=0 rootdelay=300 console=ttyS0 earlyprintk=ttyS0 net.ifnames=0",
 		bootable:      true,
@@ -1004,6 +1025,9 @@ func New() distro.Distro {
 			// TODO setfiles failes because of usr/sbin/timedatex. Exlude until
 			// https://errata.devel.redhat.com/advisory/47339 lands
 			"timedatex",
+		},
+		disabledServices: []string{
+			"rhsmcertd.service",
 		},
 		kernelOptions: "ro net.ifnames=0",
 		bootable:      true,

--- a/test/data/manifests/rhel_84-x86_64-ami-boot.json
+++ b/test/data/manifests/rhel_84-x86_64-ami-boot.json
@@ -3104,6 +3104,15 @@
           }
         },
         {
+          "name": "org.osbuild.systemd",
+          "options": {
+            "disabled_services": [
+              "rhsmcertd.service"
+            ],
+            "default_target": "multi-user.target"
+          }
+        },
+        {
           "name": "org.osbuild.selinux",
           "options": {
             "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
@@ -9186,6 +9195,7 @@
       "remote-cryptsetup.target",
       "rhsm-facts.service",
       "rhsm.service",
+      "rhsmcertd.service",
       "rngd-wake-threshold.service",
       "runlevel0.target",
       "runlevel6.target",
@@ -9225,7 +9235,6 @@
       "microcode.service",
       "nis-domainname.service",
       "remote-fs.target",
-      "rhsmcertd.service",
       "rngd.service",
       "rsyslog.service",
       "selinux-autorelabel-mark.service",

--- a/test/data/manifests/rhel_84-x86_64-openstack-boot.json
+++ b/test/data/manifests/rhel_84-x86_64-openstack-boot.json
@@ -3353,6 +3353,14 @@
           }
         },
         {
+          "name": "org.osbuild.systemd",
+          "options": {
+            "disabled_services": [
+              "rhsmcertd.service"
+            ]
+          }
+        },
+        {
           "name": "org.osbuild.selinux",
           "options": {
             "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
@@ -9805,6 +9813,7 @@
       "iprupdate.service",
       "iprutils.target",
       "kexec.target",
+      "rhsmcertd.service",
       "nftables.service",
       "poweroff.target",
       "qemu-guest-agent.service",
@@ -9813,6 +9822,7 @@
       "remote-cryptsetup.target",
       "rhsm-facts.service",
       "rhsm.service",
+      "rhsmcertd.service",
       "rngd-wake-threshold.service",
       "runlevel0.target",
       "runlevel6.target",
@@ -9844,7 +9854,6 @@
       "dbus-org.fedoraproject.FirewallD1.service",
       "dbus-org.freedesktop.nm-dispatcher.service",
       "dnf-makecache.timer",
-      "firewalld.service",
       "getty@.service",
       "import-state.service",
       "irqbalance.service",
@@ -9853,7 +9862,6 @@
       "microcode.service",
       "nis-domainname.service",
       "remote-fs.target",
-      "rhsmcertd.service",
       "rngd.service",
       "rsyslog.service",
       "selinux-autorelabel-mark.service",

--- a/test/data/manifests/rhel_84-x86_64-qcow2-boot.json
+++ b/test/data/manifests/rhel_84-x86_64-qcow2-boot.json
@@ -3482,6 +3482,14 @@
           }
         },
         {
+          "name": "org.osbuild.systemd",
+          "options": {
+            "disabled_services": [
+              "rhsmcertd.service"
+            ]
+          }
+        },
+        {
           "name": "org.osbuild.selinux",
           "options": {
             "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
@@ -10183,6 +10191,7 @@
       "remote-cryptsetup.target",
       "rhsm-facts.service",
       "rhsm.service",
+      "rhsmcertd.service",
       "rngd-wake-threshold.service",
       "runlevel0.target",
       "runlevel6.target",
@@ -10224,7 +10233,6 @@
       "nfs-convert.service",
       "nis-domainname.service",
       "remote-fs.target",
-      "rhsmcertd.service",
       "rngd.service",
       "rpcbind.service",
       "rpcbind.socket",

--- a/test/data/manifests/rhel_84-x86_64-qcow2-customize.json
+++ b/test/data/manifests/rhel_84-x86_64-qcow2-customize.json
@@ -3587,6 +3587,7 @@
               "sshd.socket"
             ],
             "disabled_services": [
+              "rhsmcertd.service",
               "bluetooth.service"
             ]
           }
@@ -10297,6 +10298,7 @@
       "remote-cryptsetup.target",
       "rhsm-facts.service",
       "rhsm.service",
+      "rhsmcertd.service",
       "rngd-wake-threshold.service",
       "runlevel0.target",
       "runlevel6.target",
@@ -10337,7 +10339,6 @@
       "nfs-convert.service",
       "nis-domainname.service",
       "remote-fs.target",
-      "rhsmcertd.service",
       "rngd.service",
       "rpcbind.service",
       "rpcbind.socket",

--- a/test/data/manifests/rhel_84-x86_64-vhd-boot.json
+++ b/test/data/manifests/rhel_84-x86_64-vhd-boot.json
@@ -3314,6 +3314,9 @@
               "sshd",
               "waagent"
             ],
+            "disabled_services": [
+              "rhsmcertd.service"
+            ],
             "default_target": "multi-user.target"
           }
         },
@@ -9721,6 +9724,7 @@
       "remote-cryptsetup.target",
       "rhsm-facts.service",
       "rhsm.service",
+      "rhsmcertd.service",
       "rngd-wake-threshold.service",
       "runlevel0.target",
       "runlevel6.target",
@@ -9762,7 +9766,6 @@
       "microcode.service",
       "nis-domainname.service",
       "remote-fs.target",
-      "rhsmcertd.service",
       "rngd.service",
       "rsyslog.service",
       "selinux-autorelabel-mark.service",

--- a/test/data/manifests/rhel_84-x86_64-vmdk-boot.json
+++ b/test/data/manifests/rhel_84-x86_64-vmdk-boot.json
@@ -3170,6 +3170,14 @@
           }
         },
         {
+          "name": "org.osbuild.systemd",
+          "options": {
+            "disabled_services": [
+              "rhsmcertd.service"
+            ]
+          }
+        },
+        {
           "name": "org.osbuild.selinux",
           "options": {
             "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
@@ -9332,6 +9340,7 @@
       "remote-cryptsetup.target",
       "rhsm-facts.service",
       "rhsm.service",
+      "rhsmcertd.service",
       "rngd-wake-threshold.service",
       "run-vmblock\\x2dfuse.mount",
       "runlevel0.target",
@@ -9370,7 +9379,6 @@
       "microcode.service",
       "nis-domainname.service",
       "remote-fs.target",
-      "rhsmcertd.service",
       "rngd.service",
       "rsyslog.service",
       "selinux-autorelabel-mark.service",


### PR DESCRIPTION
The rhsmcertd service is now disabled for all image types for the RHEL 8.4 guest image. The test manifests are updated.

I am opening this as a draft because alongside disabling the rhsmcertd service we need to set `enabled=0` in both `/etc/yum/pluginconf.d/product-id.conf` and `/etc/yum/pluginconf.d/subscription-manager.conf`. In the official kickstarter this is done with `sed`. @gicmo do you think this should be done in any particular osbuild stage?

