### PR TITLE
Improve OSTree ref and URL handling in Weldr API

### DIFF
--- a/docs/news/unreleased/ostree-ref-handling.md
+++ b/docs/news/unreleased/ostree-ref-handling.md
@@ -1,0 +1,3 @@
+# Improve OSTree Repository URL and Ref parsing
+
+If the OSTree Repository URL did not end in a `/` the parsing would fail with a less-than-useful error message.  This has been fixed. Error messages for different failure cases have also been improved.

--- a/internal/weldr/api.go
+++ b/internal/weldr/api.go
@@ -1805,17 +1805,13 @@ func ostreeResolveRef(location, ref string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	u, err = u.Parse("refs/heads/")
-	if err != nil {
-		return "", err
-	}
-	u, err = u.Parse(ref)
-	if err != nil {
-		return "", err
-	}
+	u.Path = path.Join(u.Path, "refs/heads/", ref)
 	resp, err := http.Get(u.String())
 	if err != nil {
 		return "", err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("ostree repository %q returned status: %s", u.String(), resp.Status)
 	}
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
@@ -1825,7 +1821,7 @@ func ostreeResolveRef(location, ref string) (string, error) {
 	// Check that this is at least a hex string.
 	_, err = hex.DecodeString(parent)
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("ostree repository %q returned invalid reference", u.String())
 	}
 	return parent, nil
 }

--- a/internal/weldr/api.go
+++ b/internal/weldr/api.go
@@ -89,6 +89,7 @@ func (api *API) systemRepoNames() (names []string) {
 }
 
 var ValidBlueprintName = regexp.MustCompile(`^[a-zA-Z0-9._-]+$`)
