### PR TITLE
Jobqueue: get all job parameters

### DIFF
--- a/docs/news/unreleased/koji-manifests.md
+++ b/docs/news/unreleased/koji-manifests.md
@@ -1,0 +1,9 @@
+# Koji API: New endpoint for getting the manifests of a compose job
+
+A new endpoint is available in the Koji API: `GET /compose/{ID}/manifests`.
+Returns the manifests for a running or finished compose. Returns one manifest
+for each image in the request, in the order they were defined.
+
+Relevant PRs:
+https://github.com/osbuild/osbuild-composer/pull/1155
+https://github.com/osbuild/osbuild-composer/pull/1165

--- a/internal/jobqueue/fsjobqueue/fsjobqueue.go
+++ b/internal/jobqueue/fsjobqueue/fsjobqueue.go
@@ -287,13 +287,16 @@ func (q *fsJobQueue) JobStatus(id uuid.UUID) (result json.RawMessage, queued, st
 	return
 }
 
-func (q *fsJobQueue) JobArgs(id uuid.UUID) (args json.RawMessage, err error) {
+func (q *fsJobQueue) Job(id uuid.UUID) (jobType string, args json.RawMessage, dependencies []uuid.UUID, err error) {
 	j, err := q.readJob(id)
 	if err != nil {
 		return
 	}
 
+	jobType = j.Type
 	args = j.Args
+	dependencies = j.Dependencies
+
 	return
 }
 

--- a/internal/jobqueue/fsjobqueue/fsjobqueue_test.go
+++ b/internal/jobqueue/fsjobqueue/fsjobqueue_test.go
@@ -103,10 +103,12 @@ func TestArgs(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, twoargs, parsedArgs)
 
-	// Read args after Dequeue
-	jargs, err := q.JobArgs(id)
+	// Read job params after Dequeue
+	jtype, jargs, jdeps, err := q.Job(id)
 	require.NoError(t, err)
 	require.Equal(t, args, jargs)
+	require.Equal(t, deps, jdeps)
+	require.Equal(t, typ, jtype)
 
 	id, deps, typ, args, err = q.Dequeue(context.Background(), []string{"fish"})
 	require.NoError(t, err)
@@ -117,12 +119,13 @@ func TestArgs(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, oneargs, parsedArgs)
 
-	// Read args directly after Dequeue
-	jargs, err = q.JobArgs(id)
+	jtype, jargs, jdeps, err = q.Job(id)
 	require.NoError(t, err)
 	require.Equal(t, args, jargs)
+	require.Equal(t, deps, jdeps)
+	require.Equal(t, typ, jtype)
 
-	_, err = q.JobArgs(uuid.New())
+	_, _, _, err = q.Job(uuid.New())
 	require.Error(t, err)
 }
 

