### PR TITLE
distro/rhel84: remove rng-tools from qcow2

### DIFF
--- a/docs/news/unreleased/rhel84-differences-fixed.md
+++ b/docs/news/unreleased/rhel84-differences-fixed.md
@@ -6,12 +6,12 @@ and disabled services. To remedy these differences the following changes have
 been made:
 
 The following packages have been added to our qcow2 image: oddjob, 
-oddjob-mkhomedir, psmisc, authselect-compat, rng-tools, dbxtool.
+oddjob-mkhomedir, psmisc, authselect-compat, dbxtool.
 
 The following packages have been removed from our qcow2 image: 
 dnf-plugin-spacewalk, fwupd, nss, and udisks2.
 
-The following services have been enabled: rngd.service, nfs-convert.service.
+The following services have been enabled: nfs-convert.service.
 
 The following services have been removed/disabled: mdmonitor.service, 
 udisks2.service, fwupd-refresh.timer, mdcheck_continue.timer, 

--- a/internal/distro/rhel84/distro.go
+++ b/internal/distro/rhel84/distro.go
@@ -958,10 +958,8 @@ func New() distro.Distro {
 			"libertas-usb8388-firmware",
 			"nss",
 			"plymouth",
+			"rng-tools",
 			"udisks2",
-		},
-		enabledServices: []string{
-			"rngd.service",
 		},
 		defaultTarget:           "multi-user.target",
 		kernelOptions:           "console=tty0 console=ttyS0,115200n8 no_timer_check net.ifnames=0 crashkernel=auto",

--- a/test/data/manifests/rhel_84-x86_64-qcow2-boot.json
+++ b/test/data/manifests/rhel_84-x86_64-qcow2-boot.json
@@ -828,9 +828,6 @@
           "sha256:9d2a2ef762444163e91c433c83ce91ef37acb2318ba168a81ac0dd4d65b834ef": {
             "url": "https://rpmrepo.osbuild.org/v1/psi/el8/el8-x86_64-baseos-8.4.0.n-20201010/Packages/subscription-manager-1.27.16-1.el8.x86_64.rpm"
           },
-          "sha256:9d9d1bdfba4cd852f90232ebe2c4247e7b3a88c4476578c820788a91d6838e55": {
-            "url": "https://rpmrepo.osbuild.org/v1/psi/el8/el8-x86_64-baseos-8.4.0.n-20201010/Packages/rng-tools-6.8-3.el8.x86_64.rpm"
-          },
           "sha256:9e08c0338eac83abf9a0118cb05fb646d4554c1b2513ab6801e9587aede40b28": {
             "url": "https://rpmrepo.osbuild.org/v1/psi/el8/el8-x86_64-appstream-8.4.0.n-20201010/Packages/python3-babel-2.5.1-5.el8.noarch.rpm"
           },
