### PR TITLE
test/regression: Start composer on rhel-like systems

### DIFF
--- a/test/cases/regression-start-on-rhel-like-systems.sh
+++ b/test/cases/regression-start-on-rhel-like-systems.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+set -xeuo pipefail
+
+function cleanup()
+{
+    echo "Running cleanup function"
+    sudo mv /etc/os-release.backup /etc/os-release || echo "There was no backup for etc/os-release."
+
+}
+
+trap cleanup EXIT
+
+sudo mv /etc/os-release /etc/os-release.backup
+sudo tee /etc/os-release << STOPHERE
+NAME="Rocky Linux"
+VERSION="8"
+ID="rocky"
+ID_LIKE="rhel fedora"
+VERSION_ID="8"
+PLATFORM_ID="platform:el8"
+PRETTY_NAME="Rocky Linux 8"
+ANSI_COLOR="0;31"
+CPE_NAME="cpe:/o:rocky:rocky:8"
+HOME_URL="https://rockylinux.org/"
+BUG_REPORT_URL="https://bugs.rockylinux.org/"
+ROCKY_SUPPORT_PRODUCT="Rocky Linux"
+ROCKY_SUPPORT_PRODUCT_VERSION="8"
+STOPHERE
+
+if ! sudo systemctl restart osbuild-composer;
+then
+    journalctl -xe --unit osbuild-composer
+    exit 1
+fi

--- a/test/cases/regression.sh
+++ b/test/cases/regression.sh
@@ -14,7 +14,9 @@ case "${ID}" in
     "rhel")
         /usr/libexec/tests/osbuild-composer/regression-include-excluded-packages.sh;;
     "centos")
-        /usr/libexec/tests/osbuild-composer/regression-include-excluded-packages.sh;;
+        /usr/libexec/tests/osbuild-composer/regression-include-excluded-packages.sh
+        /usr/libexec/tests/osbuild-composer/regression-start-on-rhel-like-systems.sh
+        ;;
     *)
         echo "unsupported distro: ${ID}-${VERSION_ID}"
 esac


### PR DESCRIPTION
Reported here: https://github.com/osbuild/osbuild-composer/issues/1411

My plan:
 * read the `ID_LIKE` field in `/etc/os-release`
 * use the same code path as we use for CentOS

Missing pieces:
 * osbuild runner
 * configurable uefi vendor string
 * every RHEL clone needs to patch their RPM to contain their own repository URLs

This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] create a file in [news/unreleased](https://github.com/osbuild/osbuild-composer/tree/main/docs/news/unreleased) directory if this change should be mentioned in the release news
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

For user-visible changes, "adequate documentation" is an entry describing the
change for users in docs/news. Please refer to docs/news/README.md for details.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`
-->
