### PR TITLE
tests: Don't execute image tests on PRs. Closes #962

### DIFF
--- a/schutzbot/Jenkinsfile
+++ b/schutzbot/Jenkinsfile
@@ -266,37 +266,6 @@ pipeline {
                         }
                     }
                 }
-                stage('F32 Image') {
-                    when {
-                        beforeAgent true
-                        expression {
-                            return env.BUILD_CAUSE != 'cron';
-                        }
-                    }
-
-                    agent { label "f32cloudbase && psi && x86_64" }
-                    environment {
-                        TEST_TYPE = "image"
-                        DISTRO_CODE = "fedora_32"
-                        AWS_CREDS = credentials('aws-credentials-osbuildci')
-                        AWS_IMAGE_TEST_CREDS = credentials('aws-credentials-osbuild-image-test')
-                        AZURE_CREDS = credentials('azure')
-                        OPENSTACK_CREDS = credentials("psi-openstack-creds")
-                        VCENTER_CREDS = credentials('vmware-vcenter-credentials')
-                    }
-                    steps {
-                        run_tests('image')
-                    }
-                    post {
-                        always {
-                            preserve_logs('fedora32-image')
-                            sh (
-                                label: "Run cloud cleaner just in case something failed",
-                                script: "schutzbot/run_cloud_cleaner.sh"
-                            )
-                        }
-                    }
-                }
                 stage('F32 Integration') {
                     when {
                         beforeAgent true
@@ -358,37 +327,6 @@ pipeline {
                     post {
                         always {
                             preserve_logs('fedora33-base')
-                        }
-                    }
-                }
-                stage('F33 Image') {
-                    when {
-                        beforeAgent true
-                        expression {
-                            return env.BUILD_CAUSE != 'cron';
-                        }
-                    }
-
-                    agent { label "f33cloudbase && psi && x86_64" }
-                    environment {
-                        TEST_TYPE = "image"
-                        DISTRO_CODE = "fedora_33"
-                        AWS_CREDS = credentials('aws-credentials-osbuildci')
-                        AWS_IMAGE_TEST_CREDS = credentials('aws-credentials-osbuild-image-test')
-                        AZURE_CREDS = credentials('azure')
-                        OPENSTACK_CREDS = credentials("psi-openstack-creds")
-                        VCENTER_CREDS = credentials('vmware-vcenter-credentials')
-                    }
-                    steps {
-                        run_tests('image')
-                    }
-                    post {
-                        always {
-                            preserve_logs('fedora33-image')
-                            sh (
-                                label: "Run cloud cleaner just in case something failed",
-                                script: "schutzbot/run_cloud_cleaner.sh"
-                            )
                         }
                     }
                 }
@@ -456,36 +394,6 @@ pipeline {
                         }
                     }
                 }
-                stage('F33 aarch64 Image') {
-                    when {
-                        beforeAgent true
-                        expression {
-                            return env.BUILD_CAUSE != 'cron';
-                        }
-                    }
-
-                    agent { label "f33cloudbase && aarch64 && aws" }
-                    environment {
-                        TEST_TYPE = "image"
-                        DISTRO_CODE = "fedora_33"
-                        AWS_IMAGE_TEST_CREDS = credentials('aws-credentials-osbuild-image-test')
-                        AZURE_CREDS = credentials('azure')
-                        OPENSTACK_CREDS = credentials("psi-openstack-creds")
-                        VCENTER_CREDS = credentials('vmware-vcenter-credentials')
-                    }
-                    steps {
-                        run_tests('image')
-                    }
-                    post {
-                        always {
-                            preserve_logs('fedora33-aarch64-image')
-                            sh (
-                                label: "Run cloud cleaner just in case something failed",
-                                script: "schutzbot/run_cloud_cleaner.sh"
-                            )
-                        }
-                    }
-                }
                 stage('F33: koji-osbuild') {
                     when {
                         beforeAgent true
@@ -523,38 +431,6 @@ pipeline {
                     post {
                         always {
                             preserve_logs('rhel8-base')
-                        }
-                    }
-                }
-                stage('EL8 Image') {
-                    when {
-                        beforeAgent true
-                        expression {
-                            return env.BUILD_CAUSE != 'cron';
-                        }
-                    }
-
-                    agent { label "rhel8cloudbase && psi && x86_64" }
-                    environment {
-                        TEST_TYPE = "image"
-                        DISTRO_CODE = "rhel_8"
-                        AWS_CREDS = credentials('aws-credentials-osbuildci')
-                        AWS_IMAGE_TEST_CREDS = credentials('aws-credentials-osbuild-image-test')
-                        AZURE_CREDS = credentials('azure')
-                        OPENSTACK_CREDS = credentials("psi-openstack-creds")
-                        RHN_REGISTRATION_SCRIPT = credentials('rhn-register-script-production')
-                        VCENTER_CREDS = credentials('vmware-vcenter-credentials')
-                    }
-                    steps {
-                        run_tests('image')
-                    }
-                    post {
-                        always {
-                            preserve_logs('rhel8-image')
-                            sh (
-                                label: "Run cloud cleaner just in case something failed",
-                                script: "schutzbot/run_cloud_cleaner.sh"
-                            )
                         }
                     }
                 }
@@ -665,30 +541,6 @@ pipeline {
                         }
                     }
                 }
