### PR TITLE
Fail early for ostree compose with kernel boot parameters

### DIFF
--- a/docs/news/unreleased/ostree-kernel-append.md
+++ b/docs/news/unreleased/ostree-kernel-append.md
@@ -1,0 +1,9 @@
+# OSTree compose types with kernel boot parameters return error
+
+Previously, specifying Kernel boot parameters in a Blueprint via the
+`[customizations.kernel]` section and requesting an OSTree image type
+(`rhel-edge-commit` or `fedora-iot-commit`) would produce an image but the boot
+parameters would be ignored.
+
+This combination now returns an error message that the configuration is not
+supported.

--- a/internal/distro/fedora32/distro.go
+++ b/internal/distro/fedora32/distro.go
@@ -222,6 +222,11 @@ func sources(packages []rpmmd.PackageSpec) *osbuild.Sources {
 }
 
 func (t *imageType) pipeline(c *blueprint.Customizations, options distro.ImageOptions, repos []rpmmd.RepoConfig, packageSpecs, buildPackageSpecs []rpmmd.PackageSpec) (*osbuild.Pipeline, error) {
+
+	if kernelOpts := c.GetKernel(); kernelOpts != nil && kernelOpts.Append != "" && t.rpmOstree {
+		return nil, fmt.Errorf("kernel boot parameter customizations are not supported for ostree types")
+	}
+
 	p := &osbuild.Pipeline{}
 	p.SetBuild(t.buildPipeline(repos, *t.arch, buildPackageSpecs), "org.osbuild.fedora32")
 

--- a/internal/distro/fedora32/distro_test.go
+++ b/internal/distro/fedora32/distro_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/osbuild/osbuild-composer/internal/blueprint"
+	"github.com/osbuild/osbuild-composer/internal/distro"
 	"github.com/osbuild/osbuild-composer/internal/distro/distro_test_common"
 	"github.com/osbuild/osbuild-composer/internal/distro/fedora32"
 	"github.com/stretchr/testify/assert"
@@ -289,6 +290,34 @@ func TestImageType_BasePackages(t *testing.T) {
 
 func TestDistro_Manifest(t *testing.T) {
 	distro_test_common.TestDistro_Manifest(t, "../../../test/data/manifests/", "fedora_32*", fedora32.New())
+}
+
+// Check that Manifest() function returns an error for unsupported
+// configurations.
+func TestDistro_ManifestError(t *testing.T) {
+	// Currently, the only unsupported configuration is OSTree commit types
+	// with Kernel boot options
+	f32distro := fedora32.New()
+	bp := blueprint.Blueprint{
+		Customizations: &blueprint.Customizations{
+			Kernel: &blueprint.KernelCustomization{
+				Append: "debug",
+			},
+		},
+	}
+
+	for _, archName := range f32distro.ListArches() {
+		arch, _ := f32distro.GetArch(archName)
+		for _, imgTypeName := range arch.ListImageTypes() {
+			imgType, _ := arch.GetImageType(imgTypeName)
+			_, err := imgType.Manifest(bp.Customizations, distro.ImageOptions{}, nil, nil, nil, 0)
+			if imgTypeName == "fedora-iot-commit" {
+				assert.EqualError(t, err, "kernel boot parameter customizations are not supported for ostree types")
+			} else {
+				assert.NoError(t, err)
+			}
+		}
+	}
 }
 
 func TestFedora32_ListArches(t *testing.T) {

--- a/internal/distro/fedora33/distro.go
+++ b/internal/distro/fedora33/distro.go
@@ -222,6 +222,11 @@ func sources(packages []rpmmd.PackageSpec) *osbuild.Sources {
 }
 
 func (t *imageType) pipeline(c *blueprint.Customizations, options distro.ImageOptions, repos []rpmmd.RepoConfig, packageSpecs, buildPackageSpecs []rpmmd.PackageSpec) (*osbuild.Pipeline, error) {
+
+	if kernelOpts := c.GetKernel(); kernelOpts != nil && kernelOpts.Append != "" && t.rpmOstree {
+		return nil, fmt.Errorf("kernel boot parameter customizations are not supported for ostree types")
+	}
+
 	p := &osbuild.Pipeline{}
 	p.SetBuild(t.buildPipeline(repos, *t.arch, buildPackageSpecs), "org.osbuild.fedora33")
 

--- a/internal/distro/rhel8/distro.go
+++ b/internal/distro/rhel8/distro.go
@@ -229,6 +229,11 @@ func sources(packages []rpmmd.PackageSpec) *osbuild.Sources {
 }
 
 func (t *imageType) pipeline(c *blueprint.Customizations, options distro.ImageOptions, repos []rpmmd.RepoConfig, packageSpecs, buildPackageSpecs []rpmmd.PackageSpec) (*osbuild.Pipeline, error) {
+
+	if kernelOpts := c.GetKernel(); kernelOpts != nil && kernelOpts.Append != "" && t.rpmOstree {
+		return nil, fmt.Errorf("kernel boot parameter customizations are not supported for ostree types")
+	}
+
 	p := &osbuild.Pipeline{}
 	p.SetBuild(t.buildPipeline(repos, *t.arch, buildPackageSpecs), "org.osbuild.rhel82")
 

--- a/internal/distro/rhel84/distro.go
+++ b/internal/distro/rhel84/distro.go
@@ -236,6 +236,11 @@ func sources(packages []rpmmd.PackageSpec) *osbuild.Sources {
 }
 
 func (t *imageType) pipeline(c *blueprint.Customizations, options distro.ImageOptions, repos []rpmmd.RepoConfig, packageSpecs, buildPackageSpecs []rpmmd.PackageSpec, rng *rand.Rand) (*osbuild.Pipeline, error) {
+
+	if kernelOpts := c.GetKernel(); kernelOpts != nil && kernelOpts.Append != "" && t.rpmOstree {
+		return nil, fmt.Errorf("kernel boot parameter customizations are not supported for ostree types")
+	}
+
 	var pt *disk.PartitionTable
 	if t.partitionTableGenerator != nil {
 		table := t.partitionTableGenerator(options, t.arch, rng)


### PR DESCRIPTION
This pull request includes:

- [x] adequate testing for the new functionality or fixed issue
- [x] adequate documentation informing people about the change

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

For user-visible changes, "adequate documentation" is an entry describing the
change for users in docs/news. Please refer to docs/news/README.md for details.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`
-->

Kernel boot parameters have no effect on ostree type images (Fedora IoT and RHEL for Edge; see #1210).  With this PR, we catch this and fail early in the pipeline creation and communicate the issue to the user.