### PR TITLE
Distro: replace Packages() / BuildPackages() with PackageSets()

### DIFF
--- a/cmd/osbuild-dnf-json-tests/main_test.go
+++ b/cmd/osbuild-dnf-json-tests/main_test.go
@@ -80,12 +80,12 @@ func TestCrossArchDepsolve(t *testing.T) {
 							imgType, err := arch.GetImageType(imgTypeStr)
 							require.NoError(t, err)
 
-							buildPackages := imgType.BuildPackages()
-							_, _, err = rpm.Depsolve(buildPackages, []string{}, repos[archStr], distroStruct.ModulePlatformID(), archStr)
+							packages := imgType.PackageSets(blueprint.Blueprint{})
+
+							_, _, err = rpm.Depsolve(packages["build-packages"], repos[archStr], distroStruct.ModulePlatformID(), archStr)
 							assert.NoError(t, err)
 
-							basePackagesInclude, basePackagesExclude := imgType.Packages(blueprint.Blueprint{})
-							_, _, err = rpm.Depsolve(basePackagesInclude, basePackagesExclude, repos[archStr], distroStruct.ModulePlatformID(), archStr)
+							_, _, err = rpm.Depsolve(packages["packages"], repos[archStr], distroStruct.ModulePlatformID(), archStr)
 							assert.NoError(t, err)
 						})
 					}

