### PR TITLE
Add sysconfig stage

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ provided infrastructure and services.
 
 The requirements for this project are:
 
- * `osbuild >= 23`
+ * `osbuild >= 24`
  * `systemd >= 244`
 
 At build-time, the following software is required:

--- a/Schutzfile
+++ b/Schutzfile
@@ -9,7 +9,7 @@
   "rhel-8.3": {
     "dependencies": {
       "osbuild": {
-        "commit": "5aee7b9fa724575daa010a55cad0558fbb7b9ad1"
+        "commit": "20a142d8f9b8b5d0a69f4d91631dc94118d209ca"
       }
     },
     "dependants": {

--- a/docs/news/unreleased/osbuild-24.md
+++ b/docs/news/unreleased/osbuild-24.md
@@ -1,0 +1,5 @@
+# OSBuild: spec: update to osbuild version 24
+
+In order to add the newly supported sysconfig stage, the osbuild dependency 
+needs to be updated to version 24. This update is reflected in both the spec 
+file dependency and in the testing dependency.

--- a/docs/news/unreleased/sysconfig.md
+++ b/docs/news/unreleased/sysconfig.md
@@ -1,0 +1,13 @@
+# RHEL 8.4: add support for org.osbuild.sysconfig stage
+
+The kernel and network sysconfigs need to have certain values set in RHEL 8.4.
+Currently, the following values are set for all image types in 8.4:
+
+  kernel:
+    UPDATEDEFAULT=yes
+    DEFAULTKERNEL=kernel
+    
+  network:
+    NETWORKING=yes
+    NOZEROCONF=yes
+    

--- a/internal/distro/rhel84/distro.go
+++ b/internal/distro/rhel84/distro.go
@@ -329,6 +329,18 @@ func (t *imageType) pipeline(c *blueprint.Customizations, options distro.ImageOp
 
 	p.AddStage(osbuild.NewSELinuxStage(t.selinuxStageOptions()))
 
+	// These are the current defaults for the sysconfig stage. This can be changed to be image type exclusive if different configs are needed.
+	p.AddStage(osbuild.NewSysconfigStage(&osbuild.SysconfigStageOptions{
+		Kernel: osbuild.SysconfigKernelOptions{
+			UpdateDefault: true,
+			DefaultKernel: "kernel",
+		},
+		Network: osbuild.SysconfigNetworkOptions{
+			Networking: true,
+			NoZeroConf: true,
+		},
+	}))
+
 	if t.rpmOstree {
 		p.AddStage(osbuild.NewRPMOSTreeStage(&osbuild.RPMOSTreeStageOptions{
 			EtcGroupMembers: []string{

--- a/internal/osbuild/sysconfig_stage.go
+++ b/internal/osbuild/sysconfig_stage.go
@@ -1,0 +1,25 @@
+package osbuild
+
+type SysconfigStageOptions struct {
+	Kernel  SysconfigKernelOptions  `json:"kernel,omitempty"`
+	Network SysconfigNetworkOptions `json:"network,omitempty"`
+}
+
+type SysconfigNetworkOptions struct {
+	Networking bool `json:"networking,omitempty"`
+	NoZeroConf bool `json:"no_zero_conf,omitempty"`
+}
+
+type SysconfigKernelOptions struct {
+	UpdateDefault bool   `json:"update_default,omitempty"`
+	DefaultKernel string `json:"default_kernel,omitempty"`
+}
+
+func (SysconfigStageOptions) isStageOptions() {}
+
+func NewSysconfigStage(options *SysconfigStageOptions) *Stage {
+	return &Stage{
+		Name:    "org.osbuild.sysconfig",
+		Options: options,
+	}
+}

--- a/internal/osbuild/sysconfig_stage_test.go
+++ b/internal/osbuild/sysconfig_stage_test.go
@@ -1,0 +1,16 @@
+package osbuild
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewSysconfigStage(t *testing.T) {
+	expectedStage := &Stage{
+		Name:    "org.osbuild.sysconfig",
+		Options: &SysconfigStageOptions{},
+	}
+	actualStage := NewSysconfigStage(&SysconfigStageOptions{})
+	assert.Equal(t, expectedStage, actualStage)
+}

--- a/osbuild-composer.spec
+++ b/osbuild-composer.spec
@@ -272,8 +272,8 @@ The core osbuild-composer binary. This is suitable both for spawning in containe
 Summary:    The worker for osbuild-composer
 Requires:   systemd
 Requires:   qemu-img
-Requires:   osbuild >= 23
-Requires:   osbuild-ostree >= 23
+Requires:   osbuild >= 24
+Requires:   osbuild-ostree >= 24
 
 # remove in F34
 Obsoletes: golang-github-osbuild-composer-worker < %{version}-%{release}

--- a/test/data/manifests/rhel_84-x86_64-ami-boot.json
+++ b/test/data/manifests/rhel_84-x86_64-ami-boot.json
@@ -3285,6 +3285,19 @@
           "options": {
             "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
           }
+        },
+        {
+          "name": "org.osbuild.sysconfig",
+          "options": {
+            "kernel": {
+              "update_default": true,
+              "default_kernel": "kernel"
+            },
+            "network": {
+              "networking": true,
+              "no_zero_conf": true
+            }
+          }
         }
       ],
       "assembler": {
@@ -9700,6 +9713,16 @@
       "udisks2.service",
       "unbound-anchor.timer"
     ],
+    "sysconfig": {
+      "kernel": {
+        "DEFAULTKERNEL": "kernel",
+        "UPDATEDEFAULT": "yes"
+      },
+      "network": {
+        "NETWORKING": "yes",
+        "NOZEROCONF": "yes"
+      }
+    },
     "timezone": "New_York"
   }
 }

--- a/test/data/manifests/rhel_84-x86_64-openstack-boot.json
+++ b/test/data/manifests/rhel_84-x86_64-openstack-boot.json
@@ -3528,6 +3528,19 @@
           "options": {
             "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
           }
+        },
+        {
+          "name": "org.osbuild.sysconfig",
+          "options": {
+            "kernel": {
+              "update_default": true,
+              "default_kernel": "kernel"
+            },
+            "network": {
+              "networking": true,
+              "no_zero_conf": true
+            }
+          }
         }
       ],
       "assembler": {
@@ -10321,6 +10334,16 @@
       "udisks2.service",
       "unbound-anchor.timer"
     ],
+    "sysconfig": {
+      "kernel": {
+        "DEFAULTKERNEL": "kernel",
+        "UPDATEDEFAULT": "yes"
+      },
+      "network": {
+        "NETWORKING": "yes",
+        "NOZEROCONF": "yes"
+      }
+    },
     "timezone": "New_York"
   }
 }

