### PR TITLE
image-info: show format version for qcow2

### DIFF
--- a/test/data/manifests/centos_8-x86_64-ami-boot.json
+++ b/test/data/manifests/centos_8-x86_64-ami-boot.json
@@ -10329,7 +10329,9 @@
       "video:x:39:",
       "wheel:x:10:"
     ],
-    "image-format": "raw",
+    "image-format": {
+      "type": "raw"
+    },
     "os-release": {
       "ANSI_COLOR": "0;31",
       "BUG_REPORT_URL": "https://bugzilla.redhat.com/",

--- a/test/data/manifests/centos_8-x86_64-openstack-boot.json
+++ b/test/data/manifests/centos_8-x86_64-openstack-boot.json
@@ -11038,7 +11038,10 @@
       "video:x:39:",
       "wheel:x:10:"
     ],
-    "image-format": "qcow2",
+    "image-format": {
+      "type": "qcow2",
+      "compat": "1.1"
+    },
     "os-release": {
       "ANSI_COLOR": "0;31",
       "BUG_REPORT_URL": "https://bugzilla.redhat.com/",

--- a/test/data/manifests/centos_8-x86_64-qcow2-boot.json
+++ b/test/data/manifests/centos_8-x86_64-qcow2-boot.json
@@ -11030,7 +11030,10 @@
       "video:x:39:",
       "wheel:x:10:"
     ],
-    "image-format": "qcow2",
+    "image-format": {
+      "type": "qcow2",
+      "compat": "1.1"
+    },
     "os-release": {
       "ANSI_COLOR": "0;31",
       "BUG_REPORT_URL": "https://bugzilla.redhat.com/",

--- a/test/data/manifests/centos_8-x86_64-qcow2-customize.json
+++ b/test/data/manifests/centos_8-x86_64-qcow2-customize.json
@@ -11124,7 +11124,10 @@
       "wheel:x:10:"
     ],
     "hostname": "my-host",
-    "image-format": "qcow2",
+    "image-format": {
+      "type": "qcow2",
+      "compat": "1.1"
+    },
     "os-release": {
       "ANSI_COLOR": "0;31",
       "BUG_REPORT_URL": "https://bugzilla.redhat.com/",

--- a/test/data/manifests/centos_8-x86_64-vhd-boot.json
+++ b/test/data/manifests/centos_8-x86_64-vhd-boot.json
@@ -10952,7 +10952,9 @@
       "video:x:39:",
       "wheel:x:10:"
     ],
-    "image-format": "raw",
+    "image-format": {
+      "type": "raw"
+    },
     "os-release": {
       "ANSI_COLOR": "0;31",
       "BUG_REPORT_URL": "https://bugzilla.redhat.com/",

--- a/test/data/manifests/centos_8-x86_64-vmdk-boot.json
+++ b/test/data/manifests/centos_8-x86_64-vmdk-boot.json
@@ -10540,7 +10540,9 @@
       "video:x:39:",
       "wheel:x:10:"
     ],
-    "image-format": "vmdk",
+    "image-format": {
+      "type": "vmdk"
+    },
     "os-release": {
       "ANSI_COLOR": "0;31",
       "BUG_REPORT_URL": "https://bugzilla.redhat.com/",

--- a/test/data/manifests/fedora_32-aarch64-ami-boot.json
+++ b/test/data/manifests/fedora_32-aarch64-ami-boot.json
@@ -8957,7 +8957,9 @@
       "video:x:39:",
       "wheel:x:10:"
     ],
-    "image-format": "raw",
+    "image-format": {
+      "type": "raw"
+    },
     "os-release": {
       "ANSI_COLOR": "0;34",
       "BUG_REPORT_URL": "https://bugzilla.redhat.com/",

--- a/test/data/manifests/fedora_32-aarch64-openstack-boot.json
+++ b/test/data/manifests/fedora_32-aarch64-openstack-boot.json
@@ -9311,7 +9311,10 @@
       "video:x:39:",
       "wheel:x:10:"
     ],
-    "image-format": "qcow2",
+    "image-format": {
+      "type": "qcow2",
+      "compat": "1.1"
+    },
     "os-release": {
       "ANSI_COLOR": "0;34",
       "BUG_REPORT_URL": "https://bugzilla.redhat.com/",

--- a/test/data/manifests/fedora_32-aarch64-qcow2-boot.json
+++ b/test/data/manifests/fedora_32-aarch64-qcow2-boot.json
@@ -8811,7 +8811,10 @@
       "video:x:39:",
       "wheel:x:10:"
     ],