@@ -3098,9 +3095,6 @@
                 "checksum": "sha256:9be187fd62ada3a61cb494a383b8a60fd6c705c93897a13051600dbbeb1d914f"
               },
               {
-                "checksum": "sha256:9d9d1bdfba4cd852f90232ebe2c4247e7b3a88c4476578c820788a91d6838e55"
-              },
-              {
                 "checksum": "sha256:ad060f60303b6764e08657436147cc24cfc4bb1ccc1431796407ba005a7bcec0"
               },
               {
@@ -3460,9 +3454,6 @@
         {
           "name": "org.osbuild.systemd",
           "options": {
-            "enabled_services": [
-              "rngd.service"
-            ],
             "default_target": "multi-user.target"
           }
         },
@@ -8555,15 +8546,6 @@
         "checksum": "sha256:9be187fd62ada3a61cb494a383b8a60fd6c705c93897a13051600dbbeb1d914f"
       },
       {
-        "name": "rng-tools",
-        "epoch": 0,
-        "version": "6.8",
-        "release": "3.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v1/psi/el8/el8-x86_64-baseos-8.4.0.n-20201010/Packages/rng-tools-6.8-3.el8.x86_64.rpm",
-        "checksum": "sha256:9d9d1bdfba4cd852f90232ebe2c4247e7b3a88c4476578c820788a91d6838e55"
-      },
-      {
         "name": "rootfiles",
         "epoch": 0,
         "version": "8.1",
@@ -9524,7 +9506,6 @@
       "polkitd:x:996:",
       "redhat:x:1000:",
       "render:x:998:",
-      "rngd:x:988:",
       "root:x:0:",
       "rpc:x:32:",
       "rpcuser:x:29:",
@@ -9952,7 +9933,6 @@
       "redhat-release-8.4-0.5.el8.x86_64",
       "redhat-release-eula-8.4-0.5.el8.x86_64",
       "rhsm-icons-1.27.16-1.el8.noarch",
-      "rng-tools-6.8-3.el8.x86_64",
       "rootfiles-8.1-22.el8.noarch",
       "rpcbind-1.2.5-7.el8.x86_64",
       "rpm-4.14.3-4.el8.x86_64",
@@ -10064,7 +10044,6 @@
       "operator:x:11:0:operator:/root:/sbin/nologin",
       "polkitd:x:998:996:User for polkitd:/:/sbin/nologin",
       "redhat:x:1000:1000::/home/redhat:/bin/bash",
-      "rngd:x:991:988:Random Number Generator Daemon:/var/lib/rngd:/sbin/nologin",
       "root:x:0:0:root:/root:/bin/bash",
       "rpc:x:32:32:Rpcbind Daemon:/var/lib/rpcbind:/sbin/nologin",
       "rpcuser:x:29:29:RPC Service User:/var/lib/nfs:/sbin/nologin",
@@ -10120,7 +10099,6 @@
       "remote-cryptsetup.target",
       "rhsm-facts.service",
       "rhsm.service",
-      "rngd-wake-threshold.service",
       "runlevel0.target",
       "runlevel6.target",
       "serial-getty@.service",
@@ -10163,7 +10141,6 @@
       "nis-domainname.service",
       "remote-fs.target",
       "rhsmcertd.service",
-      "rngd.service",
       "rpcbind.service",
       "rpcbind.socket",
       "rsyslog.service",

--- a/test/data/manifests/rhel_84-x86_64-qcow2-customize.json
+++ b/test/data/manifests/rhel_84-x86_64-qcow2-customize.json
@@ -880,9 +880,6 @@
           "sha256:9d2a2ef762444163e91c433c83ce91ef37acb2318ba168a81ac0dd4d65b834ef": {
             "url": "https://rpmrepo.osbuild.org/v1/psi/el8/el8-x86_64-baseos-8.4.0.n-20201010/Packages/subscription-manager-1.27.16-1.el8.x86_64.rpm"
           },
-          "sha256:9d9d1bdfba4cd852f90232ebe2c4247e7b3a88c4476578c820788a91d6838e55": {
-            "url": "https://rpmrepo.osbuild.org/v1/psi/el8/el8-x86_64-baseos-8.4.0.n-20201010/Packages/rng-tools-6.8-3.el8.x86_64.rpm"
-          },
           "sha256:9e08c0338eac83abf9a0118cb05fb646d4554c1b2513ab6801e9587aede40b28": {
             "url": "https://rpmrepo.osbuild.org/v1/psi/el8/el8-x86_64-appstream-8.4.0.n-20201010/Packages/python3-babel-2.5.1-5.el8.noarch.rpm"
           },
@@ -3150,9 +3147,6 @@
                 "checksum": "sha256:9be187fd62ada3a61cb494a383b8a60fd6c705c93897a13051600dbbeb1d914f"
               },
               {
-                "checksum": "sha256:9d9d1bdfba4cd852f90232ebe2c4247e7b3a88c4476578c820788a91d6838e55"
-              },
-              {
                 "checksum": "sha256:ad060f60303b6764e08657436147cc24cfc4bb1ccc1431796407ba005a7bcec0"
               },
               {
@@ -3554,7 +3548,6 @@
           "name": "org.osbuild.systemd",
           "options": {
             "enabled_services": [
-              "rngd.service",
               "sshd.socket"
             ],
             "disabled_services": [
@@ -8652,15 +8645,6 @@
         "checksum": "sha256:9be187fd62ada3a61cb494a383b8a60fd6c705c93897a13051600dbbeb1d914f"
       },
       {
-        "name": "rng-tools",
-        "epoch": 0,
-        "version": "6.8",
-        "release": "3.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v1/psi/el8/el8-x86_64-baseos-8.4.0.n-20201010/Packages/rng-tools-6.8-3.el8.x86_64.rpm",
-        "checksum": "sha256:9d9d1bdfba4cd852f90232ebe2c4247e7b3a88c4476578c820788a91d6838e55"
-      },
-      {
         "name": "rootfiles",
         "epoch": 0,
         "version": "8.1",
@@ -9622,7 +9606,6 @@
       "nobody:x:65534:",
       "polkitd:x:996:",
       "render:x:998:",
-      "rngd:x:988:",
       "root:x:0:",
       "rpc:x:32:",
       "rpcuser:x:29:",
@@ -10051,7 +10034,6 @@
       "redhat-release-8.4-0.5.el8.x86_64",
       "redhat-release-eula-8.4-0.5.el8.x86_64",
       "rhsm-icons-1.27.16-1.el8.noarch",
-      "rng-tools-6.8-3.el8.x86_64",
       "rootfiles-8.1-22.el8.noarch",
       "rpcbind-1.2.5-7.el8.x86_64",
       "rpm-4.14.3-4.el8.x86_64",
@@ -10162,7 +10144,6 @@
       "nobody:x:65534:65534:Kernel Overflow User:/:/sbin/nologin",
       "operator:x:11:0:operator:/root:/sbin/nologin",
       "polkitd:x:998:996:User for polkitd:/:/sbin/nologin",
-      "rngd:x:991:988:Random Number Generator Daemon:/var/lib/rngd:/sbin/nologin",
       "root:x:0:0:root:/root:/bin/bash",
       "rpc:x:32:32:Rpcbind Daemon:/var/lib/rpcbind:/sbin/nologin",
       "rpcuser:x:29:29:RPC Service User:/var/lib/nfs:/sbin/nologin",
@@ -10221,7 +10202,6 @@
       "remote-cryptsetup.target",
       "rhsm-facts.service",
       "rhsm.service",
-      "rngd-wake-threshold.service",
       "runlevel0.target",
       "runlevel6.target",
       "serial-getty@.service",
@@ -10263,7 +10243,6 @@
       "nis-domainname.service",
       "remote-fs.target",
       "rhsmcertd.service",
-      "rngd.service",
       "rpcbind.service",
       "rpcbind.socket",
       "rsyslog.service",


### PR DESCRIPTION
`rng-tools` was added back into the qcow2 packages by mistake. It should be an excluded package and `rngd.service` should not be enabled. After #1178 `rng-tools` won't need to be an excluded package since it won't be included by `@core` but it is easiest to explicitly exclude it for now.


This pull request includes:

- [x] adequate testing for the new functionality or fixed issue
- [x] adequate documentation informing people about the change
