### PR TITLE
test/cases: Introduce common "regression" test for all distros

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -54,6 +54,7 @@ Base:
   script:
     - schutzbot/deploy.sh
     - /usr/libexec/tests/osbuild-composer/base_tests.sh
+    - /usr/libexec/tests/osbuild-composer/regression.sh
   parallel:
     matrix:
       - RUNNER:

--- a/schutzbot/Jenkinsfile
+++ b/schutzbot/Jenkinsfile
@@ -651,10 +651,6 @@ pipeline {
                     }
                     steps {
                         run_tests('base')
-                        sh (
-                            label: "Regression tests",
-                            script: "/usr/libexec/tests/osbuild-composer/regression.sh"
-                        )
                     }
                     post {
                         always {
@@ -788,6 +784,11 @@ void run_tests(test_type) {
         sh (
             label: "Base tests",
             script: "/usr/libexec/tests/osbuild-composer/base_tests.sh"
+        )
+
+        sh (
+            label: "Regression tests",
+            script: "/usr/libexec/tests/osbuild-composer/regression.sh"
         )
     }
 

--- a/test/cases/regression-include-excluded-packages.sh
+++ b/test/cases/regression-include-excluded-packages.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+
+# This test case verifies that a blueprint can include a package which
+# is listed among "excluded" for a certain image type and osbuild-composer
+# doesn't fail to depsolve this blueprint.
+#
+# The script currently works only for RHEL and CentOS which provide
+# "redhat-lsb-core" package and exclude "nss" package in the image type
+# definition. The testing blueprint contains explicit "nss" requirement
+# to remove it from the list of excluded packages and thus enable the
+# installation of "redhat-lsb-core".
+#
+# Bug report: https://github.com/osbuild/osbuild-composer/issues/921
+
+set -xeuo pipefail
+
+# Provision the software under tet.
+BLUEPRINT_FILE=/tmp/blueprint.toml
+COMPOSE_START=/tmp/compose-start.json
+COMPOSE_INFO=/tmp/compose-info.json
+
+# Write a basic blueprint for our image.
+tee "$BLUEPRINT_FILE" > /dev/null << EOF
+name = "redhat-lsb-core"
+description = "A base system with redhat-lsb-core"
+version = "0.0.1"
+
+[[packages]]
+name = "redhat-lsb-core"
+
+[[packages]]
+# The nss package is excluded in the RHEL8.4 image type, but it is required by the
+# redhat-lsb-core package. This test verifies it can be added again when explicitly
+# mentioned in the blueprint.
+name = "nss"
+EOF
+
+sudo composer-cli blueprints push "$BLUEPRINT_FILE"
+sudo composer-cli blueprints depsolve redhat-lsb-core
+sudo composer-cli --json compose start redhat-lsb-core qcow2 | tee "${COMPOSE_START}"
+COMPOSE_ID=$(jq -r '.build_id' "$COMPOSE_START")
+
+# Wait for the compose to finish.
+echo "⏱ Waiting for compose to finish: ${COMPOSE_ID}"
+while true; do
+    sudo composer-cli --json compose info "${COMPOSE_ID}" | tee "$COMPOSE_INFO" > /dev/null
+    COMPOSE_STATUS=$(jq -r '.queue_status' "$COMPOSE_INFO")
+
+    # Is the compose finished?
+    if [[ $COMPOSE_STATUS != RUNNING ]] && [[ $COMPOSE_STATUS != WAITING ]]; then
+        break
+    fi
+
+    # Wait 30 seconds and try again.
+    sleep 30
+done
+
+jq . "${COMPOSE_INFO}"
+
+# Did the compose finish with success?
+if [[ $COMPOSE_STATUS != FINISHED ]]; then
+    echo "Something went wrong with the compose. 😢"
+    exit 1
+fi

--- a/test/cases/regression.sh
+++ b/test/cases/regression.sh
@@ -1,53 +1,20 @@
 #!/bin/bash
-set -xeuo pipefail
+set -euo pipefail
+
+# Get OS data.
+source /etc/os-release
 
 # Provision the software under tet.
 /usr/libexec/osbuild-composer-test/provision.sh
 
-BLUEPRINT_FILE=/tmp/blueprint.toml
-COMPOSE_START=/tmp/compose-start.json
-COMPOSE_INFO=/tmp/compose-info.json
-
-# Write a basic blueprint for our image.
-tee "$BLUEPRINT_FILE" > /dev/null << EOF
-name = "redhat-lsb-core"
-description = "A base system with redhat-lsb-core"
-version = "0.0.1"
-
-[[packages]]
-name = "redhat-lsb-core"
-
-[[packages]]
-# The nss package is excluded in the RHEL8.4 image type, but it is required by the
-# redhat-lsb-core package. This test verifies it can be added again when explicitly
-# mentioned in the blueprint.
-name = "nss"
-EOF
-
-sudo composer-cli blueprints push "$BLUEPRINT_FILE"
-sudo composer-cli blueprints depsolve redhat-lsb-core
-sudo composer-cli --json compose start redhat-lsb-core qcow2 | tee "${COMPOSE_START}"
-COMPOSE_ID=$(jq -r '.build_id' "$COMPOSE_START")
-
-# Wait for the compose to finish.
-echo "⏱ Waiting for compose to finish: ${COMPOSE_ID}"
-while true; do
-    sudo composer-cli --json compose info "${COMPOSE_ID}" | tee "$COMPOSE_INFO" > /dev/null
-    COMPOSE_STATUS=$(jq -r '.queue_status' "$COMPOSE_INFO")
-
-    # Is the compose finished?
-    if [[ $COMPOSE_STATUS != RUNNING ]] && [[ $COMPOSE_STATUS != WAITING ]]; then
-        break
-    fi
-
-    # Wait 30 seconds and try again.
-    sleep 30
-done
-
-jq . "${COMPOSE_INFO}"
-
-# Did the compose finish with success?
-if [[ $COMPOSE_STATUS != FINISHED ]]; then
-    echo "Something went wrong with the compose. 😢"
-    exit 1
-fi
+# Set os-variant and boot location used by virt-install.
+case "${ID}" in
+    "fedora")
+        echo "No regression test for Fedora";;
+    "rhel")
+        /usr/libexec/tests/osbuild-composer/regression-include-excluded-packages.sh;;
+    "centos")
+        /usr/libexec/tests/osbuild-composer/regression-include-excluded-packages.sh;;
+    *)
+        echo "unsupported distro: ${ID}-${VERSION_ID}"
+esac


### PR DESCRIPTION
Create an entry point for all regression test called "regression.sh" and
run it as part of integration tests for all our distros. This entry
point contains logic for running only the test cases that are
appropriate for a given distribution.


This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] create a file in [news/unreleased](https://github.com/osbuild/osbuild-composer/tree/main/docs/news/unreleased) directory if this change should be mentioned in the release news
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

For user-visible changes, "adequate documentation" is an entry describing the
change for users in docs/news. Please refer to docs/news/README.md for details.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`
-->
