### PR TITLE
test cases: Introduce a directory for regression test cases

### DIFF
--- a/osbuild-composer.spec
+++ b/osbuild-composer.spec
@@ -191,6 +191,9 @@ install -m 0755 -vp tools/libvirt_test.sh                       %{buildroot}%{_l
 install -m 0755 -vd                                             %{buildroot}%{_libexecdir}/tests/osbuild-composer
 install -m 0755 -vp test/cases/*                                %{buildroot}%{_libexecdir}/tests/osbuild-composer/
 
+install -m 0755 -vd                                             %{buildroot}%{_libexecdir}/tests/osbuild-composer/regression-cases
+install -m 0755 -vp test/regression-cases/*                     %{buildroot}%{_libexecdir}/tests/osbuild-composer/regression-cases/
+
 install -m 0755 -vd                                             %{buildroot}%{_datadir}/tests/osbuild-composer/ansible
 install -m 0644 -vp test/data/ansible/*                         %{buildroot}%{_datadir}/tests/osbuild-composer/ansible/
 

--- a/schutzbot/Jenkinsfile
+++ b/schutzbot/Jenkinsfile
@@ -653,7 +653,7 @@ pipeline {
                         run_tests('base')
                         sh (
                             label: "Regression tests",
-                            script: "/usr/libexec/tests/osbuild-composer/regression.sh"
+                            script: "/usr/libexec/tests/osbuild-composer/regression-cases/blueprint-can-include-excluded-package.sh"
                         )
                     }
                     post {

--- a/test/README.md
+++ b/test/README.md
@@ -277,6 +277,11 @@ section and run `/usr/libexec/tests/osbuild-composer/api.sh gcp`.
 
 [gcp_creds]: https://cloud.google.com/docs/authentication/getting-started#setting_the_environment_variable
 
+## Regression testing
+
+These tests make sure bugs that have been fixed do not appear again. They live in the
+`test/regression-cases` directory. Each test should contain an explanation of its purpose.
+
 ## Downstream testing notes
 
 To make it easier for us to test & verify downstream builds we are going to

--- a/test/regression-cases/blueprint-can-include-excluded-package.sh
+++ b/test/regression-cases/blueprint-can-include-excluded-package.sh
@@ -1,4 +1,15 @@
 #!/bin/bash
+
+# This test case verifies that a blueprint can include a package which
+# is listed among "excluded" for a certain image type and osbuild-composer
+# doesn't fail to depsolve this blueprint.
+#
+# The script currently works only for RHEL and CentOS which provide
+# "redhat-lsb-core" package and exclude "nss" package in the image type
+# definition. The testing blueprint contains explicit "nss" requirement
+# to remove it from the list of excluded packages and thus enable the
+# installation of "redhat-lsb-core".
+
 set -xeuo pipefail
 
 # Provision the software under tet.


### PR DESCRIPTION
I'm about to propose 2 more regression test cases next week:
 * https://github.com/osbuild/osbuild-composer/pull/1386
 * a test case for the issue with Satellite repos

Therefore I thought it'd be a good idea to introduce a structure in the regression test cases and possibly a reasonable naming scheme. This PR is my proposal.

This pull request includes:

- N/A adequate testing for the new functionality or fixed issue
- [X] adequate documentation informing people about the change such as
  - N/A create a file in [news/unreleased](https://github.com/osbuild/osbuild-composer/tree/main/docs/news/unreleased) directory if this change should be mentioned in the release news
  - N/A submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/
  - [X] Entry in the `test/README.md` file

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

For user-visible changes, "adequate documentation" is an entry describing the
change for users in docs/news. Please refer to docs/news/README.md for details.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`
-->
