### PR TITLE
distro/rhel84: remove dbxtool

### DIFF
--- a/internal/distro/rhel84/distro.go
+++ b/internal/distro/rhel84/distro.go
@@ -909,7 +909,6 @@ func New() distro.Distro {
 			"cloud-utils-growpart",
 			"cockpit-system",
 			"cockpit-ws",
-			"dbxtool",
 			"dhcp-client",
 			"dnf",
 			"dnf-utils",


### PR DESCRIPTION
dbxtool is not available on s390x or ppc64le. So, it cannot be included for now without breaking image builds for these architectures.

It seems that dbxtool will be installed without the explicit declaration since the regenerating the test manifests for x86_64 did not remove it. I am unsure why it was missing in the image-info for the nightly I was comparing the package list for.