### PR TITLE
distro/rhel84: include timedatex in qcow2 image

### DIFF
--- a/docs/news/unreleased/timedatex.md
+++ b/docs/news/unreleased/timedatex.md
@@ -1,0 +1,7 @@
+# RHEL 8.4: Include timedatex in qcow2 images
+
+Timedatex was an excluded package due to an selinux-policy issue that has been
+fixed. Therefore, timedatex should be in the qcow2 image we build. Our list of 
+excluded packages for RHEL 8.4 was not being included in our nightly builds so 
+we did not realize that timedatex was still being excluded. The issue with the 
+excluded packages is now fixed and timedatex is now removed from this list.

--- a/internal/distro/rhel84/distro.go
+++ b/internal/distro/rhel84/distro.go
@@ -953,10 +953,6 @@ func New() distro.Distro {
 			"fedora-release",
 			"fedora-repos",
 			"rng-tools",
-
-			// TODO setfiles failes because of usr/sbin/timedatex. Exlude until
-			// https://errata.devel.redhat.com/advisory/47339 lands
-			"timedatex",
 		},
 		defaultTarget:           "multi-user.target",
 		kernelOptions:           "console=tty0 console=ttyS0,115200n8 no_timer_check net.ifnames=0 crashkernel=auto",

--- a/test/data/manifests/rhel_84-x86_64-qcow2-boot.json
+++ b/test/data/manifests/rhel_84-x86_64-qcow2-boot.json
@@ -1140,6 +1140,9 @@
           "sha256:d4736913c9527c97b95cbd12eb3a181c3c980be9c29758fb909f2d60bf378c53": {
             "url": "https://rpmrepo.osbuild.org/v1/psi/el8/el8-x86_64-baseos-8.4.0.n-20201010/Packages/python3-urllib3-1.24.2-4.el8.noarch.rpm"
           },
+          "sha256:d4dc248be7aacad57e6684036d48d7fc1697bb0f1aa880c2a77dbd3ed714c642": {
+            "url": "https://rpmrepo.osbuild.org/v1/psi/el8/el8-x86_64-baseos-8.4.0.n-20201010/Packages/timedatex-0.5-3.el8.x86_64.rpm"
+          },
           "sha256:d570af0578f5b2c6225f1f2354404f65bccf91c3974e98dcbc0c7b55a61b9b46": {
             "url": "https://rpmrepo.osbuild.org/v1/psi/el8/el8-x86_64-baseos-8.4.0.n-20201010/Packages/grep-3.1-6.el8.x86_64.rpm"
           },
@@ -3216,6 +3219,9 @@
               },
               {
                 "checksum": "sha256:9137a707b7793567b38e7d8dba78fcf3f70c39320e68a9ee0b745b3a77f182ee"
+              },
+              {
+                "checksum": "sha256:d4dc248be7aacad57e6684036d48d7fc1697bb0f1aa880c2a77dbd3ed714c642"
               },
               {
                 "checksum": "sha256:a16b38fc2975ab7c8b6200fafb7e577c7434c5c0ab0683653f1f4f630e05a053"
@@ -8900,6 +8906,15 @@
         "checksum": "sha256:9137a707b7793567b38e7d8dba78fcf3f70c39320e68a9ee0b745b3a77f182ee"
       },
       {
+        "name": "timedatex",
+        "epoch": 0,
+        "version": "0.5",
+        "release": "3.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v1/psi/el8/el8-x86_64-baseos-8.4.0.n-20201010/Packages/timedatex-0.5-3.el8.x86_64.rpm",
+        "checksum": "sha256:d4dc248be7aacad57e6684036d48d7fc1697bb0f1aa880c2a77dbd3ed714c642"
+      },
+      {
         "name": "trousers",
         "epoch": 0,
         "version": "0.3.14",
@@ -10055,6 +10070,7 @@
       "tar-1.30-5.el8.x86_64",
       "tcpdump-4.9.3-1.el8.x86_64",
       "teamd-1.31-2.el8.x86_64",
+      "timedatex-0.5-3.el8.x86_64",
       "trousers-0.3.14-4.el8.x86_64",
       "trousers-lib-0.3.14-4.el8.x86_64",
       "tuned-2.14.0-3.el8.noarch",
@@ -10207,6 +10223,7 @@
       "cloud-init.service",
       "crond.service",
       "dbus-org.freedesktop.nm-dispatcher.service",
+      "dbus-org.freedesktop.timedate1.service",
       "dnf-makecache.timer",
       "getty@.service",
       "import-state.service",
@@ -10227,6 +10244,7 @@
       "sssd-kcm.socket",
       "sssd.service",
       "syslog.service",
+      "timedatex.service",
       "tuned.service",
       "unbound-anchor.timer"
     ],

