### PR TITLE
test/api.sh: set the username for centos-8

### DIFF
--- a/test/cases/api.sh
+++ b/test/cases/api.sh
@@ -119,6 +119,7 @@ case $(set +x; . /etc/os-release; echo "$ID-$VERSION_ID") in
   ;;
   "centos-8")
     DISTRO="centos-8"
+    SSH_USER="cloud-user"
   ;;
 esac
 


### PR DESCRIPTION
This is a merge race condition. Sanne added a new variable, I added a new distro.

Signed-off-by: Ondřej Budai <ondrej@budai.cz>


This pull request includes:

- [x] adequate testing for the new functionality or fixed issue
- [x] adequate documentation informing people about the change

both irrelevant

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

For user-visible changes, "adequate documentation" is an entry describing the
change for users in docs/news. Please refer to docs/news/README.md for details.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`
-->
