### PR TITLE
tests: Use full repo name to ubi8-minimal to workaround bug

### DIFF
--- a/test/data/ansible/check_ostree.yaml
+++ b/test/data/ansible/check_ostree.yaml
@@ -275,7 +275,7 @@
 
     # case: check running container with podman
     - name: run ubi8 image
-      command: podman run ubi8-minimal:latest cat /etc/redhat-release
+      command: podman run registry.access.redhat.com/ubi8/ubi-minimal:latest cat /etc/redhat-release
       register: podman_result
       become: yes
 


### PR DESCRIPTION
/etc/containers/registries.conf.d/rhel-shortnames.conf shipped in
containers-common-1:1.2.2-1.module+el8.4.0+10073+30e5ea69 has a wrong
shortname for ubi8-minimal:

"ubi8-minimal" = "registry.access.redhat.com/repository/ubi8-minimal"

resulting in `name unknown: Repo not found` when trying to pull the image
via its short name.

Related: rhbz#1931785


This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

For user-visible changes, "adequate documentation" is an entry describing the
change for users in docs/news. Please refer to docs/news/README.md for details.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`
-->
