### PR TITLE
tests: Use CI_BUILD_ID, not CI_PIPELINE_ID. Fixes #1448

### DIFF
--- a/test/cases/azure.sh
+++ b/test/cases/azure.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 source /etc/os-release
 DISTRO_CODE="${DISTRO_CODE:-${ID}_${VERSION_ID//./}}"
 BRANCH_NAME="${BRANCH_NAME:-${CI_COMMIT_BRANCH}}"
-BUILD_ID="${BUILD_ID:-${CI_PIPELINE_ID}}"
+BUILD_ID="${BUILD_ID:-${CI_BUILD_ID}}"
 
 # Colorful output.
 function greenprint {


### PR DESCRIPTION
PIPELINE_ID is the same across different jobs running in the same
pipeline while BUILD_ID is unique for every job.

Note: In the case where we have 1 test script/runner
CI_BUILD_ID == CI_JOB_ID

