### PR TITLE
distro/rhel84: use a random uuid for XFS partition

### DIFF
--- a/cmd/osbuild-pipeline/main.go
+++ b/cmd/osbuild-pipeline/main.go
@@ -44,6 +44,8 @@ type rpmMD struct {
 func main() {
 	var rpmmdArg bool
 	flag.BoolVar(&rpmmdArg, "rpmmd", false, "output rpmmd struct instead of pipeline manifest")
+	var seedArg int64
+	flag.Int64Var(&seedArg, "seed", 0, "seed for generating manifests (default: 0)")
 	flag.Parse()
 
 	// Path to composeRequet or '-' for stdin
@@ -152,7 +154,8 @@ func main() {
 			},
 			repos,
 			packageSpecs,
-			buildPackageSpecs)
+			buildPackageSpecs,
+			seedArg)
 		if err != nil {
 			panic(err.Error())
 		}

--- a/cmd/osbuild-store-dump/main.go
+++ b/cmd/osbuild-store-dump/main.go
@@ -26,7 +26,7 @@ func getManifest(bp blueprint.Blueprint, t distro.ImageType, a distro.Arch, d di
 	if err != nil {
 		panic(err)
 	}
-	manifest, err := t.Manifest(bp.Customizations, distro.ImageOptions{}, repos, pkgs, buildPkgs)
+	manifest, err := t.Manifest(bp.Customizations, distro.ImageOptions{}, repos, pkgs, buildPkgs, 0)
 	if err != nil {
 		panic(err)
 	}

--- a/internal/cloudapi/server.go
+++ b/internal/cloudapi/server.go
@@ -5,6 +5,7 @@ package cloudapi
 import (
 	"encoding/json"
 	"fmt"
+	"math/rand"
 	"net/http"
 
 	"github.com/go-chi/chi"
@@ -81,6 +82,9 @@ func (server *Server) Compose(w http.ResponseWriter, r *http.Request) {
 	imageRequests := make([]imageRequest, len(request.ImageRequests))
 	var targets []*target.Target
 
+	// use the same seed for all images so we get the same IDs
+	manifestSeed := rand.Int63()
+
 	for i, ir := range request.ImageRequests {
 		arch, err := distribution.GetArch(ir.Architecture)
 		if err != nil {
@@ -139,7 +143,7 @@ func (server *Server) Compose(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 
-		manifest, err := imageType.Manifest(nil, imageOptions, repositories, packages, buildPackages)
+		manifest, err := imageType.Manifest(nil, imageOptions, repositories, packages, buildPackages, manifestSeed)
 		if err != nil {
 			http.Error(w, fmt.Sprintf("Failed to get manifest for for %s/%s/%s: %s", ir.ImageType, ir.Architecture, request.Distribution, err), http.StatusBadRequest)
 			return

--- a/internal/disk/disk.go
+++ b/internal/disk/disk.go
@@ -1,0 +1,80 @@
+// Disk package contains abstract data-types to define disk-related entities.
+//
+// PartitionTable, Partition and Filesystem types are currently defined.
+// All of them can be 1:1 converted to osbuild.QEMUAssemblerOptions.
+package disk
+
+import "github.com/osbuild/osbuild-composer/internal/osbuild"
+
+type PartitionTable struct {
+	// Size of the disk.
+	Size uint64
+	UUID string
+	// Partition table type, e.g. dos, gpt.
+	Type       string
+	Partitions []Partition
+}
+
+type Partition struct {
+	Start    uint64
+	Size     uint64
+	Type     string
+	Bootable bool
+	// ID of the partition, dos doesn't use traditional UUIDs, therefore this
+	// is just a string.
+	UUID string
+	// If nil, the partition is raw; It doesn't contain a filesystem.
+	Filesystem *Filesystem
+}
+
+type Filesystem struct {
+	Type string
+	// ID of the filesystem, vfat doesn't use traditional UUIDs, therefore this
+	// is just a string.
+	UUID       string
+	Label      string
+	Mountpoint string
+}
+
+// Converts PartitionTable to osbuild.QEMUAssemblerOptions that encode
+// the same partition table.
+func (pt PartitionTable) QEMUAssemblerOptions() osbuild.QEMUAssemblerOptions {
+	var partitions []osbuild.QEMUPartition
+	for _, p := range pt.Partitions {
+		partitions = append(partitions, p.QEMUPartition())
+	}
+
+	return osbuild.QEMUAssemblerOptions{
+		Size:       pt.Size,
+		PTUUID:     pt.UUID,
+		PTType:     pt.Type,
+		Partitions: partitions,
+	}
+}
+
+// Converts Partition to osbuild.QEMUPartition that encodes the same partition.
+func (p Partition) QEMUPartition() osbuild.QEMUPartition {
+	var fs *osbuild.QEMUFilesystem
+	if p.Filesystem != nil {
+		f := p.Filesystem.QEMUFilesystem()
+		fs = &f
+	}
+	return osbuild.QEMUPartition{
+		Start:      p.Start,
+		Size:       p.Size,
+		Type:       p.Type,
+		Bootable:   p.Bootable,
+		UUID:       p.UUID,
+		Filesystem: fs,
+	}
+}
+
+// Converts Filesystem to osbuild.QEMUFilesystem that encodes the same fs.
+func (fs Filesystem) QEMUFilesystem() osbuild.QEMUFilesystem {
+	return osbuild.QEMUFilesystem{
+		Type:       fs.Type,
+		UUID:       fs.UUID,
+		Label:      fs.Label,
+		Mountpoint: fs.Mountpoint,
+	}
+}

--- a/internal/disk/disk.go
+++ b/internal/disk/disk.go
@@ -82,6 +82,23 @@ func (pt PartitionTable) FSTabStageOptions() *osbuild.FSTabStageOptions {
 	return &options
 }
 
+// Returns the root partition (the partition whose filesystem has / as
+// a mountpoint) of the partition table. Nil is returned if there's no such
+// partition.
+func (pt PartitionTable) RootPartition() *Partition {
+	for _, p := range pt.Partitions {
+		if p.Filesystem == nil {
+			continue
+		}
+
+		if p.Filesystem.Mountpoint == "/" {
+			return &p
+		}
+	}
+
+	return nil
+}
+
 // Converts Partition to osbuild.QEMUPartition that encodes the same partition.
 func (p Partition) QEMUPartition() osbuild.QEMUPartition {
 	var fs *osbuild.QEMUFilesystem

--- a/internal/distro/distro.go
+++ b/internal/distro/distro.go
@@ -79,7 +79,7 @@ type ImageType interface {
 	// Returns an osbuild manifest, containing the sources and pipeline necessary
 	// to build an image, given output format with all packages and customizations
 	// specified in the given blueprint.
-	Manifest(b *blueprint.Customizations, options ImageOptions, repos []rpmmd.RepoConfig, packageSpecs, buildPackageSpecs []rpmmd.PackageSpec) (Manifest, error)
+	Manifest(b *blueprint.Customizations, options ImageOptions, repos []rpmmd.RepoConfig, packageSpecs, buildPackageSpecs []rpmmd.PackageSpec, seed int64) (Manifest, error)
 }
 
 // The ImageOptions specify options for a specific image build

--- a/internal/distro/distro_test_common/distro_test_common.go
+++ b/internal/distro/distro_test_common/distro_test_common.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/osbuild/osbuild-composer/internal/blueprint"
 	"github.com/osbuild/osbuild-composer/internal/distro"
 	"github.com/osbuild/osbuild-composer/internal/rpmmd"
@@ -95,7 +96,14 @@ func TestDistro_Manifest(t *testing.T, pipelinePath string, prefix string, distr
 				return
 			}
 			if tt.Manifest != nil {
-				require.JSONEqf(t, string(tt.Manifest), string(got), "Distro: %s\nArch: %s\nImage type: %s\nTest case file: %s\n", d.Name(), arch.Name(), imageType.Name(), fileName)
+				var expected, actual interface{}
+				err = json.Unmarshal(tt.Manifest, &expected)
+				require.NoError(t, err)
+				err = json.Unmarshal(got, &actual)
+				require.NoError(t, err)
+
+				diff := cmp.Diff(expected, actual)
+				require.Emptyf(t, diff, "Distro: %s\nArch: %s\nImage type: %s\nTest case file: %s\n", d.Name(), arch.Name(), imageType.Name(), fileName)
 			}
 		})
 	}

--- a/internal/distro/distro_test_common/distro_test_common.go
+++ b/internal/distro/distro_test_common/distro_test_common.go
@@ -16,6 +16,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const RandomTestSeed = 0
+
 func TestDistro_Manifest(t *testing.T, pipelinePath string, prefix string, distros ...distro.Distro) {
 	assert := assert.New(t)
 	fileNames, err := filepath.Glob(filepath.Join(pipelinePath, prefix))
@@ -89,7 +91,8 @@ func TestDistro_Manifest(t *testing.T, pipelinePath string, prefix string, distr
 				},
 				repos,
 				tt.RpmMD.Packages,
-				tt.RpmMD.BuildPackages)
+				tt.RpmMD.BuildPackages,
+				RandomTestSeed)
 
 			if (err == nil && tt.Manifest == nil) || (err != nil && tt.Manifest != nil) {
 				t.Errorf("distro.Manifest() error = %v", err)

--- a/internal/distro/fedora32/distro.go
+++ b/internal/distro/fedora32/distro.go
@@ -183,7 +183,8 @@ func (t *imageType) Manifest(c *blueprint.Customizations,
 	options distro.ImageOptions,
 	repos []rpmmd.RepoConfig,
 	packageSpecs,
-	buildPackageSpecs []rpmmd.PackageSpec) (distro.Manifest, error) {
+	buildPackageSpecs []rpmmd.PackageSpec,
+	seed int64) (distro.Manifest, error) {
 	pipeline, err := t.pipeline(c, options, repos, packageSpecs, buildPackageSpecs)
 	if err != nil {
 		return distro.Manifest{}, err

--- a/internal/distro/fedora33/distro.go
+++ b/internal/distro/fedora33/distro.go
@@ -183,7 +183,8 @@ func (t *imageType) Manifest(c *blueprint.Customizations,
 	options distro.ImageOptions,
 	repos []rpmmd.RepoConfig,
 	packageSpecs,
-	buildPackageSpecs []rpmmd.PackageSpec) (distro.Manifest, error) {
+	buildPackageSpecs []rpmmd.PackageSpec,
+	seed int64) (distro.Manifest, error) {
 	pipeline, err := t.pipeline(c, options, repos, packageSpecs, buildPackageSpecs)
 	if err != nil {
 		return distro.Manifest{}, err

--- a/internal/distro/fedoratest/distro.go
+++ b/internal/distro/fedoratest/distro.go
@@ -95,7 +95,8 @@ func (t *imageType) Manifest(c *blueprint.Customizations,
 	options distro.ImageOptions,
 	repos []rpmmd.RepoConfig,
 	packageSpecs,
-	buildPackageSpecs []rpmmd.PackageSpec) (distro.Manifest, error) {
+	buildPackageSpecs []rpmmd.PackageSpec,
+	seed int64) (distro.Manifest, error) {
 
 	return json.Marshal(
 		osbuild.Manifest{

--- a/internal/distro/rhel8/distro.go
+++ b/internal/distro/rhel8/distro.go
@@ -185,7 +185,8 @@ func (t *imageType) Manifest(c *blueprint.Customizations,
 	options distro.ImageOptions,
 	repos []rpmmd.RepoConfig,
 	packageSpecs,
-	buildPackageSpecs []rpmmd.PackageSpec) (distro.Manifest, error) {
+	buildPackageSpecs []rpmmd.PackageSpec,
+	seed int64) (distro.Manifest, error) {
 	pipeline, err := t.pipeline(c, options, repos, packageSpecs, buildPackageSpecs)
 	if err != nil {
 		return distro.Manifest{}, err

--- a/internal/distro/test_distro/distro.go
+++ b/internal/distro/test_distro/distro.go
@@ -75,7 +75,7 @@ func (t *TestImageType) BuildPackages() []string {
 	return nil
 }
 
-func (t *TestImageType) Manifest(b *blueprint.Customizations, options distro.ImageOptions, repos []rpmmd.RepoConfig, packageSpecs, buildPackageSpecs []rpmmd.PackageSpec) (distro.Manifest, error) {
+func (t *TestImageType) Manifest(b *blueprint.Customizations, options distro.ImageOptions, repos []rpmmd.RepoConfig, packageSpecs, buildPackageSpecs []rpmmd.PackageSpec, seed int64) (distro.Manifest, error) {
 	return json.Marshal(
 		osbuild.Manifest{
 			Sources:  osbuild.Sources{},

--- a/internal/kojiapi/server.go
+++ b/internal/kojiapi/server.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"math/rand"
 	"net/http"
 	"strings"
 	"time"
@@ -87,6 +88,9 @@ func (h *apiHandlers) PostCompose(ctx echo.Context) error {
 	kojiFilenames := make([]string, len(request.ImageRequests))
 	kojiDirectory := "osbuild-composer-koji-" + uuid.New().String()
 
+	// use the same seed for all images so we get the same IDs
+	manifestSeed := rand.Int63()
+
 	for i, ir := range request.ImageRequests {
 		arch, err := d.GetArch(ir.Architecture)
 		if err != nil {
@@ -119,7 +123,7 @@ func (h *apiHandlers) PostCompose(ctx echo.Context) error {
 			return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Failed to depsolve build packages for %s/%s/%s: %s", ir.ImageType, ir.Architecture, request.Distribution, err))
 		}
 
-		manifest, err := imageType.Manifest(nil, distro.ImageOptions{Size: imageType.Size(0)}, repositories, packages, buildPackages)
+		manifest, err := imageType.Manifest(nil, distro.ImageOptions{Size: imageType.Size(0)}, repositories, packages, buildPackages, manifestSeed)
 		if err != nil {
 			return echo.NewHTTPError(http.StatusBadGateway, fmt.Sprintf("Failed to get manifest for for %s/%s/%s: %s", ir.ImageType, ir.Architecture, request.Distribution, err))
 		}

--- a/internal/store/fixtures.go
+++ b/internal/store/fixtures.go
@@ -57,7 +57,7 @@ func FixtureBase() *Store {
 	if err != nil {
 		panic("invalid image type qcow2 for x86_64 @ fedoratest")
 	}
-	manifest, err := imgType.Manifest(nil, distro.ImageOptions{}, nil, nil, nil)
+	manifest, err := imgType.Manifest(nil, distro.ImageOptions{}, nil, nil, nil, 0)
 	if err != nil {
 		panic("could not create manifest")
 	}
@@ -160,7 +160,7 @@ func FixtureFinished() *Store {
 	if err != nil {
 		panic("invalid image type qcow2 for x86_64 @ fedoratest")
 	}
-	manifest, err := imgType.Manifest(nil, distro.ImageOptions{}, nil, nil, nil)
+	manifest, err := imgType.Manifest(nil, distro.ImageOptions{}, nil, nil, nil, 0)
 	if err != nil {
 		panic("could not create manifest")
 	}

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -51,7 +51,7 @@ func (suite *storeTest) SetupSuite() {
 	suite.myDistro = test_distro.New()
 	suite.myArch, _ = suite.myDistro.GetArch("test_arch")
 	suite.myImageType, _ = suite.myArch.GetImageType("test_type")
-	suite.myManifest, _ = suite.myImageType.Manifest(&suite.myCustomizations, suite.myImageOptions, suite.myRepoConfig, nil, suite.myPackageSpec)
+	suite.myManifest, _ = suite.myImageType.Manifest(&suite.myCustomizations, suite.myImageOptions, suite.myRepoConfig, nil, suite.myPackageSpec, 0)
 	suite.mySourceConfig = SourceConfig{
 		Name: "testSourceConfig",
 	}

--- a/internal/weldr/api.go
+++ b/internal/weldr/api.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"math/rand"
 	"net"
 	"net/http"
 	"net/url"
@@ -1846,7 +1847,8 @@ func (api *API) composeHandler(writer http.ResponseWriter, request *http.Request
 		},
 		api.allRepositories(),
 		packages,
-		buildPackages)
+		buildPackages,
+		rand.Int63())
 	if err != nil {
 		errors := responseError{
 			ID:  "ManifestCreationFailed",

--- a/internal/weldr/api_test.go
+++ b/internal/weldr/api_test.go
@@ -461,7 +461,7 @@ func TestCompose(t *testing.T) {
 	require.NoError(t, err)
 	imgType, err := arch.GetImageType("qcow2")
 	require.NoError(t, err)
-	manifest, err := imgType.Manifest(nil, distro.ImageOptions{}, nil, nil, nil)
+	manifest, err := imgType.Manifest(nil, distro.ImageOptions{}, nil, nil, nil, 0)
 	require.NoError(t, err)
 	expectedComposeLocal := &store.Compose{
 		Blueprint: &blueprint.Blueprint{

--- a/internal/worker/server_test.go
+++ b/internal/worker/server_test.go
@@ -60,7 +60,7 @@ func TestCreate(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error getting image type from arch")
 	}
-	manifest, err := imageType.Manifest(nil, distro.ImageOptions{Size: imageType.Size(0)}, nil, nil, nil)
+	manifest, err := imageType.Manifest(nil, distro.ImageOptions{Size: imageType.Size(0)}, nil, nil, nil, 0)
 	if err != nil {
 		t.Fatalf("error creating osbuild manifest")
 	}
@@ -84,7 +84,7 @@ func TestCancel(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error getting image type from arch")
 	}
-	manifest, err := imageType.Manifest(nil, distro.ImageOptions{Size: imageType.Size(0)}, nil, nil, nil)
+	manifest, err := imageType.Manifest(nil, distro.ImageOptions{Size: imageType.Size(0)}, nil, nil, nil, 0)
 	if err != nil {
 		t.Fatalf("error creating osbuild manifest")
 	}
@@ -121,7 +121,7 @@ func TestUpdate(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error getting image type from arch")
 	}
-	manifest, err := imageType.Manifest(nil, distro.ImageOptions{Size: imageType.Size(0)}, nil, nil, nil)
+	manifest, err := imageType.Manifest(nil, distro.ImageOptions{Size: imageType.Size(0)}, nil, nil, nil, 0)
 	if err != nil {
 		t.Fatalf("error creating osbuild manifest")
 	}
@@ -152,7 +152,7 @@ func TestUpload(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error getting image type from arch")
 	}
-	manifest, err := imageType.Manifest(nil, distro.ImageOptions{Size: imageType.Size(0)}, nil, nil, nil)
+	manifest, err := imageType.Manifest(nil, distro.ImageOptions{Size: imageType.Size(0)}, nil, nil, nil, 0)
 	if err != nil {
 		t.Fatalf("error creating osbuild manifest")
 	}

--- a/test/data/manifests/rhel_84-x86_64-ami-boot.json
+++ b/test/data/manifests/rhel_84-x86_64-ami-boot.json
@@ -3065,7 +3065,7 @@
           "options": {
             "filesystems": [
               {
-                "uuid": "efe8afea-c0a8-45dc-8e6e-499279f6fa5d",
+                "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
                 "vfs_type": "xfs",
                 "path": "/",
                 "options": "defaults"
@@ -3083,7 +3083,7 @@
         {
           "name": "org.osbuild.grub2",
           "options": {
-            "root_fs_uuid": "efe8afea-c0a8-45dc-8e6e-499279f6fa5d",
+            "root_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
             "kernel_opts": "console=ttyS0,115200n8 console=tty0 net.ifnames=0 rd.blacklist=nouveau nvme_core.io_timeout=4294967295 crashkernel=auto",
             "legacy": "i386-pc",
             "uefi": {
@@ -3140,7 +3140,7 @@
               "uuid": "6264D520-3FB9-423F-8AB8-7A0A8E3D3562",
               "filesystem": {
                 "type": "xfs",
-                "uuid": "efe8afea-c0a8-45dc-8e6e-499279f6fa5d",
+                "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
                 "label": "root",
                 "mountpoint": "/"
               }
@@ -8589,7 +8589,7 @@
   },
   "image-info": {
     "boot-environment": {
-      "kernelopts": "root=UUID=efe8afea-c0a8-45dc-8e6e-499279f6fa5d console=ttyS0,115200n8 console=tty0 net.ifnames=0 rd.blacklist=nouveau nvme_core.io_timeout=4294967295 crashkernel=auto"
+      "kernelopts": "root=UUID=0194fdc2-fa2f-4cc0-81d3-ff12045b73c8 console=ttyS0,115200n8 console=tty0 net.ifnames=0 rd.blacklist=nouveau nvme_core.io_timeout=4294967295 crashkernel=auto"
     },
     "bootloader": "grub",
     "bootmenu": [
@@ -8607,20 +8607,20 @@
     ],
     "fstab": [
       [
+        "UUID=0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+        "/",
+        "xfs",
+        "defaults",
+        "0",
+        "0"
+      ],
+      [
         "UUID=7B77-95E7",
         "/boot/efi",
         "vfat",
         "defaults,uid=0,gid=0,umask=077,shortname=winnt",
         "0",
         "2"
-      ],
-      [
-        "UUID=efe8afea-c0a8-45dc-8e6e-499279f6fa5d",
-        "/",
-        "xfs",
-        "defaults",
-        "0",
-        "0"
       ]
     ],
     "groups": [
@@ -9106,7 +9106,7 @@
         "size": 6335479296,
         "start": 106954752,
         "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
-        "uuid": "efe8afea-c0a8-45dc-8e6e-499279f6fa5d"
+        "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8"
       }
     ],
     "passwd": [

--- a/test/data/manifests/rhel_84-x86_64-openstack-boot.json
+++ b/test/data/manifests/rhel_84-x86_64-openstack-boot.json
@@ -3304,7 +3304,7 @@
           "options": {
             "filesystems": [
               {
-                "uuid": "efe8afea-c0a8-45dc-8e6e-499279f6fa5d",
+                "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
                 "vfs_type": "xfs",
                 "path": "/",
                 "options": "defaults"
@@ -3322,7 +3322,7 @@
         {
           "name": "org.osbuild.grub2",
           "options": {
-            "root_fs_uuid": "efe8afea-c0a8-45dc-8e6e-499279f6fa5d",
+            "root_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
             "kernel_opts": "ro net.ifnames=0",
             "legacy": "i386-pc",
             "uefi": {
@@ -3389,7 +3389,7 @@
               "uuid": "6264D520-3FB9-423F-8AB8-7A0A8E3D3562",
               "filesystem": {
                 "type": "xfs",
-                "uuid": "efe8afea-c0a8-45dc-8e6e-499279f6fa5d",
+                "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
                 "label": "root",
                 "mountpoint": "/"
               }
@@ -9171,7 +9171,7 @@
   },
   "image-info": {
     "boot-environment": {
-      "kernelopts": "root=UUID=efe8afea-c0a8-45dc-8e6e-499279f6fa5d ro net.ifnames=0"
+      "kernelopts": "root=UUID=0194fdc2-fa2f-4cc0-81d3-ff12045b73c8 ro net.ifnames=0"
     },
     "bootloader": "grub",
     "bootmenu": [
@@ -9194,20 +9194,20 @@
     ],
     "fstab": [
       [
+        "UUID=0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+        "/",
+        "xfs",
+        "defaults",
+        "0",
+        "0"
+      ],
+      [
         "UUID=7B77-95E7",
         "/boot/efi",
         "vfat",
         "defaults,uid=0,gid=0,umask=077,shortname=winnt",
         "0",
         "2"
-      ],
-      [
-        "UUID=efe8afea-c0a8-45dc-8e6e-499279f6fa5d",
-        "/",
-        "xfs",
-        "defaults",
-        "0",
-        "0"
       ]
     ],
     "groups": [
@@ -9730,7 +9730,7 @@
         "size": 4187995648,
         "start": 106954752,
         "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
-        "uuid": "efe8afea-c0a8-45dc-8e6e-499279f6fa5d"
+        "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8"
       }
     ],
     "passwd": [

--- a/test/data/manifests/rhel_84-x86_64-qcow2-boot.json
+++ b/test/data/manifests/rhel_84-x86_64-qcow2-boot.json
@@ -3433,7 +3433,7 @@
           "options": {
             "filesystems": [
               {
-                "uuid": "efe8afea-c0a8-45dc-8e6e-499279f6fa5d",
+                "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
                 "vfs_type": "xfs",
                 "path": "/",
                 "options": "defaults"
@@ -3451,7 +3451,7 @@
         {
           "name": "org.osbuild.grub2",
           "options": {
-            "root_fs_uuid": "efe8afea-c0a8-45dc-8e6e-499279f6fa5d",
+            "root_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
             "kernel_opts": "console=tty0 console=ttyS0,115200n8 no_timer_check net.ifnames=0 crashkernel=auto",
             "legacy": "i386-pc",
             "uefi": {
@@ -3518,7 +3518,7 @@
               "uuid": "6264D520-3FB9-423F-8AB8-7A0A8E3D3562",
               "filesystem": {
                 "type": "xfs",
-                "uuid": "efe8afea-c0a8-45dc-8e6e-499279f6fa5d",
+                "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
                 "label": "root",
                 "mountpoint": "/"
               }
@@ -9507,7 +9507,7 @@
   },
   "image-info": {
     "boot-environment": {
-      "kernelopts": "root=UUID=efe8afea-c0a8-45dc-8e6e-499279f6fa5d console=tty0 console=ttyS0,115200n8 no_timer_check net.ifnames=0 crashkernel=auto"
+      "kernelopts": "root=UUID=0194fdc2-fa2f-4cc0-81d3-ff12045b73c8 console=tty0 console=ttyS0,115200n8 no_timer_check net.ifnames=0 crashkernel=auto"
     },
     "bootloader": "grub",
     "bootmenu": [
@@ -9525,20 +9525,20 @@
     ],
     "fstab": [
       [
+        "UUID=0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+        "/",
+        "xfs",
+        "defaults",
+        "0",
+        "0"
+      ],
+      [
         "UUID=7B77-95E7",
         "/boot/efi",
         "vfat",
         "defaults,uid=0,gid=0,umask=077,shortname=winnt",
         "0",
         "2"
-      ],
-      [
-        "UUID=efe8afea-c0a8-45dc-8e6e-499279f6fa5d",
-        "/",
-        "xfs",
-        "defaults",
-        "0",
-        "0"
       ]
     ],
     "groups": [
@@ -10091,7 +10091,7 @@
         "size": 10630446592,
         "start": 106954752,
         "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
-        "uuid": "efe8afea-c0a8-45dc-8e6e-499279f6fa5d"
+        "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8"
       }
     ],
     "passwd": [

--- a/test/data/manifests/rhel_84-x86_64-qcow2-customize.json
+++ b/test/data/manifests/rhel_84-x86_64-qcow2-customize.json
@@ -3485,7 +3485,7 @@
           "options": {
             "filesystems": [
               {
-                "uuid": "efe8afea-c0a8-45dc-8e6e-499279f6fa5d",
+                "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
                 "vfs_type": "xfs",
                 "path": "/",
                 "options": "defaults"
@@ -3503,7 +3503,7 @@
         {
           "name": "org.osbuild.grub2",
           "options": {
-            "root_fs_uuid": "efe8afea-c0a8-45dc-8e6e-499279f6fa5d",
+            "root_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
             "kernel_opts": "console=tty0 console=ttyS0,115200n8 no_timer_check net.ifnames=0 crashkernel=auto debug",
             "legacy": "i386-pc",
             "uefi": {
@@ -3628,7 +3628,7 @@
               "uuid": "6264D520-3FB9-423F-8AB8-7A0A8E3D3562",
               "filesystem": {
                 "type": "xfs",
-                "uuid": "efe8afea-c0a8-45dc-8e6e-499279f6fa5d",
+                "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
                 "label": "root",
                 "mountpoint": "/"
               }
@@ -9617,7 +9617,7 @@
   },
   "image-info": {
     "boot-environment": {
-      "kernelopts": "root=UUID=efe8afea-c0a8-45dc-8e6e-499279f6fa5d console=tty0 console=ttyS0,115200n8 no_timer_check net.ifnames=0 crashkernel=auto debug"
+      "kernelopts": "root=UUID=0194fdc2-fa2f-4cc0-81d3-ff12045b73c8 console=tty0 console=ttyS0,115200n8 no_timer_check net.ifnames=0 crashkernel=auto debug"
     },
     "bootloader": "grub",
     "bootmenu": [
@@ -9635,20 +9635,20 @@
     ],
     "fstab": [
       [
+        "UUID=0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+        "/",
+        "xfs",
+        "defaults",
+        "0",
+        "0"
+      ],
+      [
         "UUID=7B77-95E7",
         "/boot/efi",
         "vfat",
         "defaults,uid=0,gid=0,umask=077,shortname=winnt",
         "0",
         "2"
-      ],
-      [
-        "UUID=efe8afea-c0a8-45dc-8e6e-499279f6fa5d",
-        "/",
-        "xfs",
-        "defaults",
-        "0",
-        "0"
       ]
     ],
     "groups": [
@@ -10203,7 +10203,7 @@
         "size": 10630446592,
         "start": 106954752,
         "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
-        "uuid": "efe8afea-c0a8-45dc-8e6e-499279f6fa5d"
+        "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8"
       }
     ],
     "passwd": [

--- a/test/data/manifests/rhel_84-x86_64-vhd-boot.json
+++ b/test/data/manifests/rhel_84-x86_64-vhd-boot.json
@@ -3259,7 +3259,7 @@
           "options": {
             "filesystems": [
               {
-                "uuid": "efe8afea-c0a8-45dc-8e6e-499279f6fa5d",
+                "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
                 "vfs_type": "xfs",
                 "path": "/",
                 "options": "defaults"
@@ -3277,7 +3277,7 @@
         {
           "name": "org.osbuild.grub2",
           "options": {
-            "root_fs_uuid": "efe8afea-c0a8-45dc-8e6e-499279f6fa5d",
+            "root_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
             "kernel_opts": "ro biosdevname=0 rootdelay=300 console=ttyS0 earlyprintk=ttyS0 net.ifnames=0",
             "legacy": "i386-pc",
             "uefi": {
@@ -3354,7 +3354,7 @@
               "uuid": "6264D520-3FB9-423F-8AB8-7A0A8E3D3562",
               "filesystem": {
                 "type": "xfs",
-                "uuid": "efe8afea-c0a8-45dc-8e6e-499279f6fa5d",
+                "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
                 "label": "root",
                 "mountpoint": "/"
               }
@@ -9082,7 +9082,7 @@
   },
   "image-info": {
     "boot-environment": {
-      "kernelopts": "root=UUID=efe8afea-c0a8-45dc-8e6e-499279f6fa5d ro biosdevname=0 rootdelay=300 console=ttyS0 earlyprintk=ttyS0 net.ifnames=0"
+      "kernelopts": "root=UUID=0194fdc2-fa2f-4cc0-81d3-ff12045b73c8 ro biosdevname=0 rootdelay=300 console=ttyS0 earlyprintk=ttyS0 net.ifnames=0"
     },
     "bootloader": "grub",
     "bootmenu": [
@@ -9105,20 +9105,20 @@
     ],
     "fstab": [
       [
+        "UUID=0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+        "/",
+        "xfs",
+        "defaults",
+        "0",
+        "0"
+      ],
+      [
         "UUID=7B77-95E7",
         "/boot/efi",
         "vfat",
         "defaults,uid=0,gid=0,umask=077,shortname=winnt",
         "0",
         "2"
-      ],
-      [
-        "UUID=efe8afea-c0a8-45dc-8e6e-499279f6fa5d",
-        "/",
-        "xfs",
-        "defaults",
-        "0",
-        "0"
       ]
     ],
     "groups": [
@@ -9636,7 +9636,7 @@
         "size": 4187995648,
         "start": 106954752,
         "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
-        "uuid": "efe8afea-c0a8-45dc-8e6e-499279f6fa5d"
+        "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8"
       }
     ],
     "passwd": [

--- a/test/data/manifests/rhel_84-x86_64-vmdk-boot.json
+++ b/test/data/manifests/rhel_84-x86_64-vmdk-boot.json
@@ -3121,7 +3121,7 @@
           "options": {
             "filesystems": [
               {
-                "uuid": "efe8afea-c0a8-45dc-8e6e-499279f6fa5d",
+                "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
                 "vfs_type": "xfs",
                 "path": "/",
                 "options": "defaults"
@@ -3139,7 +3139,7 @@
         {
           "name": "org.osbuild.grub2",
           "options": {
-            "root_fs_uuid": "efe8afea-c0a8-45dc-8e6e-499279f6fa5d",
+            "root_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
             "kernel_opts": "ro net.ifnames=0",
             "legacy": "i386-pc",
             "uefi": {
@@ -3206,7 +3206,7 @@
               "uuid": "6264D520-3FB9-423F-8AB8-7A0A8E3D3562",
               "filesystem": {
                 "type": "xfs",
-                "uuid": "efe8afea-c0a8-45dc-8e6e-499279f6fa5d",
+                "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
                 "label": "root",
                 "mountpoint": "/"
               }
@@ -8718,7 +8718,7 @@
   },
   "image-info": {
     "boot-environment": {
-      "kernelopts": "root=UUID=efe8afea-c0a8-45dc-8e6e-499279f6fa5d ro net.ifnames=0"
+      "kernelopts": "root=UUID=0194fdc2-fa2f-4cc0-81d3-ff12045b73c8 ro net.ifnames=0"
     },
     "bootloader": "grub",
     "bootmenu": [
@@ -8741,20 +8741,20 @@
     ],
     "fstab": [
       [
+        "UUID=0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+        "/",
+        "xfs",
+        "defaults",
+        "0",
+        "0"
+      ],
+      [
         "UUID=7B77-95E7",
         "/boot/efi",
         "vfat",
         "defaults,uid=0,gid=0,umask=077,shortname=winnt",
         "0",
         "2"
-      ],
-      [
-        "UUID=efe8afea-c0a8-45dc-8e6e-499279f6fa5d",
-        "/",
-        "xfs",
-        "defaults",
-        "0",
-        "0"
       ]
     ],
     "groups": [
@@ -9248,7 +9248,7 @@
         "size": 4187995648,
         "start": 106954752,
         "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
-        "uuid": "efe8afea-c0a8-45dc-8e6e-499279f6fa5d"
+        "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8"
       }
     ],
     "passwd": [


### PR DESCRIPTION
Imagine this situation: You have a RHEL system booted from an image produced
by osbuild-composer. On this system, you want to use osbuild-composer to
create another image of RHEL.

However, there's currently something funny with partitions:

All RHEL images built by osbuild-composer contain a root xfs partition. The
interesting bit is that they all share the same xfs partition UUID. This might
sound like a good thing for reproducibility but it has a quirk.

The issue appears when osbuild runs the qemu assembler: it needs to mount all
partitions of the future image to copy the OS tree into it.

Imagine that osbuild-composer is running on a system booted from an image
produced by osbuild-composer. This means that its root xfs partition has this
uuid:

efe8afea-c0a8-45dc-8e6e-499279f6fa5d

When osbuild-composer builds an image on this system, it runs osbuild that
runs the qemu assembler at some point. As I said previously, it will mount
all partitions of the future image. That means that it will also try to
mount the root xfs partition with this uuid:

efe8afea-c0a8-45dc-8e6e-499279f6fa5d

Do you remember this one? Yeah, it's the same one as before. However, the xfs
kernel driver doesn't like that. It contains a global table[1] of all xfs
partitions that forbids to mount 2 xfs partitions with the same uuid.

I mean... uuids are meant to be unique, right?

This commit changes the way we build RHEL 8.4 images: Each one now has a
unique uuid. It's now literally a unique universally unique identifier. haha

\[1\]: https://github.com/torvalds/linux/blob/a349e4c659609fd20e4beea89e5c4a4038e33a95/fs/xfs/xfs_mount.c#L51