### PR TITLE
Suport building for other distros/releases

### DIFF
--- a/internal/blueprint/blueprint.go
+++ b/internal/blueprint/blueprint.go
@@ -17,6 +17,7 @@ type Blueprint struct {
 	Modules        []Package       `json:"modules" toml:"modules"`
 	Groups         []Group         `json:"groups" toml:"groups"`
 	Customizations *Customizations `json:"customizations,omitempty" toml:"customizations,omitempty"`
+	Distro         string          `json:"distro"`
 }
 
 type Change struct {

--- a/internal/blueprint/blueprint.go
+++ b/internal/blueprint/blueprint.go
@@ -17,7 +17,7 @@ type Blueprint struct {
 	Modules        []Package       `json:"modules" toml:"modules"`
 	Groups         []Group         `json:"groups" toml:"groups"`
 	Customizations *Customizations `json:"customizations,omitempty" toml:"customizations,omitempty"`
-	Distro         string          `json:"distro"`
+	Distro         string          `json:"distro" toml:"distro"`
 }
 
 type Change struct {

--- a/internal/client/blueprints_test.go
+++ b/internal/client/blueprints_test.go
@@ -16,6 +16,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/osbuild/osbuild-composer/internal/common"
+
 	"github.com/BurntSushi/toml"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -606,7 +608,7 @@ func TestBumpBlueprintVersionV0(t *testing.T) {
 
 	// If the blueprint already exists it needs to be deleted to start from a known state
 	sorted := sort.StringSlice(list)
-	if isStringInSlice(sorted, "test-bump-blueprint-1-v0") {
+	if common.IsStringInSlice(sorted, "test-bump-blueprint-1-v0") {
 		// Delete this blueprint if it already exists
 		resp, err := DeleteBlueprintV0(testState.socket, "test-bump-blueprint-1-v0")
 		require.NoError(t, err, "DELETE blueprint failed with a client error")

--- a/internal/client/unit_test.go
+++ b/internal/client/unit_test.go
@@ -51,7 +51,7 @@ func executeTests(m *testing.M) int {
 	}
 	repos := []rpmmd.RepoConfig{{Name: "test-system-repo", BaseURL: "http://example.com/test/os/test_arch"}}
 	logger := log.New(os.Stdout, "", 0)
-	api := weldr.New(rpm, arch, distro, repos, logger, fixture.Store, fixture.Workers, "")
+	api := weldr.NewTestAPI(rpm, arch, distro, repos, logger, fixture.Store, fixture.Workers, "")
 	server := http.Server{Handler: api}
 	defer server.Close()
 

--- a/internal/client/utils.go
+++ b/internal/client/utils.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"net"
 	"net/http"
-	"sort"
 	"strconv"
 )
 
@@ -18,17 +17,6 @@ type TestState struct {
 	apiVersion int
 	repoDir    string
 	unitTest   bool
-}
-
-// isStringInSlice returns true if the string is present, false if not
-// slice must be sorted
-// TODO decide if this belongs in a more widely useful package location
-func isStringInSlice(slice []string, s string) bool {
-	i := sort.SearchStrings(slice, s)
-	if i < len(slice) && slice[i] == s {
-		return true
-	}
-	return false
 }
 
 func setUpTestState(socketPath string, unitTest bool) (*TestState, error) {

--- a/internal/common/helpers.go
+++ b/internal/common/helpers.go
@@ -1,6 +1,9 @@
 package common
 
-import "runtime"
+import (
+	"runtime"
+	"sort"
+)
 
 var RuntimeGOARCH = runtime.GOARCH
 
@@ -22,4 +25,14 @@ func PanicOnError(err error) {
 	if err != nil {
 		panic(err)
 	}
+}
+
+// IsStringInSlice returns true if the string is present, false if not
+// slice must be sorted
+func IsStringInSlice(slice []string, s string) bool {
+	i := sort.SearchStrings(slice, s)
+	if i < len(slice) && slice[i] == s {
+		return true
+	}
+	return false
 }

--- a/internal/weldr/api.go
+++ b/internal/weldr/api.go
@@ -1742,6 +1742,22 @@ func (api *API) blueprintsNewHandler(writer http.ResponseWriter, request *http.R
 		return
 	}
 
+	// Check the blueprint's distro to make sure it is valid
+	// or if it doesn't have one set it to the host distro.
+	if len(blueprint.Distro) > 0 {
+		_, ok := api.distroRepos[blueprint.Distro]
+		if !ok {
+			errors := responseError{
+				ID:  "BlueprintsError",
+				Msg: fmt.Sprintf("'%s' is not a valid distribution", blueprint.Distro),
+			}
+			statusResponseError(writer, http.StatusBadRequest, errors)
+			return
+		}
+	} else {
+		blueprint.Distro = api.hostDistroName
+	}
+
 	commitMsg := "Recipe " + blueprint.Name + ", version " + blueprint.Version + " saved."
 	err = api.store.PushBlueprint(blueprint, commitMsg)
 	if err != nil {

--- a/internal/weldr/api.go
+++ b/internal/weldr/api.go
@@ -254,6 +254,7 @@ func setupRouter(api *API) *API {
 	api.router.POST("/api/v:version/upload/providers/save", api.providersSaveHandler)
 	api.router.DELETE("/api/v:version/upload/providers/delete/:provider/:profile", api.providersDeleteHandler)
 
+	api.router.GET("/api/v:version/distros/list", api.distrosListHandler)
 	return api
 }
 
@@ -2941,4 +2942,19 @@ func (api *API) providersDeleteHandler(writer http.ResponseWriter, request *http
 
 	// TODO: implement this route (it is v1 only)
 	notImplementedHandler(writer, request, params)
+}
+
+func (api *API) distrosListHandler(writer http.ResponseWriter, request *http.Request, params httprouter.Params) {
+	if !verifyRequestVersion(writer, params, 1) {
+		return
+	}
+
+	var reply struct {
+		Distros []string `json:"distros"`
+	}
+	reply.Distros = api.distros.List()
+	sort.Strings(reply.Distros)
+
+	err := json.NewEncoder(writer).Encode(reply)
+	common.PanicOnError(err)
 }

--- a/internal/weldr/api.go
+++ b/internal/weldr/api.go
@@ -160,10 +160,10 @@ func New(repoPaths []string, stateDir string, rpm rpmmd.RPMMD,
 	distroRepos := make(map[string]map[string][]rpmmd.RepoConfig, len(distros.List()))
 	for _, distro := range distros.List() {
 		// TODO How to mangle this for non-host distro?
-		distro = mangleName(distro, false, false)
-		repo, err := rpmmd.LoadRepositories(repoPaths, distro)
+		repoName := mangleName(distro, false, false)
+		repo, err := rpmmd.LoadRepositories(repoPaths, repoName)
 		if err != nil {
-			return nil, fmt.Errorf("Error loading repositories for %s: %v", distro, err)
+			return nil, fmt.Errorf("Error loading repositories for %s/%s: %v", distro, repoName, err)
 		}
 		distroRepos[distro] = repo
 	}

--- a/internal/weldr/api.go
+++ b/internal/weldr/api.go
@@ -1843,6 +1843,22 @@ func (api *API) blueprintsWorkspaceHandler(writer http.ResponseWriter, request *
 		return
 	}
 
+	// Check the blueprint's distro to make sure it is valid
+	// or if it doesn't have one set it to the host distro.
+	if len(blueprint.Distro) > 0 {
+		_, ok := api.distroRepos[blueprint.Distro]
+		if !ok {
+			errors := responseError{
+				ID:  "BlueprintsError",
+				Msg: fmt.Sprintf("'%s' is not a valid distribution", blueprint.Distro),
+			}
+			statusResponseError(writer, http.StatusBadRequest, errors)
+			return
+		}
+	} else {
+		blueprint.Distro = api.hostDistroName
+	}
+
 	err = api.store.PushBlueprintToWorkspace(blueprint)
 	if err != nil {
 		errors := responseError{

--- a/internal/weldr/api.go
+++ b/internal/weldr/api.go
@@ -935,7 +935,18 @@ func (api *API) modulesListHandler(writer http.ResponseWriter, request *http.Req
 
 	modulesParam := params.ByName("modules")
 
-	availablePackages, err := api.fetchPackageList(api.hostDistroName)
+	// Optional distro parameter
+	// If it is empty it will return api.hostDistroName
+	distro, err := api.parseDistro(request.URL.Query())
+	if err != nil {
+		errors := responseError{
+			ID:  "DistroError",
+			Msg: err.Error(),
+		}
+		statusResponseError(writer, http.StatusBadRequest, errors)
+		return
+	}
+	availablePackages, err := api.fetchPackageList(distro)
 
 	if err != nil {
 		errors := responseError{

--- a/internal/weldr/api.go
+++ b/internal/weldr/api.go
@@ -1115,7 +1115,18 @@ func (api *API) modulesInfoHandler(writer http.ResponseWriter, request *http.Req
 
 	names := strings.Split(modules, ",")
 
-	availablePackages, err := api.fetchPackageList(api.hostDistroName)
+	// Optional distro parameter
+	// If it is empty it will return api.hostDistroName
+	distro, err := api.parseDistro(request.URL.Query())
+	if err != nil {
+		errors := responseError{
+			ID:  "DistroError",
+			Msg: err.Error(),
+		}
+		statusResponseError(writer, http.StatusBadRequest, errors)
+		return
+	}
+	availablePackages, err := api.fetchPackageList(distro)
 
 	if err != nil {
 		errors := responseError{

--- a/internal/weldr/api_test.go
+++ b/internal/weldr/api_test.go
@@ -41,7 +41,7 @@ func createWeldrAPI(tempdir string, fixtureGenerator rpmmd_mock.FixtureGenerator
 		panic(err)
 	}
 
-	return New(rpm, arch, d, repos, nil, fixture.Store, fixture.Workers, ""), fixture.Store
+	return NewTestAPI(rpm, arch, d, repos, nil, fixture.Store, fixture.Workers, ""), fixture.Store
 }
 
 func TestBasic(t *testing.T) {

--- a/internal/weldr/api_test.go
+++ b/internal/weldr/api_test.go
@@ -263,9 +263,9 @@ func TestBlueprintsInfo(t *testing.T) {
 		ExpectedStatus int
 		ExpectedJSON   string
 	}{
-		{"GET", "/api/v0/blueprints/info/test1", ``, http.StatusOK, `{"blueprints":[{"name":"test1","description":"Test","modules":[],"packages":[{"name":"httpd","version":"2.4.*"}],"groups":[],"version":"0.0.0"}],
+		{"GET", "/api/v0/blueprints/info/test1", ``, http.StatusOK, `{"blueprints":[{"name":"test1","description":"Test","distro":"fedora-30","modules":[],"packages":[{"name":"httpd","version":"2.4.*"}],"groups":[],"version":"0.0.0"}],
 		"changes":[{"name":"test1","changed":false}], "errors":[]}`},
-		{"GET", "/api/v0/blueprints/info/test2", ``, http.StatusOK, `{"blueprints":[{"name":"test2","description":"Test","modules":[],"packages":[{"name":"systemd","version":"123"}],"groups":[],"version":"0.0.0"}],
+		{"GET", "/api/v0/blueprints/info/test2", ``, http.StatusOK, `{"blueprints":[{"name":"test2","description":"Test","distro":"fedora-30","modules":[],"packages":[{"name":"systemd","version":"123"}],"groups":[],"version":"0.0.0"}],
 		"changes":[{"name":"test2","changed":true}], "errors":[]}`},
 		{"GET", "/api/v0/blueprints/info/test3-non", ``, http.StatusOK, `{"blueprints":[],"changes":[],"errors":[{"id":"UnknownBlueprint","msg":"test3-non: "}]}`},
 	}
@@ -291,7 +291,7 @@ func TestBlueprintsInfoToml(t *testing.T) {
 	defer os.RemoveAll(tempdir)
 
 	api, _ := createWeldrAPI(tempdir, rpmmd_mock.BaseFixture)
-	test.SendHTTP(api, true, "POST", "/api/v0/blueprints/new", `{"name":"test1","description":"Test","packages":[{"name":"httpd","version":"2.4.*"}],"version":"0.0.0"}`)
+	test.SendHTTP(api, true, "POST", "/api/v0/blueprints/new", `{"name":"test1","description":"Test","distro":"fedora-30","packages":[{"name":"httpd","version":"2.4.*"}],"version":"0.0.0"}`)
 
 	req := httptest.NewRequest("GET", "/api/v0/blueprints/info/test1?format=toml", nil)
 	recorder := httptest.NewRecorder()
@@ -307,6 +307,7 @@ func TestBlueprintsInfoToml(t *testing.T) {
 	expected := blueprint.Blueprint{
 		Name:        "test1",
 		Description: "Test",
+		Distro:      "fedora-30",
 		Version:     "0.0.0",
 		Packages: []blueprint.Package{
 			{
@@ -386,7 +387,7 @@ func TestBlueprintsFreeze(t *testing.T) {
 			ExpectedStatus int
 			ExpectedJSON   string
 		}{
-			{rpmmd_mock.BaseFixture, "/api/v0/blueprints/freeze/test,test2", http.StatusOK, `{"blueprints":[{"blueprint":{"name":"test","description":"Test","version":"0.0.1","packages":[{"name":"dep-package1","version":"1.33-2.fc30.x86_64"},{"name":"dep-package3","version":"7:3.0.3-1.fc30.x86_64"}],"modules":[{"name":"dep-package2","version":"2.9-1.fc30.x86_64"}],"groups":[]}},{"blueprint":{"name":"test2","description":"Test","version":"0.0.0","packages":[{"name":"dep-package1","version":"1.33-2.fc30.x86_64"},{"name":"dep-package3","version":"7:3.0.3-1.fc30.x86_64"}],"modules":[{"name":"dep-package2","version":"2.9-1.fc30.x86_64"}],"groups":[]}}],"errors":[]}`},
+			{rpmmd_mock.BaseFixture, "/api/v0/blueprints/freeze/test,test2", http.StatusOK, `{"blueprints":[{"blueprint":{"name":"test","description":"Test","distro":"fedora-30","version":"0.0.1","packages":[{"name":"dep-package1","version":"1.33-2.fc30.x86_64"},{"name":"dep-package3","version":"7:3.0.3-1.fc30.x86_64"}],"modules":[{"name":"dep-package2","version":"2.9-1.fc30.x86_64"}],"groups":[]}},{"blueprint":{"name":"test2","description":"Test","distro":"fedora-30","version":"0.0.0","packages":[{"name":"dep-package1","version":"1.33-2.fc30.x86_64"},{"name":"dep-package3","version":"7:3.0.3-1.fc30.x86_64"}],"modules":[{"name":"dep-package2","version":"2.9-1.fc30.x86_64"}],"groups":[]}}],"errors":[]}`},
 		}
 
 		tempdir, err := ioutil.TempDir("", "weldr-tests-")
@@ -408,7 +409,7 @@ func TestBlueprintsFreeze(t *testing.T) {
 			ExpectedStatus int
 			ExpectedTOML   string
 		}{
-			{rpmmd_mock.BaseFixture, "/api/v0/blueprints/freeze/test?format=toml", http.StatusOK, "name=\"test\"\n description=\"Test\"\n version=\"0.0.1\"\n groups = []\n [[packages]]\n name=\"dep-package1\"\n version=\"1.33-2.fc30.x86_64\"\n [[packages]]\n name=\"dep-package3\"\n version=\"7:3.0.3-1.fc30.x86_64\"\n [[modules]]\n name=\"dep-package2\"\n version=\"2.9-1.fc30.x86_64\""},
+			{rpmmd_mock.BaseFixture, "/api/v0/blueprints/freeze/test?format=toml", http.StatusOK, "name=\"test\"\n description=\"Test\"\n distro=\"fedora-30\"\n version=\"0.0.1\"\n groups = []\n [[packages]]\n name=\"dep-package1\"\n version=\"1.33-2.fc30.x86_64\"\n [[packages]]\n name=\"dep-package3\"\n version=\"7:3.0.3-1.fc30.x86_64\"\n [[modules]]\n name=\"dep-package2\"\n version=\"2.9-1.fc30.x86_64\""},
 			{rpmmd_mock.BaseFixture, "/api/v0/blueprints/freeze/missing?format=toml", http.StatusOK, ""},
 		}
 
@@ -519,9 +520,9 @@ func TestBlueprintsDepsolve(t *testing.T) {
 		ExpectedStatus int
 		ExpectedJSON   string
 	}{
-		{rpmmd_mock.BaseFixture, http.StatusOK, `{"blueprints":[{"blueprint":{"name":"test","description":"Test","version":"0.0.1","packages":[{"name":"dep-package1","version":"*"}],"groups":[],"modules":[{"name":"dep-package3","version":"*"}]},"dependencies":[{"name":"dep-package3","epoch":7,"version":"3.0.3","release":"1.fc30","arch":"x86_64"},{"name":"dep-package1","epoch":0,"version":"1.33","release":"2.fc30","arch":"x86_64"},{"name":"dep-package2","epoch":0,"version":"2.9","release":"1.fc30","arch":"x86_64"}]}],"errors":[]}`},
-		{rpmmd_mock.NonExistingPackage, http.StatusOK, `{"blueprints":[{"blueprint":{"name":"test","description":"Test","version":"0.0.1","packages":[{"name":"dep-package1","version":"*"}],"groups":[],"modules":[{"name":"dep-package3","version":"*"}]},"dependencies":[]}],"errors":[{"id":"BlueprintsError","msg":"test: DNF error occured: MarkingErrors: Error occurred when marking packages for installation: Problems in request:\nmissing packages: fash"}]}`},
-		{rpmmd_mock.BadDepsolve, http.StatusOK, `{"blueprints":[{"blueprint":{"name":"test","description":"Test","version":"0.0.1","packages":[{"name":"dep-package1","version":"*"}],"groups":[],"modules":[{"name":"dep-package3","version":"*"}]},"dependencies":[]}],"errors":[{"id":"BlueprintsError","msg":"test: DNF error occured: DepsolveError: There was a problem depsolving ['go2rpm']: \n Problem: conflicting requests\n  - nothing provides askalono-cli needed by go2rpm-1-4.fc31.noarch"}]}`},
+		{rpmmd_mock.BaseFixture, http.StatusOK, `{"blueprints":[{"blueprint":{"name":"test","description":"Test","distro":"fedora-30","version":"0.0.1","packages":[{"name":"dep-package1","version":"*"}],"groups":[],"modules":[{"name":"dep-package3","version":"*"}]},"dependencies":[{"name":"dep-package3","epoch":7,"version":"3.0.3","release":"1.fc30","arch":"x86_64"},{"name":"dep-package1","epoch":0,"version":"1.33","release":"2.fc30","arch":"x86_64"},{"name":"dep-package2","epoch":0,"version":"2.9","release":"1.fc30","arch":"x86_64"}]}],"errors":[]}`},
+		{rpmmd_mock.NonExistingPackage, http.StatusOK, `{"blueprints":[{"blueprint":{"name":"test","description":"Test","distro":"fedora-30","version":"0.0.1","packages":[{"name":"dep-package1","version":"*"}],"groups":[],"modules":[{"name":"dep-package3","version":"*"}]},"dependencies":[]}],"errors":[{"id":"BlueprintsError","msg":"test: DNF error occured: MarkingErrors: Error occurred when marking packages for installation: Problems in request:\nmissing packages: fash"}]}`},
+		{rpmmd_mock.BadDepsolve, http.StatusOK, `{"blueprints":[{"blueprint":{"name":"test","description":"Test","distro":"fedora-30","version":"0.0.1","packages":[{"name":"dep-package1","version":"*"}],"groups":[],"modules":[{"name":"dep-package3","version":"*"}]},"dependencies":[]}],"errors":[{"id":"BlueprintsError","msg":"test: DNF error occured: DepsolveError: There was a problem depsolving ['go2rpm']: \n Problem: conflicting requests\n  - nothing provides askalono-cli needed by go2rpm-1-4.fc31.noarch"}]}`},
 	}
 
 	tempdir, err := ioutil.TempDir("", "weldr-tests-")
@@ -587,6 +588,7 @@ func TestCompose(t *testing.T) {
 		Blueprint: &blueprint.Blueprint{
 			Name:           "test",
 			Version:        "0.0.0",
+			Distro:         "fedora-30",
 			Packages:       []blueprint.Package{},
 			Modules:        []blueprint.Package{},
 			Groups:         []blueprint.Group{},
@@ -603,6 +605,7 @@ func TestCompose(t *testing.T) {
 		Blueprint: &blueprint.Blueprint{
 			Name:           "test",
 			Version:        "0.0.0",
+			Distro:         "fedora-30",
 			Packages:       []blueprint.Package{},
 			Modules:        []blueprint.Package{},
 			Groups:         []blueprint.Group{},
@@ -634,6 +637,7 @@ func TestCompose(t *testing.T) {
 		Blueprint: &blueprint.Blueprint{
 			Name:           "test",
 			Version:        "0.0.0",
+			Distro:         "fedora-30",
 			Packages:       []blueprint.Package{},
 			Modules:        []blueprint.Package{},
 			Groups:         []blueprint.Group{},
@@ -650,6 +654,7 @@ func TestCompose(t *testing.T) {
 		Blueprint: &blueprint.Blueprint{
 			Name:           "test",
 			Version:        "0.0.0",
+			Distro:         "fedora-30",
 			Packages:       []blueprint.Package{},
 			Modules:        []blueprint.Package{},
 			Groups:         []blueprint.Group{},
@@ -788,8 +793,8 @@ func TestComposeInfo(t *testing.T) {
 		ExpectedStatus int
 		ExpectedJSON   string
 	}{
-		{rpmmd_mock.BaseFixture, "GET", "/api/v0/compose/info/30000000-0000-0000-0000-000000000000", ``, http.StatusOK, `{"id":"30000000-0000-0000-0000-000000000000","config":"","blueprint":{"name":"test","description":"","version":"0.0.0","packages":[],"modules":[],"groups":[]},"commit":"","deps":{"packages":[]},"compose_type":"qcow2","queue_status":"WAITING","image_size":0}`},
-		{rpmmd_mock.BaseFixture, "GET", "/api/v1/compose/info/30000000-0000-0000-0000-000000000000", ``, http.StatusOK, `{"id":"30000000-0000-0000-0000-000000000000","config":"","blueprint":{"name":"test","description":"","version":"0.0.0","packages":[],"modules":[],"groups":[]},"commit":"","deps":{"packages":[]},"compose_type":"qcow2","queue_status":"WAITING","image_size":0,"uploads":[{"uuid":"10000000-0000-0000-0000-000000000000","status":"WAITING","provider_name":"aws","image_name":"awsimage","creation_time":1574857140,"settings":{"region":"frankfurt","bucket":"clay","key":"imagekey"}}]}`},
+		{rpmmd_mock.BaseFixture, "GET", "/api/v0/compose/info/30000000-0000-0000-0000-000000000000", ``, http.StatusOK, `{"id":"30000000-0000-0000-0000-000000000000","config":"","blueprint":{"name":"test","description":"","distro":"","version":"0.0.0","packages":[],"modules":[],"groups":[]},"commit":"","deps":{"packages":[]},"compose_type":"qcow2","queue_status":"WAITING","image_size":0}`},
+		{rpmmd_mock.BaseFixture, "GET", "/api/v1/compose/info/30000000-0000-0000-0000-000000000000", ``, http.StatusOK, `{"id":"30000000-0000-0000-0000-000000000000","config":"","blueprint":{"name":"test","description":"","distro":"","version":"0.0.0","packages":[],"modules":[],"groups":[]},"commit":"","deps":{"packages":[]},"compose_type":"qcow2","queue_status":"WAITING","image_size":0,"uploads":[{"uuid":"10000000-0000-0000-0000-000000000000","status":"WAITING","provider_name":"aws","image_name":"awsimage","creation_time":1574857140,"settings":{"region":"frankfurt","bucket":"clay","key":"imagekey"}}]}`},
 		{rpmmd_mock.BaseFixture, "GET", "/api/v1/compose/info/30000000-0000-0000-0000", ``, http.StatusBadRequest, `{"status":false,"errors":[{"id":"UnknownUUID","msg":"30000000-0000-0000-0000 is not a valid build uuid"}]}`},
 		{rpmmd_mock.BaseFixture, "GET", "/api/v1/compose/info/42000000-0000-0000-0000-000000000000", ``, http.StatusBadRequest, `{"status":false,"errors":[{"id":"UnknownUUID","msg":"42000000-0000-0000-0000-000000000000 is not a valid build uuid"}]}`},
 	}


### PR DESCRIPTION
This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] create a file in [news/unreleased](https://github.com/osbuild/osbuild-composer/tree/main/docs/news/unreleased) directory if this change should be mentioned in the release news
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/
- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`


(leaving the above alone for now)

What we have here is a bunch of changes that make it possible to build images for all the other supported distributions.
The blueprint now supports a `distro` field that tells it which distro to build for when a compose is started. If it is missing it builds for the host system's distro.

You can list supported distros with `curl --unix-socket /run/weldr/api.socket http://localhost:4000/api/v1/distros/list | python -m json.tool` -

```
{
    "distros": [
        "centos-8",
        "fedora-32",
        "fedora-33",
        "rhel-8",
        "rhel-84",
        "rhel-90"
    ]
}
```

Routes that could return different results based on distro selection now support an optional ?distro=DISTRONAME parameter.
This includes compose/types since image types are implemented per-distro there may be a different set available.

FYI - composer-cli has not been updated to support any of these new features. You can still use it to push a new blueprint though, it doesn't care what the content is.

Currently this doesn't limit what you can build. In production I think we want to limit building to similar releases of the host's distro (although, in my fedora-33 VM I can successfully build a centos-8 image). We need to figure out what these limits are, and they may be limited for support reasons more than technical reasons.

This does not include any changes to the sources API or TOML yet. The plan there is to default to supporting the host distro, or adding a `distros` list to the source to list the distros it supports. Possibly with wildcard? eg. `distros="fedora-*"`

Some of these commits still need cleanup and documentation. But this 'snapshot' of things builds, passes tests, and can build other distros, depsolve, etc.

