### PR TITLE
Docker-compose and Dockerfile for worker container

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -52,19 +52,36 @@ containers. Building and starting containers is generally faster than building
 RPMs and installing them in a VM, so this method is more convenient for
 developing and testing changes quickly.
 
+### Configuration
+
 Each service (*composer* and *worker*) requires a configuration file and a set
-of certificates. Use the [`tools/gen-certs.sh`](./tools/gen-certs.sh) script to
+of certificates. The storage location for these is shared between the
+containers for simplicity. By default it's configured to be at
+`./containers/config`, but this can be changed in the
+[`./distribution/.env`](./distribution/.env) file by modifying the value of the
+`$CONTAIN£R_CONFIG_DIR` variable (both absolute and relative paths work).
+
+Use the [`tools/gen-certs.sh`](./tools/gen-certs.sh) script to
 generate the certificates (using the test OpenSSL config file):
 
     ./tools/gen-certs.sh ./test/data/x509/openssl.cnf ./containers/config  ./containers/config/ca
 
-The services also require a config file (each) which they expect to be in the
+Note that the two arguments `./containers/config` and `./containers/config/ca`
+should be the same location as the `$CONTAINER_CONFIG_DIR` described above
+
+The services also require a config file each which they expect to be in the
 same directory. The following test files can be copied into it:
 
     cp ./test/data/composer/osbuild-composer.toml ./test/data/composer/osbuild-worker.toml ./containers/config/
 
