### PR TITLE
osbuild-worker: Report job status back to worker API in all cases

### DIFF
--- a/cmd/osbuild-worker/jobimpl-osbuild.go
+++ b/cmd/osbuild-worker/jobimpl-osbuild.go
@@ -65,7 +65,7 @@ func osbuildStagesToRPMs(stages []osbuild.StageResult) []koji.RPM {
 
 func appendTargetError(res *worker.OSBuildJobResult, err error) {
 	errStr := err.Error()
-	fmt.Printf("target errored: %s", errStr)
+	log.Printf("target errored: %s", errStr)
 	res.TargetErrors = append(res.TargetErrors, errStr)
 }
 

--- a/cmd/osbuild-worker/jobimpl-osbuild.go
+++ b/cmd/osbuild-worker/jobimpl-osbuild.go
@@ -65,7 +65,7 @@ func osbuildStagesToRPMs(stages []osbuild.StageResult) []koji.RPM {
 
 func appendTargetError(res *worker.OSBuildJobResult, err error) {
 	errStr := err.Error()
-	log.Printf("target errored: %s", errStr)
+	log.Printf("target failed: %s", errStr)
 	res.TargetErrors = append(res.TargetErrors, errStr)
 }
 

--- a/cmd/osbuild-worker/jobimpl-osbuild.go
+++ b/cmd/osbuild-worker/jobimpl-osbuild.go
@@ -451,7 +451,7 @@ func (impl *OSBuildJobImpl) Run(job worker.Job) error {
 			osbuildJobResult.Success = true
 			osbuildJobResult.UploadStatus = "success"
 		default:
-			err = fmt.Errorf("invalid target type")
+			err = fmt.Errorf("invalid target type: %s", args.Targets[0].Name)
 			appendTargetError(osbuildJobResult, err)
 			return nil
 		}


### PR DESCRIPTION
The previous implementation exited before reporting back to the worker
API in few branches. This left the compose status in RUNNING state even
though the worker did not work of the job any more. Refactoring the
API call into the `deref` part makes sure it gets called every time.

Fixes: #1276

This pull request includes:

- [X] adequate testing for the new functionality or fixed issue
  - This functionality is already covered by tests. (well not the cases of failure, but we don't have any test cases like that)
- [X] adequate documentation informing people about the change
  - Ideally this change does not affect anyone.

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

For user-visible changes, "adequate documentation" is an entry describing the
change for users in docs/news. Please refer to docs/news/README.md for details.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`
-->