-    "image-format": "qcow2",
+    "image-format": {
+      "type": "qcow2",
+      "compat": "1.1"
+    },
     "os-release": {
       "ANSI_COLOR": "0;34",
       "BUG_REPORT_URL": "https://bugzilla.redhat.com/",

--- a/test/data/manifests/fedora_32-x86_64-ami-boot.json
+++ b/test/data/manifests/fedora_32-x86_64-ami-boot.json
@@ -9207,7 +9207,9 @@
       "video:x:39:",
       "wheel:x:10:"
     ],
-    "image-format": "raw",
+    "image-format": {
+      "type": "raw"
+    },
     "os-release": {
       "ANSI_COLOR": "0;34",
       "BUG_REPORT_URL": "https://bugzilla.redhat.com/",

--- a/test/data/manifests/fedora_32-x86_64-openstack-boot.json
+++ b/test/data/manifests/fedora_32-x86_64-openstack-boot.json
@@ -9561,7 +9561,10 @@
       "video:x:39:",
       "wheel:x:10:"
     ],
-    "image-format": "qcow2",
+    "image-format": {
+      "type": "qcow2",
+      "compat": "1.1"
+    },
     "os-release": {
       "ANSI_COLOR": "0;34",
       "BUG_REPORT_URL": "https://bugzilla.redhat.com/",

--- a/test/data/manifests/fedora_32-x86_64-qcow2-boot.json
+++ b/test/data/manifests/fedora_32-x86_64-qcow2-boot.json
@@ -9197,7 +9197,10 @@
       "video:x:39:",
       "wheel:x:10:"
     ],
-    "image-format": "qcow2",
+    "image-format": {
+      "type": "qcow2",
+      "compat": "1.1"
+    },
     "os-release": {
       "ANSI_COLOR": "0;34",
       "BUG_REPORT_URL": "https://bugzilla.redhat.com/",

--- a/test/data/manifests/fedora_32-x86_64-qcow2-customize.json
+++ b/test/data/manifests/fedora_32-x86_64-qcow2-customize.json
@@ -9312,7 +9312,10 @@
       "wheel:x:10:"
     ],
     "hostname": "my-host",
-    "image-format": "qcow2",
+    "image-format": {
+      "type": "qcow2",
+      "compat": "1.1"
+    },
     "os-release": {
       "ANSI_COLOR": "0;34",
       "BUG_REPORT_URL": "https://bugzilla.redhat.com/",

--- a/test/data/manifests/fedora_32-x86_64-vhd-boot.json
+++ b/test/data/manifests/fedora_32-x86_64-vhd-boot.json
@@ -8809,7 +8809,9 @@
       "video:x:39:",
       "wheel:x:10:"
     ],
-    "image-format": "raw",
+    "image-format": {
+      "type": "raw"
+    },
     "os-release": {
       "ANSI_COLOR": "0;34",
       "BUG_REPORT_URL": "https://bugzilla.redhat.com/",

--- a/test/data/manifests/fedora_32-x86_64-vmdk-boot.json
+++ b/test/data/manifests/fedora_32-x86_64-vmdk-boot.json
@@ -8915,7 +8915,9 @@
       "video:x:39:",
       "wheel:x:10:"
     ],
-    "image-format": "vmdk",
+    "image-format": {
+      "type": "vmdk"
+    },
     "os-release": {
       "ANSI_COLOR": "0;34",
       "BUG_REPORT_URL": "https://bugzilla.redhat.com/",

--- a/test/data/manifests/fedora_33-aarch64-ami-boot.json
+++ b/test/data/manifests/fedora_33-aarch64-ami-boot.json
@@ -9878,7 +9878,9 @@
       "wheel:x:10:"
     ],
     "hostname": "localhost.localdomain",
-    "image-format": "raw",
+    "image-format": {
+      "type": "raw"
+    },
     "os-release": {
       "ANSI_COLOR": "0;38;2;60;110;180",
       "BUG_REPORT_URL": "https://bugzilla.redhat.com/",

--- a/test/data/manifests/fedora_33-x86_64-ami-boot.json
+++ b/test/data/manifests/fedora_33-x86_64-ami-boot.json
@@ -9449,7 +9449,9 @@
       "wheel:x:10:"
     ],
     "hostname": "localhost.localdomain",
