### PR TITLE
ci: do not run the unit tests with verbose on

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -48,7 +48,7 @@ jobs:
         run: $(go env GOPATH)/bin/golangci-lint run --timeout 5m0s
 
       - name: Run unit tests
-        run: go test -v -race -covermode=atomic -coverprofile=coverage.txt -coverpkg=./... ./...
+        run: go test -race -covermode=atomic -coverprofile=coverage.txt -coverpkg=./... ./...
 
       - name: Send coverage to codecov.io
         run: bash <(curl -s https://codecov.io/bash)


### PR DESCRIPTION
When unit tests succeed, no one cares about them.

When unit tests fail, it's hard to find which one failed. This commit removes
the verbose flag, so it's easy to spot what failed.


This pull request includes:

- [x] adequate testing for the new functionality or fixed issue
- [x] adequate documentation informing people about the change

Both irrelevant.

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

For user-visible changes, "adequate documentation" is an entry describing the
change for users in docs/news. Please refer to docs/news/README.md for details.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`
-->