--- a/test/data/manifests/rhel_84-x86_64-qcow2-boot.json
+++ b/test/data/manifests/rhel_84-x86_64-qcow2-boot.json
@@ -3468,6 +3468,19 @@
           "options": {
             "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
           }
+        },
+        {
+          "name": "org.osbuild.sysconfig",
+          "options": {
+            "kernel": {
+              "update_default": true,
+              "default_kernel": "kernel"
+            },
+            "network": {
+              "networking": true,
+              "no_zero_conf": true
+            }
+          }
         }
       ],
       "assembler": {
@@ -10168,6 +10181,16 @@
       "tuned.service",
       "unbound-anchor.timer"
     ],
+    "sysconfig": {
+      "kernel": {
+        "DEFAULTKERNEL": "kernel",
+        "UPDATEDEFAULT": "yes"
+      },
+      "network": {
+        "NETWORKING": "yes",
+        "NOZEROCONF": "yes"
+      }
+    },
     "timezone": "New_York"
   }
 }

--- a/test/data/manifests/rhel_84-x86_64-qcow2-customize.json
+++ b/test/data/manifests/rhel_84-x86_64-qcow2-customize.json
@@ -3567,6 +3567,19 @@
           "options": {
             "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
           }
+        },
+        {
+          "name": "org.osbuild.sysconfig",
+          "options": {
+            "kernel": {
+              "update_default": true,
+              "default_kernel": "kernel"
+            },
+            "network": {
+              "networking": true,
+              "no_zero_conf": true
+            }
+          }
         }
       ],
       "assembler": {
@@ -10271,6 +10284,16 @@
       "tuned.service",
       "unbound-anchor.timer"
     ],
