### PR TITLE
distro: remove unused field from `distribution` struct

### DIFF
--- a/internal/distro/fedora32/distro.go
+++ b/internal/distro/fedora32/distro.go
@@ -22,7 +22,6 @@ const ostreeRef = "fedora/32/%s/iot"
 
 type distribution struct {
 	arches        map[string]architecture
-	imageTypes    map[string]imageType
 	buildPackages []string
 }
 
@@ -765,7 +764,6 @@ func New() distro.Distro {
 	}
 
 	r := distribution{
-		imageTypes: map[string]imageType{},
 		buildPackages: []string{
 			"dnf",
 			"dosfstools",

--- a/internal/distro/fedora33/distro.go
+++ b/internal/distro/fedora33/distro.go
@@ -22,7 +22,6 @@ const ostreeRef = "fedora/33/%s/iot"
 
 type distribution struct {
 	arches        map[string]architecture
-	imageTypes    map[string]imageType
 	buildPackages []string
 }
 
@@ -800,7 +799,6 @@ func New() distro.Distro {
 	}
 
 	r := distribution{
-		imageTypes: map[string]imageType{},
 		buildPackages: []string{
 			"dnf",
 			"dosfstools",

--- a/internal/distro/rhel8/distro.go
+++ b/internal/distro/rhel8/distro.go
@@ -22,7 +22,6 @@ const ostreeRef = "rhel/8/%s/edge"
 
 type distribution struct {
 	arches        map[string]architecture
-	imageTypes    map[string]imageType
 	buildPackages []string
 }
 
@@ -1025,7 +1024,6 @@ func New() distro.Distro {
 	}
 
 	r := distribution{
-		imageTypes: map[string]imageType{},
 		buildPackages: []string{
 			"dnf",
 			"dosfstools",

--- a/internal/distro/rhel84/distro.go
+++ b/internal/distro/rhel84/distro.go
@@ -26,7 +26,6 @@ const ostreeRef = "rhel/8/%s/edge"
 
 type distribution struct {
 	arches        map[string]architecture
-	imageTypes    map[string]distro.ImageType
 	buildPackages []string
 	isCentos      bool
 }
@@ -1208,7 +1207,6 @@ func newDistro(isCentos bool) distro.Distro {
 	}
 
 	r := distribution{
-		imageTypes: map[string]distro.ImageType{},
 		buildPackages: []string{
 			"dnf",
 			"dosfstools",

--- a/internal/distro/rhel90/distro.go
+++ b/internal/distro/rhel90/distro.go
@@ -24,7 +24,6 @@ const modulePlatformID = "platform:el9"
 
 type distribution struct {
 	arches        map[string]architecture
-	imageTypes    map[string]distro.ImageType
 	buildPackages []string
 }
 
@@ -801,7 +800,6 @@ func New() distro.Distro {
 	}
 
 	r := distribution{
-		imageTypes: map[string]distro.ImageType{},
 		buildPackages: []string{
 			"dnf",
 			"dosfstools",


### PR DESCRIPTION
The `distribution` struct defined in multiple distributions contained unused `imageTypes` field. Remove it to simplify code.