### PR TITLE
[PoC]worker/depsolve: add a depsolve job type

### DIFF
--- a/cmd/osbuild-worker/jobimpl-depsolve.go
+++ b/cmd/osbuild-worker/jobimpl-depsolve.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/osbuild/osbuild-composer/internal/rpmmd"
+	"github.com/osbuild/osbuild-composer/internal/worker"
+)
+
+type DepsolveJobImpl struct {
+	RPMMD rpmmd.RPMMD
+}
+
+func (impl *DepsolveJobImpl) depsolve(packageSets map[string]rpmmd.PackageSet, repos []rpmmd.RepoConfig, modulePlatformID, arch string) (map[string][]rpmmd.PackageSpec, error) {
+	packageSpecs := make(map[string][]rpmmd.PackageSpec)
+	for name, packageSet := range packageSets {
+		packageSpec, _, err := impl.RPMMD.Depsolve(packageSet, repos, modulePlatformID, arch)
+		if err != nil {
+			return nil, err
+		}
+		packageSpecs[name] = packageSpec
+	}
+	return packageSpecs, nil
+}
+
+func (impl *DepsolveJobImpl) Run(job worker.Job) error {
+	var args worker.DepsolveJob
+	err := job.Args(&args)
+	if err != nil {
+		return err
+	}
+
+	var result worker.DepsolveJobResult
+	result.PackageSpecs, err = impl.depsolve(args.PackageSets, args.Repos, args.ModulePlatformID, args.Arch)
+	if err != nil {
+		result.Error = err.Error()
+	}
+
+	err = job.Update(&result)
+	if err != nil {
+		return fmt.Errorf("Error reporting job result: %v", err)
+	}
+
+	return nil
+}

--- a/cmd/osbuild-worker/main.go
+++ b/cmd/osbuild-worker/main.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/BurntSushi/toml"
 
+	"github.com/osbuild/osbuild-composer/internal/rpmmd"
 	"github.com/osbuild/osbuild-composer/internal/upload/azure"
 	"github.com/osbuild/osbuild-composer/internal/upload/koji"
 	"github.com/osbuild/osbuild-composer/internal/worker"
@@ -124,6 +125,7 @@ func main() {
 		log.Fatal("CACHE_DIRECTORY is not set. Is the service file missing CacheDirectory=?")
 	}
 	store := path.Join(cacheDirectory, "osbuild-store")
+	rpmmd_cache := path.Join(cacheDirectory, "rpmmd")
 	output := path.Join(cacheDirectory, "output")
 	_ = os.Mkdir(output, os.ModeDir)
 
@@ -187,6 +189,9 @@ func main() {
 		},
 		"koji-finalize": &KojiFinalizeJobImpl{
 			KojiServers: kojiServers,
+		},
+		"depsolve": &DepsolveJobImpl{
+			RPMMD: rpmmd.NewRPMMD(rpmmd_cache, "/usr/libexec/osbuild-composer/dnf-json"),
 		},
 	}
 

--- a/internal/worker/json.go
+++ b/internal/worker/json.go
@@ -6,6 +6,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/osbuild/osbuild-composer/internal/distro"
 	"github.com/osbuild/osbuild-composer/internal/osbuild"
+	"github.com/osbuild/osbuild-composer/internal/rpmmd"
 	"github.com/osbuild/osbuild-composer/internal/target"
 )
 
@@ -71,6 +72,18 @@ type KojiFinalizeJob struct {
 
 type KojiFinalizeJobResult struct {
 	KojiError string `json:"koji_error"`
+}
+
+type DepsolveJob struct {
+	PackageSets      map[string]rpmmd.PackageSet `json:"package_sets"`
+	Repos            []rpmmd.RepoConfig          `json:"repos"`
+	ModulePlatformID string                      `json:"module_platform_id"`
+	Arch             string                      `json:"arch"`
+}
+
+type DepsolveJobResult struct {
+	PackageSpecs map[string][]rpmmd.PackageSpec `json:"package_specs"`
+	Error        string                         `json:"error"`
 }
 
 //


### PR DESCRIPTION
Allow depsolving to be done in a worker through the job queue rather
than synchronously in composer.

The benefit this might unlock include:
 - no more blocking calls in the cloud/koji APIs
 - only workers accessing repositoires
   - no VPN access from composer
   - composer not needing to be subscribed to CDN, etc
 - no dnf cache managment in composer

Potential problems:
 - the version of composer (so the distro definitions) that
   triggered a depsolve, may not be the same that uses the
   result to generate a manfiset

Signed-off-by: Tom Gundersen <teg@jklm.no>


This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

For user-visible changes, "adequate documentation" is an entry describing the
change for users in docs/news. Please refer to docs/news/README.md for details.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`
-->
