### PR TITLE
distro/{rhel8,rhel84}: set systemd default targets

### DIFF
--- a/internal/distro/rhel8/distro.go
+++ b/internal/distro/rhel8/distro.go
@@ -288,7 +288,7 @@ func (t *imageType) pipeline(c *blueprint.Customizations, options distro.ImageOp
 		p.AddStage(osbuild.NewUsersStage(options))
 	}
 
-	if services := c.GetServices(); services != nil || t.enabledServices != nil {
+	if services := c.GetServices(); services != nil || t.enabledServices != nil || t.disabledServices != nil || t.defaultTarget != "" {
 		p.AddStage(osbuild.NewSystemdStage(t.systemdStageOptions(t.enabledServices, t.disabledServices, services, t.defaultTarget)))
 	}
 

--- a/internal/distro/rhel84/distro.go
+++ b/internal/distro/rhel84/distro.go
@@ -315,7 +315,7 @@ func (t *imageType) pipeline(c *blueprint.Customizations, options distro.ImageOp
 		p.AddStage(osbuild.NewUsersStage(options))
 	}
 
-	if services := c.GetServices(); services != nil || t.enabledServices != nil {
+	if services := c.GetServices(); services != nil || t.enabledServices != nil || t.disabledServices != nil || t.defaultTarget != "" {
 		p.AddStage(osbuild.NewSystemdStage(t.systemdStageOptions(t.enabledServices, t.disabledServices, services, t.defaultTarget)))
 	}
 
@@ -958,6 +958,7 @@ func New() distro.Distro {
 			// https://errata.devel.redhat.com/advisory/47339 lands
 			"timedatex",
 		},
+		defaultTarget:           "multi-user.target",
 		kernelOptions:           "console=tty0 console=ttyS0,115200n8 no_timer_check net.ifnames=0 crashkernel=auto",
 		bootable:                true,
 		defaultSize:             10 * GigaByte,

--- a/test/data/manifests/fedora_32-aarch64-ami-boot.json
+++ b/test/data/manifests/fedora_32-aarch64-ami-boot.json
@@ -8902,6 +8902,7 @@
       "mdns",
       "dhcpv6-client"
     ],
+    "default-target": "graphical.target",
     "fstab": [
       [
         "UUID=46BB-8120",

--- a/test/data/manifests/fedora_32-aarch64-openstack-boot.json
+++ b/test/data/manifests/fedora_32-aarch64-openstack-boot.json
@@ -9252,6 +9252,7 @@
       "mdns",
       "dhcpv6-client"
     ],
+    "default-target": "graphical.target",
     "fstab": [
       [
         "UUID=46BB-8120",

--- a/test/data/manifests/fedora_32-aarch64-qcow2-boot.json
+++ b/test/data/manifests/fedora_32-aarch64-qcow2-boot.json
@@ -8754,6 +8754,7 @@
         "version": "5.6.6-300.fc32.aarch64"
       }
     ],
+    "default-target": "graphical.target",
     "fstab": [
       [
         "UUID=46BB-8120",

--- a/test/data/manifests/fedora_32-x86_64-ami-boot.json
+++ b/test/data/manifests/fedora_32-x86_64-ami-boot.json
@@ -9160,6 +9160,7 @@
       "mdns",
       "dhcpv6-client"
     ],
+    "default-target": "graphical.target",
     "fstab": [
       [
         "UUID=76a22bf4-f153-4541-b6c7-0332c0dfaeac",

--- a/test/data/manifests/fedora_32-x86_64-fedora_iot_commit-boot.json
+++ b/test/data/manifests/fedora_32-x86_64-fedora_iot_commit-boot.json
@@ -10135,6 +10135,7 @@
     }
   },
   "image-info": {
+    "default-target": "graphical.target",
     "firewall-enabled": [
       "ssh",
       "mdns",

--- a/test/data/manifests/fedora_32-x86_64-openstack-boot.json
+++ b/test/data/manifests/fedora_32-x86_64-openstack-boot.json
@@ -9510,6 +9510,7 @@
       "mdns",
       "dhcpv6-client"
     ],
+    "default-target": "graphical.target",
     "fstab": [
       [
         "UUID=76a22bf4-f153-4541-b6c7-0332c0dfaeac",

--- a/test/data/manifests/fedora_32-x86_64-qcow2-boot.json
+++ b/test/data/manifests/fedora_32-x86_64-qcow2-boot.json
@@ -9114,6 +9114,7 @@
         "version": "5.6.6-300.fc32.x86_64"
       }
     ],
+    "default-target": "graphical.target",
     "fstab": [
       [
         "UUID=76a22bf4-f153-4541-b6c7-0332c0dfaeac",

--- a/test/data/manifests/fedora_32-x86_64-qcow2-customize.json
+++ b/test/data/manifests/fedora_32-x86_64-qcow2-customize.json
@@ -9217,6 +9217,7 @@
         "version": "5.6.6-300.fc32.x86_64"
       }
     ],
+    "default-target": "graphical.target",
     "fstab": [
       [
         "UUID=76a22bf4-f153-4541-b6c7-0332c0dfaeac",

--- a/test/data/manifests/fedora_32-x86_64-vhd-boot.json
+++ b/test/data/manifests/fedora_32-x86_64-vhd-boot.json
@@ -8761,6 +8761,7 @@
       "mdns",
       "dhcpv6-client"
     ],
+    "default-target": "graphical.target",
     "fstab": [
       [
         "UUID=76a22bf4-f153-4541-b6c7-0332c0dfaeac",

--- a/test/data/manifests/fedora_32-x86_64-vmdk-boot.json
+++ b/test/data/manifests/fedora_32-x86_64-vmdk-boot.json
@@ -8867,6 +8867,7 @@
       "mdns",
       "dhcpv6-client"
     ],
+    "default-target": "graphical.target",
     "fstab": [
       [
         "UUID=76a22bf4-f153-4541-b6c7-0332c0dfaeac",

--- a/test/data/manifests/fedora_33-aarch64-ami-boot.json
+++ b/test/data/manifests/fedora_33-aarch64-ami-boot.json
@@ -9822,6 +9822,7 @@
       "mdns",
       "dhcpv6-client"
     ],
+    "default-target": "graphical.target",
     "fstab": [
       [
         "UUID=46BB-8120",

--- a/test/data/manifests/fedora_33-x86_64-ami-boot.json
+++ b/test/data/manifests/fedora_33-x86_64-ami-boot.json
@@ -9401,6 +9401,7 @@
       "mdns",
       "dhcpv6-client"
     ],
+    "default-target": "graphical.target",
     "fstab": [
       [
         "UUID=76a22bf4-f153-4541-b6c7-0332c0dfaeac",

--- a/test/data/manifests/fedora_33-x86_64-fedora_iot_commit-boot.json
+++ b/test/data/manifests/fedora_33-x86_64-fedora_iot_commit-boot.json
@@ -10577,6 +10577,7 @@
     }
   },
   "image-info": {
+    "default-target": "graphical.target",
     "firewall-enabled": [
       "ssh",
       "mdns",

--- a/test/data/manifests/fedora_33-x86_64-openstack-boot.json
+++ b/test/data/manifests/fedora_33-x86_64-openstack-boot.json
@@ -9716,6 +9716,7 @@
       "mdns",
       "dhcpv6-client"
     ],
+    "default-target": "graphical.target",
     "fstab": [
       [
         "UUID=76a22bf4-f153-4541-b6c7-0332c0dfaeac",

--- a/test/data/manifests/fedora_33-x86_64-qcow2-boot.json
+++ b/test/data/manifests/fedora_33-x86_64-qcow2-boot.json
@@ -9289,6 +9289,7 @@
         "version": "5.8.15-301.fc33.x86_64"
       }
     ],
+    "default-target": "graphical.target",
     "fstab": [
       [
         "UUID=76a22bf4-f153-4541-b6c7-0332c0dfaeac",

--- a/test/data/manifests/fedora_33-x86_64-qcow2-customize.json
+++ b/test/data/manifests/fedora_33-x86_64-qcow2-customize.json
@@ -9387,6 +9387,7 @@
         "version": "5.8.15-301.fc33.x86_64"
       }
     ],
+    "default-target": "graphical.target",
     "fstab": [
       [
         "UUID=76a22bf4-f153-4541-b6c7-0332c0dfaeac",

--- a/test/data/manifests/fedora_33-x86_64-vhd-boot.json
+++ b/test/data/manifests/fedora_33-x86_64-vhd-boot.json
@@ -9002,6 +9002,7 @@
       "mdns",
       "dhcpv6-client"
     ],
+    "default-target": "graphical.target",
     "fstab": [
       [
         "UUID=76a22bf4-f153-4541-b6c7-0332c0dfaeac",

--- a/test/data/manifests/fedora_33-x86_64-vmdk-boot.json
+++ b/test/data/manifests/fedora_33-x86_64-vmdk-boot.json
@@ -9289,6 +9289,7 @@
         "version": "5.8.15-301.fc33.x86_64"
       }
     ],
+    "default-target": "graphical.target",
     "fstab": [
       [
         "UUID=76a22bf4-f153-4541-b6c7-0332c0dfaeac",

--- a/test/data/manifests/rhel_8-aarch64-ami-boot.json
+++ b/test/data/manifests/rhel_8-aarch64-ami-boot.json
@@ -3158,6 +3158,12 @@
           }
         },
         {
+          "name": "org.osbuild.systemd",
+          "options": {
+            "default_target": "multi-user.target"
+          }
+        },
+        {
           "name": "org.osbuild.selinux",
           "options": {
             "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
@@ -8724,6 +8730,7 @@
         "version": "4.18.0-221.el8.aarch64"
       }
     ],
+    "default-target": "multi-user.target",
     "fstab": [
       [
         "UUID=0bd700f8-090f-4556-b797-b340297ea1bd",

--- a/test/data/manifests/rhel_8-aarch64-openstack-boot.json
+++ b/test/data/manifests/rhel_8-aarch64-openstack-boot.json
@@ -9296,6 +9296,7 @@
       "dhcpv6-client",
       "cockpit"
     ],
+    "default-target": "graphical.target",
     "fstab": [
       [
         "UUID=0bd700f8-090f-4556-b797-b340297ea1bd",

--- a/test/data/manifests/rhel_8-aarch64-qcow2-boot.json
+++ b/test/data/manifests/rhel_8-aarch64-qcow2-boot.json
@@ -9495,6 +9495,7 @@
         "version": "4.18.0-221.el8.aarch64"
       }
     ],
+    "default-target": "graphical.target",
     "fstab": [
       [
         "UUID=0bd700f8-090f-4556-b797-b340297ea1bd",

--- a/test/data/manifests/rhel_8-aarch64-rhel_edge_commit-boot.json
+++ b/test/data/manifests/rhel_8-aarch64-rhel_edge_commit-boot.json
@@ -8206,6 +8206,7 @@
     }
   },
   "image-info": {
+    "default-target": "graphical.target",
     "firewall-enabled": [
       "ssh",
       "dhcpv6-client",

--- a/test/data/manifests/rhel_8-ppc64le-qcow2-boot.json
+++ b/test/data/manifests/rhel_8-ppc64le-qcow2-boot.json
@@ -10254,6 +10254,7 @@
         "version": "4.18.0-221.el8.ppc64le"
       }
     ],
+    "default-target": "graphical.target",
     "fstab": [
       [
         "UUID=0bd700f8-090f-4556-b797-b340297ea1bd",

--- a/test/data/manifests/rhel_8-s390x-qcow2-boot.json
+++ b/test/data/manifests/rhel_8-s390x-qcow2-boot.json
@@ -10209,6 +10209,7 @@
         "version": "4.18.0-193.el8.s390x"
       }
     ],
+    "default-target": "graphical.target",
     "fstab": [
       [
         "UUID=0bd700f8-090f-4556-b797-b340297ea1bd",

--- a/test/data/manifests/rhel_8-x86_64-ami-boot.json
+++ b/test/data/manifests/rhel_8-x86_64-ami-boot.json
@@ -3157,6 +3157,12 @@
           }
         },
         {
+          "name": "org.osbuild.systemd",
+          "options": {
+            "default_target": "multi-user.target"
+          }
+        },
+        {
           "name": "org.osbuild.selinux",
           "options": {
             "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
@@ -8731,6 +8737,7 @@
         "version": "4.18.0-221.el8.x86_64"
       }
     ],
+    "default-target": "multi-user.target",
     "fstab": [
       [
         "UUID=0bd700f8-090f-4556-b797-b340297ea1bd",

--- a/test/data/manifests/rhel_8-x86_64-openstack-boot.json
+++ b/test/data/manifests/rhel_8-x86_64-openstack-boot.json
@@ -9329,6 +9329,7 @@
       "dhcpv6-client",
       "cockpit"
     ],
+    "default-target": "graphical.target",
     "fstab": [
       [
         "UUID=0bd700f8-090f-4556-b797-b340297ea1bd",

--- a/test/data/manifests/rhel_8-x86_64-qcow2-boot.json
+++ b/test/data/manifests/rhel_8-x86_64-qcow2-boot.json
@@ -9498,6 +9498,7 @@
         "version": "4.18.0-221.el8.x86_64"
       }
     ],
+    "default-target": "graphical.target",
     "fstab": [
       [
         "UUID=0bd700f8-090f-4556-b797-b340297ea1bd",

--- a/test/data/manifests/rhel_8-x86_64-qcow2-customize.json
+++ b/test/data/manifests/rhel_8-x86_64-qcow2-customize.json
@@ -9586,6 +9586,7 @@
         "version": "4.18.0-221.el8.x86_64"
       }
     ],
+    "default-target": "graphical.target",
     "fstab": [
       [
         "UUID=0bd700f8-090f-4556-b797-b340297ea1bd",

--- a/test/data/manifests/rhel_8-x86_64-rhel_edge_commit-boot.json
+++ b/test/data/manifests/rhel_8-x86_64-rhel_edge_commit-boot.json
@@ -8502,6 +8502,7 @@
     }
   },
   "image-info": {
+    "default-target": "graphical.target",
     "firewall-enabled": [
       "ssh",
       "dhcpv6-client",

--- a/test/data/manifests/rhel_8-x86_64-tar-boot.json
+++ b/test/data/manifests/rhel_8-x86_64-tar-boot.json
@@ -5431,6 +5431,7 @@
   },
   "image-info": {
     "bootmenu": [],
+    "default-target": "graphical.target",
     "groups": [
       "adm:x:4:",
       "audio:x:63:",

--- a/test/data/manifests/rhel_8-x86_64-vhd-boot.json
+++ b/test/data/manifests/rhel_8-x86_64-vhd-boot.json
@@ -9240,6 +9240,7 @@
       "dhcpv6-client",
       "cockpit"
     ],
+    "default-target": "multi-user.target",
     "fstab": [
       [
         "UUID=0bd700f8-090f-4556-b797-b340297ea1bd",

--- a/test/data/manifests/rhel_8-x86_64-vmdk-boot.json
+++ b/test/data/manifests/rhel_8-x86_64-vmdk-boot.json
@@ -8966,6 +8966,7 @@
       "dhcpv6-client",
       "cockpit"
     ],
+    "default-target": "graphical.target",
     "fstab": [
       [
         "UUID=0bd700f8-090f-4556-b797-b340297ea1bd",

--- a/test/data/manifests/rhel_84-x86_64-ami-boot.json
+++ b/test/data/manifests/rhel_84-x86_64-ami-boot.json
@@ -3104,6 +3104,12 @@
           }
         },
         {
+          "name": "org.osbuild.systemd",
+          "options": {
+            "default_target": "multi-user.target"
+          }
+        },
+        {
           "name": "org.osbuild.selinux",
           "options": {
             "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
@@ -8611,6 +8617,7 @@
         "version": "4.18.0-240.4.el8.x86_64"
       }
     ],
+    "default-target": "multi-user.target",
     "fstab": [
       [
         "UUID=0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",

--- a/test/data/manifests/rhel_84-x86_64-openstack-boot.json
+++ b/test/data/manifests/rhel_84-x86_64-openstack-boot.json
@@ -9193,6 +9193,7 @@
         "version": "4.18.0-240.4.el8.x86_64"
       }
     ],
+    "default-target": "graphical.target",
     "firewall-enabled": [
       "ssh",
       "dhcpv6-client",

--- a/test/data/manifests/rhel_84-x86_64-qcow2-boot.json
+++ b/test/data/manifests/rhel_84-x86_64-qcow2-boot.json
@@ -3482,6 +3482,12 @@
           }
         },
         {
+          "name": "org.osbuild.systemd",
+          "options": {
+            "default_target": "multi-user.target"
+          }
+        },
+        {
           "name": "org.osbuild.selinux",
           "options": {
             "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
@@ -9529,6 +9535,7 @@
         "version": "4.18.0-240.4.el8.x86_64"
       }
     ],
+    "default-target": "multi-user.target",
     "fstab": [
       [
         "UUID=0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",

--- a/test/data/manifests/rhel_84-x86_64-qcow2-customize.json
+++ b/test/data/manifests/rhel_84-x86_64-qcow2-customize.json
@@ -3582,7 +3582,8 @@
             ],
             "disabled_services": [
               "bluetooth.service"
-            ]
+            ],
+            "default_target": "multi-user.target"
           }
         },
         {
@@ -9633,6 +9634,7 @@
         "version": "4.18.0-240.4.el8.x86_64"
       }
     ],
+    "default-target": "multi-user.target",
     "fstab": [
       [
         "UUID=0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",

--- a/test/data/manifests/rhel_84-x86_64-vhd-boot.json
+++ b/test/data/manifests/rhel_84-x86_64-vhd-boot.json
@@ -9104,6 +9104,7 @@
         "version": "4.18.0-240.4.el8.x86_64"
       }
     ],
+    "default-target": "multi-user.target",
     "firewall-enabled": [
       "ssh",
       "dhcpv6-client",

--- a/test/data/manifests/rhel_84-x86_64-vmdk-boot.json
+++ b/test/data/manifests/rhel_84-x86_64-vmdk-boot.json
@@ -8740,6 +8740,7 @@
         "version": "4.18.0-240.4.el8.x86_64"
       }
     ],
+    "default-target": "graphical.target",
     "firewall-enabled": [
       "ssh",
       "dhcpv6-client",

--- a/tools/image-info
+++ b/tools/image-info
@@ -269,6 +269,10 @@ def read_services(tree, state):
     return subprocess_check_output(["systemctl", f"--root={tree}", "list-unit-files"], (lambda s: parse_unit_files(s, state)))
 
 
+def read_default_target(tree):
+    return subprocess_check_output(["systemctl", f"--root={tree}", "get-default"]).rstrip()
+
+
 def read_firewall_zone(tree):
     try:
         with open(f"{tree}/etc/firewalld/firewalld.conf") as f:
@@ -308,6 +312,10 @@ def append_filesystem(report, tree, *, is_ostree=False):
 
         report["services-enabled"] = read_services(tree, "enabled")
         report["services-disabled"] = read_services(tree, "disabled")
+
+        default_target = read_default_target(tree)
+        if default_target:
+            report["default-target"] = default_target
 
         with contextlib.suppress(FileNotFoundError):
             with open(f"{tree}/etc/hostname") as f:


### PR DESCRIPTION
An image only had a systemd stage added if its blueprint contained or if its image type contained enabled services. The systemd
stage is now also added if the image type contains disabled services or a default target.

The RHEL 8.4 qcow2 image type now specifies the multi-user default target.

In order to test this the image-info tool now includes the default target in its output. Image test manifests are updated to include this change.

