### PR TITLE
RHEL 8.4.0: Fix for RHEL for Edge Ref in new image types

### DIFF
--- a/internal/distro/rhel84/distro_v2.go
+++ b/internal/distro/rhel84/distro_v2.go
@@ -322,7 +322,7 @@ func (t *imageTypeS2) ostreeCommitPipeline(options distro.ImageOptions) *osbuild
 
 	p.AddStage(osbuild.NewOSTreeCommitStage(
 		&osbuild.OSTreeCommitStageOptions{
-			Ref:       t.OSTreeRef(),
+			Ref:       options.OSTree.Ref,
 			OSVersion: "8.4", // NOTE: Set on image type?
 			Parent:    options.OSTree.Parent,
 		},
@@ -346,7 +346,7 @@ func (t *imageTypeS2) containerTreePipeline(repos []rpmmd.RepoConfig, packages [
 
 	p.AddStage(osbuild.NewOSTreePullStage(
 		&osbuild.OSTreePullStageOptions{Repo: "/var/www/html/repo"},
-		t.ostreePullStageInputs("org.osbuild.pipeline", "name:ostree-commit", t.OSTreeRef()),
+		t.ostreePullStageInputs("org.osbuild.pipeline", "name:ostree-commit", options.OSTree.Ref),
 	))
 	return p
 }
@@ -415,7 +415,7 @@ func (t *imageTypeS2) anacondaTreePipeline(repos []rpmmd.RepoConfig, packages []
 	p.AddStage(osbuild.NewAnacondaStage(t.anacondaStageOptions()))
 	p.AddStage(osbuild.NewLoraxScriptStage(t.loraxScriptStageOptions()))
 	p.AddStage(osbuild.NewDracutStage(t.dracutStageOptions(kernelVer)))
-	p.AddStage(osbuild.NewKickstartStage(t.kickstartStageOptions(fmt.Sprintf("file://%s", ostreeRepoPath))))
+	p.AddStage(osbuild.NewKickstartStage(t.kickstartStageOptions(fmt.Sprintf("file://%s", ostreeRepoPath), options.OSTree.Ref)))
 
 	return p
 }
@@ -684,13 +684,13 @@ func (t *imageTypeS2) dracutStageOptions(kernelVer string) *osbuild.DracutStageO
 	}
 }
 
-func (t *imageTypeS2) kickstartStageOptions(ostreeURL string) *osbuild.KickstartStageOptions {
+func (t *imageTypeS2) kickstartStageOptions(ostreeURL, ostreeRef string) *osbuild.KickstartStageOptions {
 	return &osbuild.KickstartStageOptions{
 		Path: "/usr/share/anaconda/interactive-defaults.ks",
 		OSTree: osbuild.OSTreeOptions{
 			OSName: "rhel",
 			URL:    ostreeURL,
-			Ref:    t.OSTreeRef(),
+			Ref:    ostreeRef,
 			GPG:    false,
 		},
 	}

--- a/test/cases/ostree-ng.sh
+++ b/test/cases/ostree-ng.sh
@@ -60,7 +60,7 @@ EOF
 
 # Set up variables.
 OSBUILD_COMPOSER_TEST_DATA=/usr/share/tests/osbuild-composer/
-OSTREE_REF="rhel/8/${ARCH}/edge"
+OSTREE_REF="test/rhel/8/${ARCH}/edge"
 OS_VARIANT="rhel8-unknown"
 TEST_UUID=$(uuidgen)
 IMAGE_KEY="osbuild-composer-ostree-test-${TEST_UUID}"
@@ -129,7 +129,10 @@ build_image() {
     else
         sudo curl --silent --header "Content-Type: application/json" --unix-socket /run/weldr/api.socket http://localhost/api/v1/compose --data "{
             \"blueprint_name\": \"$blueprint_name\",
-            \"compose_type\": \"$image_type\"
+            \"compose_type\": \"$image_type\",
+            \"ostree\": {
+                \"ref\": \"$OSTREE_REF\"
+            }
         }" | tee "$COMPOSE_START"
     fi
     COMPOSE_ID=$(jq -r '.build_id' "$COMPOSE_START")
@@ -488,7 +491,7 @@ done;
 
 # Get ostree commit value.
 greenprint "🕹 Get ostree upgrade commit value"
-UPGRADE_HASH=$(curl ${URL}refs/heads/rhel/8/x86_64/edge)
+UPGRADE_HASH=$(curl ${URL}refs/heads/"${OSTREE_REF}")
 
 # Clean compose and blueprints.
 greenprint "🧽 Clean up upgrade blueprint and compose"


### PR DESCRIPTION
_Duplicate of #1309 for RHEL 8.4.0 branch._

This pull request includes:

- [x] adequate testing for the new functionality or fixed issue
- [x] adequate documentation informing people about the change

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

For user-visible changes, "adequate documentation" is an entry describing the
change for users in docs/news. Please refer to docs/news/README.md for details.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`
-->

The new image type introduced in #1244 ignores the ostree ref supplied by the user and always uses the default rhel/8/<arch>/edge instead.

This PR fixes the issue by using the user-supplied ref when building the image. It also updates the integration test script to use a non-default ref by prefixing it with test/.

For all distros/image types, the default is only read by the weldr API when a ref isn't specified.