### PR TITLE
GCP: Report the right error when image import fails

### DIFF
--- a/cmd/osbuild-upload-gcp/main.go
+++ b/cmd/osbuild-upload-gcp/main.go
@@ -95,7 +95,7 @@ func main() {
 
 		// check error from ComputeImageImport()
 		if importErr != nil {
-			log.Fatalf("[GCP] Importing image failed: %v", err)
+			log.Fatalf("[GCP] Importing image failed: %v", importErr)
 		}
 		log.Printf("[GCP] 💿 Image URL: %s", g.ComputeImageURL(imageName))
 	}

--- a/cmd/osbuild-worker/jobimpl-osbuild.go
+++ b/cmd/osbuild-worker/jobimpl-osbuild.go
@@ -298,7 +298,7 @@ func (impl *OSBuildJobImpl) Run(job worker.Job) error {
 
 			// check error from ComputeImageImport()
 			if importErr != nil {
-				r = append(r, err)
+				r = append(r, importErr)
 				continue
 			}
 			log.Printf("[GCP] 💿 Image URL: %s", g.ComputeImageURL(t.ImageName))


### PR DESCRIPTION
Fix a bug in the worker job implementation and GCP CLI upload tool,
which causes the code to report wrong error instance in case the image
import failed for some reason.