--- a/cmd/osbuild-pipeline/main.go
+++ b/cmd/osbuild-pipeline/main.go
@@ -38,7 +38,6 @@ type composeRequest struct {
 type rpmMD struct {
 	BuildPackages []rpmmd.PackageSpec `json:"build-packages"`
 	Packages      []rpmmd.PackageSpec `json:"packages"`
-	Checksums     map[string]string   `json:"checksums"`
 }
 
 func main() {
@@ -141,7 +140,6 @@ func main() {
 		rpmMDInfo := rpmMD{
 			BuildPackages: buildPackageSpecs,
 			Packages:      packageSpecs,
-			Checksums:     checksums,
 		}
 		bytes, err = json.Marshal(rpmMDInfo)
 		if err != nil {

--- a/cmd/osbuild-store-dump/main.go
+++ b/cmd/osbuild-store-dump/main.go
@@ -16,17 +16,17 @@ import (
 	"github.com/osbuild/osbuild-composer/internal/target"
 )
 
-func getManifest(bp blueprint.Blueprint, t distro.ImageType, a distro.Arch, d distro.Distro, rpmmd rpmmd.RPMMD, repos []rpmmd.RepoConfig) distro.Manifest {
-	packages, excludePackages := t.Packages(bp)
-	pkgs, _, err := rpmmd.Depsolve(packages, excludePackages, repos, d.ModulePlatformID(), a.Name())
-	if err != nil {
-		panic(err)
+func getManifest(bp blueprint.Blueprint, t distro.ImageType, a distro.Arch, d distro.Distro, rpm_md rpmmd.RPMMD, repos []rpmmd.RepoConfig) distro.Manifest {
+	packageSets := t.PackageSets(bp)
+	pkgSpecSets := make(map[string][]rpmmd.PackageSpec)
+	for name, packages := range packageSets {
+		pkgs, _, err := rpm_md.Depsolve(packages, repos, d.ModulePlatformID(), a.Name())
+		if err != nil {
+			panic(err)
+		}
+		pkgSpecSets[name] = pkgs
 	}
-	buildPkgs, _, err := rpmmd.Depsolve(t.BuildPackages(), nil, repos, d.ModulePlatformID(), a.Name())
-	if err != nil {
-		panic(err)
-	}
-	manifest, err := t.Manifest(bp.Customizations, distro.ImageOptions{}, repos, pkgs, buildPkgs, 0)
+	manifest, err := t.Manifest(bp.Customizations, distro.ImageOptions{}, repos, pkgSpecSets, 0)
 	if err != nil {
 		panic(err)
 	}

--- a/internal/distro/distro.go
+++ b/internal/distro/distro.go
@@ -72,17 +72,16 @@ type ImageType interface {
 	// is 0 the default value for the format will be returned.
 	Size(size uint64) uint64
 
-	// Returns the default packages to include and exclude when making the image
-	// type.
-	Packages(bp blueprint.Blueprint) ([]string, []string)
-
-	// Returns the build packages for the output type.
-	BuildPackages() []string
+	// Returns the sets of packages to include and exclude when building the image.
+	// Indexed by a string label. How each set is labeled and used depends on the
+	// image type.
+	PackageSets(bp blueprint.Blueprint) map[string]rpmmd.PackageSet
 
 	// Returns an osbuild manifest, containing the sources and pipeline necessary
 	// to build an image, given output format with all packages and customizations
-	// specified in the given blueprint.
-	Manifest(b *blueprint.Customizations, options ImageOptions, repos []rpmmd.RepoConfig, packageSpecs, buildPackageSpecs []rpmmd.PackageSpec, seed int64) (Manifest, error)
+	// specified in the given blueprint. The packageSpecSets must be labelled in
+	// the same way as the originating PackageSets.
+	Manifest(b *blueprint.Customizations, options ImageOptions, repos []rpmmd.RepoConfig, packageSpecSets map[string][]rpmmd.PackageSpec, seed int64) (Manifest, error)
 }
 
 // The ImageOptions specify options for a specific image build

--- a/internal/distro/fedora33/distro_test.go
+++ b/internal/distro/fedora33/distro_test.go
@@ -121,13 +121,15 @@ func TestImageType_BuildPackages(t *testing.T) {
 				t.Errorf("d.GetArch(%v) returned err = %v; expected nil", archLabel, err)
 				continue
 			}
+			buildPkgs := itStruct.PackageSets(blueprint.Blueprint{})["build-packages"]
+			assert.NotNil(t, buildPkgs)
 			if itLabel == "fedora-iot-commit" {
 				// For now we only include rpm-ostree when building fedora-iot-commit image types, this we may want
 				// to reconsider. The only reason to specia-case it is that it might pull in a lot of dependencies
 				// for a niche usecase.
-				assert.ElementsMatch(t, append(buildPackages[archLabel], "rpm-ostree"), itStruct.BuildPackages())
+				assert.ElementsMatch(t, append(buildPackages[archLabel], "rpm-ostree"), buildPkgs.Include)
 			} else {
-				assert.ElementsMatch(t, buildPackages[archLabel], itStruct.BuildPackages())
+				assert.ElementsMatch(t, buildPackages[archLabel], buildPkgs.Include)
 			}
 		}
 	}
@@ -286,15 +288,16 @@ func TestImageType_BasePackages(t *testing.T) {
 	for _, pkgMap := range pkgMaps {
 		imgType, err := arch.GetImageType(pkgMap.name)
 		assert.NoError(t, err)
-		basePackages, excludedPackages := imgType.Packages(blueprint.Blueprint{})
+		packages := imgType.PackageSets(blueprint.Blueprint{})["packages"]
+		assert.NotNil(t, packages)
 		assert.Equalf(
 			t,
 			append(pkgMap.basePackages, pkgMap.bootloaderPackages...),
-			basePackages,
+			packages.Include,
 			"image type: %s",
 			pkgMap.name,
 		)
-		assert.Equalf(t, pkgMap.excludedPackages, excludedPackages, "image type: %s", pkgMap.name)
+		assert.Equalf(t, pkgMap.excludedPackages, packages.Exclude, "image type: %s", pkgMap.name)
 	}
 }
 
@@ -320,7 +323,7 @@ func TestDistro_ManifestError(t *testing.T) {
 		arch, _ := f33distro.GetArch(archName)
 		for _, imgTypeName := range arch.ListImageTypes() {
 			imgType, _ := arch.GetImageType(imgTypeName)
-			_, err := imgType.Manifest(bp.Customizations, distro.ImageOptions{}, nil, nil, nil, 0)
+			_, err := imgType.Manifest(bp.Customizations, distro.ImageOptions{}, nil, nil, 0)
 			if imgTypeName == "fedora-iot-commit" {
 				assert.EqualError(t, err, "kernel boot parameter customizations are not supported for ostree types")
 			} else {

--- a/internal/distro/fedoratest/distro.go
+++ b/internal/distro/fedoratest/distro.go
@@ -95,11 +95,14 @@ func (t *imageType) BuildPackages() []string {
 	return nil
 }
 
+func (t *imageType) PackageSets(bp blueprint.Blueprint) map[string]rpmmd.PackageSet {
+	return nil
+}
+
 func (t *imageType) Manifest(c *blueprint.Customizations,
 	options distro.ImageOptions,
 	repos []rpmmd.RepoConfig,
-	packageSpecs,
-	buildPackageSpecs []rpmmd.PackageSpec,
+	packageSpecSets map[string][]rpmmd.PackageSpec,
 	seed int64) (distro.Manifest, error) {
 
 	return json.Marshal(

--- a/internal/distro/rhel8/distro.go
+++ b/internal/distro/rhel8/distro.go
@@ -188,20 +188,32 @@ func (t *imageType) BuildPackages() []string {
 	return packages
 }
 
+func (t *imageType) PackageSets(bp blueprint.Blueprint) map[string]rpmmd.PackageSet {
+	includePackages, excludePackages := t.Packages(bp)
+	return map[string]rpmmd.PackageSet{
+		"packages": {
+			Include: includePackages,
+			Exclude: excludePackages,
+		},
+		"build-packages": {
+			Include: t.BuildPackages(),
+		},
+	}
+}
+
 func (t *imageType) Manifest(c *blueprint.Customizations,
 	options distro.ImageOptions,
 	repos []rpmmd.RepoConfig,
-	packageSpecs,
-	buildPackageSpecs []rpmmd.PackageSpec,
+	packageSpecSets map[string][]rpmmd.PackageSpec,
 	seed int64) (distro.Manifest, error) {
-	pipeline, err := t.pipeline(c, options, repos, packageSpecs, buildPackageSpecs)
+	pipeline, err := t.pipeline(c, options, repos, packageSpecSets["packages"], packageSpecSets["build-packages"])
 	if err != nil {
 		return distro.Manifest{}, err
 	}
 
 	return json.Marshal(
 		osbuild.Manifest{
-			Sources:  *sources(append(packageSpecs, buildPackageSpecs...)),
+			Sources:  *sources(append(packageSpecSets["packages"], packageSpecSets["build-packages"]...)),
 			Pipeline: *pipeline,
 		},
 	)

--- a/internal/distro/rhel84/distro.go
+++ b/internal/distro/rhel84/distro.go
@@ -207,22 +207,34 @@ func (t *imageType) BuildPackages() []string {
 	return packages
 }
 
+func (t *imageType) PackageSets(bp blueprint.Blueprint) map[string]rpmmd.PackageSet {
+	includePackages, excludePackages := t.Packages(bp)
+	return map[string]rpmmd.PackageSet{
+		"packages": {
+			Include: includePackages,
+			Exclude: excludePackages,
+		},
+		"build-packages": {
+			Include: t.BuildPackages(),
+		},
+	}
+}
+
 func (t *imageType) Manifest(c *blueprint.Customizations,
 	options distro.ImageOptions,
 	repos []rpmmd.RepoConfig,
-	packageSpecs,
-	buildPackageSpecs []rpmmd.PackageSpec,
+	packageSpecSets map[string][]rpmmd.PackageSpec,
 	seed int64) (distro.Manifest, error) {
 	source := rand.NewSource(seed)
 	rng := rand.New(source)
-	pipeline, err := t.pipeline(c, options, repos, packageSpecs, buildPackageSpecs, rng)
+	pipeline, err := t.pipeline(c, options, repos, packageSpecSets["packages"], packageSpecSets["build-packages"], rng)
 	if err != nil {
 		return distro.Manifest{}, err
 	}
 
 	return json.Marshal(
 		osbuild.Manifest{
-			Sources:  *sources(append(packageSpecs, buildPackageSpecs...)),
+			Sources:  *sources(append(packageSpecSets["packages"], packageSpecSets["build-packages"]...)),
 			Pipeline: *pipeline,
 		},
 	)

--- a/internal/distro/test_distro/distro.go
+++ b/internal/distro/test_distro/distro.go
@@ -79,7 +79,11 @@ func (t *TestImageType) BuildPackages() []string {
 	return nil
 }
 
-func (t *TestImageType) Manifest(b *blueprint.Customizations, options distro.ImageOptions, repos []rpmmd.RepoConfig, packageSpecs, buildPackageSpecs []rpmmd.PackageSpec, seed int64) (distro.Manifest, error) {
+func (t *TestImageType) PackageSets(bp blueprint.Blueprint) map[string]rpmmd.PackageSet {
+	return nil
+}
+
+func (t *TestImageType) Manifest(b *blueprint.Customizations, options distro.ImageOptions, repos []rpmmd.RepoConfig, packageSpecSets map[string][]rpmmd.PackageSpec, seed int64) (distro.Manifest, error) {
 	return json.Marshal(
 		osbuild.Manifest{
 			Sources:  osbuild.Sources{},

--- a/internal/kojiapi/server.go
+++ b/internal/kojiapi/server.go
@@ -118,18 +118,18 @@ func (h *apiHandlers) PostCompose(ctx echo.Context) error {
 		if err != nil {
 			panic("Could not initialize empty blueprint.")
 		}
-		packageSpecs, excludePackageSpecs := imageType.Packages(*bp)
-		packages, _, err := h.server.rpmMetadata.Depsolve(packageSpecs, excludePackageSpecs, repositories, d.ModulePlatformID(), arch.Name())
-		if err != nil {
-			return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Failed to depsolve base base packages for %s/%s/%s: %s", ir.ImageType, ir.Architecture, request.Distribution, err))
-		}
-		buildPackageSpecs := imageType.BuildPackages()
-		buildPackages, _, err := h.server.rpmMetadata.Depsolve(buildPackageSpecs, nil, repositories, d.ModulePlatformID(), arch.Name())
-		if err != nil {
-			return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Failed to depsolve build packages for %s/%s/%s: %s", ir.ImageType, ir.Architecture, request.Distribution, err))
+
+		packageSets := imageType.PackageSets(*bp)
+		packageSpecSets := make(map[string][]rpmmd.PackageSpec)
+		for name, packages := range packageSets {
+			packageSpecs, _, err := h.server.rpmMetadata.Depsolve(packages, repositories, d.ModulePlatformID(), arch.Name())
+			if err != nil {
+				return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Failed to depsolve base base packages for %s/%s/%s: %s", ir.ImageType, ir.Architecture, request.Distribution, err))
+			}
+			packageSpecSets[name] = packageSpecs
 		}
 
-		manifest, err := imageType.Manifest(nil, distro.ImageOptions{Size: imageType.Size(0)}, repositories, packages, buildPackages, manifestSeed)
+		manifest, err := imageType.Manifest(nil, distro.ImageOptions{Size: imageType.Size(0)}, repositories, packageSpecSets, manifestSeed)
 		if err != nil {
 			return echo.NewHTTPError(http.StatusBadGateway, fmt.Sprintf("Failed to get manifest for for %s/%s/%s: %s", ir.ImageType, ir.Architecture, request.Distribution, err))
 		}

--- a/internal/mocks/rpmmd/rpmmd_mock.go
+++ b/internal/mocks/rpmmd/rpmmd_mock.go
@@ -36,6 +36,6 @@ func (r *rpmmdMock) FetchMetadata(repos []rpmmd.RepoConfig, modulePlatformID str
 	return r.Fixture.fetchPackageList.ret, r.Fixture.fetchPackageList.checksums, r.Fixture.fetchPackageList.err
 }
 
-func (r *rpmmdMock) Depsolve(specs, excludeSpecs []string, repos []rpmmd.RepoConfig, modulePlatformID, arch string) ([]rpmmd.PackageSpec, map[string]string, error) {
+func (r *rpmmdMock) Depsolve(packageSet rpmmd.PackageSet, repos []rpmmd.RepoConfig, modulePlatformID, arch string) ([]rpmmd.PackageSpec, map[string]string, error) {
 	return r.Fixture.depsolve.ret, r.Fixture.fetchPackageList.checksums, r.Fixture.depsolve.err
 }

--- a/internal/store/fixtures.go
+++ b/internal/store/fixtures.go
@@ -57,7 +57,7 @@ func FixtureBase() *Store {
 	if err != nil {
 		panic("invalid image type qcow2 for x86_64 @ fedoratest")
 	}
-	manifest, err := imgType.Manifest(nil, distro.ImageOptions{}, nil, nil, nil, 0)
+	manifest, err := imgType.Manifest(nil, distro.ImageOptions{}, nil, nil, 0)
 	if err != nil {
 		panic("could not create manifest")
 	}
@@ -160,7 +160,7 @@ func FixtureFinished() *Store {
 	if err != nil {
 		panic("invalid image type qcow2 for x86_64 @ fedoratest")
 	}
-	manifest, err := imgType.Manifest(nil, distro.ImageOptions{}, nil, nil, nil, 0)
+	manifest, err := imgType.Manifest(nil, distro.ImageOptions{}, nil, nil, 0)
 	if err != nil {
 		panic("could not create manifest")
 	}

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -51,7 +51,7 @@ func (suite *storeTest) SetupSuite() {
 	suite.myDistro = test_distro.New()
 	suite.myArch, _ = suite.myDistro.GetArch("test_arch")
 	suite.myImageType, _ = suite.myArch.GetImageType("test_type")
-	suite.myManifest, _ = suite.myImageType.Manifest(&suite.myCustomizations, suite.myImageOptions, suite.myRepoConfig, nil, suite.myPackageSpec, 0)
+	suite.myManifest, _ = suite.myImageType.Manifest(&suite.myCustomizations, suite.myImageOptions, suite.myRepoConfig, nil, 0)
 	suite.mySourceConfig = SourceConfig{
 		Name: "testSourceConfig",
 	}

--- a/internal/weldr/api_test.go
+++ b/internal/weldr/api_test.go
@@ -578,7 +578,7 @@ func TestCompose(t *testing.T) {
 	require.NoError(t, err)
 	imgType, err := arch.GetImageType("qcow2")
 	require.NoError(t, err)
-	manifest, err := imgType.Manifest(nil, distro.ImageOptions{}, nil, nil, nil, 0)
+	manifest, err := imgType.Manifest(nil, distro.ImageOptions{}, nil, nil, 0)
 	require.NoError(t, err)
 	expectedComposeLocal := &store.Compose{
 		Blueprint: &blueprint.Blueprint{

--- a/internal/worker/server_test.go
+++ b/internal/worker/server_test.go
@@ -83,7 +83,7 @@ func TestCreate(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error getting image type from arch")
 	}
-	manifest, err := imageType.Manifest(nil, distro.ImageOptions{Size: imageType.Size(0)}, nil, nil, nil, 0)
+	manifest, err := imageType.Manifest(nil, distro.ImageOptions{Size: imageType.Size(0)}, nil, nil, 0)
 	if err != nil {
 		t.Fatalf("error creating osbuild manifest")
 	}
@@ -111,7 +111,7 @@ func TestCancel(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error getting image type from arch")
 	}
-	manifest, err := imageType.Manifest(nil, distro.ImageOptions{Size: imageType.Size(0)}, nil, nil, nil, 0)
+	manifest, err := imageType.Manifest(nil, distro.ImageOptions{Size: imageType.Size(0)}, nil, nil, 0)
 	if err != nil {
 		t.Fatalf("error creating osbuild manifest")
 	}
@@ -152,7 +152,7 @@ func TestUpdate(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error getting image type from arch")
 	}
-	manifest, err := imageType.Manifest(nil, distro.ImageOptions{Size: imageType.Size(0)}, nil, nil, nil, 0)
+	manifest, err := imageType.Manifest(nil, distro.ImageOptions{Size: imageType.Size(0)}, nil, nil, 0)
 	if err != nil {
 		t.Fatalf("error creating osbuild manifest")
 	}
@@ -179,7 +179,7 @@ func TestArgs(t *testing.T) {
 	require.NoError(t, err)
 	imageType, err := arch.GetImageType("qcow2")
 	require.NoError(t, err)
-	manifest, err := imageType.Manifest(nil, distro.ImageOptions{Size: imageType.Size(0)}, nil, nil, nil, 0)
+	manifest, err := imageType.Manifest(nil, distro.ImageOptions{Size: imageType.Size(0)}, nil, nil, 0)
 	require.NoError(t, err)
 
 	tempdir, err := ioutil.TempDir("", "worker-tests-")
@@ -221,7 +221,7 @@ func TestUpload(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error getting image type from arch")
 	}
-	manifest, err := imageType.Manifest(nil, distro.ImageOptions{Size: imageType.Size(0)}, nil, nil, nil, 0)
+	manifest, err := imageType.Manifest(nil, distro.ImageOptions{Size: imageType.Size(0)}, nil, nil, 0)
 	if err != nil {
 		t.Fatalf("error creating osbuild manifest")
 	}

--- a/test/data/manifests/centos_8-x86_64-ami-boot.json
+++ b/test/data/manifests/centos_8-x86_64-ami-boot.json
@@ -10247,11 +10247,7 @@
         "checksum": "sha256:a2aeabb3962859069a78acc288bc3bffb35485428e162caafec8134f5ce6ca67",
         "check_gpg": true
       }
-    ],
-    "checksums": {
-      "0": "sha256:06fa6273454f85c58ca743a0ef0202bed4cac267393049dc447839cdb39f4a54",
-      "1": "sha256:5b16e44261a7beffd5d7bf961fe269da407bd57abb1faac407c46a81969dfd63"
-    }
+    ]
   },
   "image-info": {
     "boot-environment": {

--- a/test/data/manifests/centos_8-x86_64-openstack-boot.json
+++ b/test/data/manifests/centos_8-x86_64-openstack-boot.json
@@ -10951,11 +10951,7 @@
         "checksum": "sha256:a2aeabb3962859069a78acc288bc3bffb35485428e162caafec8134f5ce6ca67",
         "check_gpg": true
       }
-    ],
-    "checksums": {
-      "0": "sha256:06fa6273454f85c58ca743a0ef0202bed4cac267393049dc447839cdb39f4a54",
-      "1": "sha256:5b16e44261a7beffd5d7bf961fe269da407bd57abb1faac407c46a81969dfd63"
-    }
+    ]
   },
   "image-info": {
     "boot-environment": {

--- a/test/data/manifests/centos_8-x86_64-qcow2-boot.json
+++ b/test/data/manifests/centos_8-x86_64-qcow2-boot.json
@@ -10924,11 +10924,7 @@
         "checksum": "sha256:a2aeabb3962859069a78acc288bc3bffb35485428e162caafec8134f5ce6ca67",
         "check_gpg": true
       }
-    ],
-    "checksums": {
-      "0": "sha256:06fa6273454f85c58ca743a0ef0202bed4cac267393049dc447839cdb39f4a54",
-      "1": "sha256:5b16e44261a7beffd5d7bf961fe269da407bd57abb1faac407c46a81969dfd63"
-    }
+    ]
   },
   "image-info": {
     "boot-environment": {

--- a/test/data/manifests/centos_8-x86_64-qcow2-customize.json
+++ b/test/data/manifests/centos_8-x86_64-qcow2-customize.json
@@ -11032,11 +11032,7 @@
         "checksum": "sha256:a2aeabb3962859069a78acc288bc3bffb35485428e162caafec8134f5ce6ca67",
         "check_gpg": true
       }
-    ],
-    "checksums": {
-      "0": "sha256:06fa6273454f85c58ca743a0ef0202bed4cac267393049dc447839cdb39f4a54",
-      "1": "sha256:5b16e44261a7beffd5d7bf961fe269da407bd57abb1faac407c46a81969dfd63"
-    }
+    ]
   },
   "image-info": {
     "boot-environment": {

--- a/test/data/manifests/centos_8-x86_64-tar-boot.json
+++ b/test/data/manifests/centos_8-x86_64-tar-boot.json
@@ -6423,11 +6423,7 @@
         "checksum": "sha256:a2aeabb3962859069a78acc288bc3bffb35485428e162caafec8134f5ce6ca67",
         "check_gpg": true
       }
-    ],
-    "checksums": {
-      "0": "sha256:06fa6273454f85c58ca743a0ef0202bed4cac267393049dc447839cdb39f4a54",
-      "1": "sha256:5b16e44261a7beffd5d7bf961fe269da407bd57abb1faac407c46a81969dfd63"
-    }
+    ]
   },
   "image-info": {
     "bootmenu": [],

--- a/test/data/manifests/centos_8-x86_64-vhd-boot.json
+++ b/test/data/manifests/centos_8-x86_64-vhd-boot.json
@@ -10864,11 +10864,7 @@
         "checksum": "sha256:a2aeabb3962859069a78acc288bc3bffb35485428e162caafec8134f5ce6ca67",
         "check_gpg": true
       }
-    ],
-    "checksums": {
-      "0": "sha256:06fa6273454f85c58ca743a0ef0202bed4cac267393049dc447839cdb39f4a54",
-      "1": "sha256:5b16e44261a7beffd5d7bf961fe269da407bd57abb1faac407c46a81969dfd63"
-    }
+    ]
   },
   "image-info": {
     "boot-environment": {

--- a/test/data/manifests/centos_8-x86_64-vmdk-boot.json
+++ b/test/data/manifests/centos_8-x86_64-vmdk-boot.json
@@ -10452,11 +10452,7 @@
         "checksum": "sha256:9ed3ad948a0dada7710d4b8b2053d4716dc0754f5648a74f4d78b59b737529dc",
         "check_gpg": true
       }
-    ],
-    "checksums": {
-      "0": "sha256:06fa6273454f85c58ca743a0ef0202bed4cac267393049dc447839cdb39f4a54",
-      "1": "sha256:5b16e44261a7beffd5d7bf961fe269da407bd57abb1faac407c46a81969dfd63"
-    }
+    ]
   },
   "image-info": {
     "boot-environment": {

--- a/test/data/manifests/fedora_32-aarch64-ami-boot.json
+++ b/test/data/manifests/fedora_32-aarch64-ami-boot.json
@@ -8872,10 +8872,7 @@
         "checksum": "sha256:df7184fef93e9f8f535d78349605595a812511db5e6dee26cbee15569a055422",
         "check_gpg": true
       }
-    ],
-    "checksums": {
-      "0": "sha256:f56d50d2c120f5fe150f53a3f72d2b8df93d0c4c51e9ae866dfa08f1d5517fb1"
-    }
+    ]
   },
   "image-info": {
     "boot-environment": {

--- a/test/data/manifests/fedora_32-aarch64-openstack-boot.json
+++ b/test/data/manifests/fedora_32-aarch64-openstack-boot.json
@@ -9225,10 +9225,7 @@
         "checksum": "sha256:df7184fef93e9f8f535d78349605595a812511db5e6dee26cbee15569a055422",
         "check_gpg": true
       }
-    ],
-    "checksums": {
-      "0": "sha256:f56d50d2c120f5fe150f53a3f72d2b8df93d0c4c51e9ae866dfa08f1d5517fb1"
-    }
+    ]
   },
   "image-info": {
     "boot-environment": {

--- a/test/data/manifests/fedora_32-aarch64-qcow2-boot.json
+++ b/test/data/manifests/fedora_32-aarch64-qcow2-boot.json
@@ -8729,10 +8729,7 @@
         "checksum": "sha256:df7184fef93e9f8f535d78349605595a812511db5e6dee26cbee15569a055422",
         "check_gpg": true
       }
-    ],
-    "checksums": {
-      "0": "sha256:f56d50d2c120f5fe150f53a3f72d2b8df93d0c4c51e9ae866dfa08f1d5517fb1"
-    }
+    ]
   },
   "image-info": {
     "boot-environment": {

--- a/test/data/manifests/fedora_32-x86_64-ami-boot.json
+++ b/test/data/manifests/fedora_32-x86_64-ami-boot.json
@@ -9130,10 +9130,7 @@
         "checksum": "sha256:c0fff40dc1092e18ed3e608bc6143c89a0d7775b9e0553319bb2caca7d324d80",
         "check_gpg": true
       }
-    ],
-    "checksums": {
-      "0": "sha256:c7f7c29a8ca90e226d2efee6d5856f2dea1d64ea758dfd114d75b4b20b56de1c"
-    }
+    ]
   },
   "image-info": {
     "boot-environment": {

--- a/test/data/manifests/fedora_32-x86_64-fedora_iot_commit-boot.json
+++ b/test/data/manifests/fedora_32-x86_64-fedora_iot_commit-boot.json
@@ -10129,10 +10129,7 @@
         "checksum": "sha256:3f7861ea2d8b4380b567f629a86fa31951a55f46f6eee017cb84ed87baf2c19e",
         "check_gpg": true
       }
-    ],
-    "checksums": {
-      "0": "sha256:c7f7c29a8ca90e226d2efee6d5856f2dea1d64ea758dfd114d75b4b20b56de1c"
-    }
+    ]
   },
   "image-info": {
     "default-target": "graphical.target",

--- a/test/data/manifests/fedora_32-x86_64-fedora_iot_commit_debug-boot.json
+++ b/test/data/manifests/fedora_32-x86_64-fedora_iot_commit_debug-boot.json
@@ -10135,10 +10135,7 @@
         "checksum": "sha256:3f7861ea2d8b4380b567f629a86fa31951a55f46f6eee017cb84ed87baf2c19e",
         "check_gpg": true
       }
