### PR TITLE
image-tests: checkpoint build root

### DIFF
--- a/cmd/osbuild-image-tests/constants/constants.go
+++ b/cmd/osbuild-image-tests/constants/constants.go
@@ -9,6 +9,7 @@ func GetOsbuildCommand(store, outputDirectory string) *exec.Cmd {
 		"osbuild",
 		"--store", store,
 		"--output-directory", outputDirectory,
+		"--checkpoint", "build",
 		"--json",
 		"-",
 	)

--- a/tools/test-case-generators/generate-all-test-cases
+++ b/tools/test-case-generators/generate-all-test-cases
@@ -705,8 +705,6 @@ class TestCaseMatrixGenerator(contextlib.AbstractContextManager):
                             log.info("Retrying image test case generation (%d of %d)", i, go_tls_timeout_retries)
 
                         stdout, stderr, retcode = runner.run_command(gen_test_cases_cmd)
-                        # clean up the osbuild-store dir
-                        runner.run_command_check_call(f"sudo rm -rf {guest_osbuild_store_dir}/*")
 
                         if retcode != 0:
                             log.error("'%s' retcode: %d\nstdout: %s\nstderr: %s", gen_test_cases_cmd, retcode,

--- a/tools/test-case-generators/generate-test-cases
+++ b/tools/test-case-generators/generate-test-cases
@@ -23,6 +23,7 @@ def run_osbuild(manifest, store, output):
             subprocess.run(["osbuild",
                             "--store", store,
                             "--output-directory", output,
+                            "--checkpoint", "build"
                             "-"],
                             stdout=log,
                             stderr=subprocess.STDOUT,


### PR DESCRIPTION
Most build roots for a given distro/arch are identical, so let's checkpoint them to avoid having to regenerate them
all the time.

This risks increasing the disk space usage in the case the build roots do not match, but in practice that should be rare.