-    "image-format": "raw",
+    "image-format": {
+      "type": "raw"
+    },
     "os-release": {
       "ANSI_COLOR": "0;38;2;60;110;180",
       "BUG_REPORT_URL": "https://bugzilla.redhat.com/",

--- a/test/data/manifests/fedora_33-x86_64-openstack-boot.json
+++ b/test/data/manifests/fedora_33-x86_64-openstack-boot.json
@@ -9768,7 +9768,10 @@
       "wheel:x:10:"
     ],
     "hostname": "localhost.localdomain",
-    "image-format": "qcow2",
+    "image-format": {
+      "type": "qcow2",
+      "compat": "1.1"
+    },
     "os-release": {
       "ANSI_COLOR": "0;38;2;60;110;180",
       "BUG_REPORT_URL": "https://bugzilla.redhat.com/",

--- a/test/data/manifests/fedora_33-x86_64-qcow2-boot.json
+++ b/test/data/manifests/fedora_33-x86_64-qcow2-boot.json
@@ -9389,7 +9389,10 @@
       "wheel:x:10:"
     ],
     "hostname": "localhost.localdomain",
-    "image-format": "qcow2",
+    "image-format": {
+      "type": "qcow2",
+      "compat": "1.1"
+    },
     "os-release": {
       "ANSI_COLOR": "0;38;2;60;110;180",
       "BUG_REPORT_URL": "https://bugzilla.redhat.com/",

--- a/test/data/manifests/fedora_33-x86_64-qcow2-customize.json
+++ b/test/data/manifests/fedora_33-x86_64-qcow2-customize.json
@@ -9492,7 +9492,10 @@
       "wheel:x:10:"
     ],
     "hostname": "my-host",
-    "image-format": "qcow2",
+    "image-format": {
+      "type": "qcow2",
+      "compat": "1.1"
+    },
     "os-release": {
       "ANSI_COLOR": "0;38;2;60;110;180",
       "BUG_REPORT_URL": "https://bugzilla.redhat.com/",

--- a/test/data/manifests/fedora_33-x86_64-vhd-boot.json
+++ b/test/data/manifests/fedora_33-x86_64-vhd-boot.json
@@ -9051,7 +9051,9 @@
       "wheel:x:10:"
     ],
     "hostname": "localhost.localdomain",
-    "image-format": "raw",
+    "image-format": {
+      "type": "raw"
+    },
     "os-release": {
       "ANSI_COLOR": "0;38;2;60;110;180",
       "BUG_REPORT_URL": "https://bugzilla.redhat.com/",

--- a/test/data/manifests/fedora_33-x86_64-vmdk-boot.json
+++ b/test/data/manifests/fedora_33-x86_64-vmdk-boot.json
@@ -9389,7 +9389,9 @@
       "wheel:x:10:"
     ],
     "hostname": "localhost.localdomain",
-    "image-format": "vmdk",
+    "image-format": {
+      "type": "vmdk"
+    },
     "os-release": {
       "ANSI_COLOR": "0;38;2;60;110;180",
       "BUG_REPORT_URL": "https://bugzilla.redhat.com/",

--- a/test/data/manifests/rhel_8-aarch64-ami-boot.json
+++ b/test/data/manifests/rhel_8-aarch64-ami-boot.json
@@ -8569,7 +8569,9 @@
       "video:x:39:",
       "wheel:x:10:"
     ],
-    "image-format": "raw",
+    "image-format": {
+      "type": "raw"
+    },
     "os-release": {
       "ANSI_COLOR": "0;31",
       "BUG_REPORT_URL": "https://bugzilla.redhat.com/",

--- a/test/data/manifests/rhel_8-aarch64-openstack-boot.json
+++ b/test/data/manifests/rhel_8-aarch64-openstack-boot.json
@@ -9138,7 +9138,10 @@
       "video:x:39:",
       "wheel:x:10:"
     ],
-    "image-format": "qcow2",
+    "image-format": {
+      "type": "qcow2",
+      "compat": "1.1"
+    },
     "os-release": {
       "ANSI_COLOR": "0;31",
       "BUG_REPORT_URL": "https://bugzilla.redhat.com/",

--- a/test/data/manifests/rhel_8-aarch64-qcow2-boot.json
+++ b/test/data/manifests/rhel_8-aarch64-qcow2-boot.json
@@ -9594,7 +9594,10 @@
       "video:x:39:",
       "wheel:x:10:"
     ],