-    ],
-    "checksums": {
-      "0": "sha256:c7f7c29a8ca90e226d2efee6d5856f2dea1d64ea758dfd114d75b4b20b56de1c"
-    }
+    ]
   },
   "image-info": {
     "default-target": "graphical.target",

--- a/test/data/manifests/fedora_32-x86_64-openstack-boot.json
+++ b/test/data/manifests/fedora_32-x86_64-openstack-boot.json
@@ -9483,10 +9483,7 @@
         "checksum": "sha256:c0fff40dc1092e18ed3e608bc6143c89a0d7775b9e0553319bb2caca7d324d80",
         "check_gpg": true
       }
-    ],
-    "checksums": {
-      "0": "sha256:c7f7c29a8ca90e226d2efee6d5856f2dea1d64ea758dfd114d75b4b20b56de1c"
-    }
+    ]
   },
   "image-info": {
     "boot-environment": {

--- a/test/data/manifests/fedora_32-x86_64-qcow2-boot.json
+++ b/test/data/manifests/fedora_32-x86_64-qcow2-boot.json
@@ -9123,10 +9123,7 @@
         "checksum": "sha256:c0fff40dc1092e18ed3e608bc6143c89a0d7775b9e0553319bb2caca7d324d80",
         "check_gpg": true
       }
-    ],
-    "checksums": {
-      "0": "sha256:c7f7c29a8ca90e226d2efee6d5856f2dea1d64ea758dfd114d75b4b20b56de1c"
-    }
+    ]
   },
   "image-info": {
     "boot-environment": {

--- a/test/data/manifests/fedora_32-x86_64-qcow2-customize.json
+++ b/test/data/manifests/fedora_32-x86_64-qcow2-customize.json
@@ -9235,10 +9235,7 @@
         "checksum": "sha256:c0fff40dc1092e18ed3e608bc6143c89a0d7775b9e0553319bb2caca7d324d80",
         "check_gpg": true
       }
-    ],
-    "checksums": {
-      "0": "sha256:c7f7c29a8ca90e226d2efee6d5856f2dea1d64ea758dfd114d75b4b20b56de1c"
-    }
+    ]
   },
   "image-info": {
     "boot-environment": {

--- a/test/data/manifests/fedora_32-x86_64-vhd-boot.json
+++ b/test/data/manifests/fedora_32-x86_64-vhd-boot.json
@@ -8731,10 +8731,7 @@
         "checksum": "sha256:c0fff40dc1092e18ed3e608bc6143c89a0d7775b9e0553319bb2caca7d324d80",
         "check_gpg": true
       }
-    ],
-    "checksums": {
-      "0": "sha256:c7f7c29a8ca90e226d2efee6d5856f2dea1d64ea758dfd114d75b4b20b56de1c"
-    }
+    ]
   },
   "image-info": {
     "boot-environment": {

--- a/test/data/manifests/fedora_32-x86_64-vmdk-boot.json
+++ b/test/data/manifests/fedora_32-x86_64-vmdk-boot.json
@@ -8837,10 +8837,7 @@
         "checksum": "sha256:c0fff40dc1092e18ed3e608bc6143c89a0d7775b9e0553319bb2caca7d324d80",
         "check_gpg": true
       }
-    ],
-    "checksums": {
-      "0": "sha256:c7f7c29a8ca90e226d2efee6d5856f2dea1d64ea758dfd114d75b4b20b56de1c"
-    }
+    ]
   },
   "image-info": {
     "boot-environment": {

--- a/test/data/manifests/fedora_33-aarch64-ami-boot.json
+++ b/test/data/manifests/fedora_33-aarch64-ami-boot.json
@@ -9792,10 +9792,7 @@
         "checksum": "sha256:99e5ac897d4dd06f0d22ddf9bd064c6081ea699a7ebc7d0c3907743128eb59f4",
         "check_gpg": true
       }
-    ],
-    "checksums": {
-      "0": "sha256:30f081c69fa61c9bb8f7ba043d73698d1765c8cd62ccf2df5173e26bde458002"
-    }
+    ]
   },
   "image-info": {
     "boot-environment": {

--- a/test/data/manifests/fedora_33-x86_64-ami-boot.json
+++ b/test/data/manifests/fedora_33-x86_64-ami-boot.json
@@ -9371,10 +9371,7 @@
         "checksum": "sha256:1ecfd9041524f8dab2eba10eab59c912eeae09acb3c3e8ada018fe13d23dda73",
         "check_gpg": true
       }
-    ],
-    "checksums": {
-      "0": "sha256:7a75be2ebd56e44c9d33252a12158c8b7079331e9c73aa62c609414299dabf06"
-    }
+    ]
   },
   "image-info": {
     "boot-environment": {

--- a/test/data/manifests/fedora_33-x86_64-fedora_iot_commit-boot.json
+++ b/test/data/manifests/fedora_33-x86_64-fedora_iot_commit-boot.json
@@ -10571,10 +10571,7 @@
         "checksum": "sha256:1ecfd9041524f8dab2eba10eab59c912eeae09acb3c3e8ada018fe13d23dda73",
         "check_gpg": true
       }
-    ],
-    "checksums": {
-      "0": "sha256:7a75be2ebd56e44c9d33252a12158c8b7079331e9c73aa62c609414299dabf06"
-    }
+    ]
   },
   "image-info": {
     "default-target": "graphical.target",

--- a/test/data/manifests/fedora_33-x86_64-fedora_iot_commit_debug-boot.json
+++ b/test/data/manifests/fedora_33-x86_64-fedora_iot_commit_debug-boot.json
@@ -10577,10 +10577,7 @@
         "checksum": "sha256:1ecfd9041524f8dab2eba10eab59c912eeae09acb3c3e8ada018fe13d23dda73",
         "check_gpg": true
       }
