### PR TITLE
disable nightly tests on main

### DIFF
--- a/schutzbot/Jenkinsfile
+++ b/schutzbot/Jenkinsfile
@@ -594,6 +594,13 @@ pipeline {
                     }
                 }
                 stage('EL9.0 Integration') {
+                    when {
+                        beforeAgent true
+                        expression {
+                            return env.BUILD_CAUSE != 'cron';
+                        }
+                    }
+
                     agent { label "rhel84cloudbase && x86_64 && psi" }
                     environment {
                         TEST_TYPE = "integration"

--- a/schutzbot/Jenkinsfile
+++ b/schutzbot/Jenkinsfile
@@ -3,9 +3,12 @@ def cron_string = BRANCH_NAME == "main" ? "@daily" : ""
 pipeline {
     agent none
 
-    triggers {
-        cron(cron_string)
-    }
+// Don't run the nightly test on main. Main currently doesn't match the
+// osbuild-composer version shipped in any RHEL versions.
+// We should resume this when we start rebasing again.
+//    triggers {
+//        cron(cron_string)
+//    }
 
     environment {
         AWS_REGION = "us-east-2"


### PR DESCRIPTION
Don't run the nightly test on main. Main currently doesn't match the
osbuild-composer version shipped in any RHEL versions.
We should resume this when we start rebasing again.

Additionally, RHEL 9 test will be never triggered anymore on the nightly test.