### PR TITLE
kojiapi,cloudapi: exclude packages when depsolving

### DIFF
--- a/internal/cloudapi/server.go
+++ b/internal/cloudapi/server.go
@@ -125,8 +125,8 @@ func (server *Server) Compose(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		packageSpecs, _ := imageType.Packages(bp)
-		packages, _, err := server.rpmMetadata.Depsolve(packageSpecs, nil, repositories, distribution.ModulePlatformID(), arch.Name())
+		packageSpecs, excludePackageSpecs := imageType.Packages(bp)
+		packages, _, err := server.rpmMetadata.Depsolve(packageSpecs, excludePackageSpecs, repositories, distribution.ModulePlatformID(), arch.Name())
 		if err != nil {
 			http.Error(w, fmt.Sprintf("Failed to depsolve base packages for %s/%s/%s: %s", ir.ImageType, ir.Architecture, request.Distribution, err), http.StatusInternalServerError)
 			return

--- a/internal/kojiapi/server.go
+++ b/internal/kojiapi/server.go
@@ -118,8 +118,8 @@ func (h *apiHandlers) PostCompose(ctx echo.Context) error {
 		if err != nil {
 			panic("Could not initialize empty blueprint.")
 		}
-		packageSpecs, _ := imageType.Packages(*bp)
-		packages, _, err := h.server.rpmMetadata.Depsolve(packageSpecs, nil, repositories, d.ModulePlatformID(), arch.Name())
+		packageSpecs, excludePackageSpecs := imageType.Packages(*bp)
+		packages, _, err := h.server.rpmMetadata.Depsolve(packageSpecs, excludePackageSpecs, repositories, d.ModulePlatformID(), arch.Name())
 		if err != nil {
 			return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Failed to depsolve base base packages for %s/%s/%s: %s", ir.ImageType, ir.Architecture, request.Distribution, err))
 		}


### PR DESCRIPTION
When rpmmd's Depsolve function is called we need to pass in the image type's excluded packages. These excluded packages are retrieved when we get the packages we include from each image type.

This should fix the issue we've been seeing with brew builds including excluded packages such as firewalld.

Thanks @ondrejbudai for the help figuring this out!!