### PR TITLE
tests: Save osbuild-composer.repo file under artifacts

### DIFF
--- a/schutzbot/Jenkinsfile
+++ b/schutzbot/Jenkinsfile
@@ -949,10 +949,13 @@ void preserve_logs(test_slug) {
     // The workspace directory is not used everywhere, tests use temporary directory under /tmp/logs.
     sh "mkdir -p ${test_slug} && find /tmp/logs/ -name '*.log' -exec mv {} ${test_slug}/ \\; || true"
 
+    // Artifact the repo file.
+    sh "mkdir -p ${test_slug} && cp /etc/yum.repos.d/osbuild*.repo ${test_slug}/ || true"
+
     // Artifact the logs.
     archiveArtifacts (
         allowEmptyArchive: true,
-        artifacts: "${test_slug}/*.log,${test_slug}/*.jpg"
+        artifacts: "${test_slug}/*.log,${test_slug}/*.jpg,${test_slug}/*.repo"
     )
 
 }


### PR DESCRIPTION
makes it easier to grab if we need it for manual testing or
in case one needs to download the RPMs from Schutzbot


This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

For user-visible changes, "adequate documentation" is an entry describing the
change for users in docs/news. Please refer to docs/news/README.md for details.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`
-->