-    ],
-    "checksums": {
-      "0": "sha256:7a75be2ebd56e44c9d33252a12158c8b7079331e9c73aa62c609414299dabf06"
-    }
+    ]
   },
   "image-info": {
     "default-target": "graphical.target",

--- a/test/data/manifests/fedora_33-x86_64-openstack-boot.json
+++ b/test/data/manifests/fedora_33-x86_64-openstack-boot.json
@@ -9689,10 +9689,7 @@
         "checksum": "sha256:1ecfd9041524f8dab2eba10eab59c912eeae09acb3c3e8ada018fe13d23dda73",
         "check_gpg": true
       }
-    ],
-    "checksums": {
-      "0": "sha256:7a75be2ebd56e44c9d33252a12158c8b7079331e9c73aa62c609414299dabf06"
-    }
+    ]
   },
   "image-info": {
     "boot-environment": {

--- a/test/data/manifests/fedora_33-x86_64-qcow2-boot.json
+++ b/test/data/manifests/fedora_33-x86_64-qcow2-boot.json
@@ -9315,10 +9315,7 @@
         "checksum": "sha256:1ecfd9041524f8dab2eba10eab59c912eeae09acb3c3e8ada018fe13d23dda73",
         "check_gpg": true
       }
-    ],
-    "checksums": {
-      "0": "sha256:7a75be2ebd56e44c9d33252a12158c8b7079331e9c73aa62c609414299dabf06"
-    }
+    ]
   },
   "image-info": {
     "boot-environment": {

--- a/test/data/manifests/fedora_33-x86_64-qcow2-customize.json
+++ b/test/data/manifests/fedora_33-x86_64-qcow2-customize.json
@@ -9416,10 +9416,7 @@
         "checksum": "sha256:1ecfd9041524f8dab2eba10eab59c912eeae09acb3c3e8ada018fe13d23dda73",
         "check_gpg": true
       }
-    ],
-    "checksums": {
-      "0": "sha256:7a75be2ebd56e44c9d33252a12158c8b7079331e9c73aa62c609414299dabf06"
-    }
+    ]
   },
   "image-info": {
     "boot-environment": {

--- a/test/data/manifests/fedora_33-x86_64-vhd-boot.json
+++ b/test/data/manifests/fedora_33-x86_64-vhd-boot.json
@@ -8972,10 +8972,7 @@
         "checksum": "sha256:1ecfd9041524f8dab2eba10eab59c912eeae09acb3c3e8ada018fe13d23dda73",
         "check_gpg": true
       }
-    ],
-    "checksums": {
-      "0": "sha256:7a75be2ebd56e44c9d33252a12158c8b7079331e9c73aa62c609414299dabf06"
-    }
+    ]
   },
   "image-info": {
     "boot-environment": {

--- a/test/data/manifests/fedora_33-x86_64-vmdk-boot.json
+++ b/test/data/manifests/fedora_33-x86_64-vmdk-boot.json
@@ -9315,10 +9315,7 @@
         "checksum": "sha256:1ecfd9041524f8dab2eba10eab59c912eeae09acb3c3e8ada018fe13d23dda73",
         "check_gpg": true
       }
-    ],
-    "checksums": {
-      "0": "sha256:7a75be2ebd56e44c9d33252a12158c8b7079331e9c73aa62c609414299dabf06"
-    }
+    ]
   },
   "image-info": {
     "boot-environment": {

--- a/test/data/manifests/rhel_8-aarch64-ami-boot.json
+++ b/test/data/manifests/rhel_8-aarch64-ami-boot.json
@@ -8487,11 +8487,7 @@
         "remote_location": "https://rpmrepo.osbuild.org/v1/psi/el8/el8-aarch64-appstream-8.3.0.r-20210120/Packages/xkeyboard-config-2.28-1.el8.noarch.rpm",
         "checksum": "sha256:340b3c65becfca3d39f2afeed9659505a33ee870270c4d115d9fefe8929ff806"
       }
-    ],
-    "checksums": {
-      "0": "sha256:517831776ae84fa2d1ceb52c043cd0bd50fc06e3761046f60f730b25f02c9519",
-      "1": "sha256:be9adc924571c59331c75639df3d3dc6c7214954db7ac000c2f06eadff631aa5"
-    }
+    ]
   },
   "image-info": {
     "boot-environment": {

--- a/test/data/manifests/rhel_8-aarch64-openstack-boot.json
+++ b/test/data/manifests/rhel_8-aarch64-openstack-boot.json
@@ -9051,11 +9051,7 @@
         "remote_location": "https://rpmrepo.osbuild.org/v1/psi/el8/el8-aarch64-appstream-8.3.0.r-20210120/Packages/xkeyboard-config-2.28-1.el8.noarch.rpm",
         "checksum": "sha256:340b3c65becfca3d39f2afeed9659505a33ee870270c4d115d9fefe8929ff806"
       }
-    ],
-    "checksums": {
-      "0": "sha256:517831776ae84fa2d1ceb52c043cd0bd50fc06e3761046f60f730b25f02c9519",
-      "1": "sha256:be9adc924571c59331c75639df3d3dc6c7214954db7ac000c2f06eadff631aa5"
-    }
+    ]
   },
   "image-info": {
     "boot-environment": {

--- a/test/data/manifests/rhel_8-aarch64-qcow2-boot.json
+++ b/test/data/manifests/rhel_8-aarch64-qcow2-boot.json
@@ -9505,11 +9505,7 @@
         "remote_location": "https://rpmrepo.osbuild.org/v1/psi/el8/el8-aarch64-appstream-8.3.0.r-20210120/Packages/xkeyboard-config-2.28-1.el8.noarch.rpm",
         "checksum": "sha256:340b3c65becfca3d39f2afeed9659505a33ee870270c4d115d9fefe8929ff806"
       }
-    ],
-    "checksums": {
-      "0": "sha256:517831776ae84fa2d1ceb52c043cd0bd50fc06e3761046f60f730b25f02c9519",
-      "1": "sha256:be9adc924571c59331c75639df3d3dc6c7214954db7ac000c2f06eadff631aa5"
-    }
+    ]
   },
   "image-info": {
     "boot-environment": {

--- a/test/data/manifests/rhel_8-aarch64-rhel_edge_commit-boot.json
+++ b/test/data/manifests/rhel_8-aarch64-rhel_edge_commit-boot.json
@@ -8226,11 +8226,7 @@
         "remote_location": "https://rpmrepo.osbuild.org/v1/psi/el8/el8-aarch64-appstream-8.3.0.r-20210120/Packages/xkeyboard-config-2.28-1.el8.noarch.rpm",
         "checksum": "sha256:340b3c65becfca3d39f2afeed9659505a33ee870270c4d115d9fefe8929ff806"
       }
-    ],
-    "checksums": {
-      "0": "sha256:517831776ae84fa2d1ceb52c043cd0bd50fc06e3761046f60f730b25f02c9519",
-      "1": "sha256:be9adc924571c59331c75639df3d3dc6c7214954db7ac000c2f06eadff631aa5"
-    }
+    ]
   },
   "image-info": {
     "default-target": "graphical.target",

--- a/test/data/manifests/rhel_8-aarch64-tar-boot.json
+++ b/test/data/manifests/rhel_8-aarch64-tar-boot.json
@@ -5351,11 +5351,7 @@
         "remote_location": "https://rpmrepo.osbuild.org/v1/psi/el8/el8-aarch64-appstream-8.3.0.r-20210120/Packages/xkeyboard-config-2.28-1.el8.noarch.rpm",
         "checksum": "sha256:340b3c65becfca3d39f2afeed9659505a33ee870270c4d115d9fefe8929ff806"
       }
