### PR TITLE
ci: run the nightly test only on the main branch

### DIFF
--- a/schutzbot/Jenkinsfile
+++ b/schutzbot/Jenkinsfile
@@ -1,8 +1,10 @@
+var cron_string = BRANCH_NAME == "main" ? "@daily" : ""
+
 pipeline {
     agent none
 
     triggers {
-        cron('@daily')
+        cron(cron_string)
     }
 
     environment {
@@ -816,7 +818,7 @@ void preserve_logs(test_slug) {
 void detect_build_cause() {
     def buildCause = currentBuild.getBuildCauses().get(0)
 
-    if ( buildCause.shortDescription == 'Started by timer') {
+    if ( buildCause.shortDescription == 'Started by timer' && env.BRANCH_NAME == 'main') {
         return "cron"
     }
 


### PR DESCRIPTION
Currently, all PRs trigger the daily nightly testing. Let's limit that to just the main branch.

I found this here:
https://stackoverflow.com/questions/39168861/build-periodically-with-a-multi-branch-pipeline-in-jenkins

Signed-off-by: Ondřej Budai <ondrej@budai.cz>


This pull request includes:

- [x] adequate testing for the new functionality or fixed issue
- [x] adequate documentation informing people about the change

both irrelevant

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

For user-visible changes, "adequate documentation" is an entry describing the
change for users in docs/news. Please refer to docs/news/README.md for details.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`
-->
