### PR TITLE
tests: Image tests update for osbuild

### DIFF
--- a/test/cases/image_tests.sh
+++ b/test/cases/image_tests.sh
@@ -6,6 +6,12 @@ source /etc/os-release
 ARCH=$(uname -m)
 DISTRO_CODE="${DISTRO_CODE:-${ID}_${VERSION_ID//./}}"
 
+if [[ -n "$CI_BUILD_ID" ]]; then
+    BUILD_ID="${BUILD_ID:-${CI_BUILD_ID}}"
+else
+    BUILD_ID="${BUILD_ID:-$(uuidgen)}"
+fi
+
 WORKING_DIRECTORY=/usr/libexec/osbuild-composer
 IMAGE_TEST_CASE_RUNNER=/usr/libexec/osbuild-composer-test/osbuild-image-tests
 IMAGE_TEST_CASES_PATH=/usr/share/tests/osbuild-composer/manifests
@@ -49,35 +55,12 @@ run_test_case () {
     echo "🏃🏻 Running test: ${TEST_NAME}"
     test_divider
 
-    # Set up the testing command with Azure secrets in the environment.
-    #
-    # This works by having a text file stored in Jenkins credentials.
-    # In Jenkinsfile, the following line assigns the path to this secret file
-    # to an environment variable called AZURE_CREDS:
-    # AZURE_CREDS = credentials('azure')
-    #
-    # The file is in the following format:
-    # KEY1=VALUE1
-    # KEY2=VALUE2
-    #
-    # Using `env $(cat $AZURE_CREDS)` we can take all the key-value pairs and
-    # save them as environment variables.
-    # Read test/README.md to see all required environment variables for Azure
-    # uploads
-    #
-    # AZURE_CREDS might not be defined in all cases (e.g. Azure doesn't
-    # support aarch64), therefore the following line sets AZURE_CREDS to
-    # /dev/null if the variable is undefined.
-    AWS_CREDS=${AWS_IMAGE_TEST_CREDS-/dev/null}
-    AZURE_CREDS=${AZURE_CREDS-/dev/null}
-    OPENSTACK_CREDS=${OPENSTACK_CREDS-/dev/null}
-    VCENTER_CREDS=${VCENTER_CREDS-/dev/null}
-    TEST_CMD="env $(cat "$AWS_CREDS" "$AZURE_CREDS" "$OPENSTACK_CREDS" "$VCENTER_CREDS") BRANCH_NAME=${BRANCH_NAME-main} BUILD_ID=$BUILD_ID DISTRO_CODE=$DISTRO_CODE $TEST_RUNNER -test.v ${IMAGE_TEST_CASES_PATH}/${TEST_CASE_FILENAME}"
+    TEST_CMD="env BRANCH_NAME=${BRANCH_NAME-main} BUILD_ID=$BUILD_ID DISTRO_CODE=$DISTRO_CODE $TEST_RUNNER -test.v ${IMAGE_TEST_CASES_PATH}/${TEST_CASE_FILENAME}"
 
     # Run the test and add the test name to the list of passed or failed
     # tests depending on the result.
     # shellcheck disable=SC2086 # We need to pass multiple arguments here.
-    if sudo $TEST_CMD 2>&1 | tee "${WORKSPACE}"/"${TEST_NAME}".log; then
+    if sudo -E $TEST_CMD 2>&1 | tee "${WORKSPACE}"/"${TEST_NAME}".log; then
         PASSED_TESTS+=("$TEST_NAME")
     else
         FAILED_TESTS+=("$TEST_NAME")


### PR DESCRIPTION
We need to update `image_tests.sh` in order to be able to run it in Gitlab CI for osbuild. Originally we had the cloud credentials in Jenkins as files but that can't be masked in Gitlab CI. I don't know which approach is best here, whether to keep the current implementation and just print the variables one by one to a file to be used by the `TEST_CMD`, print them there one by one or I don't know, I'm open to suggestions.  

This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] create a file in [news/unreleased](https://github.com/osbuild/osbuild-composer/tree/main/docs/news/unreleased) directory if this change should be mentioned in the release news
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/


<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

For user-visible changes, "adequate documentation" is an entry describing the
change for users in docs/news. Please refer to docs/news/README.md for details.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`
-->
