### PR TITLE
 🖼️ test/image: Fix test cases directory path in doc and code

### DIFF
--- a/cmd/osbuild-image-tests/constants/constants.go
+++ b/cmd/osbuild-image-tests/constants/constants.go
@@ -31,7 +31,7 @@ var TestPaths = struct {
 }{
 	ImageInfo:               "/usr/libexec/osbuild-composer-test/image-info",
 	PrivateKey:              "/usr/share/tests/osbuild-composer/keyring/id_rsa",
-	TestCasesDirectory:      "/usr/share/tests/osbuild-composer/cases",
+	TestCasesDirectory:      "/usr/share/tests/osbuild-composer/manifests",
 	UserData:                "/usr/share/tests/osbuild-composer/cloud-init/user-data",
 	MetaData:                "/usr/share/tests/osbuild-composer/cloud-init/meta-data",
 	AzureDeploymentTemplate: "/usr/share/tests/osbuild-composer/azure/deployment-template.json",

--- a/test/README.md
+++ b/test/README.md
@@ -60,7 +60,7 @@ tests, see `.github/workflows/tests.yml`.
 
 ## Image tests
 
-In the `test/data/cases` directory, sample image builds and their tests are
+In the `test/data/manifests` directory, sample image builds and their tests are
 collected for the various distros, architectures, configuration we support.
 
 Each test case describes how the image is built, the expected osbuild


### PR DESCRIPTION
The directory with image-tests test cases has been renamed from `cases`
to `manifests`. This has not been previously reflected in the test/README.md
and osbuild-image-tests code. osbuild-image-tests hardcodes the test
cases directory path and uses it in case no test case are passed
to it on the command line. Since the image_tests.sh CI test case looks
for image-tests test cases in the correct directory and passes the
relevant ones to osbuild-image-tests, the CI didn't detect this issue.

Running osbuild-images-tests without any argument and let it run all
test cases from the default test cases directory as part of CI probably
does not make sense. Due to this reason, I'm not adding any new test.