### PR TITLE
Revert "internal/distro/rhel8: un-exclude subman from edge"

### DIFF
--- a/internal/distro/rhel84/distro.go
+++ b/internal/distro/rhel84/distro.go
@@ -826,6 +826,7 @@ func newDistro(isCentos bool) distro.Distro {
 		},
 		excludedPackages: []string{
 			"rng-tools",
+			"subscription-manager",
 		},
 		enabledServices: []string{
 			"NetworkManager.service", "firewalld.service", "sshd.service",
@@ -879,6 +880,7 @@ func newDistro(isCentos bool) distro.Distro {
 		},
 		excludedPackages: []string{
 			"rng-tools",
+			"subscription-manager",
 		},
 		enabledServices: []string{
 			"NetworkManager.service", "firewalld.service", "sshd.service",

--- a/test/data/ansible/check_ostree.yaml
+++ b/test/data/ansible/check_ostree.yaml
@@ -315,7 +315,6 @@
         - name: failed count + 1
           set_fact:
             failed_counter: "{{ failed_counter | int + 1 }}"
-      when: ansible_facts['distribution'] != 'RedHat' and ansible_facts ['distribution_version'] != '8.4'
 
     # case: check installed greenboot packages
     # https://github.com/osbuild/osbuild-composer/blob/master/internal/distro/rhel8/distro.go#L634


### PR DESCRIPTION
We needed this patch to demonstrate RHC capabilities but we don't want to ship such a huge dependencies tree with subman/dnf - for 8.4 we'd revert this and revisit the dep tree.

@nullr0ute @gicmo ptal