### PR TITLE
weldr: accept rhsm parameter in sources

### DIFF
--- a/internal/client/source_test.go
+++ b/internal/client/source_test.go
@@ -490,6 +490,7 @@ func TestGetSourceInfoV1(t *testing.T) {
 		check_ssl = true
 		check_gpg = true
 		gpgkey_urls = ["https://url/path/to/gpg-key"]
+		rhsm = false
 	`
 	source = strings.Replace(source, "REPO-PATH", testState.repoDir, 1)
 
@@ -503,6 +504,7 @@ func TestGetSourceInfoV1(t *testing.T) {
 	require.Contains(t, info, "package-repo-info-v1", "No source info returned")
 	require.Equal(t, "repo for info test v1", info["package-repo-info-v1"].Name)
 	require.Equal(t, "file://"+testState.repoDir, info["package-repo-info-v1"].URL)
+	require.Equal(t, false, info["package-repo-info-v1"].RHSM)
 
 	resp, err = DeleteSourceV1(testState.socket, "package-repo-info-v1")
 	require.NoError(t, err, "DELETE source failed with a client error")

--- a/internal/store/json.go
+++ b/internal/store/json.go
@@ -63,6 +63,7 @@ type sourceV0 struct {
 	CheckSSL bool     `json:"check_ssl"`
 	System   bool     `json:"system"`
 	Distros  []string `json:"distros"`
+	RHSM     bool     `json:"rhsm"`
 }
 
 type sourcesV0 map[string]sourceV0

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -50,6 +50,7 @@ type SourceConfig struct {
 	CheckSSL bool     `json:"check_ssl" toml:"check_ssl"`
 	System   bool     `json:"system" toml:"system"`
 	Distros  []string `json:"distros" toml:"distros"`
+	RHSM     bool     `json:"rhsm" toml:"rhsm"`
 }
 
 type NotFoundError struct {
@@ -576,6 +577,7 @@ func (s *SourceConfig) RepoConfig(name string) rpmmd.RepoConfig {
 	repo.Name = name
 	repo.IgnoreSSL = !s.CheckSSL
 	repo.CheckGPG = s.CheckGPG
+	repo.RHSM = s.RHSM
 
 	if s.Type == "yum-baseurl" {
 		repo.BaseURL = s.URL

--- a/internal/weldr/api_test.go
+++ b/internal/weldr/api_test.go
@@ -1179,6 +1179,34 @@ check_gpg = false
 	}
 }
 
+func TestSourcesInfoTomlV1(t *testing.T) {
+	tempdir, err := ioutil.TempDir("", "weldr-tests-")
+	require.NoError(t, err)
+	defer os.RemoveAll(tempdir)
+
+	source := `
+id = "fish"
+name = "fish"
+url = "https://download.opensuse.org/repositories/shells:/fish:/release:/3/Fedora_29/"
+type = "yum-baseurl"
+rhsm = true
+`
+
+	sourceStr := `{"check_gpg":false,"check_ssl":false,"id":"fish","name":"fish","rhsm":true,"system":false,"type":"yum-baseurl","url":"https://download.opensuse.org/repositories/shells:/fish:/release:/3/Fedora_29/"}`
+
+	req := httptest.NewRequest("POST", "/api/v1/projects/source/new", bytes.NewReader([]byte(source)))
+	req.Header.Set("Content-Type", "text/x-toml")
+	recorder := httptest.NewRecorder()
+
+	api, _ := createWeldrAPI(tempdir, rpmmd_mock.BaseFixture)
+	api.ServeHTTP(recorder, req)
+
+	r := recorder.Result()
+	require.Equal(t, http.StatusOK, r.StatusCode)
+	test.TestRoute(t, api, true, "GET", "/api/v1/projects/source/info/fish", ``, 200, `{"sources":{"fish":`+sourceStr+`},"errors":[]}`)
+	test.TestRoute(t, api, true, "GET", "/api/v1/projects/source/info/fish?format=json", ``, 200, `{"sources":{"fish":`+sourceStr+`},"errors":[]}`)
+}
+
 // TestSourcesNewWrongTomlV1 Tests that Empty TOML, and invalid TOML should return an error
 func TestSourcesNewWrongTomlV1(t *testing.T) {
 	tempdir, err := ioutil.TempDir("", "weldr-tests-")

--- a/internal/weldr/json.go
+++ b/internal/weldr/json.go
@@ -187,6 +187,7 @@ func NewSourceConfigV1(id string, s store.SourceConfig) SourceConfigV1 {
 	sc.CheckSSL = s.CheckSSL
 	sc.System = s.System
 	sc.Distros = s.Distros
+	sc.RHSM = s.RHSM
 
 	return sc
 }
@@ -203,6 +204,7 @@ type SourceConfigV1 struct {
 	Proxy    string   `json:"proxy,omitempty" toml:"proxy,omitempty"`
 	GPGUrls  []string `json:"gpgkey_urls,omitempty" toml:"gpgkey_urls,omitempty"`
 	Distros  []string `json:"distros,omitempty" toml:"distros,omitempty"`
+	RHSM     bool     `json:"rhsm" toml:"rhsm"`
 }
 
 // Key returns the key, .ID in this case
@@ -229,6 +231,7 @@ func (s SourceConfigV1) SourceConfig() (ssc store.SourceConfig) {
 	ssc.CheckGPG = s.CheckGPG
 	ssc.CheckSSL = s.CheckSSL
 	ssc.Distros = s.Distros
+	ssc.RHSM = s.RHSM
 
 	return ssc
 }


### PR DESCRIPTION
The system sources allow specification of the rhsm parameter, but it
isn't available in the sources configured over the Weldr API. This patch
implements support for it.

Fixes: #1445


This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [x] adequate documentation informing people about the change such as
  - [x] create a file in [news/unreleased](https://github.com/osbuild/osbuild-composer/tree/main/docs/news/unreleased) directory if this change should be mentioned in the release news
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

For user-visible changes, "adequate documentation" is an entry describing the
change for users in docs/news. Please refer to docs/news/README.md for details.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`
-->
