### PR TITLE
tests: Define COMPOSE_URL/COMPOSE_ID in a single place. Fix #1397

### DIFF
--- a/osbuild-composer.spec
+++ b/osbuild-composer.spec
@@ -191,6 +191,7 @@ install -m 0755 -vp _bin/osbuild-image-tests                    %{buildroot}%{_l
 install -m 0755 -vp _bin/osbuild-auth-tests                     %{buildroot}%{_libexecdir}/osbuild-composer-test/
 install -m 0755 -vp _bin/osbuild-koji-tests                     %{buildroot}%{_libexecdir}/osbuild-composer-test/
 install -m 0755 -vp _bin/cloud-cleaner                          %{buildroot}%{_libexecdir}/osbuild-composer-test/
+install -m 0755 -vp tools/define-compose-url.sh                 %{buildroot}%{_libexecdir}/osbuild-composer-test/
 install -m 0755 -vp tools/provision.sh                          %{buildroot}%{_libexecdir}/osbuild-composer-test/
 install -m 0755 -vp tools/gen-certs.sh                          %{buildroot}%{_libexecdir}/osbuild-composer-test/
 install -m 0755 -vp tools/image-info                            %{buildroot}%{_libexecdir}/osbuild-composer-test/

--- a/schutzbot/prepare-rhel-internal.sh
+++ b/schutzbot/prepare-rhel-internal.sh
@@ -8,16 +8,7 @@ function greenprint {
 
 ARCH=$(uname -m)
 
-curl -L http://download.devel.redhat.com/rhel-8/nightly/RHEL-8/latest-RHEL-8.4/COMPOSE_ID > COMPOSE_ID
-COMPOSE_ID=$(cat COMPOSE_ID)
-
-# default to a nightly tree but respect values passed from ENV so we can test rel-eng
-# composes as well
-COMPOSE_URL="${COMPOSE_URL:-http://download.devel.redhat.com/rhel-8/nightly/RHEL-8/$COMPOSE_ID}"
-
-# in case COMPOSE_URL was defined from the outside refresh COMPOSE_ID file,
-# used for telegram messages in case of success/failure
-curl -L "$COMPOSE_URL/COMPOSE_ID" > COMPOSE_ID
+source ../tools/define-compose-url.sh
 
 # Create a repository file for installing the osbuild-composer RPMs
 greenprint "📜 Generating dnf repository file"

--- a/test/cases/ostree.sh
+++ b/test/cases/ostree.sh
@@ -2,6 +2,7 @@
 set -euo pipefail
 
 OSBUILD_COMPOSER_TEST_DATA=/usr/share/tests/osbuild-composer/
+source /usr/libexec/osbuild-composer-test/define-compose-url.sh
 
 # Get OS data.
 source /etc/os-release
@@ -31,7 +32,6 @@ case "${ID}-${VERSION_ID}" in
         IMAGE_TYPE=rhel-edge-commit
         OSTREE_REF="rhel/8/${ARCH}/edge"
         OS_VARIANT="rhel8-unknown"
-        COMPOSE_URL="${COMPOSE_URL:-http://download.devel.redhat.com/rhel-8/nightly/RHEL-8/latest-RHEL-8.4}"
         BOOT_LOCATION="$COMPOSE_URL/compose/BaseOS/x86_64/os/";;
     *)
         echo "unsupported distro: ${ID}-${VERSION_ID}"

--- a/tools/define-compose-url.sh
+++ b/tools/define-compose-url.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -euo pipefail
+
+curl -L http://download.devel.redhat.com/rhel-8/nightly/RHEL-8/latest-RHEL-8.4/COMPOSE_ID > COMPOSE_ID
+COMPOSE_ID=$(cat COMPOSE_ID)
+
+# default to a nightly tree but respect values passed from ENV so we can test rel-eng composes as well
+COMPOSE_URL="${COMPOSE_URL:-http://download.devel.redhat.com/rhel-8/nightly/RHEL-8/$COMPOSE_ID}"
+
+# in case COMPOSE_URL was defined from the outside refresh COMPOSE_ID file,
+# used for telegram messages in case of success/failure
+curl -L "$COMPOSE_URL/COMPOSE_ID" > COMPOSE_ID


### PR DESCRIPTION
we don't want this defined multiple times in different places


This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] create a file in [news/unreleased](https://github.com/osbuild/osbuild-composer/tree/main/docs/news/unreleased) directory if this change should be mentioned in the release news
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

For user-visible changes, "adequate documentation" is an entry describing the
change for users in docs/news. Please refer to docs/news/README.md for details.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`
-->
