### PR TITLE
test: Update test to align with customer scenario

### DIFF
--- a/test/cases/ostree-ng.sh
+++ b/test/cases/ostree-ng.sh
@@ -8,9 +8,6 @@ set -euo pipefail
 source /etc/os-release
 ARCH=$(uname -m)
 
-# Do not use httpd, but container
-sudo systemctl disable --now httpd
-
 # Colorful output.
 function greenprint {
     echo -e "\033[1;32m${1}\033[0m"
@@ -65,7 +62,10 @@ OS_VARIANT="rhel8-unknown"
 TEST_UUID=$(uuidgen)
 IMAGE_KEY="osbuild-composer-ostree-test-${TEST_UUID}"
 GUEST_ADDRESS=192.168.100.50
-URL=http://192.168.100.1/repo
+PROD_REPO_URL=http://192.168.100.1/repo
+PROD_REPO=/var/www/html/repo
+STAGE_REPO_ADDRESS=192.168.200.1
+STAGE_REPO_URL="http://${STAGE_REPO_ADDRESS}/repo/"
 
 # Set up temporary files.
 TEMPDIR=$(mktemp -d)
@@ -195,8 +195,14 @@ clean_up () {
     # Remove all images
     sudo podman rmi -f -a
 
+    # Remove prod repo
+    sudo rm -rf "$PROD_REPO"
+
     # Remomve tmp dir.
     sudo rm -rf "$TEMPDIR"
+
+    # Stop prod repo http service
+    sudo systemctl disable --now httpd
 }
 
 # Test result checking
@@ -210,6 +216,25 @@ check_result () {
         exit 1
     fi
 }
+
+###########################################################
+##
+## Prepare edge prod and stage repo
+##
+###########################################################
+greenprint "🔧 Prepare edge prod repo"
+# Start prod repo web service
+sudo systemctl enable --now httpd.service
+
+# Have a clean prod repo
+sudo rm -rf "$PROD_REPO"
+sudo mkdir -p "$PROD_REPO"
+sudo ostree --repo="$PROD_REPO" init --mode=archive
+sudo ostree --repo="$PROD_REPO" remote add --no-gpg-verify edge-stage "$STAGE_REPO_URL"
+
+# Prepare stage repo network
+greenprint "🔧 Prepare stage repo network"
+sudo podman network inspect edge >/dev/null 2>&1 || sudo podman network create --driver=bridge --subnet=192.168.200.0/24 --ip-range=192.168.200.0/24 --gateway=192.168.200.254 edge
 
 ##########################################################
 ##
@@ -256,15 +281,15 @@ build_image container rhel-edge-container
 greenprint "📥 Downloading the container image"
 sudo composer-cli compose image "${COMPOSE_ID}" > /dev/null
 
-# Clear container running env
-greenprint "🧹 Clearing container running env"
+# Clear stage repo running env
+greenprint "🧹 Clearing stage repo running env"
 # Remove any status containers if exist
 sudo podman ps -a -q --format "{{.ID}}" | sudo xargs --no-run-if-empty podman rm -f
 # Remove all images
 sudo podman rmi -f -a
 
-# Deal with rhel-edge container
-greenprint "🗜 Extracting and running the image"
+# Deal with stage repo image
+greenprint "🗜 Extracting image"
 IMAGE_FILENAME="${COMPOSE_ID}-rhel84-container.tar"
 sudo podman pull "oci-archive:${IMAGE_FILENAME}"
 # Workaound for issue https://bugzilla.redhat.com/show_bug.cgi?id=1933774
@@ -272,13 +297,20 @@ sudo restorecon -R /var/lib/containers/storage/overlay/
 sudo podman images
 # Clear image file
 sudo rm -f "$IMAGE_FILENAME"
+
+# Run edge stage repo
+greenprint "🛰 Running edge stage repo"
 # Get image id to run image
 EDGE_IMAGE_ID=$(sudo podman images --filter "dangling=true" --format "{{.ID}}")
-sudo podman run -d --name rhel-edge --network host "${EDGE_IMAGE_ID}"
+sudo podman run -d --name rhel-edge --network edge --ip "$STAGE_REPO_ADDRESS" "$EDGE_IMAGE_ID"
 # Wait for container to be running
 until [ "$(sudo podman inspect -f '{{.State.Running}}' rhel-edge)" == "true" ]; do
     sleep 1;
 done;
+
+# Sync installer edge content
+greenprint "📡 Sync installer content from stage repo"
+sudo ostree --repo="$PROD_REPO" pull --mirror edge-stage "$OSTREE_REF"
 
 # Clean compose and blueprints.
 greenprint "🧽 Clean up container blueprint and compose"
@@ -310,7 +342,7 @@ sudo composer-cli blueprints depsolve installer
 
 # Build installer image.
 # Test --url arg following by URL with tailling slash for bz#1942029
-build_image installer rhel-edge-installer "${URL}/"
+build_image installer rhel-edge-installer "${PROD_REPO_URL}/"
 
 # Download the image
 greenprint "📥 Downloading the installer image"
@@ -420,7 +452,7 @@ check_result
 
 ##################################################
 ##
-## upgrade rhel-edge with new upgrade container
+## upgrade rhel-edge with new upgrade commit
 ##
 ##################################################
 
@@ -461,22 +493,21 @@ sudo composer-cli blueprints push "$BLUEPRINT_FILE"
 sudo composer-cli blueprints depsolve upgrade
 
 # Build upgrade image.
-# Test --url arg following by URL without tailling slash for bz#1942029
-build_image upgrade rhel-edge-container "$URL"
+build_image upgrade rhel-edge-container "$PROD_REPO_URL"
 
 # Download the image
 greenprint "📥 Downloading the upgrade image"
 sudo composer-cli compose image "${COMPOSE_ID}" > /dev/null
 
-# Clear container running env
-greenprint "🧹 Clearing container running env"
+# Clear stage repo running env
+greenprint "🧹 Clearing stage repo running env"
 # Remove any status containers if exist
 sudo podman ps -a -q --format "{{.ID}}" | sudo xargs --no-run-if-empty podman rm -f
 # Remove all images
 sudo podman rmi -f -a
 
-# Deal with rhel-edge container
-greenprint "🗜 Extracting and running the image"
+# Deal with stage repo container
+greenprint "🗜 Extracting image"
 IMAGE_FILENAME="${COMPOSE_ID}-rhel84-container.tar"
 sudo podman pull "oci-archive:${IMAGE_FILENAME}"
 # Workaound for issue https://bugzilla.redhat.com/show_bug.cgi?id=1933774
@@ -484,17 +515,26 @@ sudo restorecon -R /var/lib/containers/storage/overlay/
 sudo podman images
 # Clear image file
 sudo rm -f "$IMAGE_FILENAME"
+
+# Run edge stage repo
+greenprint "🛰 Running edge stage repo"
 # Get image id to run image
 EDGE_IMAGE_ID=$(sudo podman images --filter "dangling=true" --format "{{.ID}}")
-sudo podman run -d --name rhel-edge --network host "${EDGE_IMAGE_ID}"
+sudo podman run -d --name rhel-edge --network edge --ip "$STAGE_REPO_ADDRESS" "$EDGE_IMAGE_ID"
 # Wait for container to be running
 until [ "$(sudo podman inspect -f '{{.State.Running}}' rhel-edge)" == "true" ]; do
     sleep 1;
 done;
 
+# Pull upgrade to prod mirror
+greenprint "⛓ Pull upgrade to prod mirror"
+sudo ostree --repo="$PROD_REPO" pull --mirror edge-stage "$OSTREE_REF"
+sudo ostree --repo="$PROD_REPO" static-delta generate "$OSTREE_REF"
+sudo ostree --repo="$PROD_REPO" summary -u
+
 # Get ostree commit value.
 greenprint "🕹 Get ostree upgrade commit value"
-UPGRADE_HASH=$(curl ${URL}/refs/heads/"${OSTREE_REF}")
+UPGRADE_HASH=$(curl "${PROD_REPO_URL}/refs/heads/${OSTREE_REF}")
 
 # Clean compose and blueprints.
 greenprint "🧽 Clean up upgrade blueprint and compose"
@@ -504,7 +544,7 @@ sudo composer-cli blueprints delete upgrade > /dev/null
 # Config remote repository for upgrade
 greenprint "🔗 Config remote repository for upgrade"
 sudo ssh "${SSH_OPTIONS[@]}" -i "${SSH_KEY}" admin@${GUEST_ADDRESS} 'sudo ostree remote delete rhel-edge'
-sudo ssh "${SSH_OPTIONS[@]}" -i "${SSH_KEY}" admin@${GUEST_ADDRESS} "sudo ostree remote add --no-gpg-verify --no-sign-verify rhel-edge ${URL}"
+sudo ssh "${SSH_OPTIONS[@]}" -i "${SSH_KEY}" admin@${GUEST_ADDRESS} "sudo ostree remote add --no-gpg-verify --no-sign-verify rhel-edge ${PROD_REPO_URL}"
 
 # Upgrade image/commit.
 greenprint "🗳 Upgrade ostree image/commit"


### PR DESCRIPTION
According to Ben's suggestion, test has been updated to aligin with customer scenario.
1. Setup ostree prod repo, building installer and edge upgrade will be from prod repo
2. Containers for building installer and edge upgrade will be running as stage repo
3. Before edge system update, prod repo will pull update content from stage repo, make static-delta and summary