### PR TITLE
Schutzbot: don't block on container build

### DIFF
--- a/schutzbot/Jenkinsfile
+++ b/schutzbot/Jenkinsfile
@@ -161,7 +161,18 @@ pipeline {
                         }
                     }
                 }
+                stage("Container build - x86_64") {
+                    when {
+                        expression {
+                            return env.BUILD_CAUSE != 'cron';
+                        }
+                    }
 
+                    agent { label "f33cloudbase && x86_64 && aws" }
+                    steps {
+                        sh "schutzbot/containerbuild.sh"
+                    }
+                }
             }
         }
 
@@ -196,19 +207,6 @@ pipeline {
                     includes: 'COMPOSE_ID',
                     name: 'compose_id'
                 )
-            }
-        }
-
-        stage("Container build - x86_64") {
-            when {
-                expression {
-                    return env.BUILD_CAUSE != 'cron';
-                }
-            }
-
-            agent { label "f33cloudbase && x86_64 && aws" }
-            steps {
-                sh "schutzbot/containerbuild.sh"
             }
         }
 


### PR DESCRIPTION
Move the container build to the same phase as the RPM builds. This does not make a huge difference, but should
shave off about two minutes of total CI runtime.