### PR TITLE
schutzbot: prolong the timeout to 12 hours

### DIFF
--- a/schutzbot/Jenkinsfile
+++ b/schutzbot/Jenkinsfile
@@ -11,7 +11,7 @@ pipeline {
         ansiColor('xterm')
         // Cancel the pipeline if it runs for more than three hours.
         timeout(
-            time: 3,
+            time: 12,
             unit: "HOURS"
         )
     }


### PR DESCRIPTION
With our limited number of machines in OpenStack, we cannot run unlimited jobs
in parallel. When there's a lot of activity in the repository, there's a high
probability that a job must wait for a free VM for quite a long time. In these cases,
tests commonly fail due to the timeout.

I decided to prolong the timeout to 12 hours. This should lower the amount of
these kinds of jobs.