### PR TITLE
distro: remove excluded package if explicitly specified in the bp

### DIFF
--- a/internal/distro/fedora32/distro.go
+++ b/internal/distro/fedora32/distro.go
@@ -51,6 +51,19 @@ type imageType struct {
 	assembler        func(uefi bool, options distro.ImageOptions, arch distro.Arch) *osbuild.Assembler
 }
 
+func removePackage(packages []string, packageToRemove string) []string {
+	for i, pkg := range packages {
+		if pkg == packageToRemove {
+			// override the package with the last one from the list
+			packages[i] = packages[len(packages)-1]
+
+			// drop the last package from the slice
+			return packages[:len(packages)-1]
+		}
+	}
+	return packages
+}
+
 func (a *architecture) Distro() distro.Distro {
 	return a.distro
 }
@@ -175,7 +188,18 @@ func (t *imageType) Packages(bp blueprint.Blueprint) ([]string, []string) {
 		packages = append(packages, t.arch.bootloaderPackages...)
 	}
 
-	return packages, t.excludedPackages
+	// copy the list of excluded packages from the image type
+	// and subtract any packages found in the blueprint (this
+	// will not handle the issue with dependencies present in
+	// the list of excluded packages, but it will create a
+	// possibility of a workaround at least)
+	excludedPackages := append([]string(nil), t.excludedPackages...)
+	for _, pkg := range bp.GetPackages() {
+		// removePackage is fine if the package doesn't exist
+		excludedPackages = removePackage(excludedPackages, pkg)
+	}
+
+	return packages, excludedPackages
 }
 
 func (t *imageType) BuildPackages() []string {

--- a/internal/distro/fedora33/distro.go
+++ b/internal/distro/fedora33/distro.go
@@ -51,6 +51,19 @@ type imageType struct {
 	assembler        func(uefi bool, options distro.ImageOptions, arch distro.Arch) *osbuild.Assembler
 }
 
+func removePackage(packages []string, packageToRemove string) []string {
+	for i, pkg := range packages {
+		if pkg == packageToRemove {
+			// override the package with the last one from the list
+			packages[i] = packages[len(packages)-1]
+
+			// drop the last package from the slice
+			return packages[:len(packages)-1]
+		}
+	}
+	return packages
+}
+
 func (a *architecture) Distro() distro.Distro {
 	return a.distro
 }
@@ -175,7 +188,18 @@ func (t *imageType) Packages(bp blueprint.Blueprint) ([]string, []string) {
 		packages = append(packages, t.arch.bootloaderPackages...)
 	}
 
-	return packages, t.excludedPackages
+	// copy the list of excluded packages from the image type
+	// and subtract any packages found in the blueprint (this
+	// will not handle the issue with dependencies present in
+	// the list of excluded packages, but it will create a
+	// possibility of a workaround at least)
+	excludedPackages := append([]string(nil), t.excludedPackages...)
+	for _, pkg := range bp.GetPackages() {
+		// removePackage is fine if the package doesn't exist
+		excludedPackages = removePackage(excludedPackages, pkg)
+	}
+
+	return packages, excludedPackages
 }
 
 func (t *imageType) BuildPackages() []string {

--- a/internal/distro/rhel8/distro.go
+++ b/internal/distro/rhel8/distro.go
@@ -52,6 +52,19 @@ type imageType struct {
 	assembler        func(uefi bool, options distro.ImageOptions, arch distro.Arch) *osbuild.Assembler
 }
 
+func removePackage(packages []string, packageToRemove string) []string {
+	for i, pkg := range packages {
+		if pkg == packageToRemove {
+			// override the package with the last one from the list
+			packages[i] = packages[len(packages)-1]
+
+			// drop the last package from the slice
+			return packages[:len(packages)-1]
+		}
+	}
+	return packages
+}
+
 func (a *architecture) Distro() distro.Distro {
 	return a.distro
 }
@@ -176,7 +189,19 @@ func (t *imageType) Packages(bp blueprint.Blueprint) ([]string, []string) {
 	if t.bootable {
 		packages = append(packages, t.arch.bootloaderPackages...)
 	}
-	return packages, t.excludedPackages
+
+	// copy the list of excluded packages from the image type
+	// and subtract any packages found in the blueprint (this
+	// will not handle the issue with dependencies present in
+	// the list of excluded packages, but it will create a
+	// possibility of a workaround at least)
+	excludedPackages := append([]string(nil), t.excludedPackages...)
+	for _, pkg := range bp.GetPackages() {
+		// removePackage is fine if the package doesn't exist
+		excludedPackages = removePackage(excludedPackages, pkg)
+	}
+
+	return packages, excludedPackages
 }
 
 func (t *imageType) BuildPackages() []string {

--- a/internal/distro/rhel84/distro.go
+++ b/internal/distro/rhel84/distro.go
@@ -217,7 +217,18 @@ func (t *imageType) Packages(bp blueprint.Blueprint) ([]string, []string) {
 		packages = removePackage(packages, "insights-client")
 	}
 
-	return packages, t.excludedPackages
+	// copy the list of excluded packages from the image type
+	// and subtract any packages found in the blueprint (this
+	// will not handle the issue with dependencies present in
+	// the list of excluded packages, but it will create a
+	// possibility of a workaround at least)
+	excludedPackages := append([]string(nil), t.excludedPackages...)
+	for _, pkg := range bp.GetPackages() {
+		// removePackage is fine if the package doesn't exist
+		excludedPackages = removePackage(excludedPackages, pkg)
+	}
+
+	return packages, excludedPackages
 }
 
 func (t *imageType) BuildPackages() []string {

--- a/internal/distro/rhel84/distro_v2.go
+++ b/internal/distro/rhel84/distro_v2.go
@@ -71,7 +71,19 @@ func (t *imageTypeS2) Packages(bp blueprint.Blueprint) ([]string, []string) {
 	if timezone != nil {
 		packages = append(packages, "chrony")
 	}
-	return packages, t.packageSets["packages"].Exclude
+
+	// copy the list of excluded packages from the image type
+	// and subtract any packages found in the blueprint (this
+	// will not handle the issue with dependencies present in
+	// the list of excluded packages, but it will create a
+	// possibility of a workaround at least)
+	excludedPackages := append([]string(nil), t.packageSets["packages"].Exclude...)
+	for _, pkg := range bp.GetPackages() {
+		// removePackage is fine if the package doesn't exist
+		excludedPackages = removePackage(excludedPackages, pkg)
+	}
+
+	return packages, excludedPackages
 }
 
 func (t *imageTypeS2) BuildPackages() []string {

--- a/schutzbot/Jenkinsfile
+++ b/schutzbot/Jenkinsfile
@@ -639,6 +639,10 @@ pipeline {
                     }
                     steps {
                         run_tests('base')
+                        sh (
+                            label: "Regression tests",
+                            script: "/usr/libexec/tests/osbuild-composer/regression.sh"
+                        )
                     }
                     post {
                         always {

--- a/test/cases/regression.sh
+++ b/test/cases/regression.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+set -xeuo pipefail
+
+# Provision the software under tet.
+/usr/libexec/osbuild-composer-test/provision.sh
+
+BLUEPRINT_FILE=/tmp/blueprint.toml
+COMPOSE_START=/tmp/compose-start.json
+COMPOSE_INFO=/tmp/compose-info.json
+
+# Write a basic blueprint for our image.
+tee "$BLUEPRINT_FILE" > /dev/null << EOF
+name = "redhat-lsb-core"
+description = "A base system with redhat-lsb-core"
+version = "0.0.1"
+
+[[packages]]
+name = "redhat-lsb-core"
+
+[[packages]]
+# The nss package is excluded in the RHEL8.4 image type, but it is required by the
+# redhat-lsb-core package. This test verifies it can be added again when explicitly
+# mentioned in the blueprint.
+name = "nss"
+EOF
+
+sudo composer-cli blueprints push "$BLUEPRINT_FILE"
+sudo composer-cli blueprints depsolve redhat-lsb-core
+sudo composer-cli --json compose start redhat-lsb-core qcow2 | tee "${COMPOSE_START}"
+COMPOSE_ID=$(jq -r '.build_id' "$COMPOSE_START")
+
+# Wait for the compose to finish.
+echo "⏱ Waiting for compose to finish: ${COMPOSE_ID}"
+while true; do
+    sudo composer-cli --json compose info "${COMPOSE_ID}" | tee "$COMPOSE_INFO" > /dev/null
+    COMPOSE_STATUS=$(jq -r '.queue_status' "$COMPOSE_INFO")
+
+    # Is the compose finished?
+    if [[ $COMPOSE_STATUS != RUNNING ]] && [[ $COMPOSE_STATUS != WAITING ]]; then
+        break
+    fi
+
+    # Wait 30 seconds and try again.
+    sleep 30
+done
+
+jq . "${COMPOSE_INFO}"
+
+# Did the compose finish with success?
+if [[ $COMPOSE_STATUS != FINISHED ]]; then
+    echo "Something went wrong with the compose. 😢"
+    exit 1
+fi


### PR DESCRIPTION
When a users wants to install a package that itself is excluded or its
dependency is excluded, it fails the build. There is no known workaround
for this shorcoming of our current design.

Therefore, remove a package from the list of excluded if it is
explicitly mentioned in a blueprint. This will not solve the issue with
dependencies, but it will create a possibility of a workaround.


This pull request includes:

- [x] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] create a file in [news/unreleased](https://github.com/osbuild/osbuild-composer/tree/main/docs/news/unreleased) directory if this change should be mentioned in the release news
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

For user-visible changes, "adequate documentation" is an entry describing the
change for users in docs/news. Please refer to docs/news/README.md for details.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`
-->
