### PR TITLE
github: create issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,25 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**Environment**
+ * OS version (`/etc/os-release` and `/etc/redhat-release`):
+ * osbuild-composer version (`rpm -qi osbuild-composer)`
+
+**To Reproduce**
+Steps to reproduce the behavior:
+ * *for example starting osbuild-composer.service or running composer-cli command, don't forget to include all configuration files you created*
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Additional context**
+Add any other context about the problem here.


### PR DESCRIPTION
Create a template to help us with the bug reporting process. This template includes a request for information we usually ask from the reporters. This way, they can include the information upfront.