--- a/internal/jobqueue/jobqueue.go
+++ b/internal/jobqueue/jobqueue.go
@@ -60,8 +60,8 @@ type JobQueue interface {
 	// Lastly, the IDs of the jobs dependencies are returned.
 	JobStatus(id uuid.UUID) (result json.RawMessage, queued, started, finished time.Time, canceled bool, deps []uuid.UUID, err error)
 
-	// Returns the job's arguments in Raw form.
-	JobArgs(id uuid.UUID) (args json.RawMessage, err error)
+	// Job returns all the parameters that define a job (everything provided during Enqueue).
+	Job(id uuid.UUID) (jobType string, args json.RawMessage, dependencies []uuid.UUID, err error)
 }
 
 var (

--- a/internal/kojiapi/server.go
+++ b/internal/kojiapi/server.go
@@ -303,7 +303,7 @@ func (h *apiHandlers) GetComposeId(ctx echo.Context, idstr string) error {
 	var finalizeResult worker.KojiFinalizeJobResult
 	finalizeStatus, deps, err := h.server.workers.JobStatus(id, &finalizeResult)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Job %s not found: %s", idstr, err))
+		return echo.NewHTTPError(http.StatusNotFound, fmt.Sprintf("Job %s not found: %s", idstr, err))
 	}
 
 	// Make sure deps[0] matches a KojiInitJob

--- a/internal/kojiapi/server.go
+++ b/internal/kojiapi/server.go
@@ -405,7 +405,7 @@ func (h *apiHandlers) GetComposeIdManifests(ctx echo.Context, idstr string) erro
 	manifests := make([]distro.Manifest, len(deps)-1)
 	for i, id := range deps[1:] {
 		var buildJob worker.OSBuildKojiJob
-		if _, err := h.server.workers.JobArgs(id, &buildJob); err != nil {
+		if _, _, _, err := h.server.workers.Job(id, &buildJob); err != nil {
 			// This is a programming error.
 			panic(err)
 		}

--- a/internal/worker/server.go
+++ b/internal/worker/server.go
@@ -121,19 +121,18 @@ func (s *Server) JobStatus(id uuid.UUID, result interface{}) (*JobStatus, []uuid
 	}, deps, nil
 }
 
-// JobArgs provides access to the arguments of a job.
-func (s *Server) JobArgs(id uuid.UUID, jobArgs interface{}) (json.RawMessage, error) {
-	rawArgs, err := s.jobs.JobArgs(id)
+// Job provides access to all the parameters of a job.
+func (s *Server) Job(id uuid.UUID, job interface{}) (string, json.RawMessage, []uuid.UUID, error) {
+	jobType, rawArgs, deps, err := s.jobs.Job(id)
 	if err != nil {
-		return nil, err
+		return "", nil, nil, err
 	}
 
-	err = json.Unmarshal(rawArgs, jobArgs)
-	if err != nil {
-		return nil, fmt.Errorf("error unmarshaling arguments for job '%s': %v", id, err)
+	if err := json.Unmarshal(rawArgs, job); err != nil {
+		return "", nil, nil, fmt.Errorf("error unmarshaling arguments for job '%s': %v", id, err)
 	}
 
-	return rawArgs, nil
+	return jobType, rawArgs, deps, nil
 }
 
 func (s *Server) Cancel(id uuid.UUID) error {

--- a/internal/worker/server_test.go
+++ b/internal/worker/server_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 
 	"github.com/osbuild/osbuild-composer/internal/distro"
@@ -198,10 +199,12 @@ func TestArgs(t *testing.T) {
 	require.NotNil(t, args)
 
 	var jobArgs worker.OSBuildJob
-	rawArgs, err := server.JobArgs(jobId, &jobArgs)
+	jobType, rawArgs, deps, err := server.Job(jobId, &jobArgs)
 	require.NoError(t, err)
 	require.Equal(t, args, rawArgs)
 	require.Equal(t, job, jobArgs)
+	require.Equal(t, jobType, "osbuild:"+arch.Name())
+	require.Equal(t, []uuid.UUID(nil), deps)
 }
 
 func TestUpload(t *testing.T) {


### PR DESCRIPTION
This pull request includes:

- [x] adequate testing for the new functionality or fixed issue
*Not sure if it's adequate, but it covers some error conditions as well as successful calls.*
- [x] adequate documentation informing people about the change

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

For user-visible changes, "adequate documentation" is an entry describing the
change for users in docs/news. Please refer to docs/news/README.md for details.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`
-->

## New JobQueue method

This PR replaces the recently introduced `JobArgs()` method of the `JobQueue` interface (see #1155) with a more general `Job()` method that returns all the arguments that were supplied to the `Enqueue()` method: `jobType`, `args`, and `dependencies`.

## Job type verification

Having access to the `jobType` makes it possible to validate the type when reading jobs from the queue, which is relevant for the Koji API.

The Koji API now includes convenience methods for reading each job type from the queue, resulting in errors if the ID doesn't match the expected type.  A downside to these functions is that it becomes harder to distinguish between an ID that doesn't exist in the queue and a type mismatch, though the error message does differ.  I'm not sure if the error message for a type mismatch is appropriate to be returned to an API client (e.g., `Job <ID> not found: expected "koji-finalize", found "koji-init" job instead`).
- Is this information relevant to the client?
- Does a 404 Not Found make sense for this error?

The type verification is also now also used when fetching job status and logs.

## Docs

Added a news item in `docs/news/unreleased` describing the introduction and purpose of the new API endpoint.  Since we didn't agree on exact naming, formatting, or linking, let me know if you think I should make any changes.

I linked to the relevant PRs (this one and #1155 where it was introduced).  I figure that might make it easier to add it to release notes in case there are any gaps in the description.

## Issues

Closes #1154