### PR TITLE
distro/rhel84: update kernel options

### DIFF
--- a/internal/distro/rhel84/distro.go
+++ b/internal/distro/rhel84/distro.go
@@ -814,7 +814,7 @@ func New() distro.Distro {
 			"timedatex",
 		},
 		defaultTarget: "multi-user.target",
-		kernelOptions: "ro console=ttyS0,115200n8 console=tty0 net.ifnames=0 rd.blacklist=nouveau nvme_core.io_timeout=4294967295 crashkernel=auto",
+		kernelOptions: "console=ttyS0,115200n8 console=tty0 net.ifnames=0 rd.blacklist=nouveau nvme_core.io_timeout=4294967295 crashkernel=auto",
 		bootable:      true,
 		defaultSize:   6 * GigaByte,
 		assembler: func(options distro.ImageOptions, arch distro.Arch) *osbuild.Assembler {
@@ -895,7 +895,7 @@ func New() distro.Distro {
 			// https://errata.devel.redhat.com/advisory/47339 lands
 			"timedatex",
 		},
-		kernelOptions: "ro console=ttyS0 console=ttyS0,115200n8 no_timer_check net.ifnames=0 crashkernel=auto",
+		kernelOptions: "console=tty0 console=ttyS0,115200n8 no_timer_check net.ifnames=0 crashkernel=auto",
 		bootable:      true,
 		defaultSize:   10 * GigaByte,
 		assembler: func(options distro.ImageOptions, arch distro.Arch) *osbuild.Assembler {

--- a/test/data/manifests/rhel_84-x86_64-ami-boot.json
+++ b/test/data/manifests/rhel_84-x86_64-ami-boot.json
@@ -3090,7 +3090,7 @@
           "name": "org.osbuild.grub2",
           "options": {
             "root_fs_uuid": "efe8afea-c0a8-45dc-8e6e-499279f6fa5d",
-            "kernel_opts": "ro console=ttyS0,115200n8 console=tty0 net.ifnames=0 rd.blacklist=nouveau nvme_core.io_timeout=4294967295 crashkernel=auto",
+            "kernel_opts": "console=ttyS0,115200n8 console=tty0 net.ifnames=0 rd.blacklist=nouveau nvme_core.io_timeout=4294967295 crashkernel=auto",
             "legacy": "i386-pc",
             "uefi": {
               "vendor": "redhat"
@@ -8604,7 +8604,7 @@
   },
   "image-info": {
     "boot-environment": {
-      "kernelopts": "root=UUID=efe8afea-c0a8-45dc-8e6e-499279f6fa5d ro console=ttyS0,115200n8 console=tty0 net.ifnames=0 rd.blacklist=nouveau nvme_core.io_timeout=4294967295 crashkernel=auto"
+      "kernelopts": "root=UUID=efe8afea-c0a8-45dc-8e6e-499279f6fa5d console=ttyS0,115200n8 console=tty0 net.ifnames=0 rd.blacklist=nouveau nvme_core.io_timeout=4294967295 crashkernel=auto"
     },
     "bootloader": "grub",
     "bootmenu": [

--- a/test/data/manifests/rhel_84-x86_64-qcow2-boot.json
+++ b/test/data/manifests/rhel_84-x86_64-qcow2-boot.json
@@ -3458,7 +3458,7 @@
           "name": "org.osbuild.grub2",
           "options": {
             "root_fs_uuid": "efe8afea-c0a8-45dc-8e6e-499279f6fa5d",
-            "kernel_opts": "ro console=ttyS0 console=ttyS0,115200n8 no_timer_check net.ifnames=0 crashkernel=auto",
+            "kernel_opts": "console=tty0 console=ttyS0,115200n8 no_timer_check net.ifnames=0 crashkernel=auto",
             "legacy": "i386-pc",
             "uefi": {
               "vendor": "redhat"
@@ -9522,7 +9522,7 @@
   },
   "image-info": {
     "boot-environment": {
-      "kernelopts": "root=UUID=efe8afea-c0a8-45dc-8e6e-499279f6fa5d ro console=ttyS0 console=ttyS0,115200n8 no_timer_check net.ifnames=0 crashkernel=auto"
+      "kernelopts": "root=UUID=efe8afea-c0a8-45dc-8e6e-499279f6fa5d console=tty0 console=ttyS0,115200n8 no_timer_check net.ifnames=0 crashkernel=auto"
     },
     "bootloader": "grub",
     "bootmenu": [

--- a/test/data/manifests/rhel_84-x86_64-qcow2-customize.json
+++ b/test/data/manifests/rhel_84-x86_64-qcow2-customize.json
@@ -3510,7 +3510,7 @@
           "name": "org.osbuild.grub2",
           "options": {
             "root_fs_uuid": "efe8afea-c0a8-45dc-8e6e-499279f6fa5d",
-            "kernel_opts": "ro console=ttyS0 console=ttyS0,115200n8 no_timer_check net.ifnames=0 crashkernel=auto debug",
+            "kernel_opts": "console=tty0 console=ttyS0,115200n8 no_timer_check net.ifnames=0 crashkernel=auto debug",
             "legacy": "i386-pc",
             "uefi": {
               "vendor": "redhat"
@@ -9632,7 +9632,7 @@
   },
   "image-info": {
     "boot-environment": {
-      "kernelopts": "root=UUID=efe8afea-c0a8-45dc-8e6e-499279f6fa5d ro console=ttyS0 console=ttyS0,115200n8 no_timer_check net.ifnames=0 crashkernel=auto debug"
+      "kernelopts": "root=UUID=efe8afea-c0a8-45dc-8e6e-499279f6fa5d console=tty0 console=ttyS0,115200n8 no_timer_check net.ifnames=0 crashkernel=auto debug"
     },
     "bootloader": "grub",
     "bootmenu": [


### PR DESCRIPTION
The kernel options are updated to remove the read only option "ro" from all image types that had it set. Also, the qcow2's kernel options are updated to only set console=ttyS0 once. It was declared twice which is redundant so now it is set for both tty0 and ttyS0.
