### PR TITLE
internal/distro/rhel8: un-exclude subman from edge

### DIFF
--- a/internal/distro/rhel84/distro.go
+++ b/internal/distro/rhel84/distro.go
@@ -816,7 +816,6 @@ func newDistro(isCentos bool) distro.Distro {
 		},
 		excludedPackages: []string{
 			"rng-tools",
-			"subscription-manager",
 		},
 		enabledServices: []string{
 			"NetworkManager.service", "firewalld.service", "sshd.service",
@@ -870,7 +869,6 @@ func newDistro(isCentos bool) distro.Distro {
 		},
 		excludedPackages: []string{
 			"rng-tools",
-			"subscription-manager",
 		},
 		enabledServices: []string{
 			"NetworkManager.service", "firewalld.service", "sshd.service",

--- a/test/data/ansible/check_ostree.yaml
+++ b/test/data/ansible/check_ostree.yaml
@@ -315,6 +315,7 @@
         - name: failed count + 1
           set_fact:
             failed_counter: "{{ failed_counter | int + 1 }}"
+      when: ansible_facts['distribution'] != 'RedHat' and ansible_facts ['distribution_version'] != '8.4'
 
     # case: check installed greenboot packages
     # https://github.com/osbuild/osbuild-composer/blob/master/internal/distro/rhel8/distro.go#L634


### PR DESCRIPTION
We aim at shrinking our deps eventually but we need subman for the time
being. This patch basically un-exclude subman which was introduced by
https://github.com/osbuild/osbuild-composer/pull/893

Signed-off-by: Antonio Murdaca <runcom@linux.com>