-    ],
-    "checksums": {
-      "0": "sha256:517831776ae84fa2d1ceb52c043cd0bd50fc06e3761046f60f730b25f02c9519",
-      "1": "sha256:be9adc924571c59331c75639df3d3dc6c7214954db7ac000c2f06eadff631aa5"
-    }
+    ]
   },
   "image-info": {
     "bootmenu": [],

--- a/test/data/manifests/rhel_8-ppc64le-qcow2-boot.json
+++ b/test/data/manifests/rhel_8-ppc64le-qcow2-boot.json
@@ -10242,11 +10242,7 @@
         "remote_location": "https://rpmrepo.osbuild.org/v1/psi/el8/el8-ppc64le-appstream-8.3.0.r-20210120/Packages/xkeyboard-config-2.28-1.el8.noarch.rpm",
         "checksum": "sha256:340b3c65becfca3d39f2afeed9659505a33ee870270c4d115d9fefe8929ff806"
       }
-    ],
-    "checksums": {
-      "0": "sha256:1337daffdff55365621a1c7963c0443c62f6f9ca39e9d6600d06a34dbe3eecea",
-      "1": "sha256:9ba8f3377e00773b22edf4c60b78252d45b777d1291a9913df3325c2aa54525e"
-    }
+    ]
   },
   "image-info": {
     "boot-environment": {

--- a/test/data/manifests/rhel_8-ppc64le-tar-boot.json
+++ b/test/data/manifests/rhel_8-ppc64le-tar-boot.json
@@ -5453,11 +5453,7 @@
         "remote_location": "https://rpmrepo.osbuild.org/v1/psi/el8/el8-ppc64le-appstream-8.3.0.r-20210120/Packages/xkeyboard-config-2.28-1.el8.noarch.rpm",
         "checksum": "sha256:340b3c65becfca3d39f2afeed9659505a33ee870270c4d115d9fefe8929ff806"
       }
-    ],
-    "checksums": {
-      "0": "sha256:1337daffdff55365621a1c7963c0443c62f6f9ca39e9d6600d06a34dbe3eecea",
-      "1": "sha256:9ba8f3377e00773b22edf4c60b78252d45b777d1291a9913df3325c2aa54525e"
-    }
+    ]
   },
   "image-info": {
     "bootmenu": [],

--- a/test/data/manifests/rhel_8-s390x-qcow2-boot.json
+++ b/test/data/manifests/rhel_8-s390x-qcow2-boot.json
@@ -10125,11 +10125,7 @@
         "remote_location": "https://rpmrepo.osbuild.org/v1/psi/el8/el8-s390x-appstream-8.3.0.r-20210120/Packages/xkeyboard-config-2.28-1.el8.noarch.rpm",
         "checksum": "sha256:340b3c65becfca3d39f2afeed9659505a33ee870270c4d115d9fefe8929ff806"
       }
