### PR TITLE
Add support for push to VMWare

### DIFF
--- a/cmd/osbuild-worker/jobimpl-osbuild.go
+++ b/cmd/osbuild-worker/jobimpl-osbuild.go
@@ -88,7 +88,7 @@ func (impl *OSBuildJobImpl) Run(job worker.Job) error {
 
 	end_time := time.Now()
 
-	var streamOptimizedPath string = ""
+	streamOptimizedPath := ""
 
 	if osbuildOutput.Success && args.ImageName != "" {
 		var f *os.File

--- a/cmd/osbuild-worker/jobimpl-osbuild.go
+++ b/cmd/osbuild-worker/jobimpl-osbuild.go
@@ -176,7 +176,7 @@ func (impl *OSBuildJobImpl) Run(job worker.Job) error {
 				continue
 			}
 
-			err = vmware.UploadImage(credentials, imagePath, t.ImageName)
+			err = vmware.UploadImage(credentials, imagePath)
 			if err != nil {
 				r = append(r, err)
 				continue

--- a/cmd/osbuild-worker/jobimpl-osbuild.go
+++ b/cmd/osbuild-worker/jobimpl-osbuild.go
@@ -138,7 +138,6 @@ func (impl *OSBuildJobImpl) Run(job worker.Job) error {
 				continue
 			}
 		case *target.VMWareTargetOptions:
-			// TODO
 			if !osbuildOutput.Success {
 				continue
 			}
@@ -154,12 +153,12 @@ func (impl *OSBuildJobImpl) Run(job worker.Job) error {
 			imagePath = f.Name()
 
 			credentials := vmware.Credentials{
-				Username:	options.Username,
-				Password:	options.Password,
-				Host:		options.Host,
-				Cluster:	options.Cluster,
-				Datacenter:	options.Datacenter,
-				Datastore:	options.Datastore,
+				Username:   options.Username,
+				Password:   options.Password,
+				Host:       options.Host,
+				Cluster:    options.Cluster,
+				Datacenter: options.Datacenter,
+				Datastore:  options.Datastore,
 			}
 			err = vmware.UploadImage(credentials, imagePath, t.ImageName)
 			if err != nil {

--- a/docs/news/unreleased/vmware-upload-target.md
+++ b/docs/news/unreleased/vmware-upload-target.md
@@ -1,0 +1,13 @@
+# Weldr API: New VMWare upload target
+
+New upload target is available that allows users to push built VMWare images directly to vSphere without the need to download and push them manually.
+
+Upload target requires following options:
+`Username`,
+`Password`,
+`Host`,
+`Datacenter`,
+`Datastore`,
+`Cluster`.
+
+Relevant PR: https://github.com/osbuild/osbuild-composer/pull/1169

--- a/internal/target/target.go
+++ b/internal/target/target.go
@@ -72,6 +72,8 @@ func UnmarshalTargetOptions(targetName string, rawOptions json.RawMessage) (Targ
 		options = new(LocalTargetOptions)
 	case "org.osbuild.koji":
 		options = new(KojiTargetOptions)
+	case "org.osbuild.vmware":
+		options = new(VMWareTargetOptions)
 	default:
 		return nil, errors.New("unexpected target name")
 	}

--- a/internal/target/vmware_target.go
+++ b/internal/target/vmware_target.go
@@ -1,0 +1,17 @@
+package target
+
+type VMWareTargetOptions struct {
+	Filename   string `json:"filename"`
+	Host       string `json:"host"`
+	Username   string `json:"username"`
+	Password   string `json:"password"`
+	Datacenter string `json:"datacenter"`
+	Cluster    string `json:"cluster"`
+	Datastore  string `json:"datastore"`
+}
+
+func (VMWareTargetOptions) isTargetOptions() {}
+
+func NewVMWareTarget(options *VMWareTargetOptions) *Target{
+	return newTarget("org.osbuild.vmware", options)
+}

--- a/internal/target/vmware_target.go
+++ b/internal/target/vmware_target.go
@@ -12,6 +12,6 @@ type VMWareTargetOptions struct {
 
 func (VMWareTargetOptions) isTargetOptions() {}
 
-func NewVMWareTarget(options *VMWareTargetOptions) *Target{
+func NewVMWareTarget(options *VMWareTargetOptions) *Target {
 	return newTarget("org.osbuild.vmware", options)
 }

--- a/internal/upload/vmware/vmware.go
+++ b/internal/upload/vmware/vmware.go
@@ -1,10 +1,24 @@
 package vmware
 
 import (
+	"errors"
+	"fmt"
 	"os"
 	"os/exec"
 	"strings"
+
+	"github.com/vmware/govmomi/govc/cli"
+	_ "github.com/vmware/govmomi/govc/importx"
 )
+
+type Credentials struct {
+	Host       string
+	Username   string
+	Password   string
+	Datacenter string
+	Cluster    string
+	Datastore  string
+}
 
 func OpenAsStreamOptimizedVmdk(imagePath string) (*os.File, error) {
 	newPath := strings.TrimSuffix(imagePath, ".vmdk") + "-stream.vmdk"
@@ -20,4 +34,23 @@ func OpenAsStreamOptimizedVmdk(imagePath string) (*os.File, error) {
 		return nil, err
 	}
 	return f, err
+}
+
+func UploadImage(creds Credentials, imagePath, imageName string) error {
+	args := []string{
+		"import.vmdk",
+		fmt.Sprintf("-u=%s:%s@%s", creds.Username, creds.Password, creds.Host),
+		"-k=true",
+		fmt.Sprintf("-pool=%s/Resources", creds.Cluster),
+		fmt.Sprintf("-dc=%s", creds.Datacenter),
+		fmt.Sprintf("-ds=%s", creds.Datastore),
+		imagePath,
+		imageName,
+	}
+	retcode := cli.Run(args)
+
+	if retcode != 0 {
+		return errors.New("importing vmdk failed")
+	}
+	return nil
 }

--- a/internal/upload/vmware/vmware.go
+++ b/internal/upload/vmware/vmware.go
@@ -36,7 +36,9 @@ func OpenAsStreamOptimizedVmdk(imagePath string) (*os.File, error) {
 	return f, err
 }
 
-func UploadImage(creds Credentials, imagePath, imageName string) error {
+// UploadImage is a function that uploads a stream optimized vmdk image to vSphere
+// uploaded image will be present in a directory of the same name
+func UploadImage(creds Credentials, imagePath string) error {
 	args := []string{
 		"import.vmdk",
 		fmt.Sprintf("-u=%s:%s@%s", creds.Username, creds.Password, creds.Host),
@@ -45,7 +47,6 @@ func UploadImage(creds Credentials, imagePath, imageName string) error {
 		fmt.Sprintf("-dc=%s", creds.Datacenter),
 		fmt.Sprintf("-ds=%s", creds.Datastore),
 		imagePath,
-		imageName,
 	}
 	retcode := cli.Run(args)
 

--- a/schutzbot/Jenkinsfile
+++ b/schutzbot/Jenkinsfile
@@ -343,6 +343,7 @@ pipeline {
                         AWS_IMAGE_TEST_CREDS = credentials('aws-credentials-osbuild-image-test')
                         RHN_REGISTRATION_SCRIPT = credentials('rhn-register-script-production')
                         AWS_API_TEST_SHARE_ACCOUNT = credentials('aws-credentials-share-account')
+                        VCENTER_CREDS = credentials('vmware-vcenter-credentials')
                     }
                     steps {
                         run_tests('integration')
@@ -420,6 +421,7 @@ pipeline {
                         AWS_CREDS = credentials('aws-credentials-osbuildci')
                         AWS_API_TEST_SHARE_ACCOUNT = credentials('aws-credentials-share-account')
                         AWS_IMAGE_TEST_CREDS = credentials('aws-credentials-osbuild-image-test')
+                        VCENTER_CREDS = credentials('vmware-vcenter-credentials')
                     }
                     steps {
                         run_tests('integration')
@@ -530,6 +532,14 @@ void run_tests(test_type) {
             label: "Integration test: API",
             script: "/usr/libexec/tests/osbuild-composer/api.sh"
         )
+
+        if (env.VCENTER_CREDS) {
+            // Run the VMWare test.
+            sh (
+                label: "Integration test: VMWare",
+                script: "/usr/libexec/tests/osbuild-composer/vmware.sh"
+            )
+        }
     }
 }
 

--- a/test/cases/vmware.sh
+++ b/test/cases/vmware.sh
@@ -1,0 +1,222 @@
+#!/bin/bash
+set -euo pipefail
+
+OSBUILD_COMPOSER_TEST_DATA=/usr/share/tests/osbuild-composer
+
+source /etc/os-release
+
+# Colorful output.
+function greenprint {
+    echo -e "\033[1;32m${1}\033[0m"
+}
+
+# Provision the software under tet.
+/usr/libexec/osbuild-composer-test/provision.sh
+
+# Apply lorax patch to work around pytoml issues in RHEL 8.x.
+# See BZ 1843704 or https://github.com/weldr/lorax/pull/1030 for more details.
+if [[ $ID == rhel ]]; then
+    sudo sed -r -i 's#toml.load\(args\[3\]\)#toml.load(open(args[3]))#' \
+        /usr/lib/python3.6/site-packages/composer/cli/compose.py
+    sudo rm -f /usr/lib/python3.6/site-packages/composer/cli/compose.pyc
+fi
+
+GOVC_CMD=/tmp/govc
+
+# shellcheck source=/dev/null
+source "$VCENTER_CREDS"
+
+# We need govc to talk to vSphere
+if ! hash govc; then
+    greenprint "Installing govc"
+    pushd /tmp
+        curl -Ls --retry 5 --output govc.gz \
+            https://github.com/vmware/govmomi/releases/download/v0.24.0/govc_linux_amd64.gz
+        gunzip -f govc.gz
+        chmod +x /tmp/govc
+        $GOVC_CMD version
+    popd
+fi
+
+TEST_UUID=$(uuidgen)
+IMAGE_KEY=osbuild-composer-vmware-test-${TEST_UUID}
+
+# Jenkins sets WORKSPACE to the job workspace, but if this script runs
+# outside of Jenkins, we can set up a temporary directory instead.
+if [[ ${WORKSPACE:-empty} == empty ]]; then
+    WORKSPACE=$(mktemp -d)
+fi
+
+# Set up temporary files
+TEMPDIR=$(mktemp -d)
+VMWARE_CONFIG=${TEMPDIR}/vmware.toml
+BLUEPRINT_FILE=${TEMPDIR}/blueprint.toml
+COMPOSE_START=${TEMPDIR}/compose-start-${IMAGE_KEY}.json
+COMPOSE_INFO=${TEMPDIR}/compose-info-${IMAGE_KEY}.json
+
+# Check that the system started and is running correctly
+running_test_check () {
+    STATUS=$(sudo ssh -i $OSBUILD_COMPOSER_TEST_DATA/keyring/id_rsa redhat@"${1}" 'systemctl --wait is-system-running')
+    if [[ $STATUS == running || $STATUS == degraded ]]; then
+        echo 0
+    else
+        echo 1
+    fi
+}
+
+# Get the compose log.
+get_compose_log () {
+    COMPOSE_ID=$1
+    LOG_FILE=${WORKSPACE}/osbuild-${ID}-${VERSION_ID}-vmware.log
+
+    # Download the logs.
+    sudo composer-cli compose log "$COMPOSE_ID" | tee "$LOG_FILE" > /dev/null
+}
+
+# Get the compose metadata.
+get_compose_metadata () {
+    COMPOSE_ID=$1
+    METADATA_FILE=${WORKSPACE}/osbuild-${ID}-${VERSION_ID}-vmware.json
+
+    # Download the metadata.
+    sudo composer-cli compose metadata "$COMPOSE_ID" > /dev/null
+
+    # Find the tarball and extract it.
+    TARBALL=$(basename "$(find . -maxdepth 1 -type f -name "*-metadata.tar")")
+    tar -xf "$TARBALL"
+    rm -f "$TARBALL"
+
+    # Move the JSON file into place.
+    cat "${COMPOSE_ID}".json | jq -M '.' | tee "$METADATA_FILE" > /dev/null
+}
+
+# Write an VMWare TOML file
+tee "$VMWARE_CONFIG" > /dev/null << EOF
+provider = "vmware"
+
+[settings]
+host = "${GOVMOMI_URL}"
+username = "${GOVMOMI_USERNAME}"
+password = "${GOVMOMI_PASSWORD}"
+cluster = "${GOVMOMI_CLUSTER}"
+dataStore = "${GOVMOMI_DATASTORE}"
+dataCenter = "${GOVMOMI_DATACENTER}"
+EOF
+
+# Write a basic blueprint for our image.
+tee "$BLUEPRINT_FILE" > /dev/null << EOF
+name = "bash"
+description = "A base system with bash"
+version = "0.0.1"
+
+[[packages]]
+name = "bash"
+
+[customizations.services]
+enabled = ["sshd"]
+
+[[customizations.user]]
+name = "redhat"
+key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC61wMCjOSHwbVb4VfVyl5sn497qW4PsdQ7Ty7aD6wDNZ/QjjULkDV/yW5WjDlDQ7UqFH0Sr7vywjqDizUAqK7zM5FsUKsUXWHWwg/ehKg8j9xKcMv11AkFoUoujtfAujnKODkk58XSA9whPr7qcw3vPrmog680pnMSzf9LC7J6kXfs6lkoKfBh9VnlxusCrw2yg0qI1fHAZBLPx7mW6+me71QZsS6sVz8v8KXyrXsKTdnF50FjzHcK9HXDBtSJS5wA3fkcRYymJe0o6WMWNdgSRVpoSiWaHHmFgdMUJaYoCfhXzyl7LtNb3Q+Sveg+tJK7JaRXBLMUllOlJ6ll5Hod root@localhost"
+EOF
+
+# Prepare the blueprint for the compose.
+greenprint "📋 Preparing blueprint"
+sudo composer-cli blueprints push "$BLUEPRINT_FILE"
+sudo composer-cli blueprints depsolve bash
+
+# Get worker unit file so we can watch the journal.
+WORKER_UNIT=$(sudo systemctl list-units | grep -o -E "osbuild.*worker.*\.service")
+sudo journalctl -af -n 1 -u "${WORKER_UNIT}" &
+WORKER_JOURNAL_PID=$!
+
+# Start the compose and upload to VMWare.
+greenprint "🚀 Starting compose"
+sudo composer-cli --json compose start bash vmdk "$IMAGE_KEY" "$VMWARE_CONFIG" | tee "$COMPOSE_START"
+COMPOSE_ID=$(jq -r '.build_id' "$COMPOSE_START")
+
+# Wait for the compose to finish.
+greenprint "⏱ Waiting for compose to finish: ${COMPOSE_ID}"
+while true; do
+    sudo composer-cli --json compose info "${COMPOSE_ID}" | tee "$COMPOSE_INFO" > /dev/null
+    COMPOSE_STATUS=$(jq -r '.queue_status' "$COMPOSE_INFO")
+
+    # Is the compose finished?
+    if [[ $COMPOSE_STATUS != RUNNING ]] && [[ $COMPOSE_STATUS != WAITING ]]; then
+        break
+    fi
+
+    # Wait 30 seconds and try again.
+    sleep 30
+
+done
+
+# Capture the compose logs from osbuild.
+greenprint "💬 Getting compose log and metadata"
+get_compose_log "$COMPOSE_ID"
+get_compose_metadata "$COMPOSE_ID"
+
+# Did the compose finish with success?
+if [[ $COMPOSE_STATUS != FINISHED ]]; then
+    echo "Something went wrong with the compose. 😢"
+    exit 1
+fi
+
+# Stop watching the worker journal.
+sudo kill ${WORKER_JOURNAL_PID}
+
+greenprint "👷🏻 Building VM in vSphere"
+$GOVC_CMD vm.create -u "${GOVMOMI_USERNAME}":"${GOVMOMI_PASSWORD}"@"${GOVMOMI_URL}" \
+    -k=true \
+    -pool="${GOVMOMI_CLUSTER}"/Resources \
+    -dc="${GOVMOMI_DATACENTER}" \
+    -ds="${GOVMOMI_DATASTORE}" \
+    -folder="${GOVMOMI_FOLDER}" \
+    -net="${GOVMOMI_NETWORK}" \
+    -m=2048 -g=rhel8_64Guest -on=true -firmware=bios \
+    -disk="${IMAGE_KEY}"/"${IMAGE_KEY}".vmdk \
+    --disk.controller=ide \
+    "${IMAGE_KEY}"
+
+greenprint "Getting IP of created VM"
+VM_IP=$($GOVC_CMD vm.ip -u "${GOVMOMI_USERNAME}":"${GOVMOMI_PASSWORD}"@"${GOVMOMI_URL}" -k=true "${IMAGE_KEY}")
+
+# Wait for the node to come online.
+greenprint "⏱ Waiting for VM to respond to ssh"
+LOOP_COUNTER=1
+while [ $LOOP_COUNTER -le 30 ]; do
+    if ssh-keyscan "$VM_IP" > /dev/null 2>&1; then
+        echo "SSH is up!"
+        ssh-keyscan "$VM_IP" | sudo tee -a /root/.ssh/known_hosts
+        break
+    fi
+
+    # ssh-keyscan has a 5 second timeout by default, so the pause per loop
+    # is 10 seconds when you include the following `sleep`.
+    echo "Retrying in 5 seconds..."
+    sleep 5
+
+    ((LOOP_COUNTER++))
+done
+
+greenprint "🛃 Checking that system is running"
+for LOOP_COUNTER in {0..10}; do
+    RESULT="$(running_test_check "$VM_IP")"
+    if [[ $RESULT == 0 ]]; then
+        echo "System is running! 🥳"
+        break
+    fi
+    sleep 5
+done
+
+# Clean up
+greenprint "🧼 Cleaning up"
+$GOVC_CMD vm.destroy -u "${GOVMOMI_USERNAME}":"${GOVMOMI_PASSWORD}"@"${GOVMOMI_URL}" -k=true "${IMAGE_KEY}"
+
+if [[ $RESULT != 0 ]]; then
+    greenprint "❌ Failed"
+    exit 1
+fi
+
+greenprint "💚 Success"
+exit 0


### PR DESCRIPTION
Add upload target for VMWare images to weldr API to allow users to push them directly to their vSphere instance without the need to download and push the image manually.


This pull request includes:

- [x] adequate testing for the new functionality or fixed issue
- [x] adequate documentation informing people about the change