-    "image-format": "qcow2",
+    "image-format": {
+      "type": "qcow2",
+      "compat": "1.1"
+    },
     "os-release": {
       "ANSI_COLOR": "0;31",
       "BUG_REPORT_URL": "https://bugzilla.redhat.com/",

--- a/test/data/manifests/rhel_8-ppc64le-qcow2-boot.json
+++ b/test/data/manifests/rhel_8-ppc64le-qcow2-boot.json
@@ -10324,7 +10324,10 @@
       "video:x:39:",
       "wheel:x:10:"
     ],
-    "image-format": "qcow2",
+    "image-format": {
+      "type": "qcow2",
+      "compat": "1.1"
+    },
     "os-release": {
       "ANSI_COLOR": "0;31",
       "BUG_REPORT_URL": "https://bugzilla.redhat.com/",

--- a/test/data/manifests/rhel_8-s390x-qcow2-boot.json
+++ b/test/data/manifests/rhel_8-s390x-qcow2-boot.json
@@ -10204,7 +10204,10 @@
       "wheel:x:10:",
       "zkeyadm:x:996:"
     ],
-    "image-format": "qcow2",
+    "image-format": {
+      "type": "qcow2",
+      "compat": "1.1"
+    },
     "os-release": {
       "ANSI_COLOR": "0;31",
       "BUG_REPORT_URL": "https://bugzilla.redhat.com/",

--- a/test/data/manifests/rhel_8-x86_64-ami-boot.json
+++ b/test/data/manifests/rhel_8-x86_64-ami-boot.json
@@ -8557,7 +8557,9 @@
       "video:x:39:",
       "wheel:x:10:"
     ],
-    "image-format": "raw",
+    "image-format": {
+      "type": "raw"
+    },
     "os-release": {
       "ANSI_COLOR": "0;31",
       "BUG_REPORT_URL": "https://bugzilla.redhat.com/",

--- a/test/data/manifests/rhel_8-x86_64-openstack-boot.json
+++ b/test/data/manifests/rhel_8-x86_64-openstack-boot.json
@@ -9141,7 +9141,10 @@
       "video:x:39:",
       "wheel:x:10:"
     ],
-    "image-format": "qcow2",
+    "image-format": {
+      "type": "qcow2",
+      "compat": "1.1"
+    },
     "os-release": {
       "ANSI_COLOR": "0;31",
       "BUG_REPORT_URL": "https://bugzilla.redhat.com/",

--- a/test/data/manifests/rhel_8-x86_64-qcow2-boot.json
+++ b/test/data/manifests/rhel_8-x86_64-qcow2-boot.json
@@ -9567,7 +9567,10 @@
       "video:x:39:",
       "wheel:x:10:"
     ],
-    "image-format": "qcow2",
+    "image-format": {
+      "type": "qcow2",
+      "compat": "1.1"
+    },
     "os-release": {
       "ANSI_COLOR": "0;31",
       "BUG_REPORT_URL": "https://bugzilla.redhat.com/",

--- a/test/data/manifests/rhel_8-x86_64-qcow2-customize.json
+++ b/test/data/manifests/rhel_8-x86_64-qcow2-customize.json
@@ -9696,7 +9696,10 @@
       "wheel:x:10:"
     ],
     "hostname": "my-host",
-    "image-format": "qcow2",
+    "image-format": {
+      "type": "qcow2",
+      "compat": "1.1"
+    },
     "os-release": {
       "ANSI_COLOR": "0;31",
       "BUG_REPORT_URL": "https://bugzilla.redhat.com/",

--- a/test/data/manifests/rhel_8-x86_64-vhd-boot.json
+++ b/test/data/manifests/rhel_8-x86_64-vhd-boot.json
@@ -9050,7 +9050,9 @@
       "video:x:39:",
       "wheel:x:10:"
     ],
-    "image-format": "raw",
+    "image-format": {
+      "type": "raw"
+    },
     "os-release": {
       "ANSI_COLOR": "0;31",
       "BUG_REPORT_URL": "https://bugzilla.redhat.com/",

--- a/test/data/manifests/rhel_8-x86_64-vmdk-boot.json
+++ b/test/data/manifests/rhel_8-x86_64-vmdk-boot.json
@@ -8693,7 +8693,9 @@
       "video:x:39:",
       "wheel:x:10:"
     ],
-    "image-format": "vmdk",
+    "image-format": {
+      "type": "vmdk"
+    },
     "os-release": {
       "ANSI_COLOR": "0;31",
       "BUG_REPORT_URL": "https://bugzilla.redhat.com/",

--- a/test/data/manifests/rhel_84-aarch64-ami-boot.json
+++ b/test/data/manifests/rhel_84-aarch64-ami-boot.json
@@ -8981,7 +8981,9 @@
       "video:x:39:",
       "wheel:x:10:"
     ],
