### PR TITLE
tools: Fix checking of args number in deploy-qemu script

### DIFF
--- a/tools/deploy-qemu
+++ b/tools/deploy-qemu
@@ -17,7 +17,7 @@
 
 set -euo pipefail
 
-if [[ -z "$1" || -z "$2" ]]; then
+if [[ "$#" != 2 ]]; then
   echo "usage: $0 IMAGE USERDATA"
   exit 1
 fi


### PR DESCRIPTION
When the deploy-qemu script is run with less than 2 arguments, it ended
with error, instead of printing usage. This was due to using 'set -u' and
trying to expand unset variables "$1" and "$2" as part of checking if
they were provided. The issue has been fixed by checking number of
provided arguments, instead of their content. The same approach is used
in 'deploy-openstack' script.