--- a/test/data/manifests/rhel_84-x86_64-qcow2-customize.json
+++ b/test/data/manifests/rhel_84-x86_64-qcow2-customize.json
@@ -1192,6 +1192,9 @@
           "sha256:d4736913c9527c97b95cbd12eb3a181c3c980be9c29758fb909f2d60bf378c53": {
             "url": "https://rpmrepo.osbuild.org/v1/psi/el8/el8-x86_64-baseos-8.4.0.n-20201010/Packages/python3-urllib3-1.24.2-4.el8.noarch.rpm"
           },
+          "sha256:d4dc248be7aacad57e6684036d48d7fc1697bb0f1aa880c2a77dbd3ed714c642": {
+            "url": "https://rpmrepo.osbuild.org/v1/psi/el8/el8-x86_64-baseos-8.4.0.n-20201010/Packages/timedatex-0.5-3.el8.x86_64.rpm"
+          },
           "sha256:d570af0578f5b2c6225f1f2354404f65bccf91c3974e98dcbc0c7b55a61b9b46": {
             "url": "https://rpmrepo.osbuild.org/v1/psi/el8/el8-x86_64-baseos-8.4.0.n-20201010/Packages/grep-3.1-6.el8.x86_64.rpm"
           },
@@ -3268,6 +3271,9 @@
               },
               {
                 "checksum": "sha256:9137a707b7793567b38e7d8dba78fcf3f70c39320e68a9ee0b745b3a77f182ee"
+              },
+              {
+                "checksum": "sha256:d4dc248be7aacad57e6684036d48d7fc1697bb0f1aa880c2a77dbd3ed714c642"
               },
               {
                 "checksum": "sha256:a16b38fc2975ab7c8b6200fafb7e577c7434c5c0ab0683653f1f4f630e05a053"
@@ -8999,6 +9005,15 @@
         "checksum": "sha256:9137a707b7793567b38e7d8dba78fcf3f70c39320e68a9ee0b745b3a77f182ee"
       },
       {
+        "name": "timedatex",
+        "epoch": 0,
+        "version": "0.5",
+        "release": "3.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v1/psi/el8/el8-x86_64-baseos-8.4.0.n-20201010/Packages/timedatex-0.5-3.el8.x86_64.rpm",
+        "checksum": "sha256:d4dc248be7aacad57e6684036d48d7fc1697bb0f1aa880c2a77dbd3ed714c642"
+      },
+      {
         "name": "trousers",
         "epoch": 0,
         "version": "0.3.14",
@@ -10156,6 +10171,7 @@
       "tar-1.30-5.el8.x86_64",
       "tcpdump-4.9.3-1.el8.x86_64",
       "teamd-1.31-2.el8.x86_64",
+      "timedatex-0.5-3.el8.x86_64",
       "trousers-0.3.14-4.el8.x86_64",
       "trousers-lib-0.3.14-4.el8.x86_64",
       "tuned-2.14.0-3.el8.noarch",
@@ -10309,6 +10325,7 @@
       "cloud-init.service",
       "crond.service",
       "dbus-org.freedesktop.nm-dispatcher.service",
+      "dbus-org.freedesktop.timedate1.service",
       "dnf-makecache.timer",
       "getty@.service",
       "import-state.service",
@@ -10330,6 +10347,7 @@
       "sssd-kcm.socket",
       "sssd.service",
       "syslog.service",
+      "timedatex.service",
       "tuned.service",
       "unbound-anchor.timer"
     ],


### PR DESCRIPTION
timedatex was an exlcuded package due to an selinux-policy issue. This
issue is resolved and timedatex is no longer excluded.


This pull request includes:

- [x] adequate testing for the new functionality or fixed issue
- [x] adequate documentation informing people about the change


I do not believe this has adequate documentation about the change but I am unsure where I would document our package list.