-    "image-format": "raw",
+    "image-format": {
+      "type": "raw"
+    },
     "os-release": {
       "ANSI_COLOR": "0;31",
       "BUG_REPORT_URL": "https://bugzilla.redhat.com/",

--- a/test/data/manifests/rhel_84-aarch64-openstack-boot.json
+++ b/test/data/manifests/rhel_84-aarch64-openstack-boot.json
@@ -9550,7 +9550,10 @@
       "video:x:39:",
       "wheel:x:10:"
     ],
-    "image-format": "qcow2",
+    "image-format": {
+      "type": "qcow2",
+      "compat": "1.1"
+    },
     "os-release": {
       "ANSI_COLOR": "0;31",
       "BUG_REPORT_URL": "https://bugzilla.redhat.com/",

--- a/test/data/manifests/rhel_84-aarch64-qcow2-boot.json
+++ b/test/data/manifests/rhel_84-aarch64-qcow2-boot.json
@@ -9472,7 +9472,10 @@
       "video:x:39:",
       "wheel:x:10:"
     ],
-    "image-format": "qcow2",
+    "image-format": {
+      "type": "qcow2",
+      "compat": "1.1"
+    },
     "os-release": {
       "ANSI_COLOR": "0;31",
       "BUG_REPORT_URL": "https://bugzilla.redhat.com/",

--- a/test/data/manifests/rhel_84-ppc64le-qcow2-boot.json
+++ b/test/data/manifests/rhel_84-ppc64le-qcow2-boot.json
@@ -10199,7 +10199,10 @@
       "video:x:39:",
       "wheel:x:10:"
     ],
-    "image-format": "qcow2",
+    "image-format": {
+      "type": "qcow2",
+      "compat": "1.1"
+    },
     "os-release": {
       "ANSI_COLOR": "0;31",
       "BUG_REPORT_URL": "https://bugzilla.redhat.com/",

--- a/test/data/manifests/rhel_84-s390x-qcow2-boot.json
+++ b/test/data/manifests/rhel_84-s390x-qcow2-boot.json
@@ -10131,7 +10131,10 @@
       "wheel:x:10:",
       "zkeyadm:x:996:"
     ],
-    "image-format": "qcow2",
+    "image-format": {
+      "type": "qcow2",
+      "compat": "1.1"
+    },
     "os-release": {
       "ANSI_COLOR": "0;31",
       "BUG_REPORT_URL": "https://bugzilla.redhat.com/",

--- a/test/data/manifests/rhel_84-x86_64-ami-boot.json
+++ b/test/data/manifests/rhel_84-x86_64-ami-boot.json
@@ -9149,7 +9149,9 @@
       "video:x:39:",
       "wheel:x:10:"
     ],
-    "image-format": "raw",
+    "image-format": {
+      "type": "raw"
+    },
     "os-release": {
       "ANSI_COLOR": "0;31",
       "BUG_REPORT_URL": "https://bugzilla.redhat.com/",

--- a/test/data/manifests/rhel_84-x86_64-openstack-boot.json
+++ b/test/data/manifests/rhel_84-x86_64-openstack-boot.json
@@ -9733,7 +9733,10 @@
       "video:x:39:",
       "wheel:x:10:"
     ],
-    "image-format": "qcow2",
+    "image-format": {
+      "type": "qcow2",
+      "compat": "1.1"
+    },
     "os-release": {
       "ANSI_COLOR": "0;31",
       "BUG_REPORT_URL": "https://bugzilla.redhat.com/",

--- a/test/data/manifests/rhel_84-x86_64-qcow2-boot.json
+++ b/test/data/manifests/rhel_84-x86_64-qcow2-boot.json
@@ -9610,7 +9610,10 @@
       "video:x:39:",
       "wheel:x:10:"
     ],
-    "image-format": "qcow2",
+    "image-format": {
+      "type": "qcow2",
+      "compat": "1.1"
+    },
     "os-release": {
       "ANSI_COLOR": "0;31",
       "BUG_REPORT_URL": "https://bugzilla.redhat.com/",

--- a/test/data/manifests/rhel_84-x86_64-qcow2-customize.json
+++ b/test/data/manifests/rhel_84-x86_64-qcow2-customize.json
@@ -9706,7 +9706,10 @@
       "wheel:x:10:"
     ],
     "hostname": "my-host",
