### PR TITLE
cherry-pick: Update dmesg test to work with only one failed log

### DIFF
--- a/test/data/ansible/check_ostree.yaml
+++ b/test/data/ansible/check_ostree.yaml
@@ -241,9 +241,8 @@
       block:
         - assert:
             that:
-              - result_dmesg_error.stdout_lines | length == 2
-              - "'pcieport 0000:00:01.6: Failed to check link status' in result_dmesg_error.stdout"
-              - "'Error: Driver \\'pcspkr\\' is already registered, aborting' in result_dmesg_error.stdout"
+              - result_dmesg_error.stdout_lines | length <= 2
+              - "'pcieport 0000:00:01.6: Failed to check link status' in result_dmesg_error.stdout or 'Error: Driver \\'pcspkr\\' is already registered, aborting' in result_dmesg_error.stdout"
             fail_msg: "more or less error and failed log"
             success_msg: "everything works as expected"
       always:


### PR DESCRIPTION
cherry-picked from main commit 3ed3f2ed951297810282b5ca514452a0921cd7e3