### PR TITLE
weldr: Remove underscores from FreezeHandler error

### DIFF
--- a/internal/weldr/api.go
+++ b/internal/weldr/api.go
@@ -1314,7 +1314,7 @@ func (api *API) blueprintsFreezeHandler(writer http.ResponseWriter, request *htt
 		if bp == nil {
 			rerr := responseError{
 				ID:  "UnknownBlueprint",
-				Msg: fmt.Sprintf("%s: blueprint_not_found", name),
+				Msg: fmt.Sprintf("%s: blueprint not found", name),
 			}
 			errors = append(errors, rerr)
 			break


### PR DESCRIPTION
This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change

I didn't include testing or documentation because it's a string meant to be read by the user when trying to freeze a blueprint that doesn't exist.
