### PR TITLE
test: Remove selinux work around and Schutzfile osbuild pinning

### DIFF
--- a/Schutzfile
+++ b/Schutzfile
@@ -21,13 +21,6 @@
       }
     }
   },
-  "rhel-8.4": {
-    "dependencies": {
-      "osbuild": {
-        "commit": "5de2d3f96bd4841738846d5e4f1e0e4ed01e7a2a"
-      }
-    }
-  },
   "centos-8": {
     "dependencies": {
       "osbuild": {

--- a/test/cases/ostree-ng.sh
+++ b/test/cases/ostree-ng.sh
@@ -267,8 +267,6 @@ sudo podman rmi -f -a
 greenprint "🗜 Extracting and running the image"
 IMAGE_FILENAME="${COMPOSE_ID}-rhel84-container.tar"
 sudo podman pull "oci-archive:${IMAGE_FILENAME}"
-# Workaound for issue https://bugzilla.redhat.com/show_bug.cgi?id=1933774
-sudo restorecon -R /var/lib/containers/storage/overlay/
 sudo podman images
 # Clear image file
 sudo rm -f "$IMAGE_FILENAME"
@@ -479,8 +477,6 @@ sudo podman rmi -f -a
 greenprint "🗜 Extracting and running the image"
 IMAGE_FILENAME="${COMPOSE_ID}-rhel84-container.tar"
 sudo podman pull "oci-archive:${IMAGE_FILENAME}"
-# Workaound for issue https://bugzilla.redhat.com/show_bug.cgi?id=1933774
-sudo restorecon -R /var/lib/containers/storage/overlay/
 sudo podman images
 # Clear image file
 sudo rm -f "$IMAGE_FILENAME"


### PR DESCRIPTION
Since selinux fix has been release in osbuild 27.1 and it's in nightly compose. It's time to remove selinux work around and Schutzfile osbuild pinning