### PR TITLE
tools: move to new utility-container builds

### DIFF
--- a/tools/run-koji-container.sh
+++ b/tools/run-koji-container.sh
@@ -57,13 +57,13 @@ koji_start() {
     -e POSTGRES_USER=koji \
     -e POSTGRES_PASSWORD=kojipass \
     -e POSTGRES_DB=koji \
-    quay.io/osbuild/postgres:v1
+    quay.io/osbuild/postgres:13-alpine
 
   ${CONTAINER_RUNTIME} run -d --name org.osbuild.koji.kdc \
     --network org.osbuild.koji \
     -v "${SHARE_DIR}:/share:z" \
     -p 88:88/udp \
-    quay.io/osbuild/kdc:v1
+    quay.io/osbuild/kdc:latest
 
   # initialize krb pricipals and create keytabs for them
   # HTTP/localhost@LOCAL for kojihub
@@ -84,7 +84,7 @@ koji_start() {
     -e POSTGRES_PASSWORD=kojipass \
     -e POSTGRES_DB=koji \
     -e POSTGRES_HOST=org.osbuild.koji.postgres \
-    quay.io/osbuild/koji:v1
+    quay.io/osbuild/koji:latest
 
   # TODO: we need to wait for the database to be initialized here. A better method should be used.
   sleep 10


### PR DESCRIPTION
Use the new tags of the `osbuild/containers` repository. The
infrastructure was simplified a lot and the new tags are much easier to
handle without any conflicts when building other images.

Note that this change uses the `latest` tag of all images. As an
alternative, we can also switch to the `latest-<date>` tags, which would
use a pinned immutable image tagged by the given date. However, these
tags are burried somewhere deep down in the ./tools/ directory and are
easy to forget upgrading. So for now use `latest` until we have better
synchronization infrastructure in place.

However, if these images ever break and we want to get back stable CI
behavior, we can always switch back to older builds by picking those
immutable tags instead of `latest`.