-    ],
-    "checksums": {
-      "0": "sha256:46d16db63c077144fb5fb7b18dfec918599e99b02ab7b29dd952eaa6b552a26b",
-      "1": "sha256:6ba75631f79a77c901ba2aff970179d3dbccc247428dd09543fca08f983f3091"
-    }
+    ]
   },
   "image-info": {
     "bootloader": "unknown",

--- a/test/data/manifests/rhel_8-s390x-tar-boot.json
+++ b/test/data/manifests/rhel_8-s390x-tar-boot.json
@@ -5998,11 +5998,7 @@
         "remote_location": "https://rpmrepo.osbuild.org/v1/psi/el8/el8-s390x-appstream-8.3.0.r-20210120/Packages/xkeyboard-config-2.28-1.el8.noarch.rpm",
         "checksum": "sha256:340b3c65becfca3d39f2afeed9659505a33ee870270c4d115d9fefe8929ff806"
       }
-    ],
-    "checksums": {
-      "0": "sha256:46d16db63c077144fb5fb7b18dfec918599e99b02ab7b29dd952eaa6b552a26b",
-      "1": "sha256:6ba75631f79a77c901ba2aff970179d3dbccc247428dd09543fca08f983f3091"
-    }
+    ]
   },
   "image-info": {
     "bootmenu": [],

--- a/test/data/manifests/rhel_8-x86_64-ami-boot.json
+++ b/test/data/manifests/rhel_8-x86_64-ami-boot.json
@@ -8483,11 +8483,7 @@
         "remote_location": "https://rpmrepo.osbuild.org/v1/psi/el8/el8-x86_64-appstream-8.3.0.r-20210120/Packages/xkeyboard-config-2.28-1.el8.noarch.rpm",
         "checksum": "sha256:340b3c65becfca3d39f2afeed9659505a33ee870270c4d115d9fefe8929ff806"
       }
-    ],
-    "checksums": {
-      "0": "sha256:fdf22c6bc4053e18287234376864d67af2fe61714b2984e9f15a1040d6e24929",
-      "1": "sha256:1d9f1600f53fadeae3ff5d355b4c6bf5821ed08e90f2e4169ba844b46cf2b811"
-    }
+    ]
   },
   "image-info": {
     "boot-environment": {

--- a/test/data/manifests/rhel_8-x86_64-openstack-boot.json
+++ b/test/data/manifests/rhel_8-x86_64-openstack-boot.json
@@ -9062,11 +9062,7 @@
         "remote_location": "https://rpmrepo.osbuild.org/v1/psi/el8/el8-x86_64-appstream-8.3.0.r-20210120/Packages/xkeyboard-config-2.28-1.el8.noarch.rpm",
         "checksum": "sha256:340b3c65becfca3d39f2afeed9659505a33ee870270c4d115d9fefe8929ff806"
       }
-    ],
-    "checksums": {
-      "0": "sha256:fdf22c6bc4053e18287234376864d67af2fe61714b2984e9f15a1040d6e24929",
-      "1": "sha256:1d9f1600f53fadeae3ff5d355b4c6bf5821ed08e90f2e4169ba844b46cf2b811"
-    }
+    ]
   },
   "image-info": {
     "boot-environment": {

--- a/test/data/manifests/rhel_8-x86_64-qcow2-boot.json
+++ b/test/data/manifests/rhel_8-x86_64-qcow2-boot.json
@@ -9486,11 +9486,7 @@
         "remote_location": "https://rpmrepo.osbuild.org/v1/psi/el8/el8-x86_64-appstream-8.3.0.r-20210120/Packages/xkeyboard-config-2.28-1.el8.noarch.rpm",
         "checksum": "sha256:340b3c65becfca3d39f2afeed9659505a33ee870270c4d115d9fefe8929ff806"
       }
-    ],
-    "checksums": {
-      "0": "sha256:fdf22c6bc4053e18287234376864d67af2fe61714b2984e9f15a1040d6e24929",
-      "1": "sha256:1d9f1600f53fadeae3ff5d355b4c6bf5821ed08e90f2e4169ba844b46cf2b811"
-    }
+    ]
   },
   "image-info": {
     "boot-environment": {

--- a/test/data/manifests/rhel_8-x86_64-qcow2-customize.json
+++ b/test/data/manifests/rhel_8-x86_64-qcow2-customize.json
@@ -9612,12 +9612,7 @@
         "remote_location": "https://rpmrepo.osbuild.org/v1/psi/el8/el8-x86_64-appstream-8.3.0.r-20210120/Packages/xkeyboard-config-2.28-1.el8.noarch.rpm",
         "checksum": "sha256:340b3c65becfca3d39f2afeed9659505a33ee870270c4d115d9fefe8929ff806"
       }
-    ],
-    "checksums": {
-      "0": "sha256:fdf22c6bc4053e18287234376864d67af2fe61714b2984e9f15a1040d6e24929",
-      "1": "sha256:1d9f1600f53fadeae3ff5d355b4c6bf5821ed08e90f2e4169ba844b46cf2b811",
-      "2": "sha256:e8649e5f0a2f970a32fa3bf51e4e6bfb1b43348fd2eb7400358cdf38b62ea313"
-    }
+    ]
   },
   "image-info": {
     "boot-environment": {

--- a/test/data/manifests/rhel_8-x86_64-rhel_edge_commit-boot.json
+++ b/test/data/manifests/rhel_8-x86_64-rhel_edge_commit-boot.json
@@ -8518,12 +8518,7 @@
         "remote_location": "https://rpmrepo.osbuild.org/v1/psi/el8/el8-x86_64-appstream-8.3.0.r-20210120/Packages/xkeyboard-config-2.28-1.el8.noarch.rpm",
         "checksum": "sha256:340b3c65becfca3d39f2afeed9659505a33ee870270c4d115d9fefe8929ff806"
       }
-    ],
-    "checksums": {
-      "0": "sha256:fdf22c6bc4053e18287234376864d67af2fe61714b2984e9f15a1040d6e24929",
-      "1": "sha256:1d9f1600f53fadeae3ff5d355b4c6bf5821ed08e90f2e4169ba844b46cf2b811",
-      "2": "sha256:e8649e5f0a2f970a32fa3bf51e4e6bfb1b43348fd2eb7400358cdf38b62ea313"
-    }
+    ]
   },
   "image-info": {
     "default-target": "graphical.target",

--- a/test/data/manifests/rhel_8-x86_64-rhel_edge_commit_rt-boot.json
+++ b/test/data/manifests/rhel_8-x86_64-rhel_edge_commit_rt-boot.json
@@ -8914,12 +8914,7 @@
         "remote_location": "https://rpmrepo.osbuild.org/v1/psi/el8/el8-x86_64-rt-8.3.0.r-20210214/Packages/tuned-profiles-realtime-2.14.0-3.el8.noarch.rpm",
         "checksum": "sha256:e89f32b9da3b4c8cc553ea7d151a3efd2874057611e6fb1cf817cc945add15f1"
       }
-    ],
-    "checksums": {
-      "0": "sha256:fdf22c6bc4053e18287234376864d67af2fe61714b2984e9f15a1040d6e24929",
-      "1": "sha256:1d9f1600f53fadeae3ff5d355b4c6bf5821ed08e90f2e4169ba844b46cf2b811",
-      "2": "sha256:e8649e5f0a2f970a32fa3bf51e4e6bfb1b43348fd2eb7400358cdf38b62ea313"
-    }
+    ]
   },
   "image-info": {
     "default-target": "graphical.target",

--- a/test/data/manifests/rhel_8-x86_64-tar-boot.json
+++ b/test/data/manifests/rhel_8-x86_64-tar-boot.json
@@ -5426,11 +5426,7 @@
         "remote_location": "https://rpmrepo.osbuild.org/v1/psi/el8/el8-x86_64-appstream-8.3.0.r-20210120/Packages/xkeyboard-config-2.28-1.el8.noarch.rpm",
         "checksum": "sha256:340b3c65becfca3d39f2afeed9659505a33ee870270c4d115d9fefe8929ff806"
       }
-    ],
-    "checksums": {
-      "0": "sha256:fdf22c6bc4053e18287234376864d67af2fe61714b2984e9f15a1040d6e24929",
-      "1": "sha256:1d9f1600f53fadeae3ff5d355b4c6bf5821ed08e90f2e4169ba844b46cf2b811"
-    }
+    ]
   },
   "image-info": {
     "bootmenu": [],

--- a/test/data/manifests/rhel_8-x86_64-vhd-boot.json
+++ b/test/data/manifests/rhel_8-x86_64-vhd-boot.json
@@ -8970,11 +8970,7 @@
         "remote_location": "https://rpmrepo.osbuild.org/v1/psi/el8/el8-x86_64-appstream-8.3.0.r-20210120/Packages/xkeyboard-config-2.28-1.el8.noarch.rpm",
         "checksum": "sha256:340b3c65becfca3d39f2afeed9659505a33ee870270c4d115d9fefe8929ff806"
       }
