### PR TITLE
add test case to push/pull edge container images in quay.io

### DIFF
--- a/osbuild-composer.spec
+++ b/osbuild-composer.spec
@@ -353,6 +353,7 @@ Requires:   httpd
 Requires:   openssl
 Requires:   podman-plugins
 Requires:   dnf-plugins-core
+Requires:   skopeo
 %if 0%{?fedora}
 # koji and ansible are not in RHEL repositories. Depending on them breaks RHEL
 # gating (see OSCI-1541). The test script must enable EPEL and install those

--- a/schutzbot/Jenkinsfile
+++ b/schutzbot/Jenkinsfile
@@ -596,6 +596,10 @@ pipeline {
                 }
                 stage('EL8.4 New OSTree') {
                     agent { label "rhel84cloudbase && psi && x86_64" }
+                    environment {
+                        QUAY_USERNAME = credentials('quay-username')
+                        QUAY_PASSWORD = credentials('quay-password')
+                    }
                     steps {
                         run_tests('ostree-ng')
                     }

--- a/test/cases/ostree-ng.sh
+++ b/test/cases/ostree-ng.sh
@@ -70,6 +70,8 @@ PROD_REPO_URL=http://192.168.100.1/repo
 PROD_REPO=/var/www/html/repo
 STAGE_REPO_ADDRESS=192.168.200.1
 STAGE_REPO_URL="http://${STAGE_REPO_ADDRESS}/repo/"
+QUAY_REPO_URL="docker://quay.io/osbuild/testing-rhel-edge-push"
+QUAY_REPO_TAG=$(tr -dc a-z0-9 < /dev/urandom | head -c 4 ; echo '')
 
 # Set up temporary files.
 TEMPDIR=$(mktemp -d)
@@ -171,6 +173,10 @@ wait_for_ssh_up () {
 # Clean up our mess.
 clean_up () {
     greenprint "🧼 Cleaning up"
+    # Remove tag from quay.io repo
+    skopeo delete --creds "${QUAY_USERNAME}:${QUAY_PASSWORD}" "${QUAY_REPO_URL}:${QUAY_REPO_TAG}"
+
+    # Clear vm
     if [[ $(sudo virsh domstate "${IMAGE_KEY}-uefi") == "running" ]]; then
         sudo virsh destroy "${IMAGE_KEY}-uefi"
     fi
@@ -277,18 +283,18 @@ sudo podman ps -a -q --format "{{.ID}}" | sudo xargs --no-run-if-empty podman rm
 sudo podman rmi -f -a
 
 # Deal with stage repo image
-greenprint "🗜 Extracting image"
+greenprint "🗜 Pushing image to quay.io"
 IMAGE_FILENAME="${COMPOSE_ID}-rhel84-container.tar"
-sudo podman pull "oci-archive:${IMAGE_FILENAME}"
+skopeo copy --dest-creds "${QUAY_USERNAME}:${QUAY_PASSWORD}" "oci-archive:${IMAGE_FILENAME}" "${QUAY_REPO_URL}:${QUAY_REPO_TAG}"
+greenprint "Downloading image from quay.io"
+sudo podman login quay.io --username "${QUAY_USERNAME}" --password "${QUAY_PASSWORD}"
+sudo podman pull "${QUAY_REPO_URL}:${QUAY_REPO_TAG}"
 sudo podman images
+greenprint "🗜 Running the image"
+sudo podman run -d --name rhel-edge --network edge --ip "$STAGE_REPO_ADDRESS" "${QUAY_REPO_URL}:${QUAY_REPO_TAG}"
 # Clear image file
 sudo rm -f "$IMAGE_FILENAME"
 
-# Run edge stage repo
-greenprint "🛰 Running edge stage repo"
-# Get image id to run image
-EDGE_IMAGE_ID=$(sudo podman images --filter "dangling=true" --format "{{.ID}}")
-sudo podman run -d --name rhel-edge --network edge --ip "$STAGE_REPO_ADDRESS" "$EDGE_IMAGE_ID"
 # Wait for container to be running
 until [ "$(sudo podman inspect -f '{{.State.Running}}' rhel-edge)" == "true" ]; do
     sleep 1;


### PR DESCRIPTION
This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] create a file in [news/unreleased](https://github.com/osbuild/osbuild-composer/tree/main/docs/news/unreleased) directory if this change should be mentioned in the release news
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

Add test case to push/pull rhel for edge container images in quay.io.
The destination quay repository is docker://quay.io/osbuild/testing-rhel-edge-push
Find the repository details and credentials in https://issues.redhat.com/browse/COMPOSER-816
