### PR TITLE
tools/image-info: don't convert raw images

### DIFF
--- a/tools/image-info
+++ b/tools/image-info
@@ -64,7 +64,7 @@ def loop_open(ctl, image, *, offset=None, size=None):
 @contextlib.contextmanager
 def open_image(ctl, image, fmt):
     with tempfile.TemporaryDirectory(dir="/var/tmp") as tmp:
-        if fmt != "raw":
+        if fmt["type"] != "raw":
             target = os.path.join(tmp, "image.raw")
             # A bug exists in qemu that causes the conversion to raw to fail
             # on aarch64 systems with a LOT of CPUs. A workaround is to use


### PR DESCRIPTION
After change to image-info [1], which shows the format version for qcow2
images, the `image-format` changed from string to a dictionary. However
the `open_image()` function still compares it with string. This causes
`raw` images to be converted by the script again to `raw` format. This
change fixes the issue, so that `raw` images are not converted, but used
as they are.

[1] https://github.com/osbuild/osbuild-composer/commit/5937b9adca96ea4ffcb0865c75ca3e80c5b9b100

Signed-off-by: Tomas Hozza <thozza@redhat.com>


This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] create a file in [news/unreleased](https://github.com/osbuild/osbuild-composer/tree/main/docs/news/unreleased) directory if this change should be mentioned in the release news
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

For user-visible changes, "adequate documentation" is an entry describing the
change for users in docs/news. Please refer to docs/news/README.md for details.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`
-->
