### PR TITLE
enable cloud-init in RHEL 9 qcow2 images

### DIFF
--- a/internal/distro/rhel90/distro.go
+++ b/internal/distro/rhel90/distro.go
@@ -813,6 +813,12 @@ func New() distro.Distro {
 			"rng-tools",
 			"udisks2",
 		},
+		enabledServices: []string{
+			"cloud-init.service",
+			"cloud-config.service",
+			"cloud-final.service",
+			"cloud-init-local.service",
+		},
 		defaultTarget:           "multi-user.target",
 		kernelOptions:           "console=tty0 console=ttyS0,115200n8 no_timer_check net.ifnames=0 crashkernel=auto",
 		bootable:                true,

--- a/test/cases/libvirt.sh
+++ b/test/cases/libvirt.sh
@@ -14,7 +14,6 @@ DISTRO_CODE="${DISTRO_CODE:-${ID}_${VERSION_ID//./}}"
 #TODO: remove this condition once there is rhel9 support for openstack and vhd image types
 if [[ "$DISTRO_CODE" != rhel_90 ]]; then
   /usr/libexec/osbuild-composer-test/libvirt_test.sh openstack
-  /usr/libexec/osbuild-composer-test/libvirt_test.sh vhd
 fi
 
 # RHEL 8.4 and Centos Stream 8 images also supports uefi, check that

--- a/test/data/manifests/rhel_90-aarch64-qcow2-boot.json
+++ b/test/data/manifests/rhel_90-aarch64-qcow2-boot.json
@@ -3453,6 +3453,12 @@
         {
           "name": "org.osbuild.systemd",
           "options": {
+            "enabled_services": [
+              "cloud-init.service",
+              "cloud-config.service",
+              "cloud-final.service",
+              "cloud-init-local.service"
+            ],
             "default_target": "multi-user.target"
           }
         },
