### PR TITLE
Add support for `org.osbuild.rhsm` osbuild stage + disable RHSM DNF plugins on RHEL qcow2 images

### DIFF
--- a/docs/news/unreleased/osbuild-rhsm-stage.md
+++ b/docs/news/unreleased/osbuild-rhsm-stage.md
@@ -1,0 +1,6 @@
+# Add support for `org.osbuild.rhsm` osbuild stage
+
+Add support for `org.osbuild.rhsm` osbuild stage. This stage is available in
+osbuild since version 24. The stage currently allows only configuring the
+enablement status of two RHSM DNF plugins, specifically of `product-id` and
+`subscription-manager` DNF plugins.

--- a/docs/news/unreleased/osbuild-rhsm-stage.md
+++ b/docs/news/unreleased/osbuild-rhsm-stage.md
@@ -4,3 +4,10 @@ Add support for `org.osbuild.rhsm` osbuild stage. This stage is available in
 osbuild since version 24. The stage currently allows only configuring the
 enablement status of two RHSM DNF plugins, specifically of `product-id` and
 `subscription-manager` DNF plugins.
+
+# RHEL 8.3 & 8.4: Disable all RHSM DNF plugins on qcow2 image
+
+Disable both available RHSM DNF plugins (`product-id` and
+`subscription-manager`) on rhel-8 and rhel-84 qcow2 images. The reason for
+disabling these DNF plugins is to make the produced images consistent in this
+regard, with what had been previously produced by the imagefactory.

--- a/internal/distro/rhel8/distro.go
+++ b/internal/distro/rhel8/distro.go
@@ -324,6 +324,20 @@ func (t *imageType) pipeline(c *blueprint.Customizations, options distro.ImageOp
 			WaitForNetwork: true,
 		},
 		))
+	} else {
+		// RHSM DNF plugins should be by default disabled on RHEL Guest KVM images
+		if t.Name() == "qcow2" {
+			p.AddStage(osbuild.NewRHSMStage(&osbuild.RHSMStageOptions{
+				DnfPlugins: &osbuild.RHSMStageOptionsDnfPlugins{
+					ProductID: &osbuild.RHSMStageOptionsDnfPlugin{
+						Enabled: false,
+					},
+					SubscriptionManager: &osbuild.RHSMStageOptionsDnfPlugin{
+						Enabled: false,
+					},
+				},
+			}))
+		}
 	}
 
 	p.Assembler = t.assembler(t.arch.uefi, options, t.arch)
@@ -1002,6 +1016,7 @@ func New() distro.Distro {
 			"glibc",
 			"policycoreutils",
 			"python36",
+			"python3-iniparse", // dependency of org.osbuild.rhsm stage
 			"qemu-img",
 			"selinux-policy-targeted",
 			"systemd",

--- a/internal/distro/rhel84/distro.go
+++ b/internal/distro/rhel84/distro.go
@@ -363,6 +363,20 @@ func (t *imageType) pipeline(c *blueprint.Customizations, options distro.ImageOp
 			WaitForNetwork: true,
 		},
 		))
+	} else {
+		// RHSM DNF plugins should be by default disabled on RHEL Guest KVM images
+		if t.Name() == "qcow2" {
+			p.AddStage(osbuild.NewRHSMStage(&osbuild.RHSMStageOptions{
+				DnfPlugins: &osbuild.RHSMStageOptionsDnfPlugins{
+					ProductID: &osbuild.RHSMStageOptionsDnfPlugin{
+						Enabled: false,
+					},
+					SubscriptionManager: &osbuild.RHSMStageOptionsDnfPlugin{
+						Enabled: false,
+					},
+				},
+			}))
+		}
 	}
 
 	p.Assembler = t.assembler(pt, options, t.arch)