-    "image-format": "qcow2",
+    "image-format": {
+      "type": "qcow2",
+      "compat": "1.1"
+    },
     "os-release": {
       "ANSI_COLOR": "0;31",
       "BUG_REPORT_URL": "https://bugzilla.redhat.com/",

--- a/test/data/manifests/rhel_84-x86_64-vhd-boot.json
+++ b/test/data/manifests/rhel_84-x86_64-vhd-boot.json
@@ -9657,7 +9657,9 @@
       "video:x:39:",
       "wheel:x:10:"
     ],
-    "image-format": "raw",
+    "image-format": {
+      "type": "raw"
+    },
     "os-release": {
       "ANSI_COLOR": "0;31",
       "BUG_REPORT_URL": "https://bugzilla.redhat.com/",

--- a/test/data/manifests/rhel_84-x86_64-vmdk-boot.json
+++ b/test/data/manifests/rhel_84-x86_64-vmdk-boot.json
@@ -9308,7 +9308,9 @@
       "video:x:39:",
       "wheel:x:10:"
     ],
-    "image-format": "vmdk",
+    "image-format": {
+      "type": "vmdk"
+    },
     "os-release": {
       "ANSI_COLOR": "0;31",
       "BUG_REPORT_URL": "https://bugzilla.redhat.com/",

--- a/test/data/manifests/rhel_90-aarch64-qcow2-boot.json
+++ b/test/data/manifests/rhel_90-aarch64-qcow2-boot.json
@@ -9569,7 +9569,10 @@
       "wheel:x:10:"
     ],
     "hostname": "localhost.localdomain",
-    "image-format": "qcow2",
+    "image-format": {
+      "type": "qcow2",
+      "compat": "1.1"
+    },
     "os-release": {
       "ANSI_COLOR": "0;31",
       "BUG_REPORT_URL": "https://bugzilla.redhat.com/",

--- a/test/data/manifests/rhel_90-ppc64le-qcow2-boot.json
+++ b/test/data/manifests/rhel_90-ppc64le-qcow2-boot.json
@@ -10320,7 +10320,10 @@
       "wheel:x:10:"
     ],
     "hostname": "localhost.localdomain",
-    "image-format": "qcow2",
+    "image-format": {
+      "type": "qcow2",
+      "compat": "1.1"
+    },
     "os-release": {
       "ANSI_COLOR": "0;31",
       "BUG_REPORT_URL": "https://bugzilla.redhat.com/",

--- a/test/data/manifests/rhel_90-s390x-qcow2-boot.json
+++ b/test/data/manifests/rhel_90-s390x-qcow2-boot.json
@@ -9775,7 +9775,10 @@
       "zkeyadm:x:987:"
     ],
     "hostname": "localhost.localdomain",
-    "image-format": "qcow2",
+    "image-format": {
+      "type": "qcow2",
+      "compat": "1.1"
+    },
     "os-release": {
       "ANSI_COLOR": "0;31",
       "BUG_REPORT_URL": "https://bugzilla.redhat.com/",

--- a/test/data/manifests/rhel_90-x86_64-qcow2-boot.json
+++ b/test/data/manifests/rhel_90-x86_64-qcow2-boot.json
@@ -9706,7 +9706,10 @@
       "wheel:x:10:"
     ],
     "hostname": "localhost.localdomain",
-    "image-format": "qcow2",
+    "image-format": {
+      "type": "qcow2",
+      "compat": "1.1"
+    },
     "os-release": {
       "ANSI_COLOR": "0;31",
       "BUG_REPORT_URL": "https://bugzilla.redhat.com/",

--- a/tools/image-info
+++ b/tools/image-info
@@ -152,7 +152,11 @@ def subprocess_check_output(argv, parse_fn=None):
 
 def read_image_format(device):
     qemu = subprocess_check_output(["qemu-img", "info", "--output=json", device], json.loads)
-    return qemu["format"]
+    format = qemu["format"]
+    result = {"type": format}
+    if format == "qcow2":
+        result["compat"] = qemu["format-specific"]["data"]["compat"]
+    return result
 
 
 def read_partition(device, partition):


### PR DESCRIPTION
Change the "image-format" from a string to a dict, with a "type":
$value entry, where $value contains the previous plain string
data.
Additionally, include the qcow2 format version, if the given
image is indeed a qcow2.
Adapt all manifest test accordingly.


This pull request includes:

- [x] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] create a file in [news/unreleased](https://github.com/osbuild/osbuild-composer/tree/main/docs/news/unreleased) directory if this change should be mentioned in the release news
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/