@@ -9570,8 +9576,8 @@
     ],
     "hostname": "localhost.localdomain",
     "image-format": {
-      "type": "qcow2",
-      "compat": "1.1"
+      "compat": "1.1",
+      "type": "qcow2"
     },
     "os-release": {
       "ANSI_COLOR": "0;31",
@@ -10128,10 +10134,6 @@
     "services-disabled": [
       "arp-ethers.service",
       "chrony-wait.service",
-      "cloud-config.service",
-      "cloud-final.service",
-      "cloud-init-local.service",
-      "cloud-init.service",
       "cockpit.socket",
       "console-getty.service",
       "cpupower.service",
@@ -10181,6 +10183,10 @@
       "auditd.service",
       "autovt@.service",
       "chronyd.service",
+      "cloud-config.service",
+      "cloud-final.service",
+      "cloud-init-local.service",
+      "cloud-init.service",
       "crond.service",
       "ctrl-alt-del.target",
       "dbus-broker.service",

--- a/test/data/manifests/rhel_90-ppc64le-qcow2-boot.json
+++ b/test/data/manifests/rhel_90-ppc64le-qcow2-boot.json
@@ -3747,6 +3747,12 @@
         {
           "name": "org.osbuild.systemd",
           "options": {
+            "enabled_services": [
+              "cloud-init.service",
+              "cloud-config.service",
+              "cloud-final.service",
+              "cloud-init-local.service"
+            ],
             "default_target": "multi-user.target"
           }
         },
@@ -10321,8 +10327,8 @@
     ],
     "hostname": "localhost.localdomain",
     "image-format": {
-      "type": "qcow2",
-      "compat": "1.1"
+      "compat": "1.1",
+      "type": "qcow2"
     },
     "os-release": {
       "ANSI_COLOR": "0;31",
@@ -10922,10 +10928,6 @@
     "services-disabled": [
       "arp-ethers.service",
       "chrony-wait.service",
-      "cloud-config.service",
-      "cloud-final.service",
-      "cloud-init-local.service",
-      "cloud-init.service",
       "cockpit.socket",
       "console-getty.service",
       "cpupower.service",
@@ -10976,6 +10978,10 @@
       "auditd.service",
       "autovt@.service",
       "chronyd.service",
+      "cloud-config.service",
+      "cloud-final.service",
+      "cloud-init-local.service",
+      "cloud-init.service",
       "crond.service",
       "ctrl-alt-del.target",
       "dbus-broker.service",

--- a/test/data/manifests/rhel_90-s390x-qcow2-boot.json
+++ b/test/data/manifests/rhel_90-s390x-qcow2-boot.json
@@ -3567,6 +3567,12 @@
         {
           "name": "org.osbuild.systemd",
           "options": {
+            "enabled_services": [
+              "cloud-init.service",
+              "cloud-config.service",
+              "cloud-final.service",
+              "cloud-init-local.service"
+            ],
             "default_target": "multi-user.target"
           }
         },
@@ -9776,8 +9782,8 @@
     ],
     "hostname": "localhost.localdomain",
     "image-format": {
-      "type": "qcow2",
-      "compat": "1.1"
+      "compat": "1.1",
+      "type": "qcow2"
     },
     "os-release": {
       "ANSI_COLOR": "0;31",
@@ -10350,10 +10356,6 @@
     "services-disabled": [
       "arp-ethers.service",
       "chrony-wait.service",
-      "cloud-config.service",
-      "cloud-final.service",
-      "cloud-init-local.service",
-      "cloud-init.service",
       "cockpit.socket",
       "console-getty.service",
       "debug-shell.service",
@@ -10402,6 +10404,10 @@
       "auditd.service",
       "autovt@.service",
       "chronyd.service",
+      "cloud-config.service",
+      "cloud-final.service",
+      "cloud-init-local.service",
+      "cloud-init.service",
       "cpi.service",
       "crond.service",
       "ctrl-alt-del.target",

--- a/test/data/manifests/rhel_90-x86_64-qcow2-boot.json
+++ b/test/data/manifests/rhel_90-x86_64-qcow2-boot.json
@@ -3499,6 +3499,12 @@
         {
           "name": "org.osbuild.systemd",
           "options": {
+            "enabled_services": [
+              "cloud-init.service",
+              "cloud-config.service",
+              "cloud-final.service",
+              "cloud-init-local.service"
+            ],
             "default_target": "multi-user.target"
           }
         },
@@ -9707,8 +9713,8 @@
     ],
     "hostname": "localhost.localdomain",
     "image-format": {
-      "type": "qcow2",
-      "compat": "1.1"
+      "compat": "1.1",
+      "type": "qcow2"
     },
     "os-release": {
       "ANSI_COLOR": "0;31",
@@ -10282,10 +10288,6 @@
     "services-disabled": [
       "arp-ethers.service",
       "chrony-wait.service",
-      "cloud-config.service",
-      "cloud-final.service",
-      "cloud-init-local.service",
-      "cloud-init.service",
       "cockpit.socket",
       "console-getty.service",
       "cpupower.service",
@@ -10335,6 +10337,10 @@
       "auditd.service",
       "autovt@.service",
       "chronyd.service",
+      "cloud-config.service",
+      "cloud-final.service",
+      "cloud-init-local.service",
+      "cloud-init.service",
       "crond.service",
       "ctrl-alt-del.target",
       "dbus-broker.service",

--- a/tools/libvirt_test.sh
+++ b/tools/libvirt_test.sh
@@ -20,12 +20,6 @@ if [[ $IMAGE_TYPE == 'openstack' ]]; then
     IMAGE_EXTENSION=qcow2
 fi
 
-# RHEL 8 cannot boot a VMDK using libvirt. See BZ 999789.
-if [[ $IMAGE_TYPE == vmdk ]]; then
-    echo "🤷 libvirt cannot boot stream-optimized VMDK."
-    exit 0
-fi
-
 # Colorful output.
 function greenprint {
     echo -e "\033[1;32m${1}\033[0m"


### PR DESCRIPTION
RHEL qcow2 images didn't have cloud-init enabled, this PR fixes that. Also, the libvirt test explicitly enabled cloud-init in a blueprint. This behavior was removed so an image without enabled cloud-init will fail the test suite from now on.

Fixes COMPOSER-920
Fixes rhbz#1960309

This pull request includes:

- [x] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] create a file in [news/unreleased](https://github.com/osbuild/osbuild-composer/tree/main/docs/news/unreleased) directory if this change should be mentioned in the release news
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

For user-visible changes, "adequate documentation" is an entry describing the
change for users in docs/news. Please refer to docs/news/README.md for details.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`
-->