-    ],
-    "checksums": {
-      "0": "sha256:fdf22c6bc4053e18287234376864d67af2fe61714b2984e9f15a1040d6e24929",
-      "1": "sha256:1d9f1600f53fadeae3ff5d355b4c6bf5821ed08e90f2e4169ba844b46cf2b811"
-    }
+    ]
   },
   "image-info": {
     "boot-environment": {

--- a/test/data/manifests/rhel_8-x86_64-vmdk-boot.json
+++ b/test/data/manifests/rhel_8-x86_64-vmdk-boot.json
@@ -8613,12 +8613,7 @@
         "remote_location": "https://rpmrepo.osbuild.org/v1/psi/el8/el8-x86_64-appstream-8.3.0.r-20210120/Packages/xmlsec1-openssl-1.2.25-4.el8.x86_64.rpm",
         "checksum": "sha256:7d07d9055f557acf574e238327f003dc1a77dd119406e2326c844d17b818417c"
       }
-    ],
-    "checksums": {
-      "0": "sha256:fdf22c6bc4053e18287234376864d67af2fe61714b2984e9f15a1040d6e24929",
-      "1": "sha256:1d9f1600f53fadeae3ff5d355b4c6bf5821ed08e90f2e4169ba844b46cf2b811",
-      "2": "sha256:e8649e5f0a2f970a32fa3bf51e4e6bfb1b43348fd2eb7400358cdf38b62ea313"
-    }
+    ]
   },
   "image-info": {
     "boot-environment": {

--- a/test/data/manifests/rhel_84-aarch64-ami-boot.json
+++ b/test/data/manifests/rhel_84-aarch64-ami-boot.json
@@ -8899,11 +8899,7 @@
         "remote_location": "https://rpmrepo.osbuild.org/v1/psi/el8/el8-aarch64-appstream-8.4.0.n-20210120/Packages/xkeyboard-config-2.28-1.el8.noarch.rpm",
         "checksum": "sha256:340b3c65becfca3d39f2afeed9659505a33ee870270c4d115d9fefe8929ff806"
       }
-    ],
-    "checksums": {
-      "0": "sha256:d25d98997ea58cab30c2c005c75b3fc0031d86aef77f75715ad645c7ac14c384",
-      "1": "sha256:fb1b5d5839852eb6ac22b1b695557f94dde0a69e51eae95f0cbe5b531514325c"
-    }
+    ]
   },
   "image-info": {
     "boot-environment": {

--- a/test/data/manifests/rhel_84-aarch64-openstack-boot.json
+++ b/test/data/manifests/rhel_84-aarch64-openstack-boot.json
@@ -9463,11 +9463,7 @@
         "remote_location": "https://rpmrepo.osbuild.org/v1/psi/el8/el8-aarch64-appstream-8.4.0.n-20210120/Packages/xkeyboard-config-2.28-1.el8.noarch.rpm",
         "checksum": "sha256:340b3c65becfca3d39f2afeed9659505a33ee870270c4d115d9fefe8929ff806"
       }
-    ],
-    "checksums": {
-      "0": "sha256:d25d98997ea58cab30c2c005c75b3fc0031d86aef77f75715ad645c7ac14c384",
-      "1": "sha256:fb1b5d5839852eb6ac22b1b695557f94dde0a69e51eae95f0cbe5b531514325c"
-    }
+    ]
   },
   "image-info": {
     "boot-environment": {

--- a/test/data/manifests/rhel_84-aarch64-qcow2-boot.json
+++ b/test/data/manifests/rhel_84-aarch64-qcow2-boot.json
@@ -9368,11 +9368,7 @@
         "remote_location": "https://rpmrepo.osbuild.org/v1/psi/el8/el8-aarch64-appstream-8.4.0.n-20210120/Packages/xkeyboard-config-2.28-1.el8.noarch.rpm",
         "checksum": "sha256:340b3c65becfca3d39f2afeed9659505a33ee870270c4d115d9fefe8929ff806"
       }
-    ],
-    "checksums": {
-      "0": "sha256:d25d98997ea58cab30c2c005c75b3fc0031d86aef77f75715ad645c7ac14c384",
-      "1": "sha256:fb1b5d5839852eb6ac22b1b695557f94dde0a69e51eae95f0cbe5b531514325c"
-    }
+    ]
   },
   "image-info": {
     "boot-environment": {

--- a/test/data/manifests/rhel_84-aarch64-rhel_edge_commit-boot.json
+++ b/test/data/manifests/rhel_84-aarch64-rhel_edge_commit-boot.json
@@ -8405,11 +8405,7 @@
         "remote_location": "https://rpmrepo.osbuild.org/v1/psi/el8/el8-aarch64-appstream-8.4.0.n-20210120/Packages/xkeyboard-config-2.28-1.el8.noarch.rpm",
         "checksum": "sha256:340b3c65becfca3d39f2afeed9659505a33ee870270c4d115d9fefe8929ff806"
       }
-    ],
-    "checksums": {
-      "0": "sha256:d25d98997ea58cab30c2c005c75b3fc0031d86aef77f75715ad645c7ac14c384",
-      "1": "sha256:fb1b5d5839852eb6ac22b1b695557f94dde0a69e51eae95f0cbe5b531514325c"
-    }
+    ]
   },
   "image-info": {
     "default-target": "graphical.target",

--- a/test/data/manifests/rhel_84-aarch64-tar-boot.json
+++ b/test/data/manifests/rhel_84-aarch64-tar-boot.json
@@ -5372,11 +5372,7 @@
         "remote_location": "https://rpmrepo.osbuild.org/v1/psi/el8/el8-aarch64-appstream-8.4.0.n-20210120/Packages/xkeyboard-config-2.28-1.el8.noarch.rpm",
         "checksum": "sha256:340b3c65becfca3d39f2afeed9659505a33ee870270c4d115d9fefe8929ff806"
       }
-    ],
-    "checksums": {
-      "0": "sha256:d25d98997ea58cab30c2c005c75b3fc0031d86aef77f75715ad645c7ac14c384",
-      "1": "sha256:fb1b5d5839852eb6ac22b1b695557f94dde0a69e51eae95f0cbe5b531514325c"
-    }
+    ]
   },
   "image-info": {
     "bootmenu": [],

--- a/test/data/manifests/rhel_84-ppc64le-qcow2-boot.json
+++ b/test/data/manifests/rhel_84-ppc64le-qcow2-boot.json
@@ -10102,11 +10102,7 @@
         "remote_location": "https://rpmrepo.osbuild.org/v1/psi/el8/el8-ppc64le-appstream-8.4.0.n-20210120/Packages/xkeyboard-config-2.28-1.el8.noarch.rpm",
         "checksum": "sha256:340b3c65becfca3d39f2afeed9659505a33ee870270c4d115d9fefe8929ff806"
       }
-    ],
-    "checksums": {
-      "0": "sha256:7063e1b6167c8853826af1215dca0cfe5eb3e02d7bec1f4691592e0270187629",
-      "1": "sha256:0c67f39559762b77775b6af23c601e5550305825fe0d716ea2901d3391d340ec"
-    }
+    ]
   },
   "image-info": {
     "boot-environment": {

--- a/test/data/manifests/rhel_84-ppc64le-tar-boot.json
+++ b/test/data/manifests/rhel_84-ppc64le-tar-boot.json
@@ -5474,11 +5474,7 @@
         "remote_location": "https://rpmrepo.osbuild.org/v1/psi/el8/el8-ppc64le-appstream-8.4.0.n-20210120/Packages/xkeyboard-config-2.28-1.el8.noarch.rpm",
         "checksum": "sha256:340b3c65becfca3d39f2afeed9659505a33ee870270c4d115d9fefe8929ff806"
       }
-    ],
-    "checksums": {
-      "0": "sha256:7063e1b6167c8853826af1215dca0cfe5eb3e02d7bec1f4691592e0270187629",
-      "1": "sha256:0c67f39559762b77775b6af23c601e5550305825fe0d716ea2901d3391d340ec"
-    }
+    ]
   },
   "image-info": {
     "bootmenu": [],

--- a/test/data/manifests/rhel_84-s390x-qcow2-boot.json
+++ b/test/data/manifests/rhel_84-s390x-qcow2-boot.json
@@ -10038,11 +10038,7 @@
         "remote_location": "https://rpmrepo.osbuild.org/v1/psi/el8/el8-s390x-appstream-8.4.0.n-20210120/Packages/xkeyboard-config-2.28-1.el8.noarch.rpm",
         "checksum": "sha256:340b3c65becfca3d39f2afeed9659505a33ee870270c4d115d9fefe8929ff806"
       }
-    ],
-    "checksums": {
-      "0": "sha256:a530a4dad3761d5b19ad29f74209a542e51b1bf41d4a0aa1b0aba569b322b949",
-      "1": "sha256:5a69a1cab53a2f452122e9708f3f828f28a7d6aef0054c5d6f936933d9632054"
-    }
+    ]
   },
   "image-info": {
     "bootloader": "unknown",

--- a/test/data/manifests/rhel_84-x86_64-ami-boot.json
+++ b/test/data/manifests/rhel_84-x86_64-ami-boot.json
@@ -9067,12 +9067,7 @@
         "remote_location": "https://rpmrepo.osbuild.org/v1/psi/el8/el8-x86_64-appstream-8.4.0.n-20210120/Packages/xkeyboard-config-2.28-1.el8.noarch.rpm",
         "checksum": "sha256:340b3c65becfca3d39f2afeed9659505a33ee870270c4d115d9fefe8929ff806"
       }
