### PR TITLE
Introduce docs/news and start a checklist in the PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,8 +1,8 @@
-# Description
+<!--
+Thanks for proposing a change to osbuild-composer!
 
-
-
-**Downstream testing notes:**
+If this pull request fixes a downstream issue, please refer to test/README.md
+and uncomment this checklist:
 
 - [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
 - [ ] PR contains automated tests for new functionality and
@@ -10,4 +10,4 @@
 - [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
 - [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`
 
-For more info see [test/README.md](../test/README.md#downstream-testing-notes)!
+-->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,13 +1,28 @@
+
+This pull request includes:
+
+- [ ] adequate testing for the new functionality or fixed issue
+- [ ] adequate documentation informing people about the change
+
 <!--
 Thanks for proposing a change to osbuild-composer!
 
-If this pull request fixes a downstream issue, please refer to test/README.md
-and uncomment this checklist:
+Please don't remove the above check list. These are things that each pull
+request must have before it is merged. It helps maintainers to not forget
+anything.
+
+If the reason for ticking any of the boxes is ambiguous, please add a short
+note explaining why.
+
+For user-visible changes, "adequate documentation" is an entry describing the
+change for users in docs/news. Please refer to docs/news/README.md for details.
+
+In addition, if this pull request fixes a downstream issue, please refer to
+test/README.md and add these additional items:
 
 - [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
 - [ ] PR contains automated tests for new functionality and
 - [ ] QE has approved reproducer/new tests and
 - [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
 - [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`
-
 -->

--- a/docs/news/README.md
+++ b/docs/news/README.md
@@ -1,0 +1,12 @@
+# Release Notes
+
+This directory contains release notes for _osbuild-composer_ in the form of
+short markdown documents, sorted into subdirectories by release.
+
+When proposing a user-visible change, please add a release note into the
+`unreleased` directory. The note should explain the change from the perspective
+of somebody using _osbuild-composer_ and ideally how the change affects them or
+how they can make use of new functionality.
+
+When preparing a release, a maintainer will rename the `unreleased` directory
+and summarize its contents in `NEWS.md`.


### PR DESCRIPTION
As we discussed last year. I really liked @ondrejbudai's idea of collecting release note entries for unreleased stuff in `docs/news`.

I've kept the checklist short for now. Suggestions for more items are very welcome :)