### PR TITLE
tests: kill journalctl even if compose fails

### DIFF
--- a/test/cases/azure.sh
+++ b/test/cases/azure.sh
@@ -150,6 +150,8 @@ sudo composer-cli blueprints depsolve bash
 WORKER_UNIT=$(sudo systemctl list-units | grep -o -E "osbuild.*worker.*\.service")
 sudo journalctl -af -n 1 -u "${WORKER_UNIT}" &
 WORKER_JOURNAL_PID=$!
+# Stop watching the worker journal when exiting.
+trap 'sudo pkill -P ${WORKER_JOURNAL_PID}' EXIT
 
 # Start the compose and upload to Azure.
 greenprint "🚀 Starting compose"
@@ -181,9 +183,6 @@ if [[ $COMPOSE_STATUS != FINISHED ]]; then
     echo "Something went wrong with the compose. 😢"
     exit 1
 fi
-
-# Stop watching the worker journal.
-sudo pkill -P ${WORKER_JOURNAL_PID}
 
 # Set up necessary variables for terraform
 export TF_VAR_RESOURCE_GROUP="$AZURE_RESOURCE_GROUP"

--- a/test/cases/ostree-ng.sh
+++ b/test/cases/ostree-ng.sh
@@ -119,6 +119,8 @@ build_image() {
     WORKER_UNIT=$(sudo systemctl list-units | grep -o -E "osbuild.*worker.*\.service")
     sudo journalctl -af -n 1 -u "${WORKER_UNIT}" &
     WORKER_JOURNAL_PID=$!
+    # Stop watching the worker journal when exiting.
+    trap 'sudo pkill -P ${WORKER_JOURNAL_PID}' EXIT
 
     # Start the compose.
     greenprint "🚀 Starting compose"
@@ -155,9 +157,6 @@ build_image() {
         echo "Something went wrong with the compose. 😢"
         exit 1
     fi
-
-    # Stop watching the worker journal.
-    sudo pkill -P ${WORKER_JOURNAL_PID}
 }
 
 # Wait for the ssh server up to be.

--- a/test/cases/ostree.sh
+++ b/test/cases/ostree.sh
@@ -146,6 +146,8 @@ build_image() {
     WORKER_UNIT=$(sudo systemctl list-units | grep -o -E "osbuild.*worker.*\.service")
     sudo journalctl -af -n 1 -u "${WORKER_UNIT}" &
     WORKER_JOURNAL_PID=$!
+    # Stop watching the worker journal when exiting.
+    trap 'sudo pkill -P ${WORKER_JOURNAL_PID}' EXIT
 
     # Start the compose.
     greenprint "🚀 Starting compose"
@@ -187,9 +189,6 @@ build_image() {
         echo "Something went wrong with the compose. 😢"
         exit 1
     fi
-
-    # Stop watching the worker journal.
-    sudo pkill -P ${WORKER_JOURNAL_PID}
 }
 
 # Wait for the ssh server up to be.

--- a/test/cases/vmware.sh
+++ b/test/cases/vmware.sh
@@ -131,6 +131,8 @@ sudo composer-cli blueprints depsolve bash
 WORKER_UNIT=$(sudo systemctl list-units | grep -o -E "osbuild.*worker.*\.service")
 sudo journalctl -af -n 1 -u "${WORKER_UNIT}" &
 WORKER_JOURNAL_PID=$!
+# Stop watching the worker journal when exiting.
+trap 'sudo pkill -P ${WORKER_JOURNAL_PID}' EXIT
 
 # Start the compose and upload to VMWare.
 greenprint "🚀 Starting compose"
@@ -163,9 +165,6 @@ if [[ $COMPOSE_STATUS != FINISHED ]]; then
     echo "Something went wrong with the compose. 😢"
     exit 1
 fi
-
-# Stop watching the worker journal.
-sudo pkill -P ${WORKER_JOURNAL_PID}
 
 greenprint "👷🏻 Building VM in vSphere"
 $GOVC_CMD vm.create -u "${GOVMOMI_USERNAME}":"${GOVMOMI_PASSWORD}"@"${GOVMOMI_URL}" \

--- a/tools/libvirt_test.sh
+++ b/tools/libvirt_test.sh
@@ -138,6 +138,8 @@ sudo composer-cli blueprints depsolve bp
 WORKER_UNIT=$(sudo systemctl list-units | grep -o -E "osbuild.*worker.*\.service")
 sudo journalctl -af -n 1 -u "${WORKER_UNIT}" &
 WORKER_JOURNAL_PID=$!
+# Stop watching the worker journal when exiting.
+trap 'sudo pkill -P ${WORKER_JOURNAL_PID}' EXIT
 
 # Start the compose
 greenprint "🚀 Starting compose"
@@ -169,9 +171,6 @@ if [[ $COMPOSE_STATUS != FINISHED ]]; then
     echo "Something went wrong with the compose. 😢"
     exit 1
 fi
-
-# Stop watching the worker journal.
-sudo pkill -P ${WORKER_JOURNAL_PID}
 
 # Download the image.
 greenprint "📥 Downloading the image"


### PR DESCRIPTION
This prevents Gitlab CI from getting stuck if something goes wrong with the compose. This can currenly be seen with the azure.sh tests ran here: https://gitlab.com/osbuild/ci/osbuild-composer/-/jobs/1314689742 

There are other tests that would get stuck in the same way so this should prevent that.


This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] create a file in [news/unreleased](https://github.com/osbuild/osbuild-composer/tree/main/docs/news/unreleased) directory if this change should be mentioned in the release news
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

For user-visible changes, "adequate documentation" is an entry describing the
change for users in docs/news. Please refer to docs/news/README.md for details.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`
-->
