### PR TITLE
cloudapi: add support for additional packages

### DIFF
--- a/docs/news/unreleased/cloudapi-packages.md
+++ b/docs/news/unreleased/cloudapi-packages.md
@@ -1,0 +1,9 @@
+# Cloud API: The compose endopint now allow additional package selection
+
+The `POST /compose` endpoint has now been extended to allow packages to
+be requested in addition to the base ones for the image type. Packages
+can only be requested by name, and the most recent ones that satisfy
+dependency solving will be chosen.
+
+Relevant PR:
+https://github.com/osbuild/osbuild-composer/pull/1208

--- a/internal/cloudapi/openapi.gen.go
+++ b/internal/cloudapi/openapi.gen.go
@@ -58,6 +58,7 @@ type ComposeStatus struct {
 
 // Customizations defines model for Customizations.
 type Customizations struct {
+	Packages     *[]string     `json:"packages,omitempty"`
 	Subscription *Subscription `json:"subscription,omitempty"`
 }
 

--- a/internal/cloudapi/openapi.yml
+++ b/internal/cloudapi/openapi.yml
@@ -221,6 +221,11 @@ components:
       properties:
         subscription:
           $ref: '#/components/schemas/Subscription'
+        packages:
+          type: array
+          example: ['postgres']
+          items:
+            type: string
     Subscription:
       type: object
       required:

--- a/internal/cloudapi/server.go
+++ b/internal/cloudapi/server.go
@@ -77,6 +77,20 @@ func (server *Server) Compose(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	var bp = blueprint.Blueprint{}
+	err = bp.Initialize()
+	if err != nil {
+		http.Error(w, "Unable to initialize blueprint", http.StatusInternalServerError)
+		return
+	}
+	if request.Customizations != nil && request.Customizations.Packages != nil {
+		for _, p := range *request.Customizations.Packages {
+			bp.Packages = append(bp.Packages, blueprint.Package{
+				Name: p,
+			})
+		}
+	}
+
 	type imageRequest struct {
 		manifest distro.Manifest
 		arch     string
@@ -116,13 +130,6 @@ func (server *Server) Compose(w http.ResponseWriter, r *http.Request) {
 				http.Error(w, "Must specify baseurl, mirrorlist, or metalink", http.StatusBadRequest)
 				return
 			}
-		}
-
-		var bp = blueprint.Blueprint{}
-		err = bp.Initialize()
-		if err != nil {
-			http.Error(w, "Unable to initialize blueprint", http.StatusInternalServerError)
-			return
 		}
 
 		packageSpecs, excludePackageSpecs := imageType.Packages(bp)

--- a/test/cases/api.sh
+++ b/test/cases/api.sh
@@ -90,6 +90,11 @@ cat > "$REQUEST_FILE" << EOF
       "architecture": "$ARCH",
       "image_type": "ami",
       "repositories": $(jq ".\"$ARCH\"" /usr/share/tests/osbuild-composer/repositories/"$DISTRO".json),
+      "customizations": {
+        "packages": [
+          "postgres"
+        ]
+      },
       "upload_requests": [
         {
           "type": "aws",


### PR DESCRIPTION
Optionally allow a pacakge set to be included in the compose request.

The specified packages are added to the base packages before
depsolving. As the base packages differ between the image types
the package customizations may have different results on the different
images part of the compose request.

Signed-off-by: Tom Gundersen <teg@jklm.no>


This pull request includes:

- [x] adequate testing for the new functionality or fixed issue
- [x] adequate documentation informing people about the change

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

For user-visible changes, "adequate documentation" is an entry describing the
change for users in docs/news. Please refer to docs/news/README.md for details.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`
-->
