### PR TITLE
composer: seed the random number generator

### DIFF
--- a/internal/cloudapi/server.go
+++ b/internal/cloudapi/server.go
@@ -3,9 +3,11 @@
 package cloudapi
 
 import (
+	"crypto/rand"
 	"encoding/json"
 	"fmt"
-	"math/rand"
+	"math"
+	"math/big"
 	"net/http"
 
 	"github.com/go-chi/chi"
@@ -83,7 +85,11 @@ func (server *Server) Compose(w http.ResponseWriter, r *http.Request) {
 	var targets []*target.Target
 
 	// use the same seed for all images so we get the same IDs
-	manifestSeed := rand.Int63()
+	bigSeed, err := rand.Int(rand.Reader, big.NewInt(math.MaxInt64))
+	if err != nil {
+		panic("cannot generate a manifest seed: " + err.Error())
+	}
+	manifestSeed := bigSeed.Int64()
 
 	for i, ir := range request.ImageRequests {
 		arch, err := distribution.GetArch(ir.Architecture)

--- a/internal/kojiapi/server.go
+++ b/internal/kojiapi/server.go
@@ -2,10 +2,12 @@
 package kojiapi
 
 import (
+	"crypto/rand"
 	"encoding/json"
 	"fmt"
 	"log"
-	"math/rand"
+	"math"
+	"math/big"
 	"net/http"
 	"strings"
 	"time"
@@ -89,7 +91,11 @@ func (h *apiHandlers) PostCompose(ctx echo.Context) error {
 	kojiDirectory := "osbuild-composer-koji-" + uuid.New().String()
 
 	// use the same seed for all images so we get the same IDs
-	manifestSeed := rand.Int63()
+	bigSeed, err := rand.Int(rand.Reader, big.NewInt(math.MaxInt64))
+	if err != nil {
+		panic("cannot generate a manifest seed: " + err.Error())
+	}
+	manifestSeed := bigSeed.Int64()
 
 	for i, ir := range request.ImageRequests {
 		arch, err := d.GetArch(ir.Architecture)


### PR DESCRIPTION
I thought rand in Go is auto-seeded but I was wrong, see \[1\].
This commit adds seed initialization.

\[1\]: https://golang.org/pkg/math/rand/#Seed