### PR TITLE
Send webhooks without credentials

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -59,11 +59,9 @@ jobs:
           WEBHOOK_PAYLOAD: ${{ toJSON(github.event) }}
           SQS_REGION: us-east-1
           SQS_QUEUE_URL: "https://sqs.us-east-1.amazonaws.com/933752197999/schutzbot_webhook_sqs-staging"
-          AWS_ACCESS_KEY_ID: ${{ secrets.WEBHOOK_AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.WEBHOOK_AWS_SECRET_ACCESS_KEY }}
         run: |
           #!/bin/bash
-          pip3 install boto3
+          pip3 install boto3 botocore
           schutzbot/send_webhook.py
 
   shellcheck:

--- a/schutzbot/send_webhook.py
+++ b/schutzbot/send_webhook.py
@@ -4,13 +4,21 @@ import json
 import os
 
 import boto3
+from botocore import UNSIGNED
+from botocore.client import Config
 
 WEBHOOK_PAYLOAD = os.environ.get("WEBHOOK_PAYLOAD")
 EVENT_NAME = os.environ.get("EVENT_NAME")
-SQS_REGION = os.environ.get("SQS_REGION")
 SQS_QUEUE_URL = os.environ.get("SQS_QUEUE_URL")
+SQS_REGION = os.environ.get("SQS_REGION")
 
-sqs = boto3.client('sqs', region_name=SQS_REGION)
+sqs = boto3.client(
+    'sqs',
+    region_name=SQS_REGION,
+    config=Config(
+        signature_version=UNSIGNED
+    )
+)
 
 payload = json.loads(WEBHOOK_PAYLOAD)
 message = {


### PR DESCRIPTION
We can now send webhook data to an SQS queue at AWS without signing the
request with credentials. This allows us to trigger Schutzbot from
forks and from branches on the main repository.

Signed-off-by: Major Hayden <major@redhat.com>