### PR TITLE
image-types: Updated RHEL-8 KVM and EC2 images information

### DIFF
--- a/image-types/rhel8/amazon-ec2.md
+++ b/image-types/rhel8/amazon-ec2.md
@@ -23,7 +23,16 @@ package depends on it.
 `dracut-config-rescue` is excluded from the image, because the boot loader
 entry it provides is broken.
 
+The most common way to consume official Red Hat content using this type of
+image is via [Red Hat Update Infrastructure (RHUI)][rhui]. RHUI is used mostly
+for Red Hat Enterprise Linux (RHEL) content, including some of its extensions
+(e.g. for SAP). To access any more specific Red Hat content, one has to use
+[Red Hat Subscription Management (RHSM)][rhsm] ([Red Hat Satellite][satellite]
+/ Red Hat CDN).
 
 [ec2]: https://aws.amazon.com/ec2
 [guidelines]: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/building-shared-amis.html
 [requirements]: https://docs.aws.amazon.com/vm-import/latest/userguide/vmie_prereqs.html
+[rhui]: https://access.redhat.com/products/red-hat-update-infrastructure/
+[rhsm]: https://access.redhat.com/products/red-hat-subscription-management
+[satellite]: https://access.redhat.com/products/red-hat-satellite/

--- a/image-types/rhel8/kvm-guest-image.md
+++ b/image-types/rhel8/kvm-guest-image.md
@@ -1,7 +1,10 @@
 # KVM Guest Image
 
-This is an image meant to be used as a generic base image for various
-virtualization environments.
+This is an image meant to be used as a generic base image for KVM
+based hypervisors. It is mainly used with [Red Hat Virtualization
+(RHV)][rhv] or [Red Hat OpenStack Platform (RHOSP)][rhosp]. Using this
+type of image with other types of hypervisors or with cloud providers
+is not supported.
 
 To be usable in common environments, it is provided in the *qcow2* format and
 has *cloud-init* installed and enabled.
@@ -16,3 +19,12 @@ The environments this image is meant to be used in usually don't require any
 specialized firmware. Thus, in order to keep the resulting image size small,
 all `-firmware` packages are excluded. An exception is the `linux-firmware`
 package, which cannot be excluded because the `kernel` package depends on it.
+
+The most common way to consume official Red Hat content using this type of
+image is via [Red Hat Subscription Management (RHSM)][rhsm] ([Red Hat
+Satellite][satellite] / Red Hat CDN).
+
+[rhv]: https://access.redhat.com/products/red-hat-virtualization/
+[rhosp]: https://access.redhat.com/products/red-hat-openstack-platform/
+[rhsm]: https://access.redhat.com/products/red-hat-subscription-management
+[satellite]: https://access.redhat.com/products/red-hat-satellite/


### PR DESCRIPTION
Updated RHEL-8 KVM and EC2 images information.

Updates in KVM image type:
- Updated the intended use of this image type, based on discussion with Virt PM.
- Added note about the most common way to consume official Red Hat content using this image type.

Updates in EC2 image type:
- Added note about the most common way to consume official Red Hat content using this image type.