### PR TITLE
image-info: do not include inputhash in the report

### DIFF
--- a/test/data/manifests/fedora_32-x86_64-fedora_iot_commit-boot.json
+++ b/test/data/manifests/fedora_32-x86_64-fedora_iot_commit-boot.json
@@ -10213,11 +10213,9 @@
       "VERSION_ID": "32"
     },
     "ostree": {
-      "refs": {
-        "fedora/32/x86_64/iot": {
-          "inputhash": "e7a265e665ce2765c90c1a51ba187202e8b77b4e0aadddfc545189171cb9c31f"
-        }
-      },
+      "refs": [
+        "fedora/32/x86_64/iot"
+      ],
       "repo": {
         "core.mode": "archive-z2"
       }

--- a/test/data/manifests/fedora_33-x86_64-fedora_iot_commit-boot.json
+++ b/test/data/manifests/fedora_33-x86_64-fedora_iot_commit-boot.json
@@ -10659,11 +10659,9 @@
       "VERSION_ID": "33"
     },
     "ostree": {
-      "refs": {
-        "fedora/33/x86_64/iot": {
-          "inputhash": "af23373725489f462ab563895f7ffff450504d0057b8e4569244e9884c3ceb71"
-        }
-      },
+      "refs": [
+        "fedora/33/x86_64/iot"
+      ],
       "repo": {
         "core.mode": "archive-z2"
       }

--- a/test/data/manifests/rhel_8-aarch64-rhel_edge_commit-boot.json
+++ b/test/data/manifests/rhel_8-aarch64-rhel_edge_commit-boot.json
@@ -8276,11 +8276,9 @@
       "VERSION_ID": "8.3"
     },
     "ostree": {
-      "refs": {
-        "rhel/8/aarch64/edge": {
-          "inputhash": "e58e63f14f7edbb5add61ef8f65bf84f5934cdb0e4119caeca5a5e04461f65d3"
-        }
-      },
+      "refs": [
+        "rhel/8/aarch64/edge"
+      ],
       "repo": {
         "core.mode": "archive-z2"
       }

--- a/test/data/manifests/rhel_8-x86_64-rhel_edge_commit-boot.json
+++ b/test/data/manifests/rhel_8-x86_64-rhel_edge_commit-boot.json
@@ -8561,11 +8561,9 @@
       "VERSION_ID": "8.3"
     },
     "ostree": {
-      "refs": {
-        "rhel/8/x86_64/edge": {
-          "inputhash": "e255d15d889add2e2a1e8dc4fad9d73b61d5e2f2608f0713cf7f99a229cdaa49"
-        }
-      },
+      "refs": [
+        "rhel/8/x86_64/edge"
+      ],
       "repo": {
         "core.mode": "archive-z2"
       }

--- a/tools/image-info
+++ b/tools/image-info
@@ -499,9 +499,6 @@ def append_ostree_repo(report, repo):
     resolved = {r: ostree("rev-parse", r).stdout.strip() for r in refs}
     commit = resolved[refs[0]]
 
-    refs = {r: {"inputhash": ostree("show", "--print-metadata-key=rpmostree.inputhash", resolved[r]).stdout.strip("'\n")} for r in refs}
-    report["ostree"]["refs"] = refs
-
     with tempfile.TemporaryDirectory(dir="/var/tmp") as tmpdir:
         tree = os.path.join(tmpdir, "tree")
         ostree("checkout", "--force-copy", commit, tree)


### PR DESCRIPTION
The algorithm from calculating changed in osbuild 24, thus breaking the
testsuite. As the the inputhash is merely a implementation detail, there's
no need to test it in the image tests. Nevertheless, the inputhash is also
tested in the osbuild's testsuite.


This pull request includes:

- [x] adequate testing for the new functionality or fixed issue
- [x] adequate documentation informing people about the change

This is a minor change of the test suite, both items are not needed imho.

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

For user-visible changes, "adequate documentation" is an entry describing the
change for users in docs/news. Please refer to docs/news/README.md for details.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`
-->
