### PR TITLE
image-tests: fix hostname typo in customizations

### DIFF
--- a/test/data/manifests/fedora_32-x86_64-qcow2-customize.json
+++ b/test/data/manifests/fedora_32-x86_64-qcow2-customize.json
@@ -24,7 +24,7 @@
         }
       ],
       "customizations": {
-        "hosname": "my-host",
+        "hostname": "my-host",
         "kernel": {
           "append": "debug"
         },
@@ -3440,6 +3440,12 @@
           "name": "org.osbuild.keymap",
           "options": {
             "keymap": "dvorak"
+          }
+        },
+        {
+          "name": "org.osbuild.hostname",
+          "options": {
+            "hostname": "my-host"
           }
         },
         {
@@ -9274,6 +9280,7 @@
       "video:x:39:",
       "wheel:x:10:"
     ],
+    "hostname": "my-host",
     "image-format": "qcow2",
     "os-release": {
       "ANSI_COLOR": "0;34",

--- a/test/data/manifests/fedora_33-x86_64-qcow2-customize.json
+++ b/test/data/manifests/fedora_33-x86_64-qcow2-customize.json
@@ -24,7 +24,7 @@
         }
       ],
       "customizations": {
-        "hosname": "my-host",
+        "hostname": "my-host",
         "kernel": {
           "append": "debug"
         },
@@ -3495,7 +3495,7 @@
         {
           "name": "org.osbuild.hostname",
           "options": {
-            "hostname": "localhost.localdomain"
+            "hostname": "my-host"
           }
         },
         {
@@ -9443,7 +9443,7 @@
       "video:x:39:",
       "wheel:x:10:"
     ],
-    "hostname": "localhost.localdomain",
+    "hostname": "my-host",
     "image-format": "qcow2",
     "os-release": {
       "ANSI_COLOR": "0;38;2;60;110;180",

--- a/test/data/manifests/rhel_8-x86_64-qcow2-customize.json
+++ b/test/data/manifests/rhel_8-x86_64-qcow2-customize.json
@@ -27,7 +27,7 @@
         }
       ],
       "customizations": {
-        "hosname": "my-host",
+        "hostname": "my-host",
         "kernel": {
           "append": "debug"
         },
@@ -3506,6 +3506,12 @@
           "name": "org.osbuild.keymap",
           "options": {
             "keymap": "dvorak"
+          }
+        },
+        {
+          "name": "org.osbuild.hostname",
+          "options": {
+            "hostname": "my-host"
           }
         },
         {
@@ -9649,6 +9655,7 @@
       "video:x:39:",
       "wheel:x:10:"
     ],
+    "hostname": "my-host",
     "image-format": "qcow2",
     "os-release": {
       "ANSI_COLOR": "0;31",

--- a/test/data/manifests/rhel_84-x86_64-qcow2-customize.json
+++ b/test/data/manifests/rhel_84-x86_64-qcow2-customize.json
@@ -29,7 +29,7 @@
         }
       ],
       "customizations": {
-        "hosname": "my-host",
+        "hostname": "my-host",
         "kernel": {
           "append": "debug"
         },
@@ -3497,6 +3497,12 @@
           "name": "org.osbuild.keymap",
           "options": {
             "keymap": "dvorak"
+          }
+        },
+        {
+          "name": "org.osbuild.hostname",
+          "options": {
+            "hostname": "my-host"
           }
         },
         {
@@ -9644,6 +9650,7 @@
       "video:x:39:",
       "wheel:x:10:"
     ],
+    "hostname": "my-host",
     "image-format": "qcow2",
     "os-release": {
       "ANSI_COLOR": "0;31",

--- a/tools/test-case-generators/generate-test-cases
+++ b/tools/test-case-generators/generate-test-cases
@@ -109,7 +109,7 @@ CUSTOMIZATIONS_BLUEPRINT =  {
         }
     ],
     "customizations": {
-        "hosname": "my-host",
+        "hostname": "my-host",
         "kernel": {
             "append": "debug"
         },


### PR DESCRIPTION
This pull request includes:

- [x] adequate testing for the new functionality or fixed issue
- [x] adequate documentation informing people about the change

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

For user-visible changes, "adequate documentation" is an entry describing the
change for users in docs/news. Please refer to docs/news/README.md for details.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`
-->

The test case generation script contained a typo in the blueprint
customizations dictionary: "hosname" instead of "hostname".

Fixed typo and regenerated relevant test cases.


