### PR TITLE
test: Replace API calling with composer-cli

### DIFF
--- a/test/cases/ostree-ng.sh
+++ b/test/cases/ostree-ng.sh
@@ -118,23 +118,9 @@ build_image() {
     greenprint "🚀 Starting compose"
     if [ $# -eq 3 ]; then
         repo_url=$3
-        sudo curl --silent --header "Content-Type: application/json" --unix-socket /run/weldr/api.socket http://localhost/api/v1/compose --data "{
-            \"blueprint_name\": \"$blueprint_name\",
-            \"compose_type\": \"$image_type\",
-            \"ostree\": {
-                \"url\": \"$repo_url\",
-                \"ref\": \"$OSTREE_REF\"
-            }
-        }" | tee "$COMPOSE_START"
+        sudo composer-cli --json compose start-ostree --ref "$OSTREE_REF" --url "$repo_url" "$blueprint_name" "$image_type" | tee "$COMPOSE_START"
     else
-        # Test ref begining with /
-        sudo curl --silent --header "Content-Type: application/json" --unix-socket /run/weldr/api.socket http://localhost/api/v1/compose --data "{
-            \"blueprint_name\": \"$blueprint_name\",
-            \"compose_type\": \"$image_type\",
-            \"ostree\": {
-                \"ref\": \"$OSTREE_REF\"
-            }
-        }" | tee "$COMPOSE_START"
+        sudo composer-cli --json compose start-ostree "$blueprint_name" "$image_type" | tee "$COMPOSE_START"
     fi
     COMPOSE_ID=$(jq -r '.build_id' "$COMPOSE_START")
 


### PR DESCRIPTION
composer-cli-28.14.58 is in nightly compose of RHEL 8.4, it's time to replace API calling with composer-cli