### PR TITLE
tests: Revert a lorax patch

### DIFF
--- a/test/cases/aws.sh
+++ b/test/cases/aws.sh
@@ -19,14 +19,6 @@ fi
 # Provision the software under tet.
 /usr/libexec/osbuild-composer-test/provision.sh
 
-# Apply lorax patch to work around pytoml issues in RHEL 8.x.
-# See BZ 1843704 or https://github.com/weldr/lorax/pull/1030 for more details.
-if [[ $ID == rhel ]]; then
-    sudo sed -r -i 's#toml.load\(args\[3\]\)#toml.load(open(args[3]))#' \
-        /usr/lib/python3.6/site-packages/composer/cli/compose.py
-    sudo rm -f /usr/lib/python3.6/site-packages/composer/cli/compose.pyc
-fi
-
 # We need awscli to talk to AWS.
 if ! hash aws; then
     greenprint "Installing awscli"

--- a/test/cases/vmware.sh
+++ b/test/cases/vmware.sh
@@ -13,14 +13,6 @@ function greenprint {
 # Provision the software under tet.
 /usr/libexec/osbuild-composer-test/provision.sh
 
-# Apply lorax patch to work around pytoml issues in RHEL 8.x.
-# See BZ 1843704 or https://github.com/weldr/lorax/pull/1030 for more details.
-if [[ $ID == rhel ]]; then
-    sudo sed -r -i 's#toml.load\(args\[3\]\)#toml.load(open(args[3]))#' \
-        /usr/lib/python3.6/site-packages/composer/cli/compose.py
-    sudo rm -f /usr/lib/python3.6/site-packages/composer/cli/compose.pyc
-fi
-
 GOVC_CMD=/tmp/govc
 
 # shellcheck source=/dev/null

--- a/tools/libvirt_test.sh
+++ b/tools/libvirt_test.sh
@@ -26,14 +26,6 @@ if [[ $IMAGE_TYPE == vmdk ]]; then
     exit 0
 fi
 
-# Apply lorax patch to work around pytoml issues in RHEL 8.x.
-# See BZ 1843704 or https://github.com/weldr/lorax/pull/1030 for more details.
-if [[ $ID == rhel ]]; then
-    sudo sed -r -i 's#toml.load\(args\[3\]\)#toml.load(open(args[3]))#' \
-        /usr/lib/python3.6/site-packages/composer/cli/compose.py
-    sudo rm -f /usr/lib/python3.6/site-packages/composer/cli/compose.pyc
-fi
-
 # Colorful output.
 function greenprint {
     echo -e "\033[1;32m${1}\033[0m"


### PR DESCRIPTION
BZ 1843704 has been fixed and shipped in 8.3. We shouldn't need this
patch anymore!


This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] create a file in [news/unreleased](https://github.com/osbuild/osbuild-composer/tree/main/docs/news/unreleased) directory if this change should be mentioned in the release news
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

For user-visible changes, "adequate documentation" is an entry describing the
change for users in docs/news. Please refer to docs/news/README.md for details.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`
-->