+var ValidOSTreeRef = regexp.MustCompile(`^(?:[\w\d][-._\w\d]*\/)*[\w\d][-._\w\d]*$`)
 
 func New(rpmmd rpmmd.RPMMD, arch distro.Arch, distro distro.Distro, repos []rpmmd.RepoConfig, logger *log.Logger, store *store.Store, workers *worker.Server, compatOutputDir string) *API {
 	api := &API{
@@ -370,6 +371,18 @@ func verifyStringsWithRegex(writer http.ResponseWriter, strings []string, re *re
 		return false
 	}
 	return true
+}
+
+func verifyOSTreeRef(writer http.ResponseWriter, ref string, re *regexp.Regexp) bool {
+	if len(ref) > 0 && re.MatchString(ref) {
+		return true
+	}
+	errors := responseError{
+		ID:  "InvalidChars",
+		Msg: "Invalid ostree ref",
+	}
+	statusResponseError(writer, http.StatusBadRequest, errors)
+	return false
 }
 
 func statusResponseError(writer http.ResponseWriter, code int, errors ...responseError) {
@@ -1901,6 +1914,8 @@ func (api *API) composeHandler(writer http.ResponseWriter, request *http.Request
 	// set default ostree ref, if one not provided
 	if cr.OSTree.Ref == "" {
 		cr.OSTree.Ref = imageType.OSTreeRef()
+	} else if !verifyOSTreeRef(writer, cr.OSTree.Ref, ValidOSTreeRef) {
+		return
 	}
 
 	if !verifyStringsWithRegex(writer, []string{cr.BlueprintName}, ValidBlueprintName) {

--- a/internal/weldr/api_test.go
+++ b/internal/weldr/api_test.go
@@ -674,6 +674,7 @@ func TestCompose(t *testing.T) {
 		{false, "POST", "/api/v1/compose", `{"blueprint_name": "test","compose_type":"qcow2","branch":"master","ostree":{"ref":"refid","parent":"parentid","url":""}}`, http.StatusOK, `{"status": true}`, expectedComposeOSTreeRef, []string{"build_id"}},
 		{false, "POST", "/api/v1/compose?test=2", `{"blueprint_name": "test","compose_type":"qcow2","branch":"master","ostree":{"ref":"refid","parent":"","url":"http://ostree/"}}`, http.StatusOK, `{"status": true}`, expectedComposeOSTreeURL, []string{"build_id"}},
 		{false, "POST", "/api/v1/compose", `{"blueprint_name": "test","compose_type":"qcow2","branch":"master","ostree":{"ref":"refid","parent":"","url":"invalid-url"}}`, http.StatusBadRequest, `{"status":false,"errors":[{"id":"OSTreeCommitError","msg":"Get \"invalid-url/refs/heads/refid\": unsupported protocol scheme \"\""}]}`, nil, []string{"build_id"}},
+		{false, "POST", "/api/v1/compose", `{"blueprint_name": "test","compose_type":"qcow2","branch":"master","ostree":{"ref":"/bad/ref","parent":"","url":"http://ostree/"}}`, http.StatusBadRequest, `{"status":false,"errors":[{"id":"InvalidChars","msg":"Invalid ostree ref"}]}`, expectedComposeOSTreeURL, []string{"build_id"}},
 	}
 
 	tempdir, err := ioutil.TempDir("", "weldr-tests-")

--- a/test/cases/ostree-ng.sh
+++ b/test/cases/ostree-ng.sh
@@ -65,7 +65,7 @@ OS_VARIANT="rhel8-unknown"
 TEST_UUID=$(uuidgen)
 IMAGE_KEY="osbuild-composer-ostree-test-${TEST_UUID}"
 GUEST_ADDRESS=192.168.100.50
-URL=http://192.168.100.1/repo/
+URL=http://192.168.100.1/repo
 
 # Set up temporary files.
 TEMPDIR=$(mktemp -d)
@@ -127,6 +127,7 @@ build_image() {
             }
         }" | tee "$COMPOSE_START"
     else
+        # Test ref begining with /
         sudo curl --silent --header "Content-Type: application/json" --unix-socket /run/weldr/api.socket http://localhost/api/v1/compose --data "{
             \"blueprint_name\": \"$blueprint_name\",
             \"compose_type\": \"$image_type\",
@@ -308,7 +309,8 @@ sudo composer-cli blueprints push "$BLUEPRINT_FILE"
 sudo composer-cli blueprints depsolve installer
 
 # Build installer image.
-build_image installer rhel-edge-installer "$URL"
+# Test --url arg following by URL with tailling slash for bz#1942029
+build_image installer rhel-edge-installer "${URL}/"
 
 # Download the image
 greenprint "📥 Downloading the installer image"
@@ -459,6 +461,7 @@ sudo composer-cli blueprints push "$BLUEPRINT_FILE"
 sudo composer-cli blueprints depsolve upgrade
 
 # Build upgrade image.
+# Test --url arg following by URL without tailling slash for bz#1942029
 build_image upgrade rhel-edge-container "$URL"
 
 # Download the image
@@ -491,7 +494,7 @@ done;
 
 # Get ostree commit value.
 greenprint "🕹 Get ostree upgrade commit value"
-UPGRADE_HASH=$(curl ${URL}refs/heads/"${OSTREE_REF}")
+UPGRADE_HASH=$(curl ${URL}/refs/heads/"${OSTREE_REF}")
 
 # Clean compose and blueprints.
 greenprint "🧽 Clean up upgrade blueprint and compose"


### PR DESCRIPTION
This pull request includes:

- [x] adequate testing for the new functionality or fixed issue
- [x] adequate documentation informing people about the change

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

For user-visible changes, "adequate documentation" is an entry describing the
change for users in docs/news. Please refer to docs/news/README.md for details.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`
-->

Replacing repeated calls to u.Parse() with path.Join() on the URL's path. This method handles certain edge cases differently:
- location not ending in / (http://example.org/repo):
    - with the old method, the subsequent parsing of "refs/heads/" would overwrite the path segment of the original URL, resulting in       http://example.org/refs/heads
    - with the new method, "refs/heads" is appended to the location and a / is added between the two parts if necessary.
- ref begins with / (location: http://example.org/repo/, ref: /ref):
    - with the old method, the final parsing of ref would overwrite the path segment of the URL, resulting in http://example.org/ref
    - with the new method, the ref is appended and a / is added between parts where necessary (same as above).
- ref is a full URL (location: http://example.org/repo/, ref: http://example.com):
    - with the old method, u.Parse(ref) would completely overwrite the existing URL in u.
    - with the new method, the ref is added as a sanitised URL path resulting in http://example.org/refs/heads/http:/example.com.

The last one will probably result in an error in either case, but it's probably less incorrect to coerce the ref argument into a path.

Addresses [rhbz#1942029](https://bugzilla.redhat.com/show_bug.cgi?id=1942029).