-                stage('EL8.4 Image') {
-                    agent { label "rhel84cloudbase && psi && x86_64" }
-                    environment {
-                        TEST_TYPE = "image"
-                        DISTRO_CODE = "rhel_84"
-                        AWS_CREDS = credentials('aws-credentials-osbuildci')
-                        AWS_IMAGE_TEST_CREDS = credentials('aws-credentials-osbuild-image-test')
-                        AZURE_CREDS = credentials('azure')
-                        OPENSTACK_CREDS = credentials("psi-openstack-creds")
-                        VCENTER_CREDS = credentials('vmware-vcenter-credentials')
-                    }
-                    steps {
-                        run_tests('image')
-                    }
-                    post {
-                        always {
-                            preserve_logs('rhel84-image')
-                            sh (
-                                label: "Run cloud cleaner just in case something failed",
-                                script: "schutzbot/run_cloud_cleaner.sh"
-                            )
-                        }
-                    }
-                }
                 stage('EL8.4 Integration') {
                     agent { label "rhel84cloudbase && x86_64 && psi" }
                     environment {
@@ -738,30 +590,6 @@ pipeline {
                         }
                     }
                 }
-                stage('EL9.0 Image') {
-                    agent { label "f33cloudbase && psi && x86_64" }
-                    environment {
-                        TEST_TYPE = "image"
-                        DISTRO_CODE = "rhel_90"
-                        AWS_CREDS = credentials('aws-credentials-osbuildci')
-                        AWS_IMAGE_TEST_CREDS = credentials('aws-credentials-osbuild-image-test')
-                        AZURE_CREDS = credentials('azure')
-                        OPENSTACK_CREDS = credentials("psi-openstack-creds")
-                        VCENTER_CREDS = credentials('vmware-vcenter-credentials')
-                    }
-                    steps {
-                        run_tests('image')
-                    }
-                    post {
-                        always {
-                            preserve_logs('rhel90-image')
-                            sh (
-                                label: "Run cloud cleaner just in case something failed",
-                                script: "schutzbot/run_cloud_cleaner.sh"
-                            )
-                        }
-                    }
-                }
                 stage('EL9.0 Integration') {
                     agent { label "rhel84cloudbase && x86_64 && psi" }
                     environment {
@@ -805,37 +633,6 @@ pipeline {
                     post {
                         always {
                             preserve_logs('cs8-base')
-                        }
-                    }
-                }
-                stage('CS8 Image') {
-                    when {
-                        beforeAgent true
-                        expression {
-                            return env.BUILD_CAUSE != 'cron';
-                        }
-                    }
-
-                    agent { label "cs8cloudbase && psi && x86_64" }
-                    environment {
-                        TEST_TYPE = "image"
-                        DISTRO_CODE = "centos_8"
-                        AWS_CREDS = credentials('aws-credentials-osbuildci')
-                        AWS_IMAGE_TEST_CREDS = credentials('aws-credentials-osbuild-image-test')
-                        AZURE_CREDS = credentials('azure')
-                        OPENSTACK_CREDS = credentials("psi-openstack-creds")
-                        VCENTER_CREDS = credentials('vmware-vcenter-credentials')
-                    }
-                    steps {
-                        run_tests('image')
-                    }
-                    post {
-                        always {
-                            preserve_logs('cs8-image')
-                            sh (
-                                label: "Run cloud cleaner just in case something failed",
-                                script: "schutzbot/run_cloud_cleaner.sh"
-                            )
                         }
                     }
                 }
@@ -890,37 +687,6 @@ pipeline {
                     post {
                         always {
                             preserve_logs('cs8-aarch64-base')
-                        }
-                    }
-                }
-                stage('CS8 aarch64 Image') {
-                    when {
-                        beforeAgent true
-                        expression {
-                            return env.BUILD_CAUSE != 'cron';
-                        }
-                    }
-
-                    agent { label "cs8cloudbase && aarch64 && aws" }
-                    environment {
-                        TEST_TYPE = "image"
-                        AWS_CREDS = credentials('aws-credentials-osbuildci')
-                        AWS_IMAGE_TEST_CREDS = credentials('aws-credentials-osbuild-image-test')
-                        AZURE_CREDS = credentials('azure')
-                        OPENSTACK_CREDS = credentials("psi-openstack-creds")
-                        VCENTER_CREDS = credentials('vmware-vcenter-credentials')
-                        DISTRO_CODE = "centos_8"
-                    }
-                    steps {
-                        run_tests('image')
-                    }
-                    post {
-                        always {
-                            preserve_logs('cs8-aarch64-image')
-                            sh (
-                                label: "Run cloud cleaner just in case something failed",
-                                script: "schutzbot/run_cloud_cleaner.sh"
-                            )
                         }
                     }
                 }
@@ -998,12 +764,13 @@ void run_tests(test_type) {
         )
     }
 
-    if (test_type == 'image') {
-        sh (
-            label: "Image tests",
-            script: "/usr/libexec/tests/osbuild-composer/image_tests.sh"
-        )
-    }
+    // Disabled. See commit log for details.
+    //if (test_type == 'image') {
+    //    sh (
+    //        label: "Image tests",
+    //        script: "/usr/libexec/tests/osbuild-composer/image_tests.sh"
+    //    )
+    //}
 
     if (test_type == 'ostree') {
         sh (


### PR DESCRIPTION
- image_tests.sh is already being executed from the osbuild
  repository by installing osbuild-composer-tests & calling the
  script directly
- in this repo we've got distro_test.go::TestDistro_Manifest() and
  distro_test_common.TestDistro_Manifest() which compare the static
  manifests stored in this repository with the ones generated
  dynamically by the code base. This is executed via `go test` and
  runs against all available json files.

The above two items cover the part where we want to make sure that
the resulting content is what we expect.

Additionally the existing integration tests cover the part where
we build images, upload them to a cloud vendor and boot a new VM
from the image.


This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

For user-visible changes, "adequate documentation" is an entry describing the
change for users in docs/news. Please refer to docs/news/README.md for details.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`
-->
