### PR TITLE
Don't check branch name when deciding if build was started by cron

### DIFF
--- a/schutzbot/Jenkinsfile
+++ b/schutzbot/Jenkinsfile
@@ -357,7 +357,7 @@ void preserve_logs(test_slug) {
 void detect_build_cause() {
     def buildCause = currentBuild.getBuildCauses().get(0)
 
-    if ( buildCause.shortDescription == 'Started by timer' && env.BRANCH_NAME == 'main') {
+    if ( buildCause.shortDescription == 'Started by timer' ) {
         return "cron"
     }
 


### PR DESCRIPTION
because we already have cron jobs on multiple branches!


This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

For user-visible changes, "adequate documentation" is an entry describing the
change for users in docs/news. Please refer to docs/news/README.md for details.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`
-->
