### PR TITLE
readme: require systemd 239

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ provided infrastructure and services.
 The requirements for this project are:
 
  * `osbuild >= 26`
- * `systemd >= 244`
+ * `systemd >= 239`
 
 At build-time, the following software is required:
 


### PR DESCRIPTION
Systemd 239 is used in RHEL 8 and we test osbuild-composer against it
therefore it's safe to say that 239 is the minimal version we require.

Fixes #1216

[skip ci]

Signed-off-by: Ondřej Budai <ondrej@budai.cz>


This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

For user-visible changes, "adequate documentation" is an entry describing the
change for users in docs/news. Please refer to docs/news/README.md for details.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`
-->
