### PR TITLE
distro/rhel84/qcow2: add net-tools

### DIFF
--- a/docs/news/unreleased/rhel83-84-difference-fixed.md
+++ b/docs/news/unreleased/rhel83-84-difference-fixed.md
@@ -1,0 +1,7 @@
+# RHEL 8.4: Update rhel-84 distro to better match RHEL 8.3
+
+This restores net-tools to the default package set.
+
+In RHEL8.3 cloud-init depended on net-tools, but in RHEL8.4,
+the dependency was dropped. We still want net-tools in the
+default package set, so add the dependency explicitly.

--- a/internal/distro/rhel84/distro.go
+++ b/internal/distro/rhel84/distro.go
@@ -999,6 +999,7 @@ func newDistro(isCentos bool) distro.Distro {
 			"dracut-norescue",
 			"insights-client",
 			"NetworkManager",
+			"net-tools",
 			"nfs-utils",
 			"oddjob",
 			"oddjob-mkhomedir",

--- a/test/data/manifests/centos_8-x86_64-qcow2-boot.json
+++ b/test/data/manifests/centos_8-x86_64-qcow2-boot.json
@@ -1139,6 +1139,9 @@
           "sha256:c5359c27606e5e72856c40c3428e7de03d9cfd9dc4e67f2bb6889b2ccb0e1bea": {
             "url": "https://composes.centos.org/CentOS-Stream-8-20210209.n.0/compose/BaseOS/x86_64/os/Packages/libpwquality-1.4.4-1.el8.x86_64.rpm"
           },
+          "sha256:c56cde3b8bc11965fa73b9baf59ab5fa7f6a45a950d5b6b369cf4679c17295ca": {
+            "url": "https://composes.centos.org/CentOS-Stream-8-20210209.n.0/compose/BaseOS/x86_64/os/Packages/net-tools-2.0-0.52.20160912git.el8.x86_64.rpm"
+          },
           "sha256:c5b5967a094ced90899052a82e2c245529b75ba3f46e0ce1a89cfc95edb935ea": {
             "url": "https://composes.centos.org/CentOS-Stream-8-20210209.n.0/compose/BaseOS/x86_64/os/Packages/python3-dateutil-2.6.1-6.el8.noarch.rpm"
           },
@@ -3332,6 +3335,10 @@
               },
               {
                 "checksum": "sha256:440ef0473d6f85c6f173020dab18d376d466b7b960876fba54772f88d4bfe050",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:c56cde3b8bc11965fa73b9baf59ab5fa7f6a45a950d5b6b369cf4679c17295ca",
                 "check_gpg": true
               },
               {
@@ -9025,6 +9032,16 @@
         "check_gpg": true
       },
       {
+        "name": "net-tools",
+        "epoch": 0,
+        "version": "2.0",
+        "release": "0.52.20160912git.el8",
+        "arch": "x86_64",
+        "remote_location": "https://composes.centos.org/CentOS-Stream-8-20210209.n.0/compose/BaseOS/x86_64/os/Packages/net-tools-2.0-0.52.20160912git.el8.x86_64.rpm",
+        "checksum": "sha256:c56cde3b8bc11965fa73b9baf59ab5fa7f6a45a950d5b6b369cf4679c17295ca",
+        "check_gpg": true
+      },
+      {
         "name": "nettle",
         "epoch": 0,
         "version": "3.4.1",
@@ -11306,6 +11323,7 @@
       "ncurses-6.1-7.20180224.el8.x86_64",
       "ncurses-base-6.1-7.20180224.el8.noarch",
       "ncurses-libs-6.1-7.20180224.el8.x86_64",
+      "net-tools-2.0-0.52.20160912git.el8.x86_64",
       "nettle-3.4.1-2.el8.x86_64",
       "newt-0.52.20-11.el8.x86_64",
       "nfs-utils-2.3.3-41.el8.x86_64",
@@ -11568,6 +11586,7 @@
       "missing": []
     },
     "services-disabled": [
+      "arp-ethers.service",
       "chrony-dnssrv@.timer",
       "chrony-wait.service",
       "cockpit.socket",

--- a/test/data/manifests/rhel_84-aarch64-qcow2-boot.json
+++ b/test/data/manifests/rhel_84-aarch64-qcow2-boot.json
@@ -1245,6 +1245,9 @@
           "sha256:edae480b0177d04b0b3ff54105c77c0cf4ec565c5234b10e2967f912290c4758": {
             "url": "https://rpmrepo.osbuild.org/v1/psi/el8/el8-aarch64-appstream-8.4.0.n-20210120/Packages/cairo-gobject-1.15.12-3.el8.aarch64.rpm"
           },
+          "sha256:edba68c63891b1171417b8d3af5827cc45a37210d18d701c0e178870e5435031": {
+            "url": "https://rpmrepo.osbuild.org/v1/psi/el8/el8-aarch64-baseos-8.4.0.n-20210120/Packages/net-tools-2.0-0.52.20160912git.el8.aarch64.rpm"
+          },
           "sha256:edc0261e273aee274fba4eaa21bf87650ff8efd64175f8501c55c02af2f806cf": {
             "url": "https://rpmrepo.osbuild.org/v1/psi/el8/el8-aarch64-baseos-8.4.0.n-20210120/Packages/teamd-1.31-2.el8.aarch64.rpm"
           },
@@ -2787,6 +2790,9 @@
               },
               {
                 "checksum": "sha256:f99f5edde9ad4574b84264c467420c910b31f78683fbf1b63d106a7e6c9d64a3"
+              },
+              {
+                "checksum": "sha256:edba68c63891b1171417b8d3af5827cc45a37210d18d701c0e178870e5435031"
               },
               {
                 "checksum": "sha256:e2c4ac0f7abf75cbcc7a6fb35412820c267f1a8ce614f41b60d901918c4616d5"
@@ -7650,6 +7656,15 @@
         "checksum": "sha256:f99f5edde9ad4574b84264c467420c910b31f78683fbf1b63d106a7e6c9d64a3"
       },
       {
+        "name": "net-tools",
+        "epoch": 0,
+        "version": "2.0",
+        "release": "0.52.20160912git.el8",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v1/psi/el8/el8-aarch64-baseos-8.4.0.n-20210120/Packages/net-tools-2.0-0.52.20160912git.el8.aarch64.rpm",
+        "checksum": "sha256:edba68c63891b1171417b8d3af5827cc45a37210d18d701c0e178870e5435031"
+      },
+      {
         "name": "nettle",
         "epoch": 0,
         "version": "3.4.1",
@@ -9748,6 +9763,7 @@
       "ncurses-6.1-7.20180224.el8.aarch64",
       "ncurses-base-6.1-7.20180224.el8.noarch",
       "ncurses-libs-6.1-7.20180224.el8.aarch64",
+      "net-tools-2.0-0.52.20160912git.el8.aarch64",
       "nettle-3.4.1-2.el8.aarch64",
       "newt-0.52.20-11.el8.aarch64",
       "nfs-utils-2.3.3-40.el8.aarch64",
@@ -10001,6 +10017,7 @@
       "missing": []
     },
     "services-disabled": [
+      "arp-ethers.service",
       "chrony-dnssrv@.timer",
       "chrony-wait.service",
       "cockpit.socket",

--- a/test/data/manifests/rhel_84-ppc64le-qcow2-boot.json
+++ b/test/data/manifests/rhel_84-ppc64le-qcow2-boot.json
@@ -1224,6 +1224,9 @@
           "sha256:d3192605b3aa6c19118f95e14f69f4394424eb09f7649e127223bbfbff676758": {
             "url": "https://rpmrepo.osbuild.org/v1/psi/el8/el8-ppc64le-appstream-8.4.0.n-20210120/Packages/python3-cairo-1.16.3-6.el8.ppc64le.rpm"
           },
+          "sha256:d381673d6d7fe39f88f7966b5dbbe733695f1dc6243aad15aba04548f0d99d9b": {
+            "url": "https://rpmrepo.osbuild.org/v1/psi/el8/el8-ppc64le-baseos-8.4.0.n-20210120/Packages/net-tools-2.0-0.52.20160912git.el8.ppc64le.rpm"
+          },
           "sha256:d3b6d1d0bc08398ecdc1ecab089318d829414811e5ccf63c2a5ffb80f8f92138": {
             "url": "https://rpmrepo.osbuild.org/v1/psi/el8/el8-ppc64le-appstream-8.4.0.n-20210120/Packages/python3-gobject-3.28.3-2.el8.ppc64le.rpm"
           },
@@ -2937,6 +2940,9 @@
               },
               {
                 "checksum": "sha256:bcd9e55362d6afab44a89acd877c8c0a8ae27572028bfc9282f3bfec0d21e27c"
+              },
+              {
+                "checksum": "sha256:d381673d6d7fe39f88f7966b5dbbe733695f1dc6243aad15aba04548f0d99d9b"
               },
               {
                 "checksum": "sha256:68c10fbde60ad63306c334df256056bc93eb04d56eaba5ddc40254e81e815056"
@@ -7970,6 +7976,15 @@
         "checksum": "sha256:bcd9e55362d6afab44a89acd877c8c0a8ae27572028bfc9282f3bfec0d21e27c"
       },
       {
+        "name": "net-tools",
+        "epoch": 0,
+        "version": "2.0",
+        "release": "0.52.20160912git.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v1/psi/el8/el8-ppc64le-baseos-8.4.0.n-20210120/Packages/net-tools-2.0-0.52.20160912git.el8.ppc64le.rpm",
+        "checksum": "sha256:d381673d6d7fe39f88f7966b5dbbe733695f1dc6243aad15aba04548f0d99d9b"
+      },
+      {
         "name": "nettle",
         "epoch": 0,
         "version": "3.4.1",
@@ -10474,6 +10489,7 @@
       "ncurses-6.1-7.20180224.el8.ppc64le",
       "ncurses-base-6.1-7.20180224.el8.noarch",
       "ncurses-libs-6.1-7.20180224.el8.ppc64le",
+      "net-tools-2.0-0.52.20160912git.el8.ppc64le",
       "nettle-3.4.1-2.el8.ppc64le",
       "newt-0.52.20-11.el8.ppc64le",
       "nfs-utils-2.3.3-40.el8.ppc64le",
@@ -10772,6 +10788,7 @@
       "missing": []
     },
     "services-disabled": [
+      "arp-ethers.service",
       "chrony-dnssrv@.timer",
       "chrony-wait.service",
       "cockpit.socket",

--- a/test/data/manifests/rhel_84-s390x-qcow2-boot.json
+++ b/test/data/manifests/rhel_84-s390x-qcow2-boot.json
@@ -966,6 +966,9 @@
           "sha256:a9170790817d95e7103c2e2067af1d5112335d4684ce53a1c5ae4e7d13705ae1": {
             "url": "https://rpmrepo.osbuild.org/v1/psi/el8/el8-s390x-baseos-8.4.0.n-20210120/Packages/kernel-tools-4.18.0-275.el8.s390x.rpm"
           },
+          "sha256:a9668870e64558cf26850b4bb2281f54ac2e9f9d55fb2f51c16fe320b4862a71": {
+            "url": "https://rpmrepo.osbuild.org/v1/psi/el8/el8-s390x-baseos-8.4.0.n-20210120/Packages/net-tools-2.0-0.52.20160912git.el8.s390x.rpm"
+          },
           "sha256:a9ee9660e50908c2da6a3e71168d9478d2f9287354ff970f3702cc397dd0512e": {
             "url": "https://rpmrepo.osbuild.org/v1/psi/el8/el8-s390x-baseos-8.4.0.n-20210120/Packages/zlib-1.2.11-17.el8.s390x.rpm"
           },
@@ -2896,6 +2899,9 @@
               },
               {
                 "checksum": "sha256:7e1b890a9e063d4041fc924cb55067db762b32980d5e30fed11e4a7a3696d026"
+              },
+              {
+                "checksum": "sha256:a9668870e64558cf26850b4bb2281f54ac2e9f9d55fb2f51c16fe320b4862a71"
               },
               {
                 "checksum": "sha256:349084cd9788761cea2c2b80d3969560df7a76e9909f3a0e8fba1120a98aa043"
@@ -7942,6 +7948,15 @@
         "checksum": "sha256:7e1b890a9e063d4041fc924cb55067db762b32980d5e30fed11e4a7a3696d026"
       },
       {
+        "name": "net-tools",
+        "epoch": 0,
+        "version": "2.0",
+        "release": "0.52.20160912git.el8",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v1/psi/el8/el8-s390x-baseos-8.4.0.n-20210120/Packages/net-tools-2.0-0.52.20160912git.el8.s390x.rpm",
+        "checksum": "sha256:a9668870e64558cf26850b4bb2281f54ac2e9f9d55fb2f51c16fe320b4862a71"
+      },
+      {
         "name": "nettle",
         "epoch": 0,
         "version": "3.4.1",
@@ -10390,6 +10405,7 @@
       "ncurses-6.1-7.20180224.el8.s390x",
       "ncurses-base-6.1-7.20180224.el8.noarch",
       "ncurses-libs-6.1-7.20180224.el8.s390x",
+      "net-tools-2.0-0.52.20160912git.el8.s390x",
       "nettle-3.4.1-2.el8.s390x",
       "newt-0.52.20-11.el8.s390x",
       "nfs-utils-2.3.3-40.el8.s390x",
@@ -10674,6 +10690,7 @@
       "missing": []
     },
     "services-disabled": [
+      "arp-ethers.service",
       "chrony-dnssrv@.timer",
       "chrony-wait.service",
       "cockpit.socket",

--- a/test/data/manifests/rhel_84-x86_64-qcow2-boot.json
+++ b/test/data/manifests/rhel_84-x86_64-qcow2-boot.json
@@ -1232,6 +1232,9 @@
           "sha256:e64a9ad8cf69086aa214b2f1082021600ac89abea338727f6bc5444190ceff42": {
             "url": "https://rpmrepo.osbuild.org/v1/psi/el8/el8-x86_64-baseos-8.4.0.n-20210120/Packages/python3-policycoreutils-2.9-9.el8.noarch.rpm"
           },
+          "sha256:e67a1c5f02c3e6fdccaad455fddf0dfdf812069da87d841a22df910bf361cfb9": {
+            "url": "https://rpmrepo.osbuild.org/v1/psi/el8/el8-x86_64-baseos-8.4.0.n-20210120/Packages/net-tools-2.0-0.52.20160912git.el8.x86_64.rpm"
+          },
           "sha256:e716ce0df8a72f26e415b8edd533b97e4213f0384a0fb64e08894f6eae694795": {
             "url": "https://rpmrepo.osbuild.org/v1/psi/el8/el8-x86_64-baseos-8.4.0.n-20210120/Packages/NetworkManager-tui-1.30.0-0.6.el8.x86_64.rpm"
           },
@@ -2830,6 +2833,9 @@
               },
               {
                 "checksum": "sha256:6d2ad3959103e46354f7491ff7911759016fa262581b0149ed5b3433b24a8129"
+              },
+              {
+                "checksum": "sha256:e67a1c5f02c3e6fdccaad455fddf0dfdf812069da87d841a22df910bf361cfb9"
               },
               {
                 "checksum": "sha256:6431a43da4fa2af839b5cc47c462d26b6d5c60f11bdd9045d363a9ba8ea8b781"
@@ -7779,6 +7785,15 @@
         "checksum": "sha256:6d2ad3959103e46354f7491ff7911759016fa262581b0149ed5b3433b24a8129"
       },
       {
+        "name": "net-tools",
+        "epoch": 0,
+        "version": "2.0",
+        "release": "0.52.20160912git.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v1/psi/el8/el8-x86_64-baseos-8.4.0.n-20210120/Packages/net-tools-2.0-0.52.20160912git.el8.x86_64.rpm",
+        "checksum": "sha256:e67a1c5f02c3e6fdccaad455fddf0dfdf812069da87d841a22df910bf361cfb9"
+      },
+      {
         "name": "nettle",
         "epoch": 0,
         "version": "3.4.1",
@@ -9889,6 +9904,7 @@
       "ncurses-6.1-7.20180224.el8.x86_64",
       "ncurses-base-6.1-7.20180224.el8.noarch",
       "ncurses-libs-6.1-7.20180224.el8.x86_64",
+      "net-tools-2.0-0.52.20160912git.el8.x86_64",
       "nettle-3.4.1-2.el8.x86_64",
       "newt-0.52.20-11.el8.x86_64",
       "nfs-utils-2.3.3-40.el8.x86_64",
@@ -10153,6 +10169,7 @@
       "missing": []
     },
     "services-disabled": [
+      "arp-ethers.service",
       "chrony-dnssrv@.timer",
       "chrony-wait.service",
       "cockpit.socket",


### PR DESCRIPTION
cloud-init not longer depends on net-tools, so we need to add in the dependency explicitly.

We aimed for the qcow2 to be equivalent to the RHEL8.4 qcow2 produced by imagefactory. However, we missed this unintended change from RHEL8.3.


This pull request includes:

- [x] adequate testing for the new functionality or fixed issue
- [x] adequate documentation informing people about the change

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

For user-visible changes, "adequate documentation" is an entry describing the
change for users in docs/news. Please refer to docs/news/README.md for details.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`
-->
