### PR TITLE
distro/rhel84: fix s390x kernel options

### DIFF
--- a/internal/distro/rhel84/distro.go
+++ b/internal/distro/rhel84/distro.go
@@ -257,7 +257,7 @@ func (t *imageType) pipeline(c *blueprint.Customizations, options distro.ImageOp
 
 		p.AddStage(osbuild.NewKernelCmdlineStage(&osbuild.KernelCmdlineStageOptions{
 			RootFsUUID: rootPartition.UUID,
-			KernelOpts: "net.ifnames=0 crashkernel=auto",
+			KernelOpts: t.kernelOptions,
 		}))
 	}
 


### PR DESCRIPTION
Our s390x images now use the kernel commandline options set in the image type's declaration.

This should fix the missing kernel cmdline args pointed out by Wei Shi.