@@ -1111,6 +1125,7 @@ func New() distro.Distro {
 			"glibc",
 			"policycoreutils",
 			"python36",
+			"python3-iniparse", // dependency of org.osbuild.rhsm stage
 			"qemu-img",
 			"selinux-policy-targeted",
 			"systemd",

--- a/internal/osbuild/rhsm_stage.go
+++ b/internal/osbuild/rhsm_stage.go
@@ -1,0 +1,34 @@
+package osbuild
+
+// RHSMStageOptions describes configuration of the RHSM stage.
+//
+// The RHSM stage allows configuration of Red Hat Subscription Manager (RHSM)
+// related components. Currently it allows only configuration of the enablement
+// state of DNF plugins used by the Subscription Manager.
+type RHSMStageOptions struct {
+	DnfPlugins *RHSMStageOptionsDnfPlugins `json:"dnf-plugins,omitempty"`
+}
+
+func (RHSMStageOptions) isStageOptions() {}
+
+// RHSMStageOptionsDnfPlugins describes configuration of all RHSM DNF plugins
+type RHSMStageOptionsDnfPlugins struct {
+	ProductID           *RHSMStageOptionsDnfPlugin `json:"product-id,omitempty"`
+	SubscriptionManager *RHSMStageOptionsDnfPlugin `json:"subscription-manager,omitempty"`
+}
+
+// RHSMStageOptionsDnfPlugin describes configuration of a specific RHSM DNF
+// plugin
+//
+// Only the enablement state of a DNF plugin can be currenlty  set.
+type RHSMStageOptionsDnfPlugin struct {
+	Enabled bool `json:"enabled"`
+}
+
+// NewRHSMStage creates a new RHSM stage
+func NewRHSMStage(options *RHSMStageOptions) *Stage {
+	return &Stage{
+		Name:    "org.osbuild.rhsm",
+		Options: options,
+	}
+}

--- a/internal/osbuild/rhsm_stage_test.go
+++ b/internal/osbuild/rhsm_stage_test.go
@@ -1,0 +1,16 @@
+package osbuild
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewRhsmStage(t *testing.T) {
+	expectedStage := &Stage{
+		Name:    "org.osbuild.rhsm",
+		Options: &RHSMStageOptions{},
+	}
+	actualStage := NewRHSMStage(&RHSMStageOptions{})
+	assert.Equal(t, expectedStage, actualStage)
+}

--- a/internal/osbuild/stage.go
+++ b/internal/osbuild/stage.go
@@ -60,6 +60,8 @@ func (stage *Stage) UnmarshalJSON(data []byte) error {
 		options = new(KeymapStageOptions)
 	case "org.osbuild.firewall":
 		options = new(FirewallStageOptions)
+	case "org.osbuild.rhsm":
+		options = new(RHSMStageOptions)
 	case "org.osbuild.rpm":
 		options = new(RPMStageOptions)
 	case "org.osbuild.rpm-ostree":

--- a/internal/osbuild/stage_test.go
+++ b/internal/osbuild/stage_test.go
@@ -173,6 +173,35 @@ func TestStage_UnmarshalJSON(t *testing.T) {
 			},
 		},
 		{
+			name: "rhsm-empty",
+			fields: fields{
+				Name:    "org.osbuild.rhsm",
+				Options: &RHSMStageOptions{},
+			},
+			args: args{
+				data: []byte(`{"name":"org.osbuild.rhsm","options":{}}`),
+			},
+		},
+		{
+			name: "rhsm",
+			fields: fields{
+				Name: "org.osbuild.rhsm",
+				Options: &RHSMStageOptions{
+					DnfPlugins: &RHSMStageOptionsDnfPlugins{
+						ProductID: &RHSMStageOptionsDnfPlugin{
+							Enabled: false,
+						},
+						SubscriptionManager: &RHSMStageOptionsDnfPlugin{
+							Enabled: false,
+						},
+					},
+				},
+			},
+			args: args{
+				data: []byte(`{"name":"org.osbuild.rhsm","options":{"dnf-plugins":{"product-id":{"enabled":false},"subscription-manager":{"enabled":false}}}}`),
+			},
+		},
+		{
 			name: "rpm-empty",
 			fields: fields{
 				Name:    "org.osbuild.rpm",

--- a/test/data/manifests/rhel_8-aarch64-ami-boot.json
+++ b/test/data/manifests/rhel_8-aarch64-ami-boot.json
@@ -1713,6 +1713,9 @@
                     "checksum": "sha256:f74dcf1a854453ea75c5159ac909c01c983cf3d2d6d46f762dfe973fdd1c55dd"
                   },
                   {
+                    "checksum": "sha256:9a6eb680e8debcd0b97575a76e9cf0d0655ef7f875b362542e0d129f5e423419"
+                  },
+                  {
                     "checksum": "sha256:3a3207904e90b42a3fcf474f906e4c1544dbdccafa0d7e6e0406c32fd31e2a63"
                   },
                   {
@@ -1732,6 +1735,9 @@
                   },
                   {
                     "checksum": "sha256:1ed3940c0466986fa38fe9d3bd5fc6370b5e62edba51f7a8359eab786b4b81ec"
+                  },
+                  {
+                    "checksum": "sha256:932cca0b2aa28d64538fca0401acc35bec34f14bfe99d3e22ea8452b79890eac"
                   },
                   {
                     "checksum": "sha256:c2f286f6b75caf1508829d748c35833ee5fba762e0175b1f5dbb23ab8ab2079e"
@@ -4613,6 +4619,15 @@
         "checksum": "sha256:f74dcf1a854453ea75c5159ac909c01c983cf3d2d6d46f762dfe973fdd1c55dd"
       },
       {
+        "name": "python3-iniparse",
+        "epoch": 0,
+        "version": "0.4",
+        "release": "31.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v1/psi/el8/el8-aarch64-baseos-8.3.0.r-20210120/Packages/python3-iniparse-0.4-31.el8.noarch.rpm",
+        "checksum": "sha256:9a6eb680e8debcd0b97575a76e9cf0d0655ef7f875b362542e0d129f5e423419"
+      },
+      {
         "name": "python3-libcomps",
         "epoch": 0,
         "version": "0.1.11",
@@ -4674,6 +4689,15 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v1/psi/el8/el8-aarch64-baseos-8.3.0.r-20210120/Packages/python3-setuptools-wheel-39.2.0-6.el8.noarch.rpm",
         "checksum": "sha256:1ed3940c0466986fa38fe9d3bd5fc6370b5e62edba51f7a8359eab786b4b81ec"
+      },
+      {
+        "name": "python3-six",
+        "epoch": 0,
+        "version": "1.11.0",
+        "release": "8.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v1/psi/el8/el8-aarch64-baseos-8.3.0.r-20210120/Packages/python3-six-1.11.0-8.el8.noarch.rpm",
+        "checksum": "sha256:932cca0b2aa28d64538fca0401acc35bec34f14bfe99d3e22ea8452b79890eac"
       },
       {
         "name": "readline",
@@ -9007,6 +9031,16 @@
       "tss:x:59:59:Account used by the trousers package to sandbox the tcsd daemon:/dev/null:/sbin/nologin",
       "unbound:x:997:994:Unbound DNS resolver:/etc/unbound:/sbin/nologin"
     ],
+    "rhsm": {
+      "dnf-plugins": {
+        "product-id": {
+          "enabled": true
+        },
+        "subscription-manager": {
+          "enabled": true
+        }
+      }
+    },
     "rpm-verify": {
       "changed": {
         "/boot/efi/EFI": ".M.......",

--- a/test/data/manifests/rhel_8-aarch64-openstack-boot.json
+++ b/test/data/manifests/rhel_8-aarch64-openstack-boot.json
@@ -1838,6 +1838,9 @@
                     "checksum": "sha256:f74dcf1a854453ea75c5159ac909c01c983cf3d2d6d46f762dfe973fdd1c55dd"
                   },
                   {
+                    "checksum": "sha256:9a6eb680e8debcd0b97575a76e9cf0d0655ef7f875b362542e0d129f5e423419"
+                  },
+                  {
                     "checksum": "sha256:3a3207904e90b42a3fcf474f906e4c1544dbdccafa0d7e6e0406c32fd31e2a63"
                   },
                   {
@@ -1857,6 +1860,9 @@
                   },
                   {
                     "checksum": "sha256:1ed3940c0466986fa38fe9d3bd5fc6370b5e62edba51f7a8359eab786b4b81ec"
+                  },
+                  {
+                    "checksum": "sha256:932cca0b2aa28d64538fca0401acc35bec34f14bfe99d3e22ea8452b79890eac"
                   },
                   {
                     "checksum": "sha256:c2f286f6b75caf1508829d748c35833ee5fba762e0175b1f5dbb23ab8ab2079e"
@@ -4850,6 +4856,15 @@
         "checksum": "sha256:f74dcf1a854453ea75c5159ac909c01c983cf3d2d6d46f762dfe973fdd1c55dd"
       },
       {
+        "name": "python3-iniparse",
+        "epoch": 0,
+        "version": "0.4",
+        "release": "31.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v1/psi/el8/el8-aarch64-baseos-8.3.0.r-20210120/Packages/python3-iniparse-0.4-31.el8.noarch.rpm",
+        "checksum": "sha256:9a6eb680e8debcd0b97575a76e9cf0d0655ef7f875b362542e0d129f5e423419"
+      },
+      {
         "name": "python3-libcomps",
         "epoch": 0,
         "version": "0.1.11",
@@ -4911,6 +4926,15 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v1/psi/el8/el8-aarch64-baseos-8.3.0.r-20210120/Packages/python3-setuptools-wheel-39.2.0-6.el8.noarch.rpm",
         "checksum": "sha256:1ed3940c0466986fa38fe9d3bd5fc6370b5e62edba51f7a8359eab786b4b81ec"
+      },
+      {
+        "name": "python3-six",
+        "epoch": 0,
+        "version": "1.11.0",
+        "release": "8.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v1/psi/el8/el8-aarch64-baseos-8.3.0.r-20210120/Packages/python3-six-1.11.0-8.el8.noarch.rpm",
+        "checksum": "sha256:932cca0b2aa28d64538fca0401acc35bec34f14bfe99d3e22ea8452b79890eac"
       },
       {
         "name": "readline",
@@ -9609,6 +9633,16 @@
       "tss:x:59:59:Account used by the trousers package to sandbox the tcsd daemon:/dev/null:/sbin/nologin",
       "unbound:x:997:994:Unbound DNS resolver:/etc/unbound:/sbin/nologin"
     ],
+    "rhsm": {
+      "dnf-plugins": {
+        "product-id": {
+          "enabled": true
+        },
+        "subscription-manager": {
+          "enabled": true
+        }
+      }
+    },
     "rpm-verify": {
       "changed": {
         "/boot/efi/EFI": ".M.......",

--- a/test/data/manifests/rhel_8-aarch64-qcow2-boot.json
+++ b/test/data/manifests/rhel_8-aarch64-qcow2-boot.json
@@ -1922,6 +1922,9 @@
                     "checksum": "sha256:f74dcf1a854453ea75c5159ac909c01c983cf3d2d6d46f762dfe973fdd1c55dd"
                   },
                   {
+                    "checksum": "sha256:9a6eb680e8debcd0b97575a76e9cf0d0655ef7f875b362542e0d129f5e423419"
+                  },
+                  {
                     "checksum": "sha256:3a3207904e90b42a3fcf474f906e4c1544dbdccafa0d7e6e0406c32fd31e2a63"
                   },
                   {
@@ -1941,6 +1944,9 @@
                   },
                   {
                     "checksum": "sha256:1ed3940c0466986fa38fe9d3bd5fc6370b5e62edba51f7a8359eab786b4b81ec"
+                  },
+                  {
+                    "checksum": "sha256:932cca0b2aa28d64538fca0401acc35bec34f14bfe99d3e22ea8452b79890eac"
                   },
                   {
                     "checksum": "sha256:c2f286f6b75caf1508829d748c35833ee5fba762e0175b1f5dbb23ab8ab2079e"
@@ -3483,6 +3489,19 @@
           "options": {
             "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
           }
+        },
+        {
+          "name": "org.osbuild.rhsm",
+          "options": {
+            "dnf-plugins": {
+              "product-id": {
+                "enabled": false
+              },
+              "subscription-manager": {
+                "enabled": false
+              }
+            }
+          }
         }
       ],
       "assembler": {
@@ -5024,6 +5043,15 @@
         "checksum": "sha256:f74dcf1a854453ea75c5159ac909c01c983cf3d2d6d46f762dfe973fdd1c55dd"
       },
       {
+        "name": "python3-iniparse",
+        "epoch": 0,
+        "version": "0.4",
+        "release": "31.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v1/psi/el8/el8-aarch64-baseos-8.3.0.r-20210120/Packages/python3-iniparse-0.4-31.el8.noarch.rpm",
+        "checksum": "sha256:9a6eb680e8debcd0b97575a76e9cf0d0655ef7f875b362542e0d129f5e423419"
+      },
+      {
         "name": "python3-libcomps",
         "epoch": 0,
         "version": "0.1.11",
@@ -5085,6 +5113,15 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v1/psi/el8/el8-aarch64-baseos-8.3.0.r-20210120/Packages/python3-setuptools-wheel-39.2.0-6.el8.noarch.rpm",
         "checksum": "sha256:1ed3940c0466986fa38fe9d3bd5fc6370b5e62edba51f7a8359eab786b4b81ec"
+      },
+      {
+        "name": "python3-six",
+        "epoch": 0,
+        "version": "1.11.0",
+        "release": "8.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v1/psi/el8/el8-aarch64-baseos-8.3.0.r-20210120/Packages/python3-six-1.11.0-8.el8.noarch.rpm",
+        "checksum": "sha256:932cca0b2aa28d64538fca0401acc35bec34f14bfe99d3e22ea8452b79890eac"
       },
       {
         "name": "readline",
@@ -10092,9 +10129,21 @@
       "tss:x:59:59:Account used by the trousers package to sandbox the tcsd daemon:/dev/null:/sbin/nologin",
       "unbound:x:997:994:Unbound DNS resolver:/etc/unbound:/sbin/nologin"
     ],
+    "rhsm": {
+      "dnf-plugins": {
+        "product-id": {
+          "enabled": false
+        },
+        "subscription-manager": {
+          "enabled": false
+        }
+      }
+    },
     "rpm-verify": {
       "changed": {
         "/boot/efi/EFI": ".M.......",
+        "/etc/dnf/plugins/product-id.conf": "..5....T.",
+        "/etc/dnf/plugins/subscription-manager.conf": "..5....T.",
         "/etc/machine-id": ".M.......",
         "/proc": ".M.......",
         "/sys": ".M.......",

--- a/test/data/manifests/rhel_8-aarch64-rhel_edge_commit-boot.json
+++ b/test/data/manifests/rhel_8-aarch64-rhel_edge_commit-boot.json
@@ -650,6 +650,9 @@
           "sha256:9a1c6f2b18126214e9afa768bbf16b29b89ce3169ccbd4bc169000eed143dcb4": {
             "url": "https://rpmrepo.osbuild.org/v1/psi/el8/el8-aarch64-baseos-8.3.0.r-20210120/Packages/dhcp-libs-4.3.6-41.el8.aarch64.rpm"
           },
+          "sha256:9a6eb680e8debcd0b97575a76e9cf0d0655ef7f875b362542e0d129f5e423419": {
+            "url": "https://rpmrepo.osbuild.org/v1/psi/el8/el8-aarch64-baseos-8.3.0.r-20210120/Packages/python3-iniparse-0.4-31.el8.noarch.rpm"
+          },
           "sha256:9a89874a5b8326c85c0b34b02c122ffc052b32a12b20354ce95859ac5296a159": {
             "url": "https://rpmrepo.osbuild.org/v1/psi/el8/el8-aarch64-baseos-8.3.0.r-20210120/Packages/pkgconf-m4-1.4.2-1.el8.noarch.rpm"
           },
@@ -1692,6 +1695,9 @@
                     "checksum": "sha256:f74dcf1a854453ea75c5159ac909c01c983cf3d2d6d46f762dfe973fdd1c55dd"
                   },
                   {
+                    "checksum": "sha256:9a6eb680e8debcd0b97575a76e9cf0d0655ef7f875b362542e0d129f5e423419"
+                  },
+                  {
                     "checksum": "sha256:3a3207904e90b42a3fcf474f906e4c1544dbdccafa0d7e6e0406c32fd31e2a63"
                   },
                   {
@@ -1711,6 +1717,9 @@
                   },
                   {
                     "checksum": "sha256:1ed3940c0466986fa38fe9d3bd5fc6370b5e62edba51f7a8359eab786b4b81ec"
+                  },
+                  {
+                    "checksum": "sha256:932cca0b2aa28d64538fca0401acc35bec34f14bfe99d3e22ea8452b79890eac"
                   },
                   {
                     "checksum": "sha256:c2f286f6b75caf1508829d748c35833ee5fba762e0175b1f5dbb23ab8ab2079e"
@@ -4535,6 +4544,15 @@
         "checksum": "sha256:f74dcf1a854453ea75c5159ac909c01c983cf3d2d6d46f762dfe973fdd1c55dd"
       },
       {
+        "name": "python3-iniparse",
+        "epoch": 0,
+        "version": "0.4",
+        "release": "31.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v1/psi/el8/el8-aarch64-baseos-8.3.0.r-20210120/Packages/python3-iniparse-0.4-31.el8.noarch.rpm",
+        "checksum": "sha256:9a6eb680e8debcd0b97575a76e9cf0d0655ef7f875b362542e0d129f5e423419"
+      },
+      {
         "name": "python3-libcomps",
         "epoch": 0,
         "version": "0.1.11",
@@ -4596,6 +4614,15 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v1/psi/el8/el8-aarch64-baseos-8.3.0.r-20210120/Packages/python3-setuptools-wheel-39.2.0-6.el8.noarch.rpm",
         "checksum": "sha256:1ed3940c0466986fa38fe9d3bd5fc6370b5e62edba51f7a8359eab786b4b81ec"
+      },
+      {
+        "name": "python3-six",
+        "epoch": 0,
+        "version": "1.11.0",
+        "release": "8.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v1/psi/el8/el8-aarch64-baseos-8.3.0.r-20210120/Packages/python3-six-1.11.0-8.el8.noarch.rpm",
+        "checksum": "sha256:932cca0b2aa28d64538fca0401acc35bec34f14bfe99d3e22ea8452b79890eac"
       },
       {
         "name": "readline",

--- a/test/data/manifests/rhel_8-aarch64-tar-boot.json
+++ b/test/data/manifests/rhel_8-aarch64-tar-boot.json
@@ -384,6 +384,9 @@
           "sha256:923b89c7c2ee61033b0860230fe2e833748364eb7a2ee64ca22523d09a23273c": {
             "url": "https://rpmrepo.osbuild.org/v1/psi/el8/el8-aarch64-baseos-8.3.0.r-20210120/Packages/kpartx-0.8.4-5.el8.aarch64.rpm"
           },
+          "sha256:932cca0b2aa28d64538fca0401acc35bec34f14bfe99d3e22ea8452b79890eac": {
+            "url": "https://rpmrepo.osbuild.org/v1/psi/el8/el8-aarch64-baseos-8.3.0.r-20210120/Packages/python3-six-1.11.0-8.el8.noarch.rpm"
+          },
           "sha256:95a000eb1262fce9d451592a13df5d713ebd0abeb88d90411d384174828153f5": {
             "url": "https://rpmrepo.osbuild.org/v1/psi/el8/el8-aarch64-baseos-8.3.0.r-20210120/Packages/grub2-common-2.02-90.el8.noarch.rpm"
           },
@@ -398,6 +401,9 @@
           },
           "sha256:98f838a9775269a0f796151bd54d52c7ac91d4bf1365186772f243bfafbb136a": {
             "url": "https://rpmrepo.osbuild.org/v1/psi/el8/el8-aarch64-baseos-8.3.0.r-20210120/Packages/libaio-0.3.112-1.el8.aarch64.rpm"
+          },
+          "sha256:9a6eb680e8debcd0b97575a76e9cf0d0655ef7f875b362542e0d129f5e423419": {
+            "url": "https://rpmrepo.osbuild.org/v1/psi/el8/el8-aarch64-baseos-8.3.0.r-20210120/Packages/python3-iniparse-0.4-31.el8.noarch.rpm"
           },
           "sha256:9bc0e71d942cc7946a01105a1a350e11877b6781d9495930cc360cf66ad493bc": {
             "url": "https://rpmrepo.osbuild.org/v1/psi/el8/el8-aarch64-baseos-8.3.0.r-20210120/Packages/libselinux-2.9-3.el8.aarch64.rpm"
@@ -1198,6 +1204,9 @@
                     "checksum": "sha256:f74dcf1a854453ea75c5159ac909c01c983cf3d2d6d46f762dfe973fdd1c55dd"
                   },
                   {
+                    "checksum": "sha256:9a6eb680e8debcd0b97575a76e9cf0d0655ef7f875b362542e0d129f5e423419"
+                  },
+                  {
                     "checksum": "sha256:3a3207904e90b42a3fcf474f906e4c1544dbdccafa0d7e6e0406c32fd31e2a63"
                   },
                   {
@@ -1217,6 +1226,9 @@
                   },
                   {
                     "checksum": "sha256:1ed3940c0466986fa38fe9d3bd5fc6370b5e62edba51f7a8359eab786b4b81ec"
+                  },
+                  {
+                    "checksum": "sha256:932cca0b2aa28d64538fca0401acc35bec34f14bfe99d3e22ea8452b79890eac"
                   },
                   {
                     "checksum": "sha256:c2f286f6b75caf1508829d748c35833ee5fba762e0175b1f5dbb23ab8ab2079e"
@@ -3403,6 +3415,15 @@
         "checksum": "sha256:f74dcf1a854453ea75c5159ac909c01c983cf3d2d6d46f762dfe973fdd1c55dd"
       },
       {
+        "name": "python3-iniparse",
+        "epoch": 0,
+        "version": "0.4",
+        "release": "31.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v1/psi/el8/el8-aarch64-baseos-8.3.0.r-20210120/Packages/python3-iniparse-0.4-31.el8.noarch.rpm",
+        "checksum": "sha256:9a6eb680e8debcd0b97575a76e9cf0d0655ef7f875b362542e0d129f5e423419"
+      },
+      {
         "name": "python3-libcomps",
         "epoch": 0,
         "version": "0.1.11",
@@ -3464,6 +3485,15 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v1/psi/el8/el8-aarch64-baseos-8.3.0.r-20210120/Packages/python3-setuptools-wheel-39.2.0-6.el8.noarch.rpm",
         "checksum": "sha256:1ed3940c0466986fa38fe9d3bd5fc6370b5e62edba51f7a8359eab786b4b81ec"
+      },
+      {
+        "name": "python3-six",
+        "epoch": 0,
+        "version": "1.11.0",
+        "release": "8.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v1/psi/el8/el8-aarch64-baseos-8.3.0.r-20210120/Packages/python3-six-1.11.0-8.el8.noarch.rpm",
+        "checksum": "sha256:932cca0b2aa28d64538fca0401acc35bec34f14bfe99d3e22ea8452b79890eac"
       },
       {
         "name": "readline",

--- a/test/data/manifests/rhel_8-ppc64le-qcow2-boot.json
+++ b/test/data/manifests/rhel_8-ppc64le-qcow2-boot.json
@@ -2075,6 +2075,9 @@
                     "checksum": "sha256:af6d0c925a95f2b23843fcce53f1eff0b449db44ff362dc2d7d62bb6dff0a553"
                   },
                   {
+                    "checksum": "sha256:9a6eb680e8debcd0b97575a76e9cf0d0655ef7f875b362542e0d129f5e423419"
+                  },
+                  {
                     "checksum": "sha256:0396d12973b68a7d16074aa51f75e706c0b7558cd24d32e5573c49a487b2497c"
                   },
                   {
@@ -2094,6 +2097,9 @@
                   },
                   {
                     "checksum": "sha256:1ed3940c0466986fa38fe9d3bd5fc6370b5e62edba51f7a8359eab786b4b81ec"
+                  },
+                  {
+                    "checksum": "sha256:932cca0b2aa28d64538fca0401acc35bec34f14bfe99d3e22ea8452b79890eac"
                   },
                   {
                     "checksum": "sha256:d8ba6a91610d87dfb599018c887514af663a0f963ed6b25a83bac8fba56fa266"
@@ -3762,6 +3768,19 @@
           "options": {
             "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
           }
+        },
+        {
+          "name": "org.osbuild.rhsm",
+          "options": {
+            "dnf-plugins": {
+              "product-id": {
+                "enabled": false
+              },
+              "subscription-manager": {
+                "enabled": false
+              }
+            }
+          }
         }
       ],
       "assembler": {
@@ -5356,6 +5375,15 @@
         "checksum": "sha256:af6d0c925a95f2b23843fcce53f1eff0b449db44ff362dc2d7d62bb6dff0a553"
       },
       {
+        "name": "python3-iniparse",
+        "epoch": 0,
+        "version": "0.4",
+        "release": "31.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v1/psi/el8/el8-ppc64le-baseos-8.3.0.r-20210120/Packages/python3-iniparse-0.4-31.el8.noarch.rpm",
+        "checksum": "sha256:9a6eb680e8debcd0b97575a76e9cf0d0655ef7f875b362542e0d129f5e423419"
+      },
+      {
         "name": "python3-libcomps",
         "epoch": 0,
         "version": "0.1.11",
@@ -5417,6 +5445,15 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v1/psi/el8/el8-ppc64le-baseos-8.3.0.r-20210120/Packages/python3-setuptools-wheel-39.2.0-6.el8.noarch.rpm",
         "checksum": "sha256:1ed3940c0466986fa38fe9d3bd5fc6370b5e62edba51f7a8359eab786b4b81ec"
+      },
+      {
+        "name": "python3-six",
+        "epoch": 0,
+        "version": "1.11.0",
+        "release": "8.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v1/psi/el8/el8-ppc64le-baseos-8.3.0.r-20210120/Packages/python3-six-1.11.0-8.el8.noarch.rpm",
+        "checksum": "sha256:932cca0b2aa28d64538fca0401acc35bec34f14bfe99d3e22ea8452b79890eac"
       },
       {
         "name": "readline",
@@ -10867,8 +10904,20 @@
       "tss:x:59:59:Account used by the trousers package to sandbox the tcsd daemon:/dev/null:/sbin/nologin",
       "unbound:x:997:993:Unbound DNS resolver:/etc/unbound:/sbin/nologin"
     ],
+    "rhsm": {
+      "dnf-plugins": {
+        "product-id": {
+          "enabled": false
+        },
+        "subscription-manager": {
+          "enabled": false
+        }
+      }
+    },
     "rpm-verify": {
       "changed": {
+        "/etc/dnf/plugins/product-id.conf": "..5....T.",
+        "/etc/dnf/plugins/subscription-manager.conf": "..5....T.",
         "/etc/machine-id": ".M.......",
         "/proc": ".M.......",
         "/sys": ".M.......",

--- a/test/data/manifests/rhel_8-ppc64le-tar-boot.json
+++ b/test/data/manifests/rhel_8-ppc64le-tar-boot.json
@@ -423,6 +423,9 @@
           "sha256:910396eda6d7874dd51011ad565afecc62a2772568f6ec1c373083f6fa8e5e57": {
             "url": "https://rpmrepo.osbuild.org/v1/psi/el8/el8-ppc64le-baseos-8.3.0.r-20210120/Packages/platform-python-3.6.8-31.el8.ppc64le.rpm"
           },
+          "sha256:932cca0b2aa28d64538fca0401acc35bec34f14bfe99d3e22ea8452b79890eac": {
+            "url": "https://rpmrepo.osbuild.org/v1/psi/el8/el8-ppc64le-baseos-8.3.0.r-20210120/Packages/python3-six-1.11.0-8.el8.noarch.rpm"
+          },
           "sha256:93e8eb519fee69ad0a90733dea8577670a1c62f02fce9348633880e0d9190f4b": {
             "url": "https://rpmrepo.osbuild.org/v1/psi/el8/el8-ppc64le-baseos-8.3.0.r-20210120/Packages/libseccomp-2.4.3-1.el8.ppc64le.rpm"
           },
@@ -443,6 +446,9 @@
           },
           "sha256:9a1782b0ff33ad11979c039999990819c66145010e17c4af41550daf4d9d15ae": {
             "url": "https://rpmrepo.osbuild.org/v1/psi/el8/el8-ppc64le-baseos-8.3.0.r-20210120/Packages/libcroco-0.6.12-4.el8_2.1.ppc64le.rpm"
+          },
+          "sha256:9a6eb680e8debcd0b97575a76e9cf0d0655ef7f875b362542e0d129f5e423419": {
+            "url": "https://rpmrepo.osbuild.org/v1/psi/el8/el8-ppc64le-baseos-8.3.0.r-20210120/Packages/python3-iniparse-0.4-31.el8.noarch.rpm"
           },
           "sha256:9bdf8e5f329b54f1ea45a5d5277d650be84f7bd2f1570d7c5e7ac743fd57cf1f": {
             "url": "https://rpmrepo.osbuild.org/v1/psi/el8/el8-ppc64le-baseos-8.3.0.r-20210120/Packages/libsmartcols-2.32.1-24.el8.ppc64le.rpm"
@@ -1234,6 +1240,9 @@
                     "checksum": "sha256:af6d0c925a95f2b23843fcce53f1eff0b449db44ff362dc2d7d62bb6dff0a553"
                   },
                   {
+                    "checksum": "sha256:9a6eb680e8debcd0b97575a76e9cf0d0655ef7f875b362542e0d129f5e423419"
+                  },
+                  {
                     "checksum": "sha256:0396d12973b68a7d16074aa51f75e706c0b7558cd24d32e5573c49a487b2497c"
                   },
                   {
@@ -1253,6 +1262,9 @@
                   },
                   {
                     "checksum": "sha256:1ed3940c0466986fa38fe9d3bd5fc6370b5e62edba51f7a8359eab786b4b81ec"
+                  },
+                  {
+                    "checksum": "sha256:932cca0b2aa28d64538fca0401acc35bec34f14bfe99d3e22ea8452b79890eac"
                   },
                   {
                     "checksum": "sha256:d8ba6a91610d87dfb599018c887514af663a0f963ed6b25a83bac8fba56fa266"
@@ -3496,6 +3508,15 @@
         "checksum": "sha256:af6d0c925a95f2b23843fcce53f1eff0b449db44ff362dc2d7d62bb6dff0a553"
       },
       {
+        "name": "python3-iniparse",
+        "epoch": 0,
+        "version": "0.4",
+        "release": "31.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v1/psi/el8/el8-ppc64le-baseos-8.3.0.r-20210120/Packages/python3-iniparse-0.4-31.el8.noarch.rpm",
+        "checksum": "sha256:9a6eb680e8debcd0b97575a76e9cf0d0655ef7f875b362542e0d129f5e423419"
+      },
+      {
         "name": "python3-libcomps",
         "epoch": 0,
         "version": "0.1.11",
@@ -3557,6 +3578,15 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v1/psi/el8/el8-ppc64le-baseos-8.3.0.r-20210120/Packages/python3-setuptools-wheel-39.2.0-6.el8.noarch.rpm",
         "checksum": "sha256:1ed3940c0466986fa38fe9d3bd5fc6370b5e62edba51f7a8359eab786b4b81ec"
+      },
+      {
+        "name": "python3-six",
+        "epoch": 0,
+        "version": "1.11.0",
+        "release": "8.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v1/psi/el8/el8-ppc64le-baseos-8.3.0.r-20210120/Packages/python3-six-1.11.0-8.el8.noarch.rpm",
+        "checksum": "sha256:932cca0b2aa28d64538fca0401acc35bec34f14bfe99d3e22ea8452b79890eac"
       },
       {
         "name": "readline",

--- a/test/data/manifests/rhel_8-s390x-qcow2-boot.json
+++ b/test/data/manifests/rhel_8-s390x-qcow2-boot.json
@@ -2033,6 +2033,9 @@
                     "checksum": "sha256:a4323036608c3e7708d688843b869177d58a17b3b39dd9baf69e53c6542c0ff6"
                   },
                   {
+                    "checksum": "sha256:9a6eb680e8debcd0b97575a76e9cf0d0655ef7f875b362542e0d129f5e423419"
+                  },
+                  {
                     "checksum": "sha256:f3b45fd08cba7c338a8103d236ba4fd2c9bbe36e6d4ef96ddcb6a722d4cf529e"
                   },
                   {
@@ -2052,6 +2055,9 @@
                   },
                   {
                     "checksum": "sha256:1ed3940c0466986fa38fe9d3bd5fc6370b5e62edba51f7a8359eab786b4b81ec"
+                  },
+                  {
+                    "checksum": "sha256:932cca0b2aa28d64538fca0401acc35bec34f14bfe99d3e22ea8452b79890eac"
                   },
                   {
                     "checksum": "sha256:3e1977c9b662e295f67e2114694d4a11d87215346cd7836c8fe8b9cec050f357"
@@ -3686,6 +3692,19 @@
           "name": "org.osbuild.selinux",
           "options": {
             "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
+          }
+        },
+        {
+          "name": "org.osbuild.rhsm",
+          "options": {
+            "dnf-plugins": {
+              "product-id": {
+                "enabled": false
+              },
+              "subscription-manager": {
+                "enabled": false
+              }
+            }
           }
         }
       ],
@@ -5347,6 +5366,15 @@
         "checksum": "sha256:a4323036608c3e7708d688843b869177d58a17b3b39dd9baf69e53c6542c0ff6"
       },
       {
+        "name": "python3-iniparse",
+        "epoch": 0,
+        "version": "0.4",
+        "release": "31.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v1/psi/el8/el8-s390x-baseos-8.3.0.r-20210120/Packages/python3-iniparse-0.4-31.el8.noarch.rpm",
+        "checksum": "sha256:9a6eb680e8debcd0b97575a76e9cf0d0655ef7f875b362542e0d129f5e423419"
+      },
+      {
         "name": "python3-libcomps",
         "epoch": 0,
         "version": "0.1.11",
@@ -5408,6 +5436,15 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v1/psi/el8/el8-s390x-baseos-8.3.0.r-20210120/Packages/python3-setuptools-wheel-39.2.0-6.el8.noarch.rpm",
         "checksum": "sha256:1ed3940c0466986fa38fe9d3bd5fc6370b5e62edba51f7a8359eab786b4b81ec"
+      },
+      {
+        "name": "python3-six",
+        "epoch": 0,
+        "version": "1.11.0",
+        "release": "8.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v1/psi/el8/el8-s390x-baseos-8.3.0.r-20210120/Packages/python3-six-1.11.0-8.el8.noarch.rpm",
+        "checksum": "sha256:932cca0b2aa28d64538fca0401acc35bec34f14bfe99d3e22ea8452b79890eac"
       },
       {
         "name": "readline",
@@ -10715,8 +10752,20 @@
       "tss:x:59:59:Account used by the trousers package to sandbox the tcsd daemon:/dev/null:/sbin/nologin",
       "unbound:x:997:993:Unbound DNS resolver:/etc/unbound:/sbin/nologin"
     ],
+    "rhsm": {
+      "dnf-plugins": {
+        "product-id": {
+          "enabled": false
+        },
+        "subscription-manager": {
+          "enabled": false
+        }
+      }
+    },
     "rpm-verify": {
       "changed": {
+        "/etc/dnf/plugins/product-id.conf": "..5....T.",
+        "/etc/dnf/plugins/subscription-manager.conf": "..5....T.",
         "/etc/machine-id": ".M.......",
         "/proc": ".M.......",
         "/sys": ".M.......",

--- a/test/data/manifests/rhel_8-s390x-tar-boot.json
+++ b/test/data/manifests/rhel_8-s390x-tar-boot.json
@@ -465,6 +465,9 @@
           "sha256:90cad0b0149c8e21613247039af49e91e138aa5e3e7d158022cfd274f349b123": {
             "url": "https://rpmrepo.osbuild.org/v1/psi/el8/el8-s390x-baseos-8.3.0.r-20210120/Packages/perl-libs-5.26.3-416.el8.s390x.rpm"
           },
+          "sha256:932cca0b2aa28d64538fca0401acc35bec34f14bfe99d3e22ea8452b79890eac": {
+            "url": "https://rpmrepo.osbuild.org/v1/psi/el8/el8-s390x-baseos-8.3.0.r-20210120/Packages/python3-six-1.11.0-8.el8.noarch.rpm"
+          },
           "sha256:957f0ffdff9579966c5c0b8cccbd8d41bec7520aa48f7704b01f7ea62dee52e2": {
             "url": "https://rpmrepo.osbuild.org/v1/psi/el8/el8-s390x-baseos-8.3.0.r-20210120/Packages/coreutils-8.30-8.el8.s390x.rpm"
           },
@@ -476,6 +479,9 @@
           },
           "sha256:998276e153886e014ce37c429a0f22b76f3ca955c1c9ba89999ce3dface1cf10": {
             "url": "https://rpmrepo.osbuild.org/v1/psi/el8/el8-s390x-baseos-8.3.0.r-20210120/Packages/libyaml-0.1.7-5.el8.s390x.rpm"
+          },
+          "sha256:9a6eb680e8debcd0b97575a76e9cf0d0655ef7f875b362542e0d129f5e423419": {
+            "url": "https://rpmrepo.osbuild.org/v1/psi/el8/el8-s390x-baseos-8.3.0.r-20210120/Packages/python3-iniparse-0.4-31.el8.noarch.rpm"
           },
           "sha256:9b88cba46414a21b780f2fc25f8e76a0cc144aabf1bec1eb9873e10369cd27c3": {
             "url": "https://rpmrepo.osbuild.org/v1/psi/el8/el8-s390x-baseos-8.3.0.r-20210120/Packages/keyutils-libs-1.5.10-6.el8.s390x.rpm"
@@ -1312,6 +1318,9 @@
                     "checksum": "sha256:a4323036608c3e7708d688843b869177d58a17b3b39dd9baf69e53c6542c0ff6"
                   },
                   {
+                    "checksum": "sha256:9a6eb680e8debcd0b97575a76e9cf0d0655ef7f875b362542e0d129f5e423419"
+                  },
+                  {
                     "checksum": "sha256:f3b45fd08cba7c338a8103d236ba4fd2c9bbe36e6d4ef96ddcb6a722d4cf529e"
                   },
                   {
@@ -1331,6 +1340,9 @@
                   },
                   {
                     "checksum": "sha256:1ed3940c0466986fa38fe9d3bd5fc6370b5e62edba51f7a8359eab786b4b81ec"
+                  },
+                  {
+                    "checksum": "sha256:932cca0b2aa28d64538fca0401acc35bec34f14bfe99d3e22ea8452b79890eac"
                   },
                   {
                     "checksum": "sha256:3e1977c9b662e295f67e2114694d4a11d87215346cd7836c8fe8b9cec050f357"
@@ -3753,6 +3765,15 @@
         "checksum": "sha256:a4323036608c3e7708d688843b869177d58a17b3b39dd9baf69e53c6542c0ff6"
       },
       {
+        "name": "python3-iniparse",
+        "epoch": 0,
+        "version": "0.4",
+        "release": "31.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v1/psi/el8/el8-s390x-baseos-8.3.0.r-20210120/Packages/python3-iniparse-0.4-31.el8.noarch.rpm",
+        "checksum": "sha256:9a6eb680e8debcd0b97575a76e9cf0d0655ef7f875b362542e0d129f5e423419"
+      },
+      {
         "name": "python3-libcomps",
         "epoch": 0,
         "version": "0.1.11",
@@ -3814,6 +3835,15 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v1/psi/el8/el8-s390x-baseos-8.3.0.r-20210120/Packages/python3-setuptools-wheel-39.2.0-6.el8.noarch.rpm",
         "checksum": "sha256:1ed3940c0466986fa38fe9d3bd5fc6370b5e62edba51f7a8359eab786b4b81ec"
+      },
+      {
+        "name": "python3-six",
+        "epoch": 0,
+        "version": "1.11.0",
+        "release": "8.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v1/psi/el8/el8-s390x-baseos-8.3.0.r-20210120/Packages/python3-six-1.11.0-8.el8.noarch.rpm",
+        "checksum": "sha256:932cca0b2aa28d64538fca0401acc35bec34f14bfe99d3e22ea8452b79890eac"
       },
       {
         "name": "readline",

--- a/test/data/manifests/rhel_8-x86_64-ami-boot.json
+++ b/test/data/manifests/rhel_8-x86_64-ami-boot.json
@@ -1719,6 +1719,9 @@
                     "checksum": "sha256:e835f84cdda741b66c3f315a0db71c8209ff4cb451f5ae3afde35b2eda0dd929"
                   },
                   {
+                    "checksum": "sha256:9a6eb680e8debcd0b97575a76e9cf0d0655ef7f875b362542e0d129f5e423419"
+                  },
+                  {
                     "checksum": "sha256:24c7b8b233b0a5a23ff5d42ba56f0ee40372234f91e4fabe36d68e8077157e23"
                   },
                   {
@@ -1738,6 +1741,9 @@
                   },
                   {
                     "checksum": "sha256:1ed3940c0466986fa38fe9d3bd5fc6370b5e62edba51f7a8359eab786b4b81ec"
+                  },
+                  {
+                    "checksum": "sha256:932cca0b2aa28d64538fca0401acc35bec34f14bfe99d3e22ea8452b79890eac"
                   },
                   {
                     "checksum": "sha256:ef221ca565f17ed425997e97fdeb5fc27261910659fa61372b18d93e1a5613e9"
@@ -4636,6 +4642,15 @@
         "checksum": "sha256:e835f84cdda741b66c3f315a0db71c8209ff4cb451f5ae3afde35b2eda0dd929"
       },
       {
+        "name": "python3-iniparse",
+        "epoch": 0,
+        "version": "0.4",
+        "release": "31.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v1/psi/el8/el8-x86_64-baseos-8.3.0.r-20210120/Packages/python3-iniparse-0.4-31.el8.noarch.rpm",
+        "checksum": "sha256:9a6eb680e8debcd0b97575a76e9cf0d0655ef7f875b362542e0d129f5e423419"
+      },
+      {
         "name": "python3-libcomps",
         "epoch": 0,
         "version": "0.1.11",
@@ -4697,6 +4712,15 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v1/psi/el8/el8-x86_64-baseos-8.3.0.r-20210120/Packages/python3-setuptools-wheel-39.2.0-6.el8.noarch.rpm",
         "checksum": "sha256:1ed3940c0466986fa38fe9d3bd5fc6370b5e62edba51f7a8359eab786b4b81ec"
+      },
+      {
+        "name": "python3-six",
+        "epoch": 0,
+        "version": "1.11.0",
+        "release": "8.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v1/psi/el8/el8-x86_64-baseos-8.3.0.r-20210120/Packages/python3-six-1.11.0-8.el8.noarch.rpm",
+        "checksum": "sha256:932cca0b2aa28d64538fca0401acc35bec34f14bfe99d3e22ea8452b79890eac"
       },
       {
         "name": "readline",
@@ -8982,6 +9006,16 @@
       "tss:x:59:59:Account used by the trousers package to sandbox the tcsd daemon:/dev/null:/sbin/nologin",
       "unbound:x:997:994:Unbound DNS resolver:/etc/unbound:/sbin/nologin"
     ],
+    "rhsm": {
+      "dnf-plugins": {
+        "product-id": {
+          "enabled": true
+        },
+        "subscription-manager": {
+          "enabled": true
+        }
+      }
+    },
     "rpm-verify": {
       "changed": {
         "/etc/machine-id": ".M.......",

--- a/test/data/manifests/rhel_8-x86_64-openstack-boot.json
+++ b/test/data/manifests/rhel_8-x86_64-openstack-boot.json
@@ -1847,6 +1847,9 @@
                     "checksum": "sha256:e835f84cdda741b66c3f315a0db71c8209ff4cb451f5ae3afde35b2eda0dd929"
                   },
                   {
+                    "checksum": "sha256:9a6eb680e8debcd0b97575a76e9cf0d0655ef7f875b362542e0d129f5e423419"
+                  },
+                  {
                     "checksum": "sha256:24c7b8b233b0a5a23ff5d42ba56f0ee40372234f91e4fabe36d68e8077157e23"
                   },
                   {
@@ -1866,6 +1869,9 @@
                   },
                   {
                     "checksum": "sha256:1ed3940c0466986fa38fe9d3bd5fc6370b5e62edba51f7a8359eab786b4b81ec"
+                  },
+                  {
+                    "checksum": "sha256:932cca0b2aa28d64538fca0401acc35bec34f14bfe99d3e22ea8452b79890eac"
                   },
                   {
                     "checksum": "sha256:ef221ca565f17ed425997e97fdeb5fc27261910659fa61372b18d93e1a5613e9"
@@ -4879,6 +4885,15 @@
         "checksum": "sha256:e835f84cdda741b66c3f315a0db71c8209ff4cb451f5ae3afde35b2eda0dd929"
       },
       {
+        "name": "python3-iniparse",
+        "epoch": 0,
+        "version": "0.4",
+        "release": "31.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v1/psi/el8/el8-x86_64-baseos-8.3.0.r-20210120/Packages/python3-iniparse-0.4-31.el8.noarch.rpm",
+        "checksum": "sha256:9a6eb680e8debcd0b97575a76e9cf0d0655ef7f875b362542e0d129f5e423419"
+      },
+      {
         "name": "python3-libcomps",
         "epoch": 0,
         "version": "0.1.11",
@@ -4940,6 +4955,15 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v1/psi/el8/el8-x86_64-baseos-8.3.0.r-20210120/Packages/python3-setuptools-wheel-39.2.0-6.el8.noarch.rpm",
         "checksum": "sha256:1ed3940c0466986fa38fe9d3bd5fc6370b5e62edba51f7a8359eab786b4b81ec"
+      },
+      {
+        "name": "python3-six",
+        "epoch": 0,
+        "version": "1.11.0",
+        "release": "8.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v1/psi/el8/el8-x86_64-baseos-8.3.0.r-20210120/Packages/python3-six-1.11.0-8.el8.noarch.rpm",
+        "checksum": "sha256:932cca0b2aa28d64538fca0401acc35bec34f14bfe99d3e22ea8452b79890eac"
       },
       {
         "name": "readline",
@@ -9600,6 +9624,16 @@
       "tss:x:59:59:Account used by the trousers package to sandbox the tcsd daemon:/dev/null:/sbin/nologin",
       "unbound:x:997:994:Unbound DNS resolver:/etc/unbound:/sbin/nologin"
     ],
+    "rhsm": {
+      "dnf-plugins": {
+        "product-id": {
+          "enabled": true
+        },
+        "subscription-manager": {
+          "enabled": true
+        }
+      }
+    },
     "rpm-verify": {
       "changed": {
         "/etc/machine-id": ".M.......",

--- a/test/data/manifests/rhel_8-x86_64-qcow2-boot.json
+++ b/test/data/manifests/rhel_8-x86_64-qcow2-boot.json
@@ -1925,6 +1925,9 @@
                     "checksum": "sha256:e835f84cdda741b66c3f315a0db71c8209ff4cb451f5ae3afde35b2eda0dd929"
                   },
                   {
+                    "checksum": "sha256:9a6eb680e8debcd0b97575a76e9cf0d0655ef7f875b362542e0d129f5e423419"
+                  },
+                  {
                     "checksum": "sha256:24c7b8b233b0a5a23ff5d42ba56f0ee40372234f91e4fabe36d68e8077157e23"
                   },
                   {
@@ -1944,6 +1947,9 @@
                   },
                   {
                     "checksum": "sha256:1ed3940c0466986fa38fe9d3bd5fc6370b5e62edba51f7a8359eab786b4b81ec"
+                  },
+                  {
+                    "checksum": "sha256:932cca0b2aa28d64538fca0401acc35bec34f14bfe99d3e22ea8452b79890eac"
                   },
                   {
                     "checksum": "sha256:ef221ca565f17ed425997e97fdeb5fc27261910659fa61372b18d93e1a5613e9"
@@ -3464,6 +3470,19 @@
           "name": "org.osbuild.selinux",
           "options": {
             "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
+          }
+        },
+        {
+          "name": "org.osbuild.rhsm",
+          "options": {
+            "dnf-plugins": {
+              "product-id": {
+                "enabled": false
+              },
+              "subscription-manager": {
+                "enabled": false
+              }
+            }
           }
         }
       ],
@@ -5041,6 +5060,15 @@
         "checksum": "sha256:e835f84cdda741b66c3f315a0db71c8209ff4cb451f5ae3afde35b2eda0dd929"
       },
       {
+        "name": "python3-iniparse",
+        "epoch": 0,
+        "version": "0.4",
+        "release": "31.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v1/psi/el8/el8-x86_64-baseos-8.3.0.r-20210120/Packages/python3-iniparse-0.4-31.el8.noarch.rpm",
+        "checksum": "sha256:9a6eb680e8debcd0b97575a76e9cf0d0655ef7f875b362542e0d129f5e423419"
+      },
+      {
         "name": "python3-libcomps",
         "epoch": 0,
         "version": "0.1.11",
@@ -5102,6 +5130,15 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v1/psi/el8/el8-x86_64-baseos-8.3.0.r-20210120/Packages/python3-setuptools-wheel-39.2.0-6.el8.noarch.rpm",
         "checksum": "sha256:1ed3940c0466986fa38fe9d3bd5fc6370b5e62edba51f7a8359eab786b4b81ec"
+      },
+      {
+        "name": "python3-six",
+        "epoch": 0,
+        "version": "1.11.0",
+        "release": "8.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v1/psi/el8/el8-x86_64-baseos-8.3.0.r-20210120/Packages/python3-six-1.11.0-8.el8.noarch.rpm",
+        "checksum": "sha256:932cca0b2aa28d64538fca0401acc35bec34f14bfe99d3e22ea8452b79890eac"
       },
       {
         "name": "readline",
@@ -10051,8 +10088,20 @@
       "tss:x:59:59:Account used by the trousers package to sandbox the tcsd daemon:/dev/null:/sbin/nologin",
       "unbound:x:997:994:Unbound DNS resolver:/etc/unbound:/sbin/nologin"
     ],
+    "rhsm": {
+      "dnf-plugins": {
+        "product-id": {
+          "enabled": false
+        },
+        "subscription-manager": {
+          "enabled": false
+        }
+      }
+    },
     "rpm-verify": {
       "changed": {
+        "/etc/dnf/plugins/product-id.conf": "..5....T.",
+        "/etc/dnf/plugins/subscription-manager.conf": "..5....T.",
         "/etc/machine-id": ".M.......",
         "/proc": ".M.......",
         "/sys": ".M.......",

--- a/test/data/manifests/rhel_8-x86_64-qcow2-customize.json
+++ b/test/data/manifests/rhel_8-x86_64-qcow2-customize.json
@@ -1977,6 +1977,9 @@
                     "checksum": "sha256:e835f84cdda741b66c3f315a0db71c8209ff4cb451f5ae3afde35b2eda0dd929"
                   },
                   {
+                    "checksum": "sha256:9a6eb680e8debcd0b97575a76e9cf0d0655ef7f875b362542e0d129f5e423419"
+                  },
+                  {
                     "checksum": "sha256:24c7b8b233b0a5a23ff5d42ba56f0ee40372234f91e4fabe36d68e8077157e23"
                   },
                   {
@@ -1996,6 +1999,9 @@
                   },
                   {
                     "checksum": "sha256:1ed3940c0466986fa38fe9d3bd5fc6370b5e62edba51f7a8359eab786b4b81ec"
+                  },
+                  {
+                    "checksum": "sha256:932cca0b2aa28d64538fca0401acc35bec34f14bfe99d3e22ea8452b79890eac"
                   },
                   {
                     "checksum": "sha256:ef221ca565f17ed425997e97fdeb5fc27261910659fa61372b18d93e1a5613e9"
@@ -3581,6 +3587,19 @@
           "options": {
             "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
           }
+        },
+        {
+          "name": "org.osbuild.rhsm",
+          "options": {
+            "dnf-plugins": {
+              "product-id": {
+                "enabled": false
+              },
+              "subscription-manager": {
+                "enabled": false
+              }
+            }
+          }
         }
       ],
       "assembler": {
@@ -5157,6 +5176,15 @@
         "checksum": "sha256:e835f84cdda741b66c3f315a0db71c8209ff4cb451f5ae3afde35b2eda0dd929"
       },
       {
+        "name": "python3-iniparse",
+        "epoch": 0,
+        "version": "0.4",
+        "release": "31.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v1/psi/el8/el8-x86_64-baseos-8.3.0.r-20210120/Packages/python3-iniparse-0.4-31.el8.noarch.rpm",
+        "checksum": "sha256:9a6eb680e8debcd0b97575a76e9cf0d0655ef7f875b362542e0d129f5e423419"
+      },
+      {
         "name": "python3-libcomps",
         "epoch": 0,
         "version": "0.1.11",
@@ -5218,6 +5246,15 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v1/psi/el8/el8-x86_64-baseos-8.3.0.r-20210120/Packages/python3-setuptools-wheel-39.2.0-6.el8.noarch.rpm",
         "checksum": "sha256:1ed3940c0466986fa38fe9d3bd5fc6370b5e62edba51f7a8359eab786b4b81ec"
+      },
+      {
+        "name": "python3-six",
+        "epoch": 0,
+        "version": "1.11.0",
+        "release": "8.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v1/psi/el8/el8-x86_64-baseos-8.3.0.r-20210120/Packages/python3-six-1.11.0-8.el8.noarch.rpm",
+        "checksum": "sha256:932cca0b2aa28d64538fca0401acc35bec34f14bfe99d3e22ea8452b79890eac"
       },
       {
         "name": "readline",
@@ -10171,9 +10208,21 @@
       "user1:x:1000:1000::/home/user1:/bin/bash",
       "user2:x:1020:1050:description 2:/home/home2:/bin/sh"
     ],
+    "rhsm": {
+      "dnf-plugins": {
+        "product-id": {
+          "enabled": false
+        },
+        "subscription-manager": {
+          "enabled": false
+        }
+      }
+    },
     "rpm-verify": {
       "changed": {
         "/etc/chrony.conf": "S.5....T.",
+        "/etc/dnf/plugins/product-id.conf": "..5....T.",
+        "/etc/dnf/plugins/subscription-manager.conf": "..5....T.",
         "/etc/machine-id": ".M.......",
         "/proc": ".M.......",
         "/sys": ".M.......",

--- a/test/data/manifests/rhel_8-x86_64-rhel_edge_commit-boot.json
+++ b/test/data/manifests/rhel_8-x86_64-rhel_edge_commit-boot.json
@@ -731,6 +731,9 @@
           "sha256:995a5401cd86404d14d08c0aeafeaa8da3f540b1806f9d0e233d75dec9e45c74": {
             "url": "https://rpmrepo.osbuild.org/v1/psi/el8/el8-x86_64-appstream-8.3.0.r-20210120/Packages/libmaxminddb-1.2.0-10.el8.x86_64.rpm"
           },
+          "sha256:9a6eb680e8debcd0b97575a76e9cf0d0655ef7f875b362542e0d129f5e423419": {
+            "url": "https://rpmrepo.osbuild.org/v1/psi/el8/el8-x86_64-baseos-8.3.0.r-20210120/Packages/python3-iniparse-0.4-31.el8.noarch.rpm"
+          },
           "sha256:9a89874a5b8326c85c0b34b02c122ffc052b32a12b20354ce95859ac5296a159": {
             "url": "https://rpmrepo.osbuild.org/v1/psi/el8/el8-x86_64-baseos-8.3.0.r-20210120/Packages/pkgconf-m4-1.4.2-1.el8.noarch.rpm"
           },
@@ -1752,6 +1755,9 @@
                     "checksum": "sha256:e835f84cdda741b66c3f315a0db71c8209ff4cb451f5ae3afde35b2eda0dd929"
                   },
                   {
+                    "checksum": "sha256:9a6eb680e8debcd0b97575a76e9cf0d0655ef7f875b362542e0d129f5e423419"
+                  },
+                  {
                     "checksum": "sha256:24c7b8b233b0a5a23ff5d42ba56f0ee40372234f91e4fabe36d68e8077157e23"
                   },
                   {
@@ -1771,6 +1777,9 @@
                   },
                   {
                     "checksum": "sha256:1ed3940c0466986fa38fe9d3bd5fc6370b5e62edba51f7a8359eab786b4b81ec"
+                  },
+                  {
+                    "checksum": "sha256:932cca0b2aa28d64538fca0401acc35bec34f14bfe99d3e22ea8452b79890eac"
                   },
                   {
                     "checksum": "sha256:ef221ca565f17ed425997e97fdeb5fc27261910659fa61372b18d93e1a5613e9"
@@ -4685,6 +4694,15 @@
         "checksum": "sha256:e835f84cdda741b66c3f315a0db71c8209ff4cb451f5ae3afde35b2eda0dd929"
       },
       {
+        "name": "python3-iniparse",
+        "epoch": 0,
+        "version": "0.4",
+        "release": "31.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v1/psi/el8/el8-x86_64-baseos-8.3.0.r-20210120/Packages/python3-iniparse-0.4-31.el8.noarch.rpm",
+        "checksum": "sha256:9a6eb680e8debcd0b97575a76e9cf0d0655ef7f875b362542e0d129f5e423419"
+      },
+      {
         "name": "python3-libcomps",
         "epoch": 0,
         "version": "0.1.11",
@@ -4746,6 +4764,15 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v1/psi/el8/el8-x86_64-baseos-8.3.0.r-20210120/Packages/python3-setuptools-wheel-39.2.0-6.el8.noarch.rpm",
         "checksum": "sha256:1ed3940c0466986fa38fe9d3bd5fc6370b5e62edba51f7a8359eab786b4b81ec"
+      },
+      {
+        "name": "python3-six",
+        "epoch": 0,
+        "version": "1.11.0",
+        "release": "8.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v1/psi/el8/el8-x86_64-baseos-8.3.0.r-20210120/Packages/python3-six-1.11.0-8.el8.noarch.rpm",
+        "checksum": "sha256:932cca0b2aa28d64538fca0401acc35bec34f14bfe99d3e22ea8452b79890eac"
       },
       {
         "name": "readline",

--- a/test/data/manifests/rhel_8-x86_64-tar-boot.json
+++ b/test/data/manifests/rhel_8-x86_64-tar-boot.json
@@ -399,6 +399,9 @@
           "sha256:90406300b99022d9a28db65bb1dd9c0e14654e8a2dd5c02f35426b3714a1d042": {
             "url": "https://rpmrepo.osbuild.org/v1/psi/el8/el8-x86_64-baseos-8.3.0.r-20210120/Packages/fuse-libs-2.9.7-12.el8.x86_64.rpm"
           },
+          "sha256:932cca0b2aa28d64538fca0401acc35bec34f14bfe99d3e22ea8452b79890eac": {
+            "url": "https://rpmrepo.osbuild.org/v1/psi/el8/el8-x86_64-baseos-8.3.0.r-20210120/Packages/python3-six-1.11.0-8.el8.noarch.rpm"
+          },
           "sha256:9461fa7a5e74bfd8d9e9961af9d3003d9d2b496830c2fd6b0641ae8b8bc8e178": {
             "url": "https://rpmrepo.osbuild.org/v1/psi/el8/el8-x86_64-baseos-8.3.0.r-20210120/Packages/libacl-2.2.53-1.el8.x86_64.rpm"
           },
@@ -416,6 +419,9 @@
           },
           "sha256:980704e06e8bca4cf302b3498e1432063539c324a3f3feb3b7d7ece5d2aefcf8": {
             "url": "https://rpmrepo.osbuild.org/v1/psi/el8/el8-x86_64-baseos-8.3.0.r-20210120/Packages/chkconfig-1.13-2.el8.x86_64.rpm"
+          },
+          "sha256:9a6eb680e8debcd0b97575a76e9cf0d0655ef7f875b362542e0d129f5e423419": {
+            "url": "https://rpmrepo.osbuild.org/v1/psi/el8/el8-x86_64-baseos-8.3.0.r-20210120/Packages/python3-iniparse-0.4-31.el8.noarch.rpm"
           },
           "sha256:9cf2e24fdbe89f25b8283291fd3fcaf73ca60554bbf5767932c38882cdd0e3c4": {
             "url": "https://rpmrepo.osbuild.org/v1/psi/el8/el8-x86_64-baseos-8.3.0.r-20210120/Packages/cracklib-2.9.6-15.el8.x86_64.rpm"
@@ -1228,6 +1234,9 @@
                     "checksum": "sha256:e835f84cdda741b66c3f315a0db71c8209ff4cb451f5ae3afde35b2eda0dd929"
                   },
                   {
+                    "checksum": "sha256:9a6eb680e8debcd0b97575a76e9cf0d0655ef7f875b362542e0d129f5e423419"
+                  },
+                  {
                     "checksum": "sha256:24c7b8b233b0a5a23ff5d42ba56f0ee40372234f91e4fabe36d68e8077157e23"
                   },
                   {
@@ -1247,6 +1256,9 @@
                   },
                   {
                     "checksum": "sha256:1ed3940c0466986fa38fe9d3bd5fc6370b5e62edba51f7a8359eab786b4b81ec"
+                  },
+                  {
+                    "checksum": "sha256:932cca0b2aa28d64538fca0401acc35bec34f14bfe99d3e22ea8452b79890eac"
                   },
                   {
                     "checksum": "sha256:ef221ca565f17ed425997e97fdeb5fc27261910659fa61372b18d93e1a5613e9"
@@ -3478,6 +3490,15 @@
         "checksum": "sha256:e835f84cdda741b66c3f315a0db71c8209ff4cb451f5ae3afde35b2eda0dd929"
       },
       {
+        "name": "python3-iniparse",
+        "epoch": 0,
+        "version": "0.4",
+        "release": "31.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v1/psi/el8/el8-x86_64-baseos-8.3.0.r-20210120/Packages/python3-iniparse-0.4-31.el8.noarch.rpm",
+        "checksum": "sha256:9a6eb680e8debcd0b97575a76e9cf0d0655ef7f875b362542e0d129f5e423419"
+      },
+      {
         "name": "python3-libcomps",
         "epoch": 0,
         "version": "0.1.11",
@@ -3539,6 +3560,15 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v1/psi/el8/el8-x86_64-baseos-8.3.0.r-20210120/Packages/python3-setuptools-wheel-39.2.0-6.el8.noarch.rpm",
         "checksum": "sha256:1ed3940c0466986fa38fe9d3bd5fc6370b5e62edba51f7a8359eab786b4b81ec"
+      },
+      {
+        "name": "python3-six",
+        "epoch": 0,
+        "version": "1.11.0",
+        "release": "8.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v1/psi/el8/el8-x86_64-baseos-8.3.0.r-20210120/Packages/python3-six-1.11.0-8.el8.noarch.rpm",
+        "checksum": "sha256:932cca0b2aa28d64538fca0401acc35bec34f14bfe99d3e22ea8452b79890eac"
       },
       {
         "name": "readline",

--- a/test/data/manifests/rhel_8-x86_64-vhd-boot.json
+++ b/test/data/manifests/rhel_8-x86_64-vhd-boot.json
@@ -1820,6 +1820,9 @@
                     "checksum": "sha256:e835f84cdda741b66c3f315a0db71c8209ff4cb451f5ae3afde35b2eda0dd929"
                   },
                   {
+                    "checksum": "sha256:9a6eb680e8debcd0b97575a76e9cf0d0655ef7f875b362542e0d129f5e423419"
+                  },
+                  {
                     "checksum": "sha256:24c7b8b233b0a5a23ff5d42ba56f0ee40372234f91e4fabe36d68e8077157e23"
                   },
                   {
@@ -1839,6 +1842,9 @@
                   },
                   {
                     "checksum": "sha256:1ed3940c0466986fa38fe9d3bd5fc6370b5e62edba51f7a8359eab786b4b81ec"
+                  },
+                  {
+                    "checksum": "sha256:932cca0b2aa28d64538fca0401acc35bec34f14bfe99d3e22ea8452b79890eac"
                   },
                   {
                     "checksum": "sha256:ef221ca565f17ed425997e97fdeb5fc27261910659fa61372b18d93e1a5613e9"
@@ -4844,6 +4850,15 @@
         "checksum": "sha256:e835f84cdda741b66c3f315a0db71c8209ff4cb451f5ae3afde35b2eda0dd929"
       },
       {
+        "name": "python3-iniparse",
+        "epoch": 0,
+        "version": "0.4",
+        "release": "31.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v1/psi/el8/el8-x86_64-baseos-8.3.0.r-20210120/Packages/python3-iniparse-0.4-31.el8.noarch.rpm",
+        "checksum": "sha256:9a6eb680e8debcd0b97575a76e9cf0d0655ef7f875b362542e0d129f5e423419"
+      },
+      {
         "name": "python3-libcomps",
         "epoch": 0,
         "version": "0.1.11",
@@ -4905,6 +4920,15 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v1/psi/el8/el8-x86_64-baseos-8.3.0.r-20210120/Packages/python3-setuptools-wheel-39.2.0-6.el8.noarch.rpm",
         "checksum": "sha256:1ed3940c0466986fa38fe9d3bd5fc6370b5e62edba51f7a8359eab786b4b81ec"
+      },
+      {
+        "name": "python3-six",
+        "epoch": 0,
+        "version": "1.11.0",
+        "release": "8.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v1/psi/el8/el8-x86_64-baseos-8.3.0.r-20210120/Packages/python3-six-1.11.0-8.el8.noarch.rpm",
+        "checksum": "sha256:932cca0b2aa28d64538fca0401acc35bec34f14bfe99d3e22ea8452b79890eac"
       },
       {
         "name": "readline",
@@ -9507,6 +9531,16 @@
       "tss:x:59:59:Account used by the trousers package to sandbox the tcsd daemon:/dev/null:/sbin/nologin",
       "unbound:x:997:994:Unbound DNS resolver:/etc/unbound:/sbin/nologin"
     ],
+    "rhsm": {
+      "dnf-plugins": {
+        "product-id": {
+          "enabled": true
+        },
+        "subscription-manager": {
+          "enabled": true
+        }
+      }
+    },
     "rpm-verify": {
       "changed": {
         "/etc/machine-id": ".M.......",

--- a/test/data/manifests/rhel_8-x86_64-vmdk-boot.json
+++ b/test/data/manifests/rhel_8-x86_64-vmdk-boot.json
@@ -1754,6 +1754,9 @@
                     "checksum": "sha256:e835f84cdda741b66c3f315a0db71c8209ff4cb451f5ae3afde35b2eda0dd929"
                   },
                   {
+                    "checksum": "sha256:9a6eb680e8debcd0b97575a76e9cf0d0655ef7f875b362542e0d129f5e423419"
+                  },
+                  {
                     "checksum": "sha256:24c7b8b233b0a5a23ff5d42ba56f0ee40372234f91e4fabe36d68e8077157e23"
                   },
                   {
@@ -1773,6 +1776,9 @@
                   },
                   {
                     "checksum": "sha256:1ed3940c0466986fa38fe9d3bd5fc6370b5e62edba51f7a8359eab786b4b81ec"
+                  },
+                  {
+                    "checksum": "sha256:932cca0b2aa28d64538fca0401acc35bec34f14bfe99d3e22ea8452b79890eac"
                   },
                   {
                     "checksum": "sha256:ef221ca565f17ed425997e97fdeb5fc27261910659fa61372b18d93e1a5613e9"
@@ -4696,6 +4702,15 @@
         "checksum": "sha256:e835f84cdda741b66c3f315a0db71c8209ff4cb451f5ae3afde35b2eda0dd929"
       },
       {
+        "name": "python3-iniparse",
+        "epoch": 0,
+        "version": "0.4",
+        "release": "31.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v1/psi/el8/el8-x86_64-baseos-8.3.0.r-20210120/Packages/python3-iniparse-0.4-31.el8.noarch.rpm",
+        "checksum": "sha256:9a6eb680e8debcd0b97575a76e9cf0d0655ef7f875b362542e0d129f5e423419"
+      },
+      {
         "name": "python3-libcomps",
         "epoch": 0,
         "version": "0.1.11",
@@ -4757,6 +4772,15 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v1/psi/el8/el8-x86_64-baseos-8.3.0.r-20210120/Packages/python3-setuptools-wheel-39.2.0-6.el8.noarch.rpm",
         "checksum": "sha256:1ed3940c0466986fa38fe9d3bd5fc6370b5e62edba51f7a8359eab786b4b81ec"
+      },
+      {
+        "name": "python3-six",
+        "epoch": 0,
+        "version": "1.11.0",
+        "release": "8.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v1/psi/el8/el8-x86_64-baseos-8.3.0.r-20210120/Packages/python3-six-1.11.0-8.el8.noarch.rpm",
+        "checksum": "sha256:932cca0b2aa28d64538fca0401acc35bec34f14bfe99d3e22ea8452b79890eac"
       },
       {
         "name": "readline",
@@ -9119,6 +9143,16 @@
       "tss:x:59:59:Account used by the trousers package to sandbox the tcsd daemon:/dev/null:/sbin/nologin",
       "unbound:x:997:994:Unbound DNS resolver:/etc/unbound:/sbin/nologin"
     ],
+    "rhsm": {
+      "dnf-plugins": {
+        "product-id": {
+          "enabled": true
+        },
+        "subscription-manager": {
+          "enabled": true
+        }
+      }
+    },
     "rpm-verify": {
       "changed": {
         "/etc/machine-id": ".M.......",

--- a/test/data/manifests/rhel_84-x86_64-ami-boot.json
+++ b/test/data/manifests/rhel_84-x86_64-ami-boot.json
@@ -1823,6 +1823,9 @@
                     "checksum": "sha256:c4fab880fc77cba297766e3f09b7242dcf0891dc11a596b390b78259656dffcd"
                   },
                   {
+                    "checksum": "sha256:9a6eb680e8debcd0b97575a76e9cf0d0655ef7f875b362542e0d129f5e423419"
+                  },
+                  {
                     "checksum": "sha256:24c7b8b233b0a5a23ff5d42ba56f0ee40372234f91e4fabe36d68e8077157e23"
                   },
                   {
@@ -1842,6 +1845,9 @@
                   },
                   {
                     "checksum": "sha256:1ed3940c0466986fa38fe9d3bd5fc6370b5e62edba51f7a8359eab786b4b81ec"
+                  },
+                  {
+                    "checksum": "sha256:932cca0b2aa28d64538fca0401acc35bec34f14bfe99d3e22ea8452b79890eac"
                   },
                   {
                     "checksum": "sha256:ef221ca565f17ed425997e97fdeb5fc27261910659fa61372b18d93e1a5613e9"
@@ -4897,6 +4903,15 @@
         "checksum": "sha256:c4fab880fc77cba297766e3f09b7242dcf0891dc11a596b390b78259656dffcd"
       },
       {
+        "name": "python3-iniparse",
+        "epoch": 0,
+        "version": "0.4",
+        "release": "31.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v1/psi/el8/el8-x86_64-baseos-8.4.0.n-20210120/Packages/python3-iniparse-0.4-31.el8.noarch.rpm",
+        "checksum": "sha256:9a6eb680e8debcd0b97575a76e9cf0d0655ef7f875b362542e0d129f5e423419"
+      },
+      {
         "name": "python3-libcomps",
         "epoch": 0,
         "version": "0.1.11",
@@ -4958,6 +4973,15 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v1/psi/el8/el8-x86_64-baseos-8.4.0.n-20210120/Packages/python3-setuptools-wheel-39.2.0-6.el8.noarch.rpm",
         "checksum": "sha256:1ed3940c0466986fa38fe9d3bd5fc6370b5e62edba51f7a8359eab786b4b81ec"
+      },
+      {
+        "name": "python3-six",
+        "epoch": 0,
+        "version": "1.11.0",
+        "release": "8.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v1/psi/el8/el8-x86_64-baseos-8.4.0.n-20210120/Packages/python3-six-1.11.0-8.el8.noarch.rpm",
+        "checksum": "sha256:932cca0b2aa28d64538fca0401acc35bec34f14bfe99d3e22ea8452b79890eac"
       },
       {
         "name": "readline",
@@ -9620,6 +9644,16 @@
       "tss:x:59:59:Account used for TPM access:/dev/null:/sbin/nologin",
       "unbound:x:997:994:Unbound DNS resolver:/etc/unbound:/sbin/nologin"
     ],
+    "rhsm": {
+      "dnf-plugins": {
+        "product-id": {
+          "enabled": true
+        },
+        "subscription-manager": {
+          "enabled": true
+        }
+      }
+    },
     "rpm-verify": {
       "changed": {
         "/boot/efi/EFI/redhat/grubx64.efi": ".......T.",

--- a/test/data/manifests/rhel_84-x86_64-openstack-boot.json
+++ b/test/data/manifests/rhel_84-x86_64-openstack-boot.json
@@ -1951,6 +1951,9 @@
                     "checksum": "sha256:c4fab880fc77cba297766e3f09b7242dcf0891dc11a596b390b78259656dffcd"
                   },
                   {
+                    "checksum": "sha256:9a6eb680e8debcd0b97575a76e9cf0d0655ef7f875b362542e0d129f5e423419"
+                  },
+                  {
                     "checksum": "sha256:24c7b8b233b0a5a23ff5d42ba56f0ee40372234f91e4fabe36d68e8077157e23"
                   },
                   {
@@ -1970,6 +1973,9 @@
                   },
                   {
                     "checksum": "sha256:1ed3940c0466986fa38fe9d3bd5fc6370b5e62edba51f7a8359eab786b4b81ec"
+                  },
+                  {
+                    "checksum": "sha256:932cca0b2aa28d64538fca0401acc35bec34f14bfe99d3e22ea8452b79890eac"
                   },
                   {
                     "checksum": "sha256:ef221ca565f17ed425997e97fdeb5fc27261910659fa61372b18d93e1a5613e9"
@@ -5140,6 +5146,15 @@
         "checksum": "sha256:c4fab880fc77cba297766e3f09b7242dcf0891dc11a596b390b78259656dffcd"
       },
       {
+        "name": "python3-iniparse",
+        "epoch": 0,
+        "version": "0.4",
+        "release": "31.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v1/psi/el8/el8-x86_64-baseos-8.4.0.n-20210120/Packages/python3-iniparse-0.4-31.el8.noarch.rpm",
+        "checksum": "sha256:9a6eb680e8debcd0b97575a76e9cf0d0655ef7f875b362542e0d129f5e423419"
+      },
+      {
         "name": "python3-libcomps",
         "epoch": 0,
         "version": "0.1.11",
@@ -5201,6 +5216,15 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v1/psi/el8/el8-x86_64-baseos-8.4.0.n-20210120/Packages/python3-setuptools-wheel-39.2.0-6.el8.noarch.rpm",
         "checksum": "sha256:1ed3940c0466986fa38fe9d3bd5fc6370b5e62edba51f7a8359eab786b4b81ec"
+      },
+      {
+        "name": "python3-six",
+        "epoch": 0,
+        "version": "1.11.0",
+        "release": "8.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v1/psi/el8/el8-x86_64-baseos-8.4.0.n-20210120/Packages/python3-six-1.11.0-8.el8.noarch.rpm",
+        "checksum": "sha256:932cca0b2aa28d64538fca0401acc35bec34f14bfe99d3e22ea8452b79890eac"
       },
       {
         "name": "readline",
@@ -10238,6 +10262,16 @@
       "tss:x:59:59:Account used for TPM access:/dev/null:/sbin/nologin",
       "unbound:x:997:994:Unbound DNS resolver:/etc/unbound:/sbin/nologin"
     ],
+    "rhsm": {
+      "dnf-plugins": {
+        "product-id": {
+          "enabled": true
+        },
+        "subscription-manager": {
+          "enabled": true
+        }
+      }
+    },
     "rpm-verify": {
       "changed": {
         "/boot/efi/EFI/redhat/grubx64.efi": ".......T.",

--- a/test/data/manifests/rhel_84-x86_64-qcow2-boot.json
+++ b/test/data/manifests/rhel_84-x86_64-qcow2-boot.json
@@ -1915,6 +1915,9 @@
                     "checksum": "sha256:c4fab880fc77cba297766e3f09b7242dcf0891dc11a596b390b78259656dffcd"
                   },
                   {
+                    "checksum": "sha256:9a6eb680e8debcd0b97575a76e9cf0d0655ef7f875b362542e0d129f5e423419"
+                  },
+                  {
                     "checksum": "sha256:24c7b8b233b0a5a23ff5d42ba56f0ee40372234f91e4fabe36d68e8077157e23"
                   },
                   {
@@ -1934,6 +1937,9 @@
                   },
                   {
                     "checksum": "sha256:1ed3940c0466986fa38fe9d3bd5fc6370b5e62edba51f7a8359eab786b4b81ec"
+                  },
+                  {
+                    "checksum": "sha256:932cca0b2aa28d64538fca0401acc35bec34f14bfe99d3e22ea8452b79890eac"
                   },
                   {
                     "checksum": "sha256:ef221ca565f17ed425997e97fdeb5fc27261910659fa61372b18d93e1a5613e9"
@@ -3479,6 +3485,19 @@
             "network": {
               "networking": true,
               "no_zero_conf": true
+            }
+          }
+        },
+        {
+          "name": "org.osbuild.rhsm",
+          "options": {
+            "dnf-plugins": {
+              "product-id": {
+                "enabled": false
+              },
+              "subscription-manager": {
+                "enabled": false
+              }
             }
           }
         }
@@ -5080,6 +5099,15 @@
         "checksum": "sha256:c4fab880fc77cba297766e3f09b7242dcf0891dc11a596b390b78259656dffcd"
       },
       {
+        "name": "python3-iniparse",
+        "epoch": 0,
+        "version": "0.4",
+        "release": "31.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v1/psi/el8/el8-x86_64-baseos-8.4.0.n-20210120/Packages/python3-iniparse-0.4-31.el8.noarch.rpm",
+        "checksum": "sha256:9a6eb680e8debcd0b97575a76e9cf0d0655ef7f875b362542e0d129f5e423419"
+      },
+      {
         "name": "python3-libcomps",
         "epoch": 0,
         "version": "0.1.11",
@@ -5141,6 +5169,15 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v1/psi/el8/el8-x86_64-baseos-8.4.0.n-20210120/Packages/python3-setuptools-wheel-39.2.0-6.el8.noarch.rpm",
         "checksum": "sha256:1ed3940c0466986fa38fe9d3bd5fc6370b5e62edba51f7a8359eab786b4b81ec"
+      },
+      {
+        "name": "python3-six",
+        "epoch": 0,
+        "version": "1.11.0",
+        "release": "8.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v1/psi/el8/el8-x86_64-baseos-8.4.0.n-20210120/Packages/python3-six-1.11.0-8.el8.noarch.rpm",
+        "checksum": "sha256:932cca0b2aa28d64538fca0401acc35bec34f14bfe99d3e22ea8452b79890eac"
       },
       {
         "name": "readline",
@@ -10087,9 +10124,21 @@
       "tss:x:59:59:Account used for TPM access:/dev/null:/sbin/nologin",
       "unbound:x:997:994:Unbound DNS resolver:/etc/unbound:/sbin/nologin"
     ],
+    "rhsm": {
+      "dnf-plugins": {
+        "product-id": {
+          "enabled": false
+        },
+        "subscription-manager": {
+          "enabled": false
+        }
+      }
+    },
     "rpm-verify": {
       "changed": {
         "/boot/efi/EFI/redhat/grubx64.efi": ".......T.",
+        "/etc/dnf/plugins/product-id.conf": "..5....T.",
+        "/etc/dnf/plugins/subscription-manager.conf": "..5....T.",
         "/etc/machine-id": ".M.......",
         "/proc": ".M.......",
         "/run/cockpit": ".M.......",

--- a/test/data/manifests/rhel_84-x86_64-qcow2-customize.json
+++ b/test/data/manifests/rhel_84-x86_64-qcow2-customize.json
@@ -1967,6 +1967,9 @@
                     "checksum": "sha256:c4fab880fc77cba297766e3f09b7242dcf0891dc11a596b390b78259656dffcd"
                   },
                   {
+                    "checksum": "sha256:9a6eb680e8debcd0b97575a76e9cf0d0655ef7f875b362542e0d129f5e423419"
+                  },
+                  {
                     "checksum": "sha256:24c7b8b233b0a5a23ff5d42ba56f0ee40372234f91e4fabe36d68e8077157e23"
                   },
                   {
@@ -1986,6 +1989,9 @@
                   },
                   {
                     "checksum": "sha256:1ed3940c0466986fa38fe9d3bd5fc6370b5e62edba51f7a8359eab786b4b81ec"
+                  },
+                  {
+                    "checksum": "sha256:932cca0b2aa28d64538fca0401acc35bec34f14bfe99d3e22ea8452b79890eac"
                   },
                   {
                     "checksum": "sha256:ef221ca565f17ed425997e97fdeb5fc27261910659fa61372b18d93e1a5613e9"
@@ -3584,6 +3590,19 @@
             "network": {
               "networking": true,
               "no_zero_conf": true
+            }
+          }
+        },
+        {
+          "name": "org.osbuild.rhsm",
+          "options": {
+            "dnf-plugins": {
+              "product-id": {
+                "enabled": false
+              },
+              "subscription-manager": {
+                "enabled": false
+              }
             }
           }
         }
@@ -5185,6 +5204,15 @@
         "checksum": "sha256:c4fab880fc77cba297766e3f09b7242dcf0891dc11a596b390b78259656dffcd"
       },
       {
+        "name": "python3-iniparse",
+        "epoch": 0,
+        "version": "0.4",
+        "release": "31.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v1/psi/el8/el8-x86_64-baseos-8.4.0.n-20210120/Packages/python3-iniparse-0.4-31.el8.noarch.rpm",
+        "checksum": "sha256:9a6eb680e8debcd0b97575a76e9cf0d0655ef7f875b362542e0d129f5e423419"
+      },
+      {
         "name": "python3-libcomps",
         "epoch": 0,
         "version": "0.1.11",
@@ -5246,6 +5274,15 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v1/psi/el8/el8-x86_64-baseos-8.4.0.n-20210120/Packages/python3-setuptools-wheel-39.2.0-6.el8.noarch.rpm",
         "checksum": "sha256:1ed3940c0466986fa38fe9d3bd5fc6370b5e62edba51f7a8359eab786b4b81ec"
+      },
+      {
+        "name": "python3-six",
+        "epoch": 0,
+        "version": "1.11.0",
+        "release": "8.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v1/psi/el8/el8-x86_64-baseos-8.4.0.n-20210120/Packages/python3-six-1.11.0-8.el8.noarch.rpm",
+        "checksum": "sha256:932cca0b2aa28d64538fca0401acc35bec34f14bfe99d3e22ea8452b79890eac"
       },
       {
         "name": "readline",
@@ -10196,10 +10233,22 @@
       "user1:x:1000:1000::/home/user1:/bin/bash",
       "user2:x:1020:1050:description 2:/home/home2:/bin/sh"
     ],
+    "rhsm": {
+      "dnf-plugins": {
+        "product-id": {
+          "enabled": false
+        },
+        "subscription-manager": {
+          "enabled": false
+        }
+      }
+    },
     "rpm-verify": {
       "changed": {
         "/boot/efi/EFI/redhat/grubx64.efi": ".......T.",
         "/etc/chrony.conf": "S.5....T.",
+        "/etc/dnf/plugins/product-id.conf": "..5....T.",
+        "/etc/dnf/plugins/subscription-manager.conf": "..5....T.",
         "/etc/machine-id": ".M.......",
         "/proc": ".M.......",
         "/run/cockpit": ".M.......",

--- a/test/data/manifests/rhel_84-x86_64-vhd-boot.json
+++ b/test/data/manifests/rhel_84-x86_64-vhd-boot.json
@@ -1927,6 +1927,9 @@
                     "checksum": "sha256:c4fab880fc77cba297766e3f09b7242dcf0891dc11a596b390b78259656dffcd"
                   },
                   {
+                    "checksum": "sha256:9a6eb680e8debcd0b97575a76e9cf0d0655ef7f875b362542e0d129f5e423419"
+                  },
+                  {
                     "checksum": "sha256:24c7b8b233b0a5a23ff5d42ba56f0ee40372234f91e4fabe36d68e8077157e23"
                   },
                   {
@@ -1946,6 +1949,9 @@
                   },
                   {
                     "checksum": "sha256:1ed3940c0466986fa38fe9d3bd5fc6370b5e62edba51f7a8359eab786b4b81ec"
+                  },
+                  {
+                    "checksum": "sha256:932cca0b2aa28d64538fca0401acc35bec34f14bfe99d3e22ea8452b79890eac"
                   },
                   {
                     "checksum": "sha256:ef221ca565f17ed425997e97fdeb5fc27261910659fa61372b18d93e1a5613e9"
@@ -5111,6 +5117,15 @@
         "checksum": "sha256:c4fab880fc77cba297766e3f09b7242dcf0891dc11a596b390b78259656dffcd"
       },
       {
+        "name": "python3-iniparse",
+        "epoch": 0,
+        "version": "0.4",
+        "release": "31.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v1/psi/el8/el8-x86_64-baseos-8.4.0.n-20210120/Packages/python3-iniparse-0.4-31.el8.noarch.rpm",
+        "checksum": "sha256:9a6eb680e8debcd0b97575a76e9cf0d0655ef7f875b362542e0d129f5e423419"
+      },
+      {
         "name": "python3-libcomps",
         "epoch": 0,
         "version": "0.1.11",
@@ -5172,6 +5187,15 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v1/psi/el8/el8-x86_64-baseos-8.4.0.n-20210120/Packages/python3-setuptools-wheel-39.2.0-6.el8.noarch.rpm",
         "checksum": "sha256:1ed3940c0466986fa38fe9d3bd5fc6370b5e62edba51f7a8359eab786b4b81ec"
+      },
+      {
+        "name": "python3-six",
+        "epoch": 0,
+        "version": "1.11.0",
+        "release": "8.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v1/psi/el8/el8-x86_64-baseos-8.4.0.n-20210120/Packages/python3-six-1.11.0-8.el8.noarch.rpm",
+        "checksum": "sha256:932cca0b2aa28d64538fca0401acc35bec34f14bfe99d3e22ea8452b79890eac"
       },
       {
         "name": "readline",
@@ -10161,6 +10185,16 @@
       "tss:x:59:59:Account used for TPM access:/dev/null:/sbin/nologin",
       "unbound:x:997:994:Unbound DNS resolver:/etc/unbound:/sbin/nologin"
     ],
+    "rhsm": {
+      "dnf-plugins": {
+        "product-id": {
+          "enabled": true
+        },
+        "subscription-manager": {
+          "enabled": true
+        }
+      }
+    },
     "rpm-verify": {
       "changed": {
         "/boot/efi/EFI/redhat/grubx64.efi": ".......T.",

--- a/test/data/manifests/rhel_84-x86_64-vmdk-boot.json
+++ b/test/data/manifests/rhel_84-x86_64-vmdk-boot.json
@@ -1864,6 +1864,9 @@
                     "checksum": "sha256:c4fab880fc77cba297766e3f09b7242dcf0891dc11a596b390b78259656dffcd"
                   },
                   {
+                    "checksum": "sha256:9a6eb680e8debcd0b97575a76e9cf0d0655ef7f875b362542e0d129f5e423419"
+                  },
+                  {
                     "checksum": "sha256:24c7b8b233b0a5a23ff5d42ba56f0ee40372234f91e4fabe36d68e8077157e23"
                   },
                   {
@@ -1883,6 +1886,9 @@
                   },
                   {
                     "checksum": "sha256:1ed3940c0466986fa38fe9d3bd5fc6370b5e62edba51f7a8359eab786b4b81ec"
+                  },
+                  {
+                    "checksum": "sha256:932cca0b2aa28d64538fca0401acc35bec34f14bfe99d3e22ea8452b79890eac"
                   },
                   {
                     "checksum": "sha256:ef221ca565f17ed425997e97fdeb5fc27261910659fa61372b18d93e1a5613e9"
@@ -4969,6 +4975,15 @@
         "checksum": "sha256:c4fab880fc77cba297766e3f09b7242dcf0891dc11a596b390b78259656dffcd"
       },
       {
+        "name": "python3-iniparse",
+        "epoch": 0,
+        "version": "0.4",
+        "release": "31.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v1/psi/el8/el8-x86_64-baseos-8.4.0.n-20210120/Packages/python3-iniparse-0.4-31.el8.noarch.rpm",
+        "checksum": "sha256:9a6eb680e8debcd0b97575a76e9cf0d0655ef7f875b362542e0d129f5e423419"
+      },
+      {
         "name": "python3-libcomps",
         "epoch": 0,
         "version": "0.1.11",
@@ -5030,6 +5045,15 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v1/psi/el8/el8-x86_64-baseos-8.4.0.n-20210120/Packages/python3-setuptools-wheel-39.2.0-6.el8.noarch.rpm",
         "checksum": "sha256:1ed3940c0466986fa38fe9d3bd5fc6370b5e62edba51f7a8359eab786b4b81ec"
+      },
+      {
+        "name": "python3-six",
+        "epoch": 0,
+        "version": "1.11.0",
+        "release": "8.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v1/psi/el8/el8-x86_64-baseos-8.4.0.n-20210120/Packages/python3-six-1.11.0-8.el8.noarch.rpm",
+        "checksum": "sha256:932cca0b2aa28d64538fca0401acc35bec34f14bfe99d3e22ea8452b79890eac"
       },
       {
         "name": "readline",
@@ -9789,6 +9813,16 @@
       "tss:x:59:59:Account used for TPM access:/dev/null:/sbin/nologin",
       "unbound:x:997:994:Unbound DNS resolver:/etc/unbound:/sbin/nologin"
     ],
+    "rhsm": {
+      "dnf-plugins": {
+        "product-id": {
+          "enabled": true
+        },
+        "subscription-manager": {
+          "enabled": true
+        }
+      }
+    },
     "rpm-verify": {
       "changed": {
         "/boot/efi/EFI/redhat/grubx64.efi": ".......T.",

--- a/tools/image-info
+++ b/tools/image-info
@@ -1,6 +1,7 @@
 #!/usr/bin/python3
 
 import argparse
+import configparser
 import contextlib
 import errno
 import functools
@@ -358,6 +359,42 @@ def read_fstab(tree):
             result = sorted([line.split() for line in f if line and not line.startswith("#")])
     return result
 
+
+# Read configuration changes possible via org.osbuild.rhsm stage
+def read_rhsm(tree):
+    result = {}
+
+    # Check RHSM DNF plugins configuration and allowed options
+    dnf_plugins_config = {
+        "product-id": f"{tree}/etc/dnf/plugins/product-id.conf",
+        "subscription-manager": f"{tree}/etc/dnf/plugins/subscription-manager.conf"
+    }
+
+    for plugin_name, plugin_path in dnf_plugins_config.items():
+        with contextlib.suppress(FileNotFoundError):
+            with open(plugin_path) as f:
+                parser = configparser.ConfigParser()
+                parser.read_file(f)
+                # only read "enabled" option from "main" section
+                with contextlib.suppress(configparser.NoSectionError, configparser.NoOptionError):
+                    # get the value as the first thing, in case it raises an exception
+                    enabled = parser.getboolean("main", "enabled")
+
+                    try:
+                        dnf_plugins_dict = result["dnf-plugins"]
+                    except KeyError as _:
+                        dnf_plugins_dict = result["dnf-plugins"] = {}
+
+                    try:
+                        plugin_dict = dnf_plugins_dict[plugin_name]
+                    except KeyError as _:
+                        plugin_dict = dnf_plugins_dict[plugin_name] = {}
+
+                    plugin_dict["enabled"] = enabled
+
+    return result
+
+
 # Create a nested dictionary for all supported sysconfigs 
 def read_sysconfig(tree):
     result = {}
@@ -412,6 +449,10 @@ def append_filesystem(report, tree, *, is_ostree=False):
         fstab = read_fstab(tree)
         if fstab:
             report["fstab"] = fstab
+
+        rhsm = read_rhsm(tree)
+        if rhsm:
+            report["rhsm"] = rhsm
 
         sysconfig = read_sysconfig(tree)
         if sysconfig:


### PR DESCRIPTION
This pull request includes:
- [X] adequate testing for the new functionality or fixed issue
  - Unit tests have been added.
  - Image test cases for affected images have been regenerated.
- [X] adequate documentation informing people about the change
  - Added new entry in `docs/news/unreleased/`

Add support to configure `org.osbuild.rhsm` osbuild stage. This stage
allows the configuration of Red Hat Subscription Manager (RHSM) related
components. Currently it is possible to configure only the enablement
status of RHSM DNF plugins.

Modify RHEL 8.3 and 8.4 KVM guest images definition to produce osbuild
manifest with `org.osbuild.rhsm` stage to disable both RHSM DNF plugins
(`product-id` and `subscription-manager`).

Add `/docs/news/unreleased/osbuild-rhsm-stage.md` with information about
the added support for `org.osbuild.rhsm` osbuild stage. Also note that RHEL
8.3 and 8.4 qcow2 image definitions are updated to disable RHSM DNF
plugins by default.

Enhance `tools/image-info` tool to add RHSM-specific section to its
output in case RHSM DNF plugins configuration exists in the tree.

Regenerate all RHEL image test cases affected by the patch set.