### PR TITLE
GCP refactoring: logging, storage cleanup, worker credentials

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -114,6 +114,7 @@ build:
 	go build -o bin/osbuild-pipeline ./cmd/osbuild-pipeline/
 	go build -o bin/osbuild-upload-azure ./cmd/osbuild-upload-azure/
 	go build -o bin/osbuild-upload-aws ./cmd/osbuild-upload-aws/
+	go build -o bin/osbuild-upload-gcp ./cmd/osbuild-upload-gcp/
 	go test -c -tags=integration -o bin/osbuild-composer-cli-tests ./cmd/osbuild-composer-cli-tests/main_test.go
 	go test -c -tags=integration -o bin/osbuild-weldr-tests ./internal/client/
 	go test -c -tags=integration -o bin/osbuild-dnf-json-tests ./cmd/osbuild-dnf-json-tests/main_test.go

--- a/cmd/osbuild-worker/jobimpl-osbuild.go
+++ b/cmd/osbuild-worker/jobimpl-osbuild.go
@@ -315,11 +315,13 @@ func (impl *OSBuildJobImpl) Run(job worker.Job) error {
 			}
 			log.Printf("[GCP] 💿 Image URL: %s", g.ComputeImageURL(t.ImageName))
 
-			log.Printf("[GCP] 🔗 Sharing the image with: %+v", options.ShareWithAccounts)
-			err = g.ComputeImageShare(t.ImageName, options.ShareWithAccounts)
-			if err != nil {
-				r = append(r, err)
-				continue
+			if len(options.ShareWithAccounts) > 0 {
+				log.Printf("[GCP] 🔗 Sharing the image with: %+v", options.ShareWithAccounts)
+				err = g.ComputeImageShare(t.ImageName, options.ShareWithAccounts)
+				if err != nil {
+					r = append(r, err)
+					continue
+				}
 			}
 
 			targetResults = append(targetResults, target.NewGCPTargetResult(&target.GCPTargetResultOptions{

--- a/cmd/osbuild-worker/jobimpl-osbuild.go
+++ b/cmd/osbuild-worker/jobimpl-osbuild.go
@@ -29,11 +29,11 @@ import (
 )
 
 type OSBuildJobImpl struct {
-	Store        string
-	Output       string
-	KojiServers  map[string]koji.GSSAPICredentials
-	GCPCredsPath string
-	AzureCreds   *azure.Credentials
+	Store       string
+	Output      string
+	KojiServers map[string]koji.GSSAPICredentials
+	GCPCreds    []byte
+	AzureCreds  *azure.Credentials
 }
 
 func packageMetadataToSignature(pkg osbuild.RPMPackageMetadata) *string {
@@ -261,20 +261,7 @@ func (impl *OSBuildJobImpl) Run(job worker.Job) error {
 				continue
 			}
 
-			// Check if the credentials file was provided in the worker configuration,
-			// otherwise let it up to the Google client library to authenticate
-			var gcpCreds []byte
-			if impl.GCPCredsPath != "" {
-				gcpCreds, err = ioutil.ReadFile(impl.GCPCredsPath)
-				if err != nil {
-					r = append(r, err)
-					continue
-				}
-			} else {
-				gcpCreds = nil
-			}
-
-			g, err := gcp.New(gcpCreds)
+			g, err := gcp.New(impl.GCPCreds)
 			if err != nil {
 				r = append(r, err)
 				continue

--- a/internal/upload/gcp/gcp.go
+++ b/internal/upload/gcp/gcp.go
@@ -1,12 +1,10 @@
 package gcp
 
 import (
-	"bytes"
 	"context"
 	"crypto/md5"
 	"fmt"
 	"io"
-	"log"
 	"os"
 	"regexp"
 	"strings"
@@ -23,10 +21,12 @@ import (
 	"google.golang.org/protobuf/types/known/durationpb"
 )
 
+// GCP structure holds necessary information to authenticate and interact with GCP.
 type GCP struct {
 	creds *google.Credentials
 }
 
+// New returns an authenticated GCP instance, allowing to interact with GCP API.
 func New(credentials []byte) (*GCP, error) {
 	scopes := []string{
 		compute.ComputeScope,   // permissions to image
@@ -66,13 +66,65 @@ func (g *GCP) GetProjectID() string {
 	return g.creds.ProjectID
 }
 
-// Upload uploads an OS image to  specified Cloud Storage bucket and object.
+// StorageObjectUpload uploads an OS image to specified Cloud Storage bucket and object.
 // The bucket must exist. MD5 sum of the image file and uploaded object is
 // compared after the upload to verify the integrity of the uploaded image.
 //
+// The ObjectAttrs is returned if the object has been created.
+//
 // Uses:
 //	- Storage API
-func (g *GCP) Upload(filename, bucket, object string) error {
+func (g *GCP) StorageObjectUpload(filename, bucket, object string) (*storage.ObjectAttrs, error) {
+	ctx := context.Background()
+
+	storageClient, err := storage.NewClient(ctx, option.WithCredentials(g.creds))
+	if err != nil {
+		return nil, fmt.Errorf("failed to get Storage client: %v", err)
+	}
+	defer storageClient.Close()
+
+	// Open the image file
+	imageFile, err := os.Open(filename)
+	if err != nil {
+		return nil, fmt.Errorf("cannot open the image: %v", err)
+	}
+	defer imageFile.Close()
+
+	// Compute MD5 checksum of the image file for later verification
+	imageFileHash := md5.New()
+	if _, err := io.Copy(imageFileHash, imageFile); err != nil {
+		return nil, fmt.Errorf("cannot create md5 of the image: %v", err)
+	}
+	// Move the cursor of opened file back to the start
+	if _, err := imageFile.Seek(0, 0); err != nil {
+		return nil, fmt.Errorf("cannot seek the image: %v", err)
+	}
+
+	// Upload the image
+	// The Bucket MUST exist and be of a STANDARD storage class
+	obj := storageClient.Bucket(bucket).Object(object)
+	wc := obj.NewWriter(ctx)
+
+	// Uploaded data is rejected if its MD5 hash does not match the set value.
+	wc.MD5 = imageFileHash.Sum(nil)
+
+	if _, err = io.Copy(wc, imageFile); err != nil {
+		return nil, fmt.Errorf("uploading the image failed: %v", err)
+	}
+
+	// The object will not be available until Close has been called.
+	if err := wc.Close(); err != nil {
+		return nil, fmt.Errorf("Writer.Close: %v", err)
+	}
+
+	return wc.Attrs(), nil
+}
+
+// StorageObjectDelete deletes the given object from a bucket.
+//
+// Uses:
+//	- Storage API
+func (g *GCP) StorageObjectDelete(bucket, object string) error {
 	ctx := context.Background()
 
 	storageClient, err := storage.NewClient(ctx, option.WithCredentials(g.creds))
@@ -81,57 +133,119 @@ func (g *GCP) Upload(filename, bucket, object string) error {
 	}
 	defer storageClient.Close()
 
-	// Open the image file
-	imageFile, err := os.Open(filename)
-	if err != nil {
-		return fmt.Errorf("cannot open the image: %v", err)
-	}
-	defer imageFile.Close()
-
-	// Compute MD5 checksum of the image file for later verification
-	imageFileHash := md5.New()
-	if _, err := io.Copy(imageFileHash, imageFile); err != nil {
-		return fmt.Errorf("cannot create md5 of the image: %v", err)
-	}
-	// Move the cursor of opened file back to the start
-	if _, err := imageFile.Seek(0, 0); err != nil {
-		return fmt.Errorf("cannot seek the image: %v", err)
-	}
-
-	// Upload the image
-	// The Bucket MUST exist and be of a STANDARD storage class
-	obj := storageClient.Bucket(bucket).Object(object)
-	wc := obj.NewWriter(ctx)
-	log.Printf("[GCP] 🚀 Uploading image to: %s/%s\n", bucket, object)
-	if _, err = io.Copy(wc, imageFile); err != nil {
-		return fmt.Errorf("uploading the image failed: %v", err)
-	}
-
-	if err := wc.Close(); err != nil {
-		return fmt.Errorf("Writer.Close: %v", err)
-	}
-
-	// Verify the MD5 sum of the uploaded file
-	objAttrs, err := obj.Attrs(ctx)
-	if err != nil {
-		return fmt.Errorf("cannot get uploaded object attributed: %v", err)
-	}
-	objChecksum := objAttrs.MD5
-	fileChecksum := imageFileHash.Sum(nil)
-	if !bytes.Equal(objChecksum, fileChecksum) {
-		return fmt.Errorf("error during image upload. the image seems to be corrupted")
+	objectHandle := storageClient.Bucket(bucket).Object(object)
+	if err = objectHandle.Delete(ctx); err != nil {
+		return fmt.Errorf("failed to delete image file object: %v", err)
 	}
 
 	return nil
 }
 
-// Import imports a previously uploaded image by submitting a Cloud Build API
+// StorageImageImportCleanup deletes all objects created as part of an Image
+// import into Compute Engine and the related Build Job. The method returns a list
+// of deleted Storage objects, as well as list of errors which occurred during
+// the cleanup. The method tries to clean up as much as possible, therefore
+// it does not return on non-fatal errors.
+//
+// The Build job stores a copy of the to-be-imported image in a region specific
+// bucket, along with the Build job logs and some cache files.
+//
+// Uses:
+//	- Compute Engine API
+//	- Storage API
+func (g *GCP) StorageImageImportCleanup(imageName string) ([]string, []error) {
+	var deletedObjects []string
+	var errors []error
+
+	ctx := context.Background()
+
+	storageClient, err := storage.NewClient(ctx, option.WithCredentials(g.creds))
+	if err != nil {
+		errors = append(errors, fmt.Errorf("failed to get Storage client: %v", err))
+		return deletedObjects, errors
+	}
+	defer storageClient.Close()
+
+	computeService, err := compute.NewService(ctx, option.WithCredentials(g.creds))
+	if err != nil {
+		errors = append(errors, fmt.Errorf("failed to get Compute Engine client: %v", err))
+		return deletedObjects, errors
+	}
+
+	// Clean up the cache bucket
+	imageGetCall := computeService.Images.Get(g.creds.ProjectID, imageName)
+	image, err := imageGetCall.Do()
+	if err != nil {
+		// Without the image, we can not determine which objects to delete, just return
+		errors = append(errors, fmt.Errorf("failed to get image: %v", err))
+		return deletedObjects, errors
+	}
+
+	// Determine the regular expression to match files related to the specific Image Import
+	// e.g. "https://www.googleapis.com/compute/v1/projects/ascendant-braid-303513/zones/europe-west1-b/disks/disk-d7tr4"
+	// e.g. "https://www.googleapis.com/compute/v1/projects/ascendant-braid-303513/zones/europe-west1-b/disks/disk-l7s2w-1"
+	// Needed is only the part between "disk-" and possible "-<num>"/"EOF"
+	ss := strings.Split(image.SourceDisk, "/")
+	srcDiskName := ss[len(ss)-1]
+	ss = strings.Split(srcDiskName, "-")
+	if len(ss) < 2 {
+		errors = append(errors, fmt.Errorf("unexpected source disk name '%s', can not clean up storage", srcDiskName))
+		return deletedObjects, errors
+	}
+	scrDiskSuffix := ss[1]
+	// e.g. "gce-image-import-2021-02-05T17:27:40Z-2xhp5/daisy-import-image-20210205-17:27:43-s6l0l/logs/daisy.log"
+	reStr := fmt.Sprintf("gce-image-import-.+-%s", scrDiskSuffix)
+	cacheFilesRe := regexp.MustCompile(reStr)
+
+	buckets := storageClient.Buckets(ctx, g.creds.ProjectID)
+	for {
+		bkt, err := buckets.Next()
+		if err == iterator.Done {
+			break
+		}
+		if err != nil {
+			errors = append(errors, fmt.Errorf("failure while iterating over storage buckets: %v", err))
+			return deletedObjects, errors
+		}
+
+		// Check all buckets created by the Image Import Build jobs
+		// These are named e.g. "<project_id>-daisy-bkt-eu" - "ascendant-braid-303513-daisy-bkt-eu"
+		if strings.HasPrefix(bkt.Name, fmt.Sprintf("%s-daisy-bkt", g.creds.ProjectID)) {
+			objects := storageClient.Bucket(bkt.Name).Objects(ctx, nil)
+			for {
+				obj, err := objects.Next()
+				if err == iterator.Done {
+					break
+				}
+				if err != nil {
+					// Do not return, just log, to clean up as much as possible!
+					errors = append(errors, fmt.Errorf("failure while iterating over bucket objects: %v", err))
+					break
+				}
+				if cacheFilesRe.FindString(obj.Name) != "" {
+					o := storageClient.Bucket(bkt.Name).Object(obj.Name)
+					if err = o.Delete(ctx); err != nil {
+						// Do not return, just log, to clean up as much as possible!
+						errors = append(errors, fmt.Errorf("failed to delete storage object: %v", err))
+					}
+					deletedObjects = append(deletedObjects, fmt.Sprintf("%s/%s", bkt.Name, obj.Name))
+				}
+			}
+		}
+	}
+
+	return deletedObjects, errors
+}
+
+// ComputeImageImport imports a previously uploaded image by submitting a Cloud Build API
 // job. The job builds an image into Compute Node from an image uploaded to the
 // storage.
 //
-// The source image file is deleted from the storage bucket after a successful
-// image import. Also all cache files created as part of the image import are
-// deleted from the respective storage bucket.
+// The Build job usually creates a number of cache files in the Storage.
+// This method does not do any cleanup, regardless if the image import succeeds or fails.
+//
+// To delete the Storage object used for image import, use StorageObjectDelete().
+// To cleanup cache files after the Build job, use StorageImageImportCleanup().
 //
 // bucket - Google storage bucket name with the uploaded image
 // object - Google storage object name of the uploaded image
@@ -153,11 +267,11 @@ func (g *GCP) Upload(filename, bucket, object string) error {
 //
 // Uses:
 //	- Cloud Build API
-func (g *GCP) Import(bucket, object, imageName, os, region string) error {
+func (g *GCP) ComputeImageImport(bucket, object, imageName, os, region string) (*cloudbuildpb.Build, error) {
 	ctx := context.Background()
 	cloudbuildClient, err := cloudbuild.NewClient(ctx, option.WithCredentials(g.creds))
 	if err != nil {
-		return fmt.Errorf("failed to get Cloud Build client: %v", err)
+		return nil, fmt.Errorf("failed to get Cloud Build client: %v", err)
 	}
 	defer cloudbuildClient.Close()
 
@@ -195,21 +309,18 @@ func (g *GCP) Import(bucket, object, imageName, os, region string) error {
 		ProjectId: g.creds.ProjectID,
 		Build:     imageBuild,
 	}
-	log.Printf("[GCP] 📥 Importing image into Compute Node as '%s'\n", imageName)
+
 	resp, err := cloudbuildClient.CreateBuild(ctx, createBuildReq)
 	if err != nil {
-		return fmt.Errorf("failed to create image import build job: %v", err)
+		return nil, fmt.Errorf("failed to create image import build job: %v", err)
 	}
 
 	// Get the returned Build struct
 	buildOpMetadata := &cloudbuildpb.BuildOperationMetadata{}
 	if err := ptypes.UnmarshalAny(resp.Metadata, buildOpMetadata); err != nil {
-		return err
+		return nil, err
 	}
 	imageBuild = buildOpMetadata.Build
-
-	log.Printf("[GCP] 📜 Image import log URL: %s\n", imageBuild.LogUrl)
-	log.Printf("[GCP] 🤔 Image import build status: %+v\n", imageBuild.Status)
 
 	getBuldReq := &cloudbuildpb.GetBuildRequest{
 		ProjectId: imageBuild.ProjectId,
@@ -217,11 +328,10 @@ func (g *GCP) Import(bucket, object, imageName, os, region string) error {
 	}
 
 	// Wait for the build to finish
-	log.Println("[GCP] 🥱 Waiting for the image import to finish")
 	for {
 		imageBuild, err = cloudbuildClient.GetBuild(ctx, getBuldReq)
 		if err != nil {
-			return fmt.Errorf("failed to get the build info: %v", err)
+			return imageBuild, fmt.Errorf("failed to get the build info: %v", err)
 		}
 		// The build finished
 		if imageBuild.Status != cloudbuildpb.Build_WORKING && imageBuild.Status != cloudbuildpb.Build_QUEUED {
@@ -230,115 +340,20 @@ func (g *GCP) Import(bucket, object, imageName, os, region string) error {
 		time.Sleep(time.Second * 30)
 	}
 
-	fmt.Printf("[GCP] 🎉 Image import finished with status: %s\n", imageBuild.Status)
-
-	// Clean up cache files created by the Image Import Build job
-	if err = g.ImageImportStorageCleanup(bucket, object, imageName); err != nil {
-		fmt.Printf("storage cleanup failed: %v", err)
-	}
-
 	if imageBuild.Status != cloudbuildpb.Build_SUCCESS {
-		return fmt.Errorf("image import didn't finish successfully: %s", imageBuild.Status)
+		return imageBuild, fmt.Errorf("image import didn't finish successfully: %s", imageBuild.Status)
 	}
 
-	fmt.Printf("[GCP] 💿 Image URL: https://console.cloud.google.com/compute/imagesDetail/projects/%s/global/images/%s\n", g.creds.ProjectID, imageName)
-
-	return nil
+	return imageBuild, nil
 }
 
-// ImageImportStorageCleanup deletes all objects created as part of an Image
-// import into Compute Engine and the related Build Job. It also deletes the
-// source image file, which has been used for image import.
-//
-// The Build job stores a copy of the to-be-imported image in a region specific
-// bucket, along with the Build job logs.
-//
-// Uses:
-//	- Compute Engine API
-//	- Storage API
-func (g *GCP) ImageImportStorageCleanup(bucket, object, imageName string) error {
-	ctx := context.Background()
-
-	storageClient, err := storage.NewClient(ctx, option.WithCredentials(g.creds))
-	if err != nil {
-		return fmt.Errorf("failed to get Storage client: %v", err)
-	}
-	defer storageClient.Close()
-
-	computeService, err := compute.NewService(ctx, option.WithCredentials(g.creds))
-	if err != nil {
-		return fmt.Errorf("failed to get Compute Engine client: %v", err)
-	}
-
-	// Clean up the cache bucket
-	imageGetCall := computeService.Images.Get(g.creds.ProjectID, imageName)
-	image, err := imageGetCall.Do()
-	if err != nil {
-		// Without the image, we can not determine which objects to delete, just return
-		return fmt.Errorf("failed to get image: %v", err)
-	}
-
-	// Determine the regular expression to match files related to the specific Image Import
-	// e.g. "https://www.googleapis.com/compute/v1/projects/ascendant-braid-303513/zones/europe-west1-b/disks/disk-d7tr4"
-	// e.g. "https://www.googleapis.com/compute/v1/projects/ascendant-braid-303513/zones/europe-west1-b/disks/disk-l7s2w-1"
-	// Needed is only the part between "disk-" and possible "-<num>"/"EOF"
-	ss := strings.Split(image.SourceDisk, "/")
-	srcDiskName := ss[len(ss)-1]
-	ss = strings.Split(srcDiskName, "-")
-	if len(ss) < 2 {
-		return fmt.Errorf("unexpected source disk name '%s', can not clean up storage", srcDiskName)
-	}
-	scrDiskSuffix := ss[1]
-	// e.g. "gce-image-import-2021-02-05T17:27:40Z-2xhp5/daisy-import-image-20210205-17:27:43-s6l0l/logs/daisy.log"
-	reStr := fmt.Sprintf("gce-image-import-.+-%s", scrDiskSuffix)
-	cacheFilesRe := regexp.MustCompile(reStr)
-
-	buckets := storageClient.Buckets(ctx, g.creds.ProjectID)
-	for {
-		bkt, err := buckets.Next()
-		if err == iterator.Done {
-			break
-		}
-		if err != nil {
-			return fmt.Errorf("failure while iterating over storage buckets: %v", err)
-		}
-
-		// Check all buckets created by the Image Import Build jobs
-		// These are named e.g. "<project_id>-daisy-bkt-eu" - "ascendant-braid-303513-daisy-bkt-eu"
-		if strings.HasPrefix(bkt.Name, fmt.Sprintf("%s-daisy-bkt", g.creds.ProjectID)) {
-			objects := storageClient.Bucket(bkt.Name).Objects(ctx, nil)
-			for {
-				obj, err := objects.Next()
-				if err == iterator.Done {
-					break
-				}
-				if err != nil {
-					// Do not return, just log, to clean up as much as possible!
-					fmt.Printf("ERROR: failure while iterating over storage objects: %v", err)
-					break
-				}
-				if cacheFilesRe.FindString(obj.Name) != "" {
-					o := storageClient.Bucket(bkt.Name).Object(obj.Name)
-					fmt.Printf("[GCP] 🧹 Deleting image import job file '%s'\n", obj.Name)
-					if err = o.Delete(ctx); err != nil {
-						// Do not return, just log, to clean up as much as possible!
-						fmt.Printf("ERROR: failed to delete storage object: %v", err)
-					}
-				}
-			}
-		}
-	}
-
-	imageFileObject := storageClient.Bucket(bucket).Object(object)
-	fmt.Printf("[GCP] 🧹 Deleting image file from Storage: %s/%s\n", bucket, object)
-	if err = imageFileObject.Delete(ctx); err != nil {
-		return fmt.Errorf("failed to delete image file object: %v", err)
-	}
-
-	return nil
+// ComputeImageURL returns an image's URL to Google Cloud Console. The method does
+// not check at all, if the image actually exists or not.
+func (g *GCP) ComputeImageURL(imageName string) string {
+	return fmt.Sprintf("https://console.cloud.google.com/compute/imagesDetail/projects/%s/global/images/%s", g.creds.ProjectID, imageName)
 }
 
-// Share shares the specified Compute Engine image with list of accounts.
+// ComputeImageShare shares the specified Compute Engine image with list of accounts.
 //
 // "shareWith" is a list of accounts to share the image with. Items can be one
 // of the following options:
@@ -357,7 +372,7 @@ func (g *GCP) ImageImportStorageCleanup(bucket, object, imageName string) error 
 //
 // Uses:
 //	- Compute Engine API
-func (g *GCP) Share(imageName string, shareWith []string) error {
+func (g *GCP) ComputeImageShare(imageName string, shareWith []string) error {
 	ctx := context.Background()
 
 	computeService, err := compute.NewService(ctx, option.WithCredentials(g.creds))
@@ -389,7 +404,6 @@ func (g *GCP) Share(imageName string, shareWith []string) error {
 		Policy: newPolicy,
 	}
 	newPolicyCall := computeService.Images.SetIamPolicy(g.creds.ProjectID, imageName, req)
-	fmt.Printf("[GCP] Sharing the image with: %+v\n", shareWith)
 	_, err = newPolicyCall.Do()
 	if err != nil {
 		return fmt.Errorf("failed to set new image policy: %v", err)

--- a/internal/upload/gcp/gcp.go
+++ b/internal/upload/gcp/gcp.go
@@ -173,8 +173,7 @@ func (g *GCP) StorageImageImportCleanup(imageName string) ([]string, []error) {
 	}
 
 	// Clean up the cache bucket
-	imageGetCall := computeService.Images.Get(g.creds.ProjectID, imageName)
-	image, err := imageGetCall.Do()
+	image, err := computeService.Images.Get(g.creds.ProjectID, imageName).Context(ctx).Do()
 	if err != nil {
 		// Without the image, we can not determine which objects to delete, just return
 		errors = append(errors, fmt.Errorf("failed to get image: %v", err))
@@ -384,8 +383,7 @@ func (g *GCP) ComputeImageShare(imageName string, shareWith []string) error {
 	imageDesiredRole := "roles/compute.imageUser"
 
 	// Get the current Policy set on the Image
-	existingPolicyCall := computeService.Images.GetIamPolicy(g.creds.ProjectID, imageName)
-	policy, err := existingPolicyCall.Do()
+	policy, err := computeService.Images.GetIamPolicy(g.creds.ProjectID, imageName).Context(ctx).Do()
 	if err != nil {
 		return fmt.Errorf("failed to get image's policy: %v", err)
 	}
@@ -403,8 +401,7 @@ func (g *GCP) ComputeImageShare(imageName string, shareWith []string) error {
 	req := &compute.GlobalSetPolicyRequest{
 		Policy: newPolicy,
 	}
-	newPolicyCall := computeService.Images.SetIamPolicy(g.creds.ProjectID, imageName, req)
-	_, err = newPolicyCall.Do()
+	_, err = computeService.Images.SetIamPolicy(g.creds.ProjectID, imageName, req).Context(ctx).Do()
 	if err != nil {
 		return fmt.Errorf("failed to set new image policy: %v", err)
 	}


### PR DESCRIPTION
This PR addresses couple of outstanding things, which popped up during the initial GCP PR and later during review of Azure support for Cloud API.

Main changes:
- Moved all logging out of the GCP internal library to the callers (worker and the CLI upload tool), similar as it is done for Azure.
- Made all GCP methods a single purpose and not to do any extra tasks (e.g. cleanup). Rather than cleaning up under the hood, an error is returned and the caller can use provided cleanup methods to delete any unwanted resources. This is true for importing image. If the image upload to Storage fails, there is no need to clean up the object since it has been not created.
- Modified the worker and CLI upload tool code to do all necessary clean up in case of errors 
- Modified worker GCP-related code to try to share the imported image only if the list of accounts is not empty.
- Minor simplification of Google Compute Node API calls in the GCP library based on project's code examples.
- Added building of `osbuild-upload-gcp` to Makefile's build target. This was previously missed.
- Refactored handling of GCP credentials file on the worker. Instead of passing the path to the file to job, the file is read on the start up and its content is passed to the job. This mimics what is done for Azure and helps to detect issues with the credentials file early. Note that there is no easy way to actually test the validity of the content of the file and credentials other than making some actual API calls. I decided to not to do any "random" calls for now.

This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
 - no new tests have been added
- [ ] adequate documentation informing people about the change
 - changes should be transparent to the end user, thus no documentation has been added