### PR TITLE
cloudapi: expose upload status

### DIFF
--- a/cmd/osbuild-worker/jobimpl-osbuild.go
+++ b/cmd/osbuild-worker/jobimpl-osbuild.go
@@ -305,10 +305,16 @@ func (impl *OSBuildJobImpl) Run(job worker.Job) error {
 		targetErrors = append(targetErrors, err.Error())
 	}
 
+	var uploadstatus string = "failure"
+	if len(targetErrors) == 0 {
+		uploadstatus = "success"
+	}
+
 	err = job.Update(&worker.OSBuildJobResult{
 		Success:       osbuildOutput.Success && len(targetErrors) == 0,
 		OSBuildOutput: osbuildOutput,
 		TargetErrors:  targetErrors,
+		UploadStatus:  uploadstatus,
 	})
 	if err != nil {
 		return fmt.Errorf("Error reporting job result: %v", err)

--- a/internal/cloudapi/openapi.gen.go
+++ b/internal/cloudapi/openapi.gen.go
@@ -39,11 +39,6 @@ type AWSUploadRequestOptionsS3 struct {
 	SecretAccessKey string `json:"secret_access_key"`
 }
 
-// AWSUploadStatus defines model for AWSUploadStatus.
-type AWSUploadStatus struct {
-	AmiId *string `json:"ami_id,omitempty"`
-}
-
 // ComposeRequest defines model for ComposeRequest.
 type ComposeRequest struct {
 	Customizations *Customizations `json:"customizations,omitempty"`
@@ -58,8 +53,7 @@ type ComposeResult struct {
 
 // ComposeStatus defines model for ComposeStatus.
 type ComposeStatus struct {
-	ImageStatuses *[]ImageStatus `json:"image_statuses,omitempty"`
-	Status        string         `json:"status"`
+	ImageStatus ImageStatus `json:"image_status"`
 }
 
 // Customizations defines model for Customizations.
@@ -77,8 +71,8 @@ type ImageRequest struct {
 
 // ImageStatus defines model for ImageStatus.
 type ImageStatus struct {
-	Status         string          `json:"status"`
-	UploadStatuses *[]UploadStatus `json:"upload_statuses,omitempty"`
+	Status       string        `json:"status"`
+	UploadStatus *UploadStatus `json:"upload_status,omitempty"`
 }
 
 // Repository defines model for Repository.
@@ -101,11 +95,22 @@ type Subscription struct {
 // UploadRequest defines model for UploadRequest.
 type UploadRequest struct {
 	Options interface{} `json:"options"`
-	Type    string      `json:"type"`
+	Type    UploadTypes `json:"type"`
 }
 
 // UploadStatus defines model for UploadStatus.
-type UploadStatus interface{}
+type UploadStatus struct {
+	Status string      `json:"status"`
+	Type   UploadTypes `json:"type"`
+}
+
+// UploadTypes defines model for UploadTypes.
+type UploadTypes string
+
+// List of UploadTypes
+const (
+	UploadTypes_aws UploadTypes = "aws"
+)
 
 // ComposeJSONBody defines parameters for Compose.
 type ComposeJSONBody ComposeRequest

--- a/internal/cloudapi/openapi.yml
+++ b/internal/cloudapi/openapi.yml
@@ -65,16 +65,10 @@ components:
   schemas:
     ComposeStatus:
       required:
-        - status
+        - image_status
       properties:
-        status:
-          type: string
-          enum: ['success', 'failure', 'pending', 'running']
-          example: 'success'
-        image_statuses:
-          type: array
-          items:
-            $ref: '#/components/schemas/ImageStatus'
+        image_status:
+          $ref: '#/components/schemas/ImageStatus'
     ImageStatus:
       required:
        - status
@@ -83,13 +77,18 @@ components:
           type: string
           enum: ['success', 'failure', 'pending', 'building', 'uploading', 'registering']
           example: 'success'
-        upload_statuses:
-          type: array
-          items:
-            $ref: '#/components/schemas/UploadStatus'
+        upload_status:
+          $ref: '#/components/schemas/UploadStatus'
     UploadStatus:
-      oneOf:
-       - $ref: '#/components/schemas/AWSUploadStatus'
+      required:
+        - status
+        - type
+      properties:
+        status:
+          type: string
+          enum: ['success', 'failure', 'pending', 'running']
+        type:
+          $ref: '#/components/schemas/UploadTypes'
     AWSUploadStatus:
       type: object
       properties:
@@ -158,11 +157,13 @@ components:
         - options
       properties:
         type:
-          type: string
-          enum: ['aws']
+          $ref: '#/components/schemas/UploadTypes'
         options:
           oneOf:
             -  $ref: '#/components/schemas/AWSUploadRequestOptions'
+    UploadTypes:
+      type: string
+      enum: ['aws']
     AWSUploadRequestOptions:
       type: object
       required:

--- a/internal/cloudapi/server.go
+++ b/internal/cloudapi/server.go
@@ -248,10 +248,11 @@ func (server *Server) ComposeStatus(w http.ResponseWriter, r *http.Request, id s
 	}
 
 	response := ComposeStatus{
-		Status: composeStatusFromJobStatus(status, &result),
-		ImageStatuses: &[]ImageStatus{
-			{
-				Status: composeStatusFromJobStatus(status, &result),
+		ImageStatus: ImageStatus{
+			Status: composeStatusFromJobStatus(status, &result),
+			UploadStatus: &UploadStatus{
+				Status: result.UploadStatus,
+				Type:   "aws",
 			},
 		},
 	}

--- a/internal/worker/json.go
+++ b/internal/worker/json.go
@@ -24,6 +24,7 @@ type OSBuildJobResult struct {
 	Success       bool            `json:"success"`
 	OSBuildOutput *osbuild.Result `json:"osbuild_output,omitempty"`
 	TargetErrors  []string        `json:"target_errors,omitempty"`
+	UploadStatus  string          `json:"upload_status"`
 }
 
 type KojiInitJob struct {

--- a/test/cases/api.sh
+++ b/test/cases/api.sh
@@ -145,10 +145,12 @@ do
     --cert /etc/osbuild-composer/client-crt.pem \
     https://localhost/api/composer/v1/compose/"$COMPOSE_ID")
 
-  COMPOSE_STATUS=$(echo "$OUTPUT" | jq -r '.status')
+  COMPOSE_STATUS=$(echo "$OUTPUT" | jq -r '.image_status.status')
+  UPLOAD_STATUS=$(echo "$OUTPUT" | jq -r '.image_status.upload_status')
 
   if [[ "$COMPOSE_STATUS" != "pending" && "$COMPOSE_STATUS" != "running" ]]; then
     test "$COMPOSE_STATUS" = "success"
+    test "$UPLOAD_STATUS" = "success"
     break
   fi
 

--- a/test/cases/api.sh
+++ b/test/cases/api.sh
@@ -146,11 +146,13 @@ do
     https://localhost/api/composer/v1/compose/"$COMPOSE_ID")
 
   COMPOSE_STATUS=$(echo "$OUTPUT" | jq -r '.image_status.status')
-  UPLOAD_STATUS=$(echo "$OUTPUT" | jq -r '.image_status.upload_status')
+  UPLOAD_STATUS=$(echo "$OUTPUT" | jq -r '.image_status.upload_status.status')
+  UPLOAD_TYPE=$(echo "$OUTPUT" | jq -r '.image_status.upload_status.type')
 
   if [[ "$COMPOSE_STATUS" != "pending" && "$COMPOSE_STATUS" != "running" ]]; then
     test "$COMPOSE_STATUS" = "success"
     test "$UPLOAD_STATUS" = "success"
+    test "$UPLOAD_TYPE" = "aws"
     break
   fi
 


### PR DESCRIPTION
Expose a more detailed job status result - specifically, include upload status alongside
image status. Expand openapi.yml accordingly and add an UploadStatus field to the 
OSBuildJobResult struct. At the moment, only represent the "success" and "failure" states 
of UploadStatus - to differentiate between "pending" and "running" would involve significant 
design decisions and should be addressed in a separate commit.


This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change

