### PR TITLE
test: replace genisoimage with mkisofs

### DIFF
--- a/internal/boot/context-managers.go
+++ b/internal/boot/context-managers.go
@@ -75,7 +75,7 @@ func withTempDir(dir, pattern string, f func(dir string) error) error {
 // metaData and writes it to the writer
 func writeCloudInitISO(writer io.Writer, userData, metaData string) error {
 	isoCmd := exec.Command(
-		"genisoimage",
+		"mkisofs",
 		"-quiet",
 		"-input-charset", "utf-8",
 		"-volid", "cidata",

--- a/osbuild-composer.spec
+++ b/osbuild-composer.spec
@@ -311,7 +311,7 @@ Summary:    Integration tests
 Requires:   %{name} = %{version}-%{release}
 Requires:   composer-cli
 Requires:   createrepo_c
-Requires:   genisoimage
+Requires:   xorriso
 Requires:   qemu-kvm-core
 Requires:   systemd-container
 Requires:   jq

--- a/tools/deploy-qemu
+++ b/tools/deploy-qemu
@@ -44,7 +44,7 @@ echo -e "instance-id: nocloud\nlocal-hostname: vm\n" > "$workdir/cidata/meta-dat
 
 case $(uname -s) in
   "Linux")
-    genisoimage \
+    mkisofs \
       -input-charset utf-8 \
       -output "$workdir/cloudinit.iso" \
       -volid cidata \

--- a/tools/libvirt_test.sh
+++ b/tools/libvirt_test.sh
@@ -228,7 +228,7 @@ greenprint "💿 Creating a cloud-init ISO"
 CLOUD_INIT_PATH=/var/lib/libvirt/images/seed.iso
 rm -f $CLOUD_INIT_PATH
 pushd "$CLOUD_INIT_DIR"
-    sudo genisoimage -o $CLOUD_INIT_PATH -V cidata \
+    sudo mkisofs -o $CLOUD_INIT_PATH -V cidata \
         -r -J user-data meta-data network-config > /dev/null 2>&1
 popd
 

--- a/tools/test-case-generators/generate-all-test-cases
+++ b/tools/test-case-generators/generate-all-test-cases
@@ -437,7 +437,7 @@ class BaseRunner(contextlib.AbstractContextManager):
         if sysname == "Linux":
             subprocess.check_call(
                 [
-                    "genisoimage",
+                    "mkisofs",
                     "-input-charset", "utf-8",
                     "-output", iso_path,
                     "-volid", "cidata",


### PR DESCRIPTION
genisoimage might be removed from RHEL 9. The users are advised to switch
to mkisofs tools from the xorriso package. It should be a drop-in replacement.

The same change was recently done by libguestfs:

https://github.com/libguestfs/libguestfs/commit/efb8a766cac4ba8e413594946136bf91e176bb8c
https://github.com/libguestfs/libguestfs/commit/2216ab2e328457ef172d6bfa534272edf2f81a3a

Signed-off-by: Ondřej Budai <ondrej@budai.cz>


This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

For user-visible changes, "adequate documentation" is an entry describing the
change for users in docs/news. Please refer to docs/news/README.md for details.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`
-->