-The `containers/config` directory will be mounted inside both containers (see
+The `$CONTAINER_CONFIG_DIR` (default `containers/config`) directory will be mounted inside both containers (see
 the [`docker-composer.yml`](./distribution/docker-compose.yml) file).
+
+### Build and run
+
+To build the containers, change into the `distribution/` directory and run:
+
+    docker-compose build
 
 To start the containers, change into the `distribution/` directory and run:
 

--- a/HACKING.md
+++ b/HACKING.md
@@ -50,7 +50,18 @@ unit tests before going through the full workflow described above.
 *osbuild-composer* and *osbuild-composer-worker* can be run using Docker
 containers. Building and starting containers is generally faster than building
 RPMs and installing them in a VM, so this method is more convenient for
-developing and testing changes quickly.
+developing and testing changes quickly. However, using this method has several
+downsides:
+- It doesn't build the RPMs so the `.spec` file isn't tested.
+- The environment is quite different from production (e.g., installation paths,
+  privileges and permissions).
+- The setup is not complete for all required services, so some functionality
+  isn't available for testing this way (e.g., Koji Hub and all its dependent
+  services).
+
+The containers are a good way to quickly test small changes, but before
+submitting a Pull Request, it's recommended to run through all the tests using
+the [Virtual Machine](#virtual-machine) setup described above.
 
 ### Configuration
 

--- a/HACKING.md
+++ b/HACKING.md
@@ -1,5 +1,7 @@
 # Hacking on osbuild-composer
 
+## Virtual Machine
+
 *osbuild-composer* cannot be run from the source tree, but has to be installed
 onto a system. We recommend doing this by building rpms, with:
 
@@ -42,3 +44,37 @@ For a quick compile and debug cycle, we recommend iterating code using thorough
 unit tests before going through the full workflow described above.
 
 [1]: https://wiki.qemu.org/Documentation/Networking#User_Networking_.28SLIRP.29
+
+## Containers
+
+*osbuild-composer* and *osbuild-composer-worker* can be run using Docker
+containers. Building and starting containers is generally faster than building
+RPMs and installing them in a VM, so this method is more convenient for
+developing and testing changes quickly.
+
+Each service (*composer* and *worker*) requires a configuration file and a set
+of certificates. Use the [`tools/gen-certs.sh`](./tools/gen-certs.sh) script to
+generate the certificates (using the test OpenSSL config file):
+
+    ./tools/gen-certs.sh ./test/data/x509/openssl.cnf ./containers/config  ./containers/config/ca
+
+The services also require a config file (each) which they expect to be in the
+same directory. The following test files can be copied into it:
+
+    cp ./test/data/composer/osbuild-composer.toml ./test/data/composer/osbuild-worker.toml ./containers/config/
+
+The `containers/config` directory will be mounted inside both containers (see
+the [`docker-composer.yml`](./distribution/docker-compose.yml) file).
+
+To start the containers, change into the `distribution/` directory and run:
+
+    docker-compose up
+
+You can send requests to the *osbuild-composer* container directly using the
+generated certificate and client key. For example, from the project root, run:
+
+    curl -k --cert ./containers/config/client-crt.pem --key ./containers/config/client-key.pem https://172.30.0.10:9196/api/composer-koji/v1/status
+
+To rebuild the containers after a change, add the `--build` flag to the `docker-compose` command:
+
+    docker-compose up --build

--- a/distribution/.env
+++ b/distribution/.env
@@ -1,0 +1,1 @@
+COMPOSE_PROJECT_NAME=osbuild

--- a/distribution/.env
+++ b/distribution/.env
@@ -1,1 +1,2 @@
 COMPOSE_PROJECT_NAME=osbuild
+CONTAINER_CONFIG_DIR=../containers/config

--- a/distribution/Dockerfile-ubi
+++ b/distribution/Dockerfile-ubi
@@ -4,7 +4,7 @@ ENV GOFLAGS=-mod=vendor
 RUN go install ./cmd/osbuild-composer/
 
 FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
-RUN microdnf install python3
+RUN microdnf install python3 python3-dnf
 RUN mkdir -p "/usr/libexec/osbuild-composer"
 RUN mkdir -p "/etc/osbuild-composer/"
 RUN mkdir -p "/run/osbuild-composer/"

--- a/distribution/Dockerfile-worker
+++ b/distribution/Dockerfile-worker
@@ -1,0 +1,15 @@
+FROM registry.access.redhat.com/ubi8/go-toolset:latest AS builder
+COPY . .
+ENV GOFLAGS=-mod=vendor
+RUN go install ./cmd/osbuild-worker
+
+FROM fedora
+RUN dnf install -y qemu-img osbuild osbuild-ostree
+RUN mkdir -p "/usr/libexec/osbuild-composer"
+RUN mkdir -p "/etc/osbuild-composer/"
+RUN mkdir -p "/run/osbuild-composer/"
+RUN mkdir -p "/var/cache/osbuild-composer/"
+RUN mkdir -p "/var/lib/osbuild-composer/"
+COPY --from=builder /opt/app-root/src/go/bin/osbuild-worker /usr/libexec/osbuild-composer/
+
+ENTRYPOINT ["/usr/libexec/osbuild-composer/osbuild-worker"]

--- a/distribution/docker-compose.yml
+++ b/distribution/docker-compose.yml
@@ -1,0 +1,40 @@
+version: '2.4'
+services:
+  composer:
+    image: local/osbuild-composer
+    build:
+      context: ..
+      dockerfile: ./distribution/Dockerfile-ubi
+    volumes:
+      - ../containers/config:/etc/osbuild-composer
+    networks:
+      net:
+        ipv4_address: 172.30.0.10
+  worker:
+    image: local/osbuild-worker
+    build:
+      context: ..
+      dockerfile: ./distribution/Dockerfile-worker
+    # override the entrypoint to specify composer hostname and port
+    entrypoint: /usr/libexec/osbuild-composer/osbuild-worker composer:8700
+    volumes:
+      - ../containers/config:/etc/osbuild-composer
+    environment:
+      - CACHE_DIRECTORY=/var/cache/osbuild-worker
+    privileged: true
+    cap_add:
+      - MKNOD
+      - SYS_ADMIN
+      - NET_ADMIN
+    networks:
+      net:
+        ipv4_address: 172.30.0.20
+    depends_on:
+      - "composer"
+
+networks:
+  net:
+    ipam:
+      driver: default
+      config:
+        - subnet: 172.30.0.0/16

--- a/distribution/docker-compose.yml
+++ b/distribution/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       context: ..
       dockerfile: ./distribution/Dockerfile-ubi
     volumes:
-      - ../containers/config:/etc/osbuild-composer
+      - ${CONTAINER_CONFIG_DIR}/:/etc/osbuild-composer
     networks:
       net:
         ipv4_address: 172.30.0.10
@@ -18,7 +18,7 @@ services:
     # override the entrypoint to specify composer hostname and port
     entrypoint: /usr/libexec/osbuild-composer/osbuild-worker composer:8700
     volumes:
-      - ../containers/config:/etc/osbuild-composer
+      - ${CONTAINER_CONFIG_DIR}/:/etc/osbuild-composer
     environment:
       - CACHE_DIRECTORY=/var/cache/osbuild-worker
     privileged: true

--- a/osbuild-composer.spec
+++ b/osbuild-composer.spec
@@ -179,6 +179,7 @@ install -m 0755 -vp _bin/osbuild-auth-tests                     %{buildroot}%{_l
 install -m 0755 -vp _bin/osbuild-koji-tests                     %{buildroot}%{_libexecdir}/osbuild-composer-test/
 install -m 0755 -vp _bin/cloud-cleaner                          %{buildroot}%{_libexecdir}/osbuild-composer-test/
 install -m 0755 -vp tools/provision.sh                          %{buildroot}%{_libexecdir}/osbuild-composer-test/
+install -m 0755 -vp tools/gen-certs.sh                          %{buildroot}%{_libexecdir}/osbuild-composer-test/
 install -m 0755 -vp tools/image-info                            %{buildroot}%{_libexecdir}/osbuild-composer-test/
 install -m 0755 -vp tools/run-koji-container.sh                 %{buildroot}%{_libexecdir}/osbuild-composer-test/
 install -m 0755 -vp tools/koji-compose.py                       %{buildroot}%{_libexecdir}/osbuild-composer-test/

--- a/tools/gen-certs.sh
+++ b/tools/gen-certs.sh
@@ -45,7 +45,7 @@ pushd "$CADIR"
         -new -nodes \
         -out /tmp/composer-csr.pem \
         -subj "/CN=localhost/emailAddress=osbuild@example.com" \
-        -addext "subjectAltName=DNS:localhost"
+        -addext "subjectAltName=DNS:localhost, DNS:composer"
 
     openssl ca -batch -config "$OPENSSL_CONFIG" \
         -extensions osbuild_server_ext \
@@ -58,7 +58,7 @@ pushd "$CADIR"
         -new -nodes \
         -out /tmp/worker-csr.pem \
         -subj "/CN=localhost/emailAddress=osbuild@example.com" \
-        -addext "subjectAltName=DNS:localhost"
+        -addext "subjectAltName=DNS:localhost, DNS:worker"
 
     openssl ca -batch -config "$OPENSSL_CONFIG" \
         -extensions osbuild_client_ext \

--- a/tools/gen-certs.sh
+++ b/tools/gen-certs.sh
@@ -1,0 +1,97 @@
+#!/bin/bash
+if (( $# != 3 )); then
+    echo "Usage: $0 <openssl-config> <certdir> <cadir>"
+    echo
+    echo "Positional arguments"
+    echo "  <openssl-config>  OpenSSL configuration file"
+    echo "  <certdir>         Destination directory for the generated files"
+    echo "  <cadir>           Working directory for the generation process"
+    exit 1
+fi
+
+set -euxo pipefail
+# Generate all X.509 certificates for the tests
+# The whole generation is done in a $CADIR to better represent how osbuild-ca
+# it.
+OPENSSL_CONFIG="$1"
+CERTDIR="$2"
+CADIR="$3"
+
+# The $CADIR might exist from a previous test (current Schutzbot's imperfection)
+rm -rf "$CADIR" || true
+mkdir -p "$CADIR" "$CERTDIR"
+
+# Convert the arguments to real paths so we can safely change working directory
+OPENSSL_CONFIG="$(realpath "${OPENSSL_CONFIG}")"
+CERTDIR="$(realpath "${CERTDIR}")"
+CADIR="$(realpath "${CADIR}")"
+
+pushd "$CADIR"
+    mkdir certs private
+    touch index.txt
+
+    # Generate a CA.
+    openssl req -config "$OPENSSL_CONFIG" \
+        -keyout private/ca.key.pem \
+        -new -nodes -x509 -extensions osbuild_ca_ext \
+        -out ca.cert.pem -subj "/CN=osbuild.org"
+
+    # Copy the private key to the location expected by the tests
+    cp ca.cert.pem "$CERTDIR"/ca-crt.pem
+
+    # Generate a composer certificate.
+    openssl req -config "$OPENSSL_CONFIG" \
+        -keyout "$CERTDIR"/composer-key.pem \
+        -new -nodes \
+        -out /tmp/composer-csr.pem \
+        -subj "/CN=localhost/emailAddress=osbuild@example.com" \
+        -addext "subjectAltName=DNS:localhost"
+
+    openssl ca -batch -config "$OPENSSL_CONFIG" \
+        -extensions osbuild_server_ext \
+        -in /tmp/composer-csr.pem \
+        -out "$CERTDIR"/composer-crt.pem
+
+    # Generate a worker certificate.
+    openssl req -config "$OPENSSL_CONFIG" \
+        -keyout "$CERTDIR"/worker-key.pem \
+        -new -nodes \
+        -out /tmp/worker-csr.pem \
+        -subj "/CN=localhost/emailAddress=osbuild@example.com" \
+        -addext "subjectAltName=DNS:localhost"
+
+    openssl ca -batch -config "$OPENSSL_CONFIG" \
+        -extensions osbuild_client_ext \
+        -in /tmp/worker-csr.pem \
+        -out "$CERTDIR"/worker-crt.pem
+
+    # Generate a client certificate.
+    openssl req -config "$OPENSSL_CONFIG" \
+        -keyout "$CERTDIR"/client-key.pem \
+        -new -nodes \
+        -out /tmp/client-csr.pem \
+        -subj "/CN=client.osbuild.org/emailAddress=osbuild@example.com" \
+        -addext "subjectAltName=DNS:client.osbuild.org"
+
+    openssl ca -batch -config "$OPENSSL_CONFIG" \
+        -extensions osbuild_client_ext \
+        -in /tmp/client-csr.pem \
+        -out "$CERTDIR"/client-crt.pem
+
+    # Client keys are used by tests to access the composer APIs. Allow all users access.
+    chmod 644 "$CERTDIR"/client-key.pem
+
+    # Generate a kojihub certificate.
+    openssl req -config "$OPENSSL_CONFIG" \
+        -keyout "$CERTDIR"/kojihub-key.pem \
+        -new -nodes \
+        -out /tmp/kojihub-csr.pem \
+        -subj "/CN=localhost/emailAddress=osbuild@example.com" \
+        -addext "subjectAltName=DNS:localhost"
+
+    openssl ca -batch -config "$OPENSSL_CONFIG" \
+        -extensions osbuild_server_ext \
+        -in /tmp/kojihub-csr.pem \
+        -out "$CERTDIR"/kojihub-crt.pem
+
+popd


### PR DESCRIPTION
Adding *osbuild-composer-worker* Dockerfile (`Dockerfile-worker`) and a `docker-compose.yml` file that makes it straightforward to set up a multi-container environment.  This is a lot faster than building RPMs and installing them in VMs for when you need to do quick compile-debug cycles.

## SSL cert generation script

The biggest change to existing tools is the SSL certificate generation script: I've moved the cert generation parts from `tools/provisioning.sh` into a new file (`tools/gen-certs.sh`).  The original workflow that uses this script should be unaffected, but having the cert generation separate makes it easy to quickly create certificates and keys in any directory using the `openssl.cnf` file from any location.

## HACKING.md

I added a section to HACKING.md that explains how to get the Docker setup up and running.  The docker-compose.yml file points to the Dockerfiles directly, so running `docker-compose up` the first time will build the images as well.

## File location

I added the new docker files to the `distribution` directory because that's where the `Dockerfile-ubi` file is kept.  I was thinking it might be more appropriate to put these in the `containers` directory instead.  Any thoughts on this?

You might also notice an `.env` file that defines the project name.  For those unfamiliar with docker-compose, this affects the names of the containers, networks, and volumes that are created.  In our case, naming the project `osbuild` makes the containers have the names `osbuild_composer_1` and `osbuild_worker_1` and the network gets named `osbuild_net`.

## Other

Added `python-dnf` to the *osbuild-composer* Dockerfile (`Dockerfile-ubi`), since it's required by the `dnf-json` script.