### PR TITLE
rhel84: fix kernel cmdline for s390x

### DIFF
--- a/internal/distro/rhel84/distro.go
+++ b/internal/distro/rhel84/distro.go
@@ -256,7 +256,7 @@ func (t *imageType) pipeline(c *blueprint.Customizations, options distro.ImageOp
 		}
 
 		p.AddStage(osbuild.NewKernelCmdlineStage(&osbuild.KernelCmdlineStageOptions{
-			RootFsUUID: rootPartition.UUID,
+			RootFsUUID: rootPartition.Filesystem.UUID,
 			KernelOpts: t.kernelOptions,
 		}))
 	}


### PR DESCRIPTION
RootFsUUID should be the UUID of a root filesystem, not of a root partition.

🤦 sorry!