+    "sysconfig": {
+      "kernel": {
+        "DEFAULTKERNEL": "kernel",
+        "UPDATEDEFAULT": "yes"
+      },
+      "network": {
+        "NETWORKING": "yes",
+        "NOZEROCONF": "yes"
+      }
+    },
     "timezone": "London"
   }
 }

--- a/test/data/manifests/rhel_84-x86_64-vhd-boot.json
+++ b/test/data/manifests/rhel_84-x86_64-vhd-boot.json
@@ -3499,6 +3499,19 @@
           "options": {
             "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
           }
+        },
+        {
+          "name": "org.osbuild.sysconfig",
+          "options": {
+            "kernel": {
+              "update_default": true,
+              "default_kernel": "kernel"
+            },
+            "network": {
+              "networking": true,
+              "no_zero_conf": true
+            }
+          }
         }
       ],
       "assembler": {
@@ -10248,6 +10261,16 @@
       "unbound-anchor.timer",
       "waagent.service"
     ],
+    "sysconfig": {
+      "kernel": {
+        "DEFAULTKERNEL": "kernel",
+        "UPDATEDEFAULT": "yes"
+      },
+      "network": {
+        "NETWORKING": "yes",
+        "NOZEROCONF": "yes"
+      }
+    },
     "timezone": "New_York"
   }
 }

--- a/test/data/manifests/rhel_84-x86_64-vmdk-boot.json
+++ b/test/data/manifests/rhel_84-x86_64-vmdk-boot.json
@@ -3357,6 +3357,19 @@
           "options": {
             "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
           }
+        },
+        {
+          "name": "org.osbuild.sysconfig",
+          "options": {
+            "kernel": {
+              "update_default": true,
+              "default_kernel": "kernel"
+            },
+            "network": {
+              "networking": true,
+              "no_zero_conf": true
+            }
+          }
         }
       ],
       "assembler": {
@@ -9873,6 +9886,16 @@
       "vgauthd.service",
       "vmtoolsd.service"
     ],
+    "sysconfig": {
+      "kernel": {
+        "DEFAULTKERNEL": "kernel",
+        "UPDATEDEFAULT": "yes"
+      },
+      "network": {
+        "NETWORKING": "yes",
+        "NOZEROCONF": "yes"
+      }
+    },
     "timezone": "New_York"
   }
 }

--- a/tools/image-info
+++ b/tools/image-info
@@ -358,6 +358,30 @@ def read_fstab(tree):
             result = sorted([line.split() for line in f if line and not line.startswith("#")])
     return result
 
+# Create a nested dictionary for all supported sysconfigs 
+def read_sysconfig(tree):
+    result = {}
+    sysconfig_paths = {
+        "kernel": f"{tree}/etc/sysconfig/kernel",
+        "network": f"{tree}/etc/sysconfig/network"
+    }
+    # iterate through supported configs
+    # based on https://github.com/osbuild/osbuild/blob/main/osbuild/util/osrelease.py#L17
+    for name, path in sysconfig_paths.items():
+        with contextlib.suppress(FileNotFoundError):
+            with open(path) as f:
+                # if file exists start with empty array of values
+                result[name] = {}
+                for line in f:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    if line[0] == "#":
+                        continue
+                    key, value = line.split("=", 1)
+                    result[name][key] = value.strip('"')
+    return result
+ 
 
 def append_filesystem(report, tree, *, is_ostree=False):
     if os.path.exists(f"{tree}/etc/os-release"):
@@ -389,6 +413,10 @@ def append_filesystem(report, tree, *, is_ostree=False):
         if fstab:
             report["fstab"] = fstab
 
+        sysconfig = read_sysconfig(tree)
+        if sysconfig:
+            report["sysconfig"] = sysconfig
+            
         with open(f"{tree}/etc/passwd") as f:
             report["passwd"] = sorted(f.read().strip().split("\n"))
 


### PR DESCRIPTION
This pull request includes:

- [x] adequate testing for the new functionality or fixed issue
- [x] adequate documentation informing people about the change



The org.osbuild.sysconfig stage is now supported. Config updates can be made to the kernel and network files. Currently, only the default values are used for all image types in rhel84. The image-info script is updated to allow testing the sysconfig info.

The default values are:
```
  kernel:
    UPDATEDEFAULT=yes
    DEFAULTKERNEL=kernel
    
  network:
    NETWORKING=yes
    NOZEROCONF=yes
```