-    ],
-    "checksums": {
-      "0": "sha256:9a3756ebef6ab7caf590c69d436846bcdcc97ff037e82967cab1f90cfb2c6ec0",
-      "1": "sha256:bfd8cfbc7ab499d9699c564f92303ee241104ce5410b9dacf2e2f6c6623eecde",
-      "2": "sha256:21e8f75a343be3b15ee3ddcfde690e9d8d3e71640ec5e8fe7ad9c64fa93ffb77"
-    }
+    ]
   },
   "image-info": {
     "boot-environment": {

--- a/test/data/manifests/rhel_84-x86_64-openstack-boot.json
+++ b/test/data/manifests/rhel_84-x86_64-openstack-boot.json
@@ -9646,12 +9646,7 @@
         "remote_location": "https://rpmrepo.osbuild.org/v1/psi/el8/el8-x86_64-appstream-8.4.0.n-20210120/Packages/xkeyboard-config-2.28-1.el8.noarch.rpm",
         "checksum": "sha256:340b3c65becfca3d39f2afeed9659505a33ee870270c4d115d9fefe8929ff806"
       }
-    ],
-    "checksums": {
-      "0": "sha256:9a3756ebef6ab7caf590c69d436846bcdcc97ff037e82967cab1f90cfb2c6ec0",
-      "1": "sha256:bfd8cfbc7ab499d9699c564f92303ee241104ce5410b9dacf2e2f6c6623eecde",
-      "2": "sha256:21e8f75a343be3b15ee3ddcfde690e9d8d3e71640ec5e8fe7ad9c64fa93ffb77"
-    }
+    ]
   },
   "image-info": {
     "boot-environment": {

--- a/test/data/manifests/rhel_84-x86_64-qcow2-boot.json
+++ b/test/data/manifests/rhel_84-x86_64-qcow2-boot.json
@@ -9506,12 +9506,7 @@
         "remote_location": "https://rpmrepo.osbuild.org/v1/psi/el8/el8-x86_64-appstream-8.4.0.n-20210120/Packages/xkeyboard-config-2.28-1.el8.noarch.rpm",
         "checksum": "sha256:340b3c65becfca3d39f2afeed9659505a33ee870270c4d115d9fefe8929ff806"
       }
-    ],
-    "checksums": {
-      "0": "sha256:9a3756ebef6ab7caf590c69d436846bcdcc97ff037e82967cab1f90cfb2c6ec0",
-      "1": "sha256:bfd8cfbc7ab499d9699c564f92303ee241104ce5410b9dacf2e2f6c6623eecde",
-      "2": "sha256:21e8f75a343be3b15ee3ddcfde690e9d8d3e71640ec5e8fe7ad9c64fa93ffb77"
-    }
+    ]
   },
   "image-info": {
     "boot-environment": {

--- a/test/data/manifests/rhel_84-x86_64-qcow2-customize.json
+++ b/test/data/manifests/rhel_84-x86_64-qcow2-customize.json
@@ -9614,12 +9614,7 @@
         "remote_location": "https://rpmrepo.osbuild.org/v1/psi/el8/el8-x86_64-appstream-8.4.0.n-20210120/Packages/xkeyboard-config-2.28-1.el8.noarch.rpm",
         "checksum": "sha256:340b3c65becfca3d39f2afeed9659505a33ee870270c4d115d9fefe8929ff806"
       }
-    ],
-    "checksums": {
-      "0": "sha256:9a3756ebef6ab7caf590c69d436846bcdcc97ff037e82967cab1f90cfb2c6ec0",
-      "1": "sha256:bfd8cfbc7ab499d9699c564f92303ee241104ce5410b9dacf2e2f6c6623eecde",
-      "2": "sha256:21e8f75a343be3b15ee3ddcfde690e9d8d3e71640ec5e8fe7ad9c64fa93ffb77"
-    }
+    ]
   },
   "image-info": {
     "boot-environment": {

--- a/test/data/manifests/rhel_84-x86_64-rhel_edge_commit-boot.json
+++ b/test/data/manifests/rhel_84-x86_64-rhel_edge_commit-boot.json
@@ -9129,12 +9129,7 @@
         "remote_location": "https://rpmrepo.osbuild.org/v1/psi/el8/el8-x86_64-appstream-8.4.0.n-20210120/Packages/xkeyboard-config-2.28-1.el8.noarch.rpm",
         "checksum": "sha256:340b3c65becfca3d39f2afeed9659505a33ee870270c4d115d9fefe8929ff806"
       }
-    ],
-    "checksums": {
-      "0": "sha256:9a3756ebef6ab7caf590c69d436846bcdcc97ff037e82967cab1f90cfb2c6ec0",
-      "1": "sha256:bfd8cfbc7ab499d9699c564f92303ee241104ce5410b9dacf2e2f6c6623eecde",
-      "2": "sha256:21e8f75a343be3b15ee3ddcfde690e9d8d3e71640ec5e8fe7ad9c64fa93ffb77"
-    }
+    ]
   },
   "image-info": {
     "default-target": "graphical.target",

--- a/test/data/manifests/rhel_84-x86_64-rhel_edge_commit_rt-boot.json
+++ b/test/data/manifests/rhel_84-x86_64-rhel_edge_commit_rt-boot.json
@@ -9435,12 +9435,7 @@
         "remote_location": "https://rpmrepo.osbuild.org/v1/psi/el8/el8-x86_64-rt-8.4.0.n-20210214/Packages/tuned-profiles-realtime-2.15.0-1.el8.noarch.rpm",
         "checksum": "sha256:2f19b8e61b334da3c9068ac340ec85aa252001eff88afd7b438aa461d73a0b2d"
       }
-    ],
-    "checksums": {
-      "0": "sha256:9a3756ebef6ab7caf590c69d436846bcdcc97ff037e82967cab1f90cfb2c6ec0",
-      "1": "sha256:bfd8cfbc7ab499d9699c564f92303ee241104ce5410b9dacf2e2f6c6623eecde",
-      "2": "sha256:21e8f75a343be3b15ee3ddcfde690e9d8d3e71640ec5e8fe7ad9c64fa93ffb77"
-    }
+    ]
   },
   "image-info": {
     "default-target": "graphical.target",

--- a/test/data/manifests/rhel_84-x86_64-tar-boot.json
+++ b/test/data/manifests/rhel_84-x86_64-tar-boot.json
@@ -5514,12 +5514,7 @@
         "remote_location": "https://rpmrepo.osbuild.org/v1/psi/el8/el8-x86_64-appstream-8.4.0.n-20210120/Packages/xkeyboard-config-2.28-1.el8.noarch.rpm",
         "checksum": "sha256:340b3c65becfca3d39f2afeed9659505a33ee870270c4d115d9fefe8929ff806"
       }
-    ],
-    "checksums": {
-      "0": "sha256:9a3756ebef6ab7caf590c69d436846bcdcc97ff037e82967cab1f90cfb2c6ec0",
-      "1": "sha256:bfd8cfbc7ab499d9699c564f92303ee241104ce5410b9dacf2e2f6c6623eecde",
-      "2": "sha256:21e8f75a343be3b15ee3ddcfde690e9d8d3e71640ec5e8fe7ad9c64fa93ffb77"
-    }
+    ]
   },
   "image-info": {
     "bootmenu": [

--- a/test/data/manifests/rhel_84-x86_64-vhd-boot.json
+++ b/test/data/manifests/rhel_84-x86_64-vhd-boot.json
@@ -9569,12 +9569,7 @@
         "remote_location": "https://rpmrepo.osbuild.org/v1/psi/el8/el8-x86_64-appstream-8.4.0.n-20210120/Packages/xkeyboard-config-2.28-1.el8.noarch.rpm",
         "checksum": "sha256:340b3c65becfca3d39f2afeed9659505a33ee870270c4d115d9fefe8929ff806"
       }
-    ],
-    "checksums": {
-      "0": "sha256:9a3756ebef6ab7caf590c69d436846bcdcc97ff037e82967cab1f90cfb2c6ec0",
-      "1": "sha256:bfd8cfbc7ab499d9699c564f92303ee241104ce5410b9dacf2e2f6c6623eecde",
-      "2": "sha256:21e8f75a343be3b15ee3ddcfde690e9d8d3e71640ec5e8fe7ad9c64fa93ffb77"
-    }
+    ]
   },
   "image-info": {
     "boot-environment": {

--- a/test/data/manifests/rhel_84-x86_64-vmdk-boot.json
+++ b/test/data/manifests/rhel_84-x86_64-vmdk-boot.json
@@ -9220,12 +9220,7 @@
         "remote_location": "https://rpmrepo.osbuild.org/v1/psi/el8/el8-x86_64-appstream-8.4.0.n-20210120/Packages/xmlsec1-openssl-1.2.25-4.el8.x86_64.rpm",
         "checksum": "sha256:7d07d9055f557acf574e238327f003dc1a77dd119406e2326c844d17b818417c"
       }
-    ],
-    "checksums": {
-      "0": "sha256:9a3756ebef6ab7caf590c69d436846bcdcc97ff037e82967cab1f90cfb2c6ec0",
-      "1": "sha256:bfd8cfbc7ab499d9699c564f92303ee241104ce5410b9dacf2e2f6c6623eecde",
-      "2": "sha256:21e8f75a343be3b15ee3ddcfde690e9d8d3e71640ec5e8fe7ad9c64fa93ffb77"
-    }
+    ]
   },
   "image-info": {
     "boot-environment": {


### PR DESCRIPTION
This is an alternative to calling depsolve from within the distros. @achilleas-k first suggested this approach, but we decided to go with calling depsolve directly to make the change simpler. I really don't see how to hook that up with the manifest tests we currently have, and I think skipping those would be a shame.

Thoughts?