### PR TITLE
cloudapi: extend the API spec with /version and /openapi.json

### DIFF
--- a/internal/cloudapi/openapi.yml
+++ b/internal/cloudapi/openapi.yml
@@ -9,6 +9,27 @@ info:
     url: https://www.apache.org/licenses/LICENSE-2.0.html
 
 paths:
+  /version:
+    get:
+      summary: get the service version
+      description: "get the service version"
+      operationId: getVersion
+      responses:
+        '200':
+          description: a service version
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Version'
+  /openapi.json:
+    get:
+      summary: get the openapi json specification
+      operationId: getOpenapiJson
+      tags:
+        - meta
+      responses:
+        '200':
+          description: returns this document
   /compose/{id}:
     get:
       summary: The status of a compose
@@ -63,6 +84,12 @@ paths:
 
 components:
   schemas:
+    Version:
+      required:
+        - version
+      properties:
+        version:
+          type: string
     ComposeStatus:
       required:
         - image_status


### PR DESCRIPTION
These endpoints are useful for clients while exploring the API. They are
also required for deploying the service into clouddot.


This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

For user-visible changes, "adequate documentation" is an entry describing the
change for users in docs/news. Please refer to docs/news/README.md for details.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`
-->
