### PR TITLE
schutzfile: test against osbuild 25 on RHEL 8.3

### DIFF
--- a/Schutzfile
+++ b/Schutzfile
@@ -9,7 +9,7 @@
   "rhel-8.3": {
     "dependencies": {
       "osbuild": {
-        "commit": "20a142d8f9b8b5d0a69f4d91631dc94118d209ca"
+        "commit": "755c07a142ce2e8e88420590be553d8a255f3326"
       }
     },
     "dependants": {


### PR DESCRIPTION
So we can update our production setups.

Signed-off-by: Ondřej Budai <ondrej@budai.cz>


This pull request includes:

- [x] adequate testing for the new functionality or fixed issue
- [x] adequate documentation informing people about the change

Not necessary.
<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

For user-visible changes, "adequate documentation" is an entry describing the
change for users in docs/news. Please refer to docs/news/README.md for details.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`
-->
