### PR TITLE
Azure: test on V2 Hyper-V generation

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -151,6 +151,11 @@ Integration:
           - aws/rhel-8-x86_64
           - aws/rhel-8.4-x86_64
         INTERNAL_NETWORK: ["true"]
+      - SCRIPT:
+         - azure_hyperv_gen2.sh
+        RUNNER:
+          - aws/rhel-8.4-x86_64
+        INTERNAL_NETWORK: ["true"]
       - <<: *INTEGRATION_TESTS
         RUNNER:
           - aws/rhel-8-x86_64

--- a/test/cases/azure.sh
+++ b/test/cases/azure.sh
@@ -5,6 +5,7 @@ source /etc/os-release
 DISTRO_CODE="${DISTRO_CODE:-${ID}_${VERSION_ID//./}}"
 BRANCH_NAME="${BRANCH_NAME:-${CI_COMMIT_BRANCH}}"
 BUILD_ID="${BUILD_ID:-${CI_BUILD_ID}}"
+HYPER_V_GEN="${HYPER_V_GEN:-V1}"
 
 # Colorful output.
 function greenprint {
@@ -194,6 +195,8 @@ export TF_VAR_STORAGE_ACCOUNT="$AZURE_STORAGE_ACCOUNT"
 export TF_VAR_CONTAINER_NAME="$AZURE_CONTAINER_NAME"
 export TF_VAR_BLOB_NAME="$IMAGE_KEY".vhd
 export TF_VAR_TEST_ID="$TEST_ID"
+# https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/image#argument-reference
+export TF_VAR_HYPER_V_GEN="${HYPER_V_GEN}"
 export BLOB_URL="https://$AZURE_STORAGE_ACCOUNT.blob.core.windows.net/$AZURE_CONTAINER_NAME/$IMAGE_KEY.vhd"
 export ARM_CLIENT_ID="$AZURE_CLIENT_ID" > /dev/null
 export ARM_CLIENT_SECRET="$AZURE_CLIENT_SECRET" > /dev/null
@@ -237,10 +240,10 @@ sudo composer-cli compose delete "${COMPOSE_ID}" > /dev/null
 
 # Use the return code of the smoke test to determine if we passed or failed.
 if [[ $RESULTS == 1 ]]; then
-    greenprint "💚 Success"
+    greenprint "💚 Success with HyperV ${HYPER_V_GEN}"
     exit 0
 elif [[ $RESULTS != 1 ]]; then
-    greenprint "❌ Failed"
+    greenprint "❌ Failed ${HYPER_V_GEN}"
     exit 1
 fi
 

--- a/test/cases/azure_hyperv_gen2.sh
+++ b/test/cases/azure_hyperv_gen2.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -euo pipefail
+
+
+# https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/image#argument-reference
+export HYPER_V_GEN="V2"
+/usr/libexec/tests/osbuild-composer/azure.sh

--- a/test/data/azure/deployment-template.json
+++ b/test/data/azure/deployment-template.json
@@ -134,7 +134,7 @@
       "apiVersion": "2019-07-01",
       "location": "[parameters('location')]",
       "properties": {
-        "hyperVGeneration": "V1",
+        "hyperVGeneration": "V2",
         "storageProfile": {
           "osDisk": {
             "osType": "Linux",

--- a/test/data/azure/main.tf
+++ b/test/data/azure/main.tf
@@ -34,6 +34,10 @@ variable "TEST_ID" {
     type = string
 }
 
+variable "HYPER_V_GEN" {
+    type = string
+}
+
 # Use existing resource group
 data "azurerm_resource_group" "testResourceGroup" {
   name = var.RESOURCE_GROUP
@@ -56,6 +60,7 @@ resource "azurerm_image" "testimage" {
   name                = join("-", ["image", var.TEST_ID])
   location            = data.azurerm_resource_group.testResourceGroup.location
   resource_group_name = data.azurerm_resource_group.testResourceGroup.name
+  hyper_v_generation = var.HYPER_V_GEN
 
   os_disk {
     os_type  = "Linux"


### PR DESCRIPTION
Related: rhbz#1896264

Update - a few more questions raised here:

1) Should we drop testing on Gen1 hypervisors or not ? This is being tracked in https://bugzilla.redhat.com/show_bug.cgi?id=1896264

2) How the heck v2 image (hypervisor) works with RHEL 8.3 that is bios-only? (we're not sure if hypervisor can auto-detect which boot mode to use)