### PR TITLE
distro/rhel84: use New York as default timezone

### DIFF
--- a/internal/distro/rhel84/distro.go
+++ b/internal/distro/rhel84/distro.go
@@ -295,6 +295,8 @@ func (t *imageType) pipeline(c *blueprint.Customizations, options distro.ImageOp
 
 	if timezone != nil {
 		p.AddStage(osbuild.NewTimezoneStage(&osbuild.TimezoneStageOptions{Zone: *timezone}))
+	} else {
+		p.AddStage(osbuild.NewTimezoneStage(&osbuild.TimezoneStageOptions{Zone: "America/New_York"}))
 	}
 
 	if len(ntpServers) > 0 {

--- a/test/data/manifests/rhel_84-x86_64-ami-boot.json
+++ b/test/data/manifests/rhel_84-x86_64-ami-boot.json
@@ -3098,6 +3098,12 @@
           }
         },
         {
+          "name": "org.osbuild.timezone",
+          "options": {
+            "zone": "America/New_York"
+          }
+        },
+        {
           "name": "org.osbuild.selinux",
           "options": {
             "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
@@ -9216,6 +9222,6 @@
       "tuned.service",
       "unbound-anchor.timer"
     ],
-    "timezone": "UTC"
+    "timezone": "New_York"
   }
 }

--- a/test/data/manifests/rhel_84-x86_64-openstack-boot.json
+++ b/test/data/manifests/rhel_84-x86_64-openstack-boot.json
@@ -3337,6 +3337,12 @@
           }
         },
         {
+          "name": "org.osbuild.timezone",
+          "options": {
+            "zone": "America/New_York"
+          }
+        },
+        {
           "name": "org.osbuild.users",
           "options": {
             "users": {
@@ -9844,6 +9850,6 @@
       "tuned.service",
       "unbound-anchor.timer"
     ],
-    "timezone": "UTC"
+    "timezone": "New_York"
   }
 }

--- a/test/data/manifests/rhel_84-x86_64-qcow2-boot.json
+++ b/test/data/manifests/rhel_84-x86_64-qcow2-boot.json
@@ -3466,6 +3466,12 @@
           }
         },
         {
+          "name": "org.osbuild.timezone",
+          "options": {
+            "zone": "America/New_York"
+          }
+        },
+        {
           "name": "org.osbuild.users",
           "options": {
             "users": {
@@ -10217,6 +10223,6 @@
       "tuned.service",
       "unbound-anchor.timer"
     ],
-    "timezone": "UTC"
+    "timezone": "New_York"
   }
 }

--- a/test/data/manifests/rhel_84-x86_64-vhd-boot.json
+++ b/test/data/manifests/rhel_84-x86_64-vhd-boot.json
@@ -3292,6 +3292,12 @@
           }
         },
         {
+          "name": "org.osbuild.timezone",
+          "options": {
+            "zone": "America/New_York"
+          }
+        },
+        {
           "name": "org.osbuild.users",
           "options": {
             "users": {
@@ -9754,6 +9760,6 @@
       "unbound-anchor.timer",
       "waagent.service"
     ],
-    "timezone": "UTC"
+    "timezone": "New_York"
   }
 }

--- a/test/data/manifests/rhel_84-x86_64-vmdk-boot.json
+++ b/test/data/manifests/rhel_84-x86_64-vmdk-boot.json
@@ -3154,6 +3154,12 @@
           }
         },
         {
+          "name": "org.osbuild.timezone",
+          "options": {
+            "zone": "America/New_York"
+          }
+        },
+        {
           "name": "org.osbuild.users",
           "options": {
             "users": {
@@ -9363,6 +9369,6 @@
       "vgauthd.service",
       "vmtoolsd.service"
     ],
-    "timezone": "UTC"
+    "timezone": "New_York"
   }
 }


### PR DESCRIPTION
RHEl 8.4 guest images need to have the default time zone of EST/EDT unless the user specifies one in their blueprint. New York is a major location for this time zone.