### PR TITLE
distro/fedora: run on unsupported version

### DIFF
--- a/internal/distro/fedora33/distro.go
+++ b/internal/distro/fedora33/distro.go
@@ -21,9 +21,11 @@ const modulePlatformID = "platform:f33"
 const ostreeRef = "fedora/33/%s/iot"
 
 type distribution struct {
-	name          string
-	arches        map[string]architecture
-	buildPackages []string
+	name             string
+	modulePlatformID string
+	ostreeRef        string
+	arches           map[string]architecture
+	buildPackages    []string
 }
 
 type architecture struct {
@@ -586,14 +588,18 @@ func ostreeCommitAssembler(options distro.ImageOptions, arch distro.Arch) *osbui
 
 // New creates a new distro object, defining the supported architectures and image types
 func New() distro.Distro {
-	return newDistro(defaultName)
+	return newDistro(defaultName, modulePlatformID, ostreeRef)
 }
 
 func NewHostDistro(name string) distro.Distro {
-	return newDistro(name)
+	return newDistro(name, modulePlatformID, ostreeRef)
 }
 
-func newDistro(name string) distro.Distro {
+func NewUnreleasedDistro(name, distroVersion string) distro.Distro {
+	return newDistro(name, "platform:f"+distroVersion, "fedora/"+distroVersion+"/%s/iot")
+}
+
+func newDistro(name, modulePlatformID, ostreeRef string) distro.Distro {
 	const GigaByte = 1024 * 1024 * 1024
 
 	iotImgType := imageType{
@@ -843,8 +849,11 @@ func newDistro(name string) distro.Distro {
 			"tar",
 			"xz",
 		},
-		name: name,
+		name:             name,
+		modulePlatformID: modulePlatformID,
+		ostreeRef:        ostreeRef,
 	}
+
 	x8664 := architecture{
 		distro: &r,
 		name:   "x86_64",

--- a/internal/distro/unsupported/utils.go
+++ b/internal/distro/unsupported/utils.go
@@ -1,0 +1,30 @@
+package unsupported
+
+import (
+	"io/ioutil"
+
+	"github.com/osbuild/osbuild-composer/internal/common"
+	"github.com/osbuild/osbuild-composer/internal/rpmmd"
+)
+
+func GenerateFedoraRepositories(version string) map[string][]rpmmd.RepoConfig {
+	content, err := ioutil.ReadFile("/etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-" + version + "-primary")
+	common.PanicOnError(err)
+
+	key_text := string(content)
+	all_repos := make(map[string][]rpmmd.RepoConfig)
+	for _, arch := range []string{"x86_64", "aarch64"} {
+		repos := []rpmmd.RepoConfig{}
+		for _, repo_name := range []string{"fedora-", "updates-released-f", "fedora-modular-", "updates-released-modular-f"} {
+			repos = append(repos, rpmmd.RepoConfig{
+				Name:     repo_name + version,
+				Metalink: "https://mirrors.fedoraproject.org/metalink?repo=" + repo_name + version + "&arch=" + arch,
+				GPGKey:   key_text,
+				CheckGPG: true,
+			})
+		}
+		all_repos[arch] = repos
+	}
+
+	return all_repos
+}

--- a/internal/reporegistry/reporegistry.go
+++ b/internal/reporegistry/reporegistry.go
@@ -44,6 +44,10 @@ func (r *RepoRegistry) ReposByImageType(imageType distro.ImageType) ([]rpmmd.Rep
 	return r.reposByImageTypeName(imageType.Arch().Distro().Name(), imageType.Arch().Name(), imageType.Name())
 }
 
+func (r *RepoRegistry) AddRepos(distro string, repos map[string][]rpmmd.RepoConfig) {
+	r.repos[distro] = repos
+}
+
 // reposByImageTypeName returns a slice of rpmmd.RepoConfig instances, which should be used for building the specific
 // image type name (of a given distribution and architecture). The method does not verify
 // if the given image type name is actually part of the architecture definition of the provided name.


### PR DESCRIPTION
Run on unsupported versions of Fedora. This is mainly useful for running osbuild-composer on Fedora 34 and 35 which is still impossible.

I can build and boot qcow2 image with this patch.

This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] create a file in [news/unreleased](https://github.com/osbuild/osbuild-composer/tree/main/docs/news/unreleased) directory if this change should be mentioned in the release news
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

For user-visible changes, "adequate documentation" is an entry describing the
change for users in docs/news. Please refer to docs/news/README.md for details.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`
-->
