### PR TITLE
Koji: Retrieve the Manifests for a compose job

### DIFF
--- a/internal/jobqueue/fsjobqueue/fsjobqueue.go
+++ b/internal/jobqueue/fsjobqueue/fsjobqueue.go
@@ -287,6 +287,16 @@ func (q *fsJobQueue) JobStatus(id uuid.UUID) (result json.RawMessage, queued, st
 	return
 }
 
+func (q *fsJobQueue) JobArgs(id uuid.UUID) (args json.RawMessage, err error) {
+	j, err := q.readJob(id)
+	if err != nil {
+		return
+	}
+
+	args = j.Args
+	return
+}
+
 // Reads job with `id`. This is a thin wrapper around `q.db.Read`, which
 // returns the job directly, or and error if a job with `id` does not exist.
 func (q *fsJobQueue) readJob(id uuid.UUID) (*job, error) {

--- a/internal/jobqueue/fsjobqueue/fsjobqueue_test.go
+++ b/internal/jobqueue/fsjobqueue/fsjobqueue_test.go
@@ -103,6 +103,11 @@ func TestArgs(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, twoargs, parsedArgs)
 
+	// Read args after Dequeue
+	jargs, err := q.JobArgs(id)
+	require.NoError(t, err)
+	require.Equal(t, args, jargs)
+
 	id, deps, typ, args, err = q.Dequeue(context.Background(), []string{"fish"})
 	require.NoError(t, err)
 	require.Equal(t, one, id)
@@ -111,6 +116,14 @@ func TestArgs(t *testing.T) {
 	err = json.Unmarshal(args, &parsedArgs)
 	require.NoError(t, err)
 	require.Equal(t, oneargs, parsedArgs)
+
+	// Read args directly after Dequeue
+	jargs, err = q.JobArgs(id)
+	require.NoError(t, err)
+	require.Equal(t, args, jargs)
+
+	_, err = q.JobArgs(uuid.New())
+	require.Error(t, err)
 }
 
 func TestJobTypes(t *testing.T) {

--- a/internal/jobqueue/jobqueue.go
+++ b/internal/jobqueue/jobqueue.go
@@ -59,6 +59,9 @@ type JobQueue interface {
 	//
 	// Lastly, the IDs of the jobs dependencies are returned.
 	JobStatus(id uuid.UUID) (result json.RawMessage, queued, started, finished time.Time, canceled bool, deps []uuid.UUID, err error)
+
+	// Returns the job's arguments in Raw form.
+	JobArgs(id uuid.UUID) (args json.RawMessage, err error)
 }
 
 var (

--- a/internal/kojiapi/api/api.gen.go
+++ b/internal/kojiapi/api/api.gen.go
@@ -87,6 +87,9 @@ type ServerInterface interface {
 	// Get logs for a compose.
 	// (GET /compose/{id}/logs)
 	GetComposeIdLogs(ctx echo.Context, id string) error
+	// Get the manifests for a compose.
+	// (GET /compose/{id}/manifests)
+	GetComposeIdManifests(ctx echo.Context, id string) error
 	// status
 	// (GET /status)
 	GetStatus(ctx echo.Context) error
@@ -138,6 +141,22 @@ func (w *ServerInterfaceWrapper) GetComposeIdLogs(ctx echo.Context) error {
 	return err
 }
 
+// GetComposeIdManifests converts echo context to params.
+func (w *ServerInterfaceWrapper) GetComposeIdManifests(ctx echo.Context) error {
+	var err error
+	// ------------- Path parameter "id" -------------
+	var id string
+
+	err = runtime.BindStyledParameter("simple", false, "id", ctx.Param("id"), &id)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter id: %s", err))
+	}
+
+	// Invoke the callback with all the unmarshalled arguments
+	err = w.Handler.GetComposeIdManifests(ctx, id)
+	return err
+}
+
 // GetStatus converts echo context to params.
 func (w *ServerInterfaceWrapper) GetStatus(ctx echo.Context) error {
 	var err error
@@ -172,6 +191,7 @@ func RegisterHandlers(router EchoRouter, si ServerInterface) {
 	router.POST("/compose", wrapper.PostCompose)
 	router.GET("/compose/:id", wrapper.GetComposeId)
 	router.GET("/compose/:id/logs", wrapper.GetComposeIdLogs)
+	router.GET("/compose/:id/manifests", wrapper.GetComposeIdManifests)
 	router.GET("/status", wrapper.GetStatus)
 
 }

--- a/internal/kojiapi/api/openapi.yml
+++ b/internal/kojiapi/api/openapi.yml
@@ -87,6 +87,36 @@ paths:
             text/plain:
               schema:
                 type: string
+  '/compose/{id}/manifests':
+    get:
+      summary: Get the manifests for a compose.
+      parameters:
+        - in: path
+          name: id
+          schema:
+            type: string
+            format: uuid
+            example: 123e4567-e89b-12d3-a456-426655440000
+          required: true
+          description: ID of compose status to get
+      description: 'Get the manifests of a running or finished compose. Returns one manifest for each image in the request. Each manifest conforms to the format defined at https://www.osbuild.org/man/osbuild-manifest.5'
+      responses:
+        '200':
+          description: The manifest for the given compose.
+          content:
+            application/json:
+        '400':
+          description: Invalid compose id
+          content:
+            text/plain:
+              schema:
+                type: string
+        '404':
+          description: Unknown compose id
+          content:
+            text/plain:
+              schema:
+                type: string
   /compose:
     post:
       summary: Create compose

--- a/internal/kojiapi/server.go
+++ b/internal/kojiapi/server.go
@@ -155,7 +155,7 @@ func (h *apiHandlers) PostCompose(ctx echo.Context) error {
 		Release: request.Release,
 	})
 	if err != nil {
-		// This is a programming errror.
+		// This is a programming error.
 		panic(err)
 	}
 
@@ -169,7 +169,7 @@ func (h *apiHandlers) PostCompose(ctx echo.Context) error {
 			KojiFilename:  kojiFilenames[i],
 		}, initID)
 		if err != nil {
-			// This is a programming errror.
+			// This is a programming error.
 			panic(err)
 		}
 		buildIDs = append(buildIDs, id)
@@ -186,7 +186,7 @@ func (h *apiHandlers) PostCompose(ctx echo.Context) error {
 		StartTime:     uint64(time.Now().Unix()),
 	}, initID, buildIDs)
 	if err != nil {
-		// This is a programming errror.
+		// This is a programming error.
 		panic(err)
 	}
 
@@ -357,7 +357,7 @@ func (h *apiHandlers) GetComposeIdLogs(ctx echo.Context, idstr string) error {
 	var initResult worker.KojiInitJobResult
 	_, _, err = h.server.workers.JobStatus(deps[0], &initResult)
 	if err != nil {
-		// This is a programming errror.
+		// This is a programming error.
 		panic(err)
 	}
 

--- a/internal/kojiapi/server_test.go
+++ b/internal/kojiapi/server_test.go
@@ -338,6 +338,8 @@ func TestCompose(t *testing.T) {
 		test.TestRoute(t, workerHandler, false, "PATCH", fmt.Sprintf("/api/worker/v1/jobs/%v", token), string(finalizeResult), http.StatusOK, `{}`)
 
 		test.TestRoute(t, handler, false, "GET", fmt.Sprintf("/api/composer-koji/v1/compose/%v", finalizeID), ``, http.StatusOK, c.composeStatus)
+
+		test.TestRoute(t, handler, false, "GET", fmt.Sprintf("/api/composer-koji/v1/compose/%v/manifests", finalizeID), ``, http.StatusOK, `[{"pipeline": {}, "sources": {}}, {"pipeline": {}, "sources": {}}]`)
 	}
 }
 

--- a/internal/worker/server.go
+++ b/internal/worker/server.go
@@ -121,6 +121,21 @@ func (s *Server) JobStatus(id uuid.UUID, result interface{}) (*JobStatus, []uuid
 	}, deps, nil
 }
 
+// JobArgs provides access to the arguments of a job.
+func (s *Server) JobArgs(id uuid.UUID, jobArgs interface{}) (json.RawMessage, error) {
+	rawArgs, err := s.jobs.JobArgs(id)
+	if err != nil {
+		return nil, err
+	}
+
+	err = json.Unmarshal(rawArgs, jobArgs)
+	if err != nil {
+		return nil, fmt.Errorf("error unmarshaling arguments for job '%s': %v", id, err)
+	}
+
+	return rawArgs, nil
+}
+
 func (s *Server) Cancel(id uuid.UUID) error {
 	return s.jobs.CancelJob(id)
 }


### PR DESCRIPTION
Added an API endpoint that returns the manifest for a given osbuild-koji job.

The Koji API function assumes that the second dependency of the incoming job ID (which should match a Finalize Job) is the first (and perhaps only) Build Job. It retrieves the arguments of the Build Job to extract the Manifest.

The tests cover basic (non-failing) cases for now. More notable is that in all test cases the manifest is empty, which isn't very interesting.

Closes #996.