### PR TITLE
rhel84/grub2: set saved_entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ provided infrastructure and services.
 
 The requirements for this project are:
 
- * `osbuild >= 24`
+ * `osbuild >= 26`
  * `systemd >= 244`
 
 At build-time, the following software is required:

--- a/Schutzfile
+++ b/Schutzfile
@@ -1,5 +1,10 @@
 {
   "fedora-32": {
+    "dependencies": {
+      "osbuild": {
+        "commit": "6f1350d72d210767062a8e346e1472305703686b"
+      }
+    },
     "dependants": {
       "koji-osbuild": {
         "commit": "4fdc457745e1147475ea3ac1e3b073e592d7b174"
@@ -9,7 +14,7 @@
   "rhel-8.3": {
     "dependencies": {
       "osbuild": {
-        "commit": "3086c7d70c304214e2855cdcf495d4b70f4b04c6"
+        "commit": "6f1350d72d210767062a8e346e1472305703686b"
       }
     },
     "dependants": {
@@ -18,6 +23,27 @@
         "pre_install_packages": [
           "https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm"
         ]
+      }
+    }
+  },
+  "fedora-33": {
+    "dependencies": {
+      "osbuild": {
+        "commit": "6f1350d72d210767062a8e346e1472305703686b"
+      }
+    }
+  },
+  "centos-8": {
+    "dependencies": {
+      "osbuild": {
+        "commit": "6f1350d72d210767062a8e346e1472305703686b"
+      }
+    }
+  },
+  "rhel-8.4": {
+    "dependencies": {
+      "osbuild": {
+        "commit": "6f1350d72d210767062a8e346e1472305703686b"
       }
     }
   }

--- a/Schutzfile
+++ b/Schutzfile
@@ -9,7 +9,7 @@
   "rhel-8.3": {
     "dependencies": {
       "osbuild": {
-        "commit": "755c07a142ce2e8e88420590be553d8a255f3326"
+        "commit": "3086c7d70c304214e2855cdcf495d4b70f4b04c6"
       }
     },
     "dependants": {

--- a/docs/news/unreleased/rhel84-grub2-saved-entry.md
+++ b/docs/news/unreleased/rhel84-grub2-saved-entry.md
@@ -1,0 +1,5 @@
+# RHEL8.4: Fix grub2 kernel selection
+
+By marking the kernel we install as the `saved_entry`, we make sure that installing additional/subsequent kernels do not unintentienally change the default kernel to be booted into.
+
+Relevant PR: https://github.com/osbuild/osbuild-composer/pull/1241

--- a/internal/blueprint/blueprint.go
+++ b/internal/blueprint/blueprint.go
@@ -104,13 +104,10 @@ func (b *Blueprint) GetPackages() []string {
 		packages = append(packages, "@"+group.Name)
 	}
 
-	if kc := b.Customizations.GetKernel(); kc != nil && kc.Name != "" {
-		kpkg := Package{Name: b.Customizations.Kernel.Name}
-		packages = append(packages, kpkg.ToNameVersion())
-	} else { // no Kernel specified; add default
-		kpkg := Package{Name: "kernel"}
-		packages = append(packages, kpkg.ToNameVersion())
-	}
+	kc := b.Customizations.GetKernel()
+	kpkg := Package{Name: kc.Name}
+	packages = append(packages, kpkg.ToNameVersion())
+
 	return packages
 }
 

--- a/internal/blueprint/customizations.go
+++ b/internal/blueprint/customizations.go
@@ -155,11 +155,21 @@ func (c *Customizations) GetGroups() []GroupCustomization {
 }
 
 func (c *Customizations) GetKernel() *KernelCustomization {
-	if c == nil {
-		return nil
+	var name string
+	var append string
+	if c != nil && c.Kernel != nil {
+		name = c.Kernel.Name
+		append = c.Kernel.Append
 	}
 
-	return c.Kernel
+	if name == "" {
+		name = "kernel"
+	}
+
+	return &KernelCustomization{
+		Name:   name,
+		Append: append,
+	}
 }
 
 func (c *Customizations) GetFirewall() *FirewallCustomization {

--- a/internal/blueprint/customizations_test.go
+++ b/internal/blueprint/customizations_test.go
@@ -1,8 +1,9 @@
 package blueprint
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestGetHostname(t *testing.T) {
@@ -22,6 +23,7 @@ func TestGetKernel(t *testing.T) {
 
 	expectedKernel := KernelCustomization{
 		Append: "--test",
+		Name:   "kernel",
 	}
 
 	TestCustomizations := Customizations{
@@ -214,7 +216,7 @@ func TestNoCustomizationsInBlueprint(t *testing.T) {
 	assert.Nil(t, TestBP.Customizations.GetHostname())
 	assert.Nil(t, TestBP.Customizations.GetUsers())
 	assert.Nil(t, TestBP.Customizations.GetGroups())
-	assert.Nil(t, TestBP.Customizations.GetKernel())
+	assert.Equal(t, &KernelCustomization{Name: "kernel"}, TestBP.Customizations.GetKernel())
 	assert.Nil(t, TestBP.Customizations.GetFirewall())
 	assert.Nil(t, TestBP.Customizations.GetServices())
 

--- a/internal/distro/fedora32/distro.go
+++ b/internal/distro/fedora32/distro.go
@@ -426,7 +426,7 @@ func (t *imageType) fsTabStageOptions(uefi bool) *osbuild.FSTabStageOptions {
 func (t *imageType) grub2StageOptions(kernelOptions string, kernel *blueprint.KernelCustomization, uefi bool) *osbuild.GRUB2StageOptions {
 	id := uuid.MustParse("76a22bf4-f153-4541-b6c7-0332c0dfaeac")
 
-	if kernel != nil {
+	if kernel != nil && kernel.Append != "" {
 		kernelOptions += " " + kernel.Append
 	}
 

--- a/internal/distro/fedora33/distro.go
+++ b/internal/distro/fedora33/distro.go
@@ -438,7 +438,7 @@ func (t *imageType) fsTabStageOptions(uefi bool) *osbuild.FSTabStageOptions {
 func (t *imageType) grub2StageOptions(kernelOptions string, kernel *blueprint.KernelCustomization, uefi bool) *osbuild.GRUB2StageOptions {
 	id := uuid.MustParse("76a22bf4-f153-4541-b6c7-0332c0dfaeac")
 
-	if kernel != nil {
+	if kernel != nil && kernel.Append != "" {
 		kernelOptions += " " + kernel.Append
 	}
 

--- a/internal/distro/rhel8/distro.go
+++ b/internal/distro/rhel8/distro.go
@@ -467,7 +467,7 @@ func (t *imageType) fsTabStageOptions(uefi bool) *osbuild.FSTabStageOptions {
 func (t *imageType) grub2StageOptions(kernelOptions string, kernel *blueprint.KernelCustomization, uefi bool) *osbuild.GRUB2StageOptions {
 	id := uuid.MustParse("0bd700f8-090f-4556-b797-b340297ea1bd")
 
-	if kernel != nil {
+	if kernel != nil && kernel.Append != "" {
 		kernelOptions += " " + kernel.Append
 	}
 

--- a/internal/distro/rhel84/distro.go
+++ b/internal/distro/rhel84/distro.go
@@ -295,7 +295,7 @@ func (t *imageType) pipeline(c *blueprint.Customizations, options distro.ImageOp
 
 	if t.bootable {
 		if t.arch.Name() != "s390x" {
-			p.AddStage(osbuild.NewGRUB2Stage(t.grub2StageOptions(pt, t.kernelOptions, c.GetKernel(), t.arch.uefi, t.arch.legacy)))
+			p.AddStage(osbuild.NewGRUB2Stage(t.grub2StageOptions(pt, t.kernelOptions, c.GetKernel(), packageSpecs, t.arch.uefi, t.arch.legacy)))
 		}
 	}
 
@@ -515,7 +515,7 @@ func (t *imageType) systemdStageOptions(enabledServices, disabledServices []stri
 	}
 }
 
-func (t *imageType) grub2StageOptions(pt *disk.PartitionTable, kernelOptions string, kernel *blueprint.KernelCustomization, uefi bool, legacy string) *osbuild.GRUB2StageOptions {
+func (t *imageType) grub2StageOptions(pt *disk.PartitionTable, kernelOptions string, kernel *blueprint.KernelCustomization, packages []rpmmd.PackageSpec, uefi bool, legacy string) *osbuild.GRUB2StageOptions {
 	if pt == nil {
 		panic("partition table must be defined for grub2 stage, this is a programming error")
 	}
@@ -524,13 +524,12 @@ func (t *imageType) grub2StageOptions(pt *disk.PartitionTable, kernelOptions str
 		panic("root partition must be defined for grub2 stage, this is a programming error")
 	}
 
-	id := uuid.MustParse(rootPartition.Filesystem.UUID)
-
-	if kernel != nil {
-		kernelOptions += " " + kernel.Append
+	stageOptions := osbuild.GRUB2StageOptions{
+		RootFilesystemUUID: uuid.MustParse(rootPartition.Filesystem.UUID),
+		KernelOptions:      kernelOptions,
+		Legacy:             legacy,
 	}
 
-	var uefiOptions *osbuild.GRUB2UEFI
 	if uefi {
 		var vendor string
 		if t.arch.distro.isCentos {
@@ -538,21 +537,28 @@ func (t *imageType) grub2StageOptions(pt *disk.PartitionTable, kernelOptions str
 		} else {
 			vendor = "redhat"
 		}
-		uefiOptions = &osbuild.GRUB2UEFI{
+		stageOptions.UEFI = &osbuild.GRUB2UEFI{
 			Vendor: vendor,
 		}
 	}
 
 	if !uefi {
-		legacy = t.arch.legacy
+		stageOptions.Legacy = t.arch.legacy
 	}
 
-	return &osbuild.GRUB2StageOptions{
-		RootFilesystemUUID: id,
-		KernelOptions:      kernelOptions,
-		Legacy:             legacy,
-		UEFI:               uefiOptions,
+	if kernel != nil {
+		if kernel.Append != "" {
+			stageOptions.KernelOptions += " " + kernel.Append
+		}
+		for _, pkg := range packages {
+			if pkg.Name == kernel.Name {
+				stageOptions.SavedEntry = "ffffffffffffffffffffffffffffffff-" + pkg.Version + "-" + pkg.Release + "." + pkg.Arch
+				break
+			}
+		}
 	}
+
+	return &stageOptions
 }
 
 func (t *imageType) selinuxStageOptions() *osbuild.SELinuxStageOptions {

--- a/internal/osbuild/grub2_stage.go
+++ b/internal/osbuild/grub2_stage.go
@@ -16,6 +16,7 @@ type GRUB2StageOptions struct {
 	KernelOptions      string     `json:"kernel_opts,omitempty"`
 	Legacy             string     `json:"legacy,omitempty"`
 	UEFI               *GRUB2UEFI `json:"uefi,omitempty"`
+	SavedEntry         string     `json:"saved_entry,omitempty"`
 }
 
 type GRUB2UEFI struct {

--- a/osbuild-composer.spec
+++ b/osbuild-composer.spec
@@ -273,8 +273,8 @@ The core osbuild-composer binary. This is suitable both for spawning in containe
 Summary:    The worker for osbuild-composer
 Requires:   systemd
 Requires:   qemu-img
-Requires:   osbuild >= 24
-Requires:   osbuild-ostree >= 24
+Requires:   osbuild >= 26
+Requires:   osbuild-ostree >= 26
 
 # remove in F34
 Obsoletes: golang-github-osbuild-composer-worker < %{version}-%{release}

--- a/test/data/manifests/centos_8-x86_64-ami-boot.json
+++ b/test/data/manifests/centos_8-x86_64-ami-boot.json
@@ -3858,7 +3858,8 @@
             "legacy": "i386-pc",
             "uefi": {
               "vendor": "centos"
-            }
+            },
+            "saved_entry": "ffffffffffffffffffffffffffffffff-4.18.0-277.el8.x86_64"
           }
         },
         {
@@ -10257,7 +10258,8 @@
   },
   "image-info": {
     "boot-environment": {
-      "kernelopts": "root=UUID=0194fdc2-fa2f-4cc0-81d3-ff12045b73c8 console=ttyS0,115200n8 console=tty0 net.ifnames=0 rd.blacklist=nouveau nvme_core.io_timeout=4294967295 crashkernel=auto"
+      "kernelopts": "root=UUID=0194fdc2-fa2f-4cc0-81d3-ff12045b73c8 console=ttyS0,115200n8 console=tty0 net.ifnames=0 rd.blacklist=nouveau nvme_core.io_timeout=4294967295 crashkernel=auto",
+      "saved_entry": "ffffffffffffffffffffffffffffffff-4.18.0-277.el8.x86_64"
     },
     "bootloader": "grub",
     "bootmenu": [

--- a/test/data/manifests/centos_8-x86_64-openstack-boot.json
+++ b/test/data/manifests/centos_8-x86_64-openstack-boot.json
@@ -4155,7 +4155,8 @@
             "legacy": "i386-pc",
             "uefi": {
               "vendor": "centos"
-            }
+            },
+            "saved_entry": "ffffffffffffffffffffffffffffffff-4.18.0-277.el8.x86_64"
           }
         },
         {
@@ -10958,7 +10959,8 @@
   },
   "image-info": {
     "boot-environment": {
-      "kernelopts": "root=UUID=0194fdc2-fa2f-4cc0-81d3-ff12045b73c8 ro net.ifnames=0"
+      "kernelopts": "root=UUID=0194fdc2-fa2f-4cc0-81d3-ff12045b73c8 ro net.ifnames=0",
+      "saved_entry": "ffffffffffffffffffffffffffffffff-4.18.0-277.el8.x86_64"
     },
     "bootloader": "grub",
     "bootmenu": [

--- a/test/data/manifests/centos_8-x86_64-qcow2-boot.json
+++ b/test/data/manifests/centos_8-x86_64-qcow2-boot.json
@@ -4132,7 +4132,8 @@
             "legacy": "i386-pc",
             "uefi": {
               "vendor": "centos"
-            }
+            },
+            "saved_entry": "ffffffffffffffffffffffffffffffff-4.18.0-277.el8.x86_64"
           }
         },
         {
@@ -10934,7 +10935,8 @@
   },
   "image-info": {
     "boot-environment": {
-      "kernelopts": "root=UUID=0194fdc2-fa2f-4cc0-81d3-ff12045b73c8 console=tty0 console=ttyS0,115200n8 no_timer_check net.ifnames=0 crashkernel=auto"
+      "kernelopts": "root=UUID=0194fdc2-fa2f-4cc0-81d3-ff12045b73c8 console=tty0 console=ttyS0,115200n8 no_timer_check net.ifnames=0 crashkernel=auto",
+      "saved_entry": "ffffffffffffffffffffffffffffffff-4.18.0-277.el8.x86_64"
     },
     "bootloader": "grub",
     "bootmenu": [

--- a/test/data/manifests/centos_8-x86_64-qcow2-customize.json
+++ b/test/data/manifests/centos_8-x86_64-qcow2-customize.json
@@ -4184,7 +4184,8 @@
             "legacy": "i386-pc",
             "uefi": {
               "vendor": "centos"
-            }
+            },
+            "saved_entry": "ffffffffffffffffffffffffffffffff-4.18.0-277.el8.x86_64"
           }
         },
         {
@@ -11039,7 +11040,8 @@
   },
   "image-info": {
     "boot-environment": {
-      "kernelopts": "root=UUID=0194fdc2-fa2f-4cc0-81d3-ff12045b73c8 console=tty0 console=ttyS0,115200n8 no_timer_check net.ifnames=0 crashkernel=auto debug"
+      "kernelopts": "root=UUID=0194fdc2-fa2f-4cc0-81d3-ff12045b73c8 console=tty0 console=ttyS0,115200n8 no_timer_check net.ifnames=0 crashkernel=auto debug",
+      "saved_entry": "ffffffffffffffffffffffffffffffff-4.18.0-277.el8.x86_64"
     },
     "bootloader": "grub",
     "bootmenu": [

--- a/test/data/manifests/centos_8-x86_64-vhd-boot.json
+++ b/test/data/manifests/centos_8-x86_64-vhd-boot.json
@@ -4111,7 +4111,8 @@
             "legacy": "i386-pc",
             "uefi": {
               "vendor": "centos"
-            }
+            },
+            "saved_entry": "ffffffffffffffffffffffffffffffff-4.18.0-277.el8.x86_64"
           }
         },
         {
@@ -10874,7 +10875,8 @@
   },
   "image-info": {
     "boot-environment": {
-      "kernelopts": "root=UUID=0194fdc2-fa2f-4cc0-81d3-ff12045b73c8 ro biosdevname=0 rootdelay=300 console=ttyS0 earlyprintk=ttyS0 net.ifnames=0"
+      "kernelopts": "root=UUID=0194fdc2-fa2f-4cc0-81d3-ff12045b73c8 ro biosdevname=0 rootdelay=300 console=ttyS0 earlyprintk=ttyS0 net.ifnames=0",
+      "saved_entry": "ffffffffffffffffffffffffffffffff-4.18.0-277.el8.x86_64"
     },
     "bootloader": "grub",
     "bootmenu": [

--- a/test/data/manifests/centos_8-x86_64-vmdk-boot.json
+++ b/test/data/manifests/centos_8-x86_64-vmdk-boot.json
@@ -3949,7 +3949,8 @@
             "legacy": "i386-pc",
             "uefi": {
               "vendor": "centos"
-            }
+            },
+            "saved_entry": "ffffffffffffffffffffffffffffffff-4.18.0-277.el8.x86_64"
           }
         },
         {
@@ -10462,7 +10463,8 @@
   },
   "image-info": {
     "boot-environment": {
-      "kernelopts": "root=UUID=0194fdc2-fa2f-4cc0-81d3-ff12045b73c8 ro net.ifnames=0"
+      "kernelopts": "root=UUID=0194fdc2-fa2f-4cc0-81d3-ff12045b73c8 ro net.ifnames=0",
+      "saved_entry": "ffffffffffffffffffffffffffffffff-4.18.0-277.el8.x86_64"
     },
     "bootloader": "grub",
     "bootmenu": [

--- a/test/data/manifests/rhel_84-aarch64-ami-boot.json
+++ b/test/data/manifests/rhel_84-aarch64-ami-boot.json
@@ -3213,7 +3213,8 @@
             "kernel_opts": "console=ttyS0,115200n8 console=tty0 net.ifnames=0 rd.blacklist=nouveau nvme_core.io_timeout=4294967295 crashkernel=auto",
             "uefi": {
               "vendor": "redhat"
-            }
+            },
+            "saved_entry": "ffffffffffffffffffffffffffffffff-4.18.0-275.el8.aarch64"
           }
         },
         {
@@ -8909,7 +8910,8 @@
   },
   "image-info": {
     "boot-environment": {
-      "kernelopts": "root=UUID=0194fdc2-fa2f-4cc0-81d3-ff12045b73c8 console=ttyS0,115200n8 console=tty0 net.ifnames=0 rd.blacklist=nouveau nvme_core.io_timeout=4294967295 crashkernel=auto"
+      "kernelopts": "root=UUID=0194fdc2-fa2f-4cc0-81d3-ff12045b73c8 console=ttyS0,115200n8 console=tty0 net.ifnames=0 rd.blacklist=nouveau nvme_core.io_timeout=4294967295 crashkernel=auto",
+      "saved_entry": "ffffffffffffffffffffffffffffffff-4.18.0-275.el8.aarch64"
     },
     "bootloader": "unknown",
     "bootmenu": [

--- a/test/data/manifests/rhel_84-aarch64-openstack-boot.json
+++ b/test/data/manifests/rhel_84-aarch64-openstack-boot.json
@@ -3446,7 +3446,8 @@
             "kernel_opts": "ro net.ifnames=0",
             "uefi": {
               "vendor": "redhat"
-            }
+            },
+            "saved_entry": "ffffffffffffffffffffffffffffffff-4.18.0-275.el8.aarch64"
           }
         },
         {
@@ -9470,7 +9471,8 @@
   },
   "image-info": {
     "boot-environment": {
-      "kernelopts": "root=UUID=0194fdc2-fa2f-4cc0-81d3-ff12045b73c8 ro net.ifnames=0"
+      "kernelopts": "root=UUID=0194fdc2-fa2f-4cc0-81d3-ff12045b73c8 ro net.ifnames=0",
+      "saved_entry": "ffffffffffffffffffffffffffffffff-4.18.0-275.el8.aarch64"
     },
     "bootloader": "unknown",
     "bootmenu": [

--- a/test/data/manifests/rhel_84-aarch64-qcow2-boot.json
+++ b/test/data/manifests/rhel_84-aarch64-qcow2-boot.json
@@ -3398,7 +3398,8 @@
             "kernel_opts": "console=tty0 console=ttyS0,115200n8 no_timer_check net.ifnames=0 crashkernel=auto",
             "uefi": {
               "vendor": "redhat"
-            }
+            },
+            "saved_entry": "ffffffffffffffffffffffffffffffff-4.18.0-275.el8.aarch64"
           }
         },
         {
@@ -9378,7 +9379,8 @@
   },
   "image-info": {
     "boot-environment": {
-      "kernelopts": "root=UUID=0194fdc2-fa2f-4cc0-81d3-ff12045b73c8 console=tty0 console=ttyS0,115200n8 no_timer_check net.ifnames=0 crashkernel=auto"
+      "kernelopts": "root=UUID=0194fdc2-fa2f-4cc0-81d3-ff12045b73c8 console=tty0 console=ttyS0,115200n8 no_timer_check net.ifnames=0 crashkernel=auto",
+      "saved_entry": "ffffffffffffffffffffffffffffffff-4.18.0-275.el8.aarch64"
     },
     "bootloader": "unknown",
     "bootmenu": [

--- a/test/data/manifests/rhel_84-ppc64le-qcow2-boot.json
+++ b/test/data/manifests/rhel_84-ppc64le-qcow2-boot.json
@@ -3677,7 +3677,8 @@
           "options": {
             "root_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
             "kernel_opts": "console=tty0 console=ttyS0,115200n8 no_timer_check net.ifnames=0 crashkernel=auto",
-            "legacy": "powerpc-ieee1275"
+            "legacy": "powerpc-ieee1275",
+            "saved_entry": "ffffffffffffffffffffffffffffffff-4.18.0-275.el8.ppc64le"
           }
         },
         {
@@ -10112,7 +10113,8 @@
   },
   "image-info": {
     "boot-environment": {
-      "kernelopts": "root=UUID=0194fdc2-fa2f-4cc0-81d3-ff12045b73c8 console=tty0 console=ttyS0,115200n8 no_timer_check net.ifnames=0 crashkernel=auto"
+      "kernelopts": "root=UUID=0194fdc2-fa2f-4cc0-81d3-ff12045b73c8 console=tty0 console=ttyS0,115200n8 no_timer_check net.ifnames=0 crashkernel=auto",
+      "saved_entry": "ffffffffffffffffffffffffffffffff-4.18.0-275.el8.ppc64le"
     },
     "bootloader": "unknown",
     "bootmenu": [

--- a/test/data/manifests/rhel_84-x86_64-ami-boot.json
+++ b/test/data/manifests/rhel_84-x86_64-ami-boot.json
@@ -3265,7 +3265,8 @@
             "legacy": "i386-pc",
             "uefi": {
               "vendor": "redhat"
-            }
+            },
+            "saved_entry": "ffffffffffffffffffffffffffffffff-4.18.0-275.el8.x86_64"
           }
         },
         {
@@ -9070,7 +9071,8 @@
   },
   "image-info": {
     "boot-environment": {
-      "kernelopts": "root=UUID=0194fdc2-fa2f-4cc0-81d3-ff12045b73c8 console=ttyS0,115200n8 console=tty0 net.ifnames=0 rd.blacklist=nouveau nvme_core.io_timeout=4294967295 crashkernel=auto"
+      "kernelopts": "root=UUID=0194fdc2-fa2f-4cc0-81d3-ff12045b73c8 console=ttyS0,115200n8 console=tty0 net.ifnames=0 rd.blacklist=nouveau nvme_core.io_timeout=4294967295 crashkernel=auto",
+      "saved_entry": "ffffffffffffffffffffffffffffffff-4.18.0-275.el8.x86_64"
     },
     "bootloader": "grub",
     "bootmenu": [

--- a/test/data/manifests/rhel_84-x86_64-openstack-boot.json
+++ b/test/data/manifests/rhel_84-x86_64-openstack-boot.json
@@ -3504,7 +3504,8 @@
             "legacy": "i386-pc",
             "uefi": {
               "vendor": "redhat"
-            }
+            },
+            "saved_entry": "ffffffffffffffffffffffffffffffff-4.18.0-275.el8.x86_64"
           }
         },
         {
@@ -9646,7 +9647,8 @@
   },
   "image-info": {
     "boot-environment": {
-      "kernelopts": "root=UUID=0194fdc2-fa2f-4cc0-81d3-ff12045b73c8 ro net.ifnames=0"
+      "kernelopts": "root=UUID=0194fdc2-fa2f-4cc0-81d3-ff12045b73c8 ro net.ifnames=0",
+      "saved_entry": "ffffffffffffffffffffffffffffffff-4.18.0-275.el8.x86_64"
     },
     "bootloader": "grub",
     "bootmenu": [

--- a/test/data/manifests/rhel_84-x86_64-qcow2-boot.json
+++ b/test/data/manifests/rhel_84-x86_64-qcow2-boot.json
@@ -3438,7 +3438,8 @@
             "legacy": "i386-pc",
             "uefi": {
               "vendor": "redhat"
-            }
+            },
+            "saved_entry": "ffffffffffffffffffffffffffffffff-4.18.0-275.el8.x86_64"
           }
         },
         {
@@ -9509,7 +9510,8 @@
   },
   "image-info": {
     "boot-environment": {
-      "kernelopts": "root=UUID=0194fdc2-fa2f-4cc0-81d3-ff12045b73c8 console=tty0 console=ttyS0,115200n8 no_timer_check net.ifnames=0 crashkernel=auto"
+      "kernelopts": "root=UUID=0194fdc2-fa2f-4cc0-81d3-ff12045b73c8 console=tty0 console=ttyS0,115200n8 no_timer_check net.ifnames=0 crashkernel=auto",
+      "saved_entry": "ffffffffffffffffffffffffffffffff-4.18.0-275.el8.x86_64"
     },
     "bootloader": "grub",
     "bootmenu": [

--- a/test/data/manifests/rhel_84-x86_64-qcow2-customize.json
+++ b/test/data/manifests/rhel_84-x86_64-qcow2-customize.json
@@ -3490,7 +3490,8 @@
             "legacy": "i386-pc",
             "uefi": {
               "vendor": "redhat"
-            }
+            },
+            "saved_entry": "ffffffffffffffffffffffffffffffff-4.18.0-275.el8.x86_64"
           }
         },
         {
@@ -9614,7 +9615,8 @@
   },
   "image-info": {
     "boot-environment": {
-      "kernelopts": "root=UUID=0194fdc2-fa2f-4cc0-81d3-ff12045b73c8 console=tty0 console=ttyS0,115200n8 no_timer_check net.ifnames=0 crashkernel=auto debug"
+      "kernelopts": "root=UUID=0194fdc2-fa2f-4cc0-81d3-ff12045b73c8 console=tty0 console=ttyS0,115200n8 no_timer_check net.ifnames=0 crashkernel=auto debug",
+      "saved_entry": "ffffffffffffffffffffffffffffffff-4.18.0-275.el8.x86_64"
     },
     "bootloader": "grub",
     "bootmenu": [

--- a/test/data/manifests/rhel_84-x86_64-vhd-boot.json
+++ b/test/data/manifests/rhel_84-x86_64-vhd-boot.json
@@ -3465,7 +3465,8 @@
             "legacy": "i386-pc",
             "uefi": {
               "vendor": "redhat"
-            }
+            },
+            "saved_entry": "ffffffffffffffffffffffffffffffff-4.18.0-275.el8.x86_64"
           }
         },
         {
@@ -9572,7 +9573,8 @@
   },
   "image-info": {
     "boot-environment": {
-      "kernelopts": "root=UUID=0194fdc2-fa2f-4cc0-81d3-ff12045b73c8 ro biosdevname=0 rootdelay=300 console=ttyS0 earlyprintk=ttyS0 net.ifnames=0"
+      "kernelopts": "root=UUID=0194fdc2-fa2f-4cc0-81d3-ff12045b73c8 ro biosdevname=0 rootdelay=300 console=ttyS0 earlyprintk=ttyS0 net.ifnames=0",
+      "saved_entry": "ffffffffffffffffffffffffffffffff-4.18.0-275.el8.x86_64"
     },
     "bootloader": "grub",
     "bootmenu": [

--- a/test/data/manifests/rhel_84-x86_64-vmdk-boot.json
+++ b/test/data/manifests/rhel_84-x86_64-vmdk-boot.json
@@ -3333,7 +3333,8 @@
             "legacy": "i386-pc",
             "uefi": {
               "vendor": "redhat"
-            }
+            },
+            "saved_entry": "ffffffffffffffffffffffffffffffff-4.18.0-275.el8.x86_64"
           }
         },
         {
@@ -9223,7 +9224,8 @@
   },
   "image-info": {
     "boot-environment": {
-      "kernelopts": "root=UUID=0194fdc2-fa2f-4cc0-81d3-ff12045b73c8 ro net.ifnames=0"
+      "kernelopts": "root=UUID=0194fdc2-fa2f-4cc0-81d3-ff12045b73c8 ro net.ifnames=0",
+      "saved_entry": "ffffffffffffffffffffffffffffffff-4.18.0-275.el8.x86_64"
     },
     "bootloader": "grub",
     "bootmenu": [


### PR DESCRIPTION
Explicitly set the kernel to boot into.

This hooks up the recent changes @gicmo made in osbuild to fix a rhel8.4 regression. No tests yet.

This pull request includes:

- [x] adequate testing for the new functionality or fixed issue
- [x] adequate documentation informing people about the change