### PR TITLE
tests: fix journalctl killing once again

### DIFF
--- a/test/cases/aws.sh
+++ b/test/cases/aws.sh
@@ -159,6 +159,10 @@ greenprint "💬 Getting compose log and metadata"
 get_compose_log "$COMPOSE_ID"
 get_compose_metadata "$COMPOSE_ID"
 
+# Kill the journal monitor immediately and remove the trap
+sudo pkill -P ${WORKER_JOURNAL_PID}
+trap - EXIT
+
 # Did the compose finish with success?
 if [[ $COMPOSE_STATUS != FINISHED ]]; then
     echo "Something went wrong with the compose. 😢"

--- a/test/cases/azure.sh
+++ b/test/cases/azure.sh
@@ -178,6 +178,10 @@ greenprint "💬 Getting compose log and metadata"
 get_compose_log "$COMPOSE_ID"
 get_compose_metadata "$COMPOSE_ID"
 
+# Kill the journal monitor immediately and remove the trap
+sudo pkill -P ${WORKER_JOURNAL_PID}
+trap - EXIT
+
 # Did the compose finish with success?
 if [[ $COMPOSE_STATUS != FINISHED ]]; then
     echo "Something went wrong with the compose. 😢"

--- a/test/cases/ostree-ng.sh
+++ b/test/cases/ostree-ng.sh
@@ -152,6 +152,10 @@ build_image() {
     get_compose_log "$COMPOSE_ID"
     get_compose_metadata "$COMPOSE_ID"
 
+    # Kill the journal monitor immediately and remove the trap
+    sudo pkill -P ${WORKER_JOURNAL_PID}
+    trap - EXIT
+
     # Did the compose finish with success?
     if [[ $COMPOSE_STATUS != FINISHED ]]; then
         echo "Something went wrong with the compose. 😢"

--- a/test/cases/ostree.sh
+++ b/test/cases/ostree.sh
@@ -184,6 +184,10 @@ build_image() {
     get_compose_log "$COMPOSE_ID"
     get_compose_metadata "$COMPOSE_ID"
 
+    # Kill the journal monitor immediately and remove the trap
+    sudo pkill -P ${WORKER_JOURNAL_PID}
+    trap - EXIT
+
     # Did the compose finish with success?
     if [[ $COMPOSE_STATUS != FINISHED ]]; then
         echo "Something went wrong with the compose. 😢"

--- a/test/cases/vmware.sh
+++ b/test/cases/vmware.sh
@@ -160,6 +160,10 @@ greenprint "💬 Getting compose log and metadata"
 get_compose_log "$COMPOSE_ID"
 get_compose_metadata "$COMPOSE_ID"
 
+# Kill the journal monitor immediately and remove the trap
+sudo pkill -P ${WORKER_JOURNAL_PID}
+trap - EXIT
+
 # Did the compose finish with success?
 if [[ $COMPOSE_STATUS != FINISHED ]]; then
     echo "Something went wrong with the compose. 😢"

--- a/tools/libvirt_test.sh
+++ b/tools/libvirt_test.sh
@@ -166,6 +166,10 @@ greenprint "💬 Getting compose log and metadata"
 get_compose_log "$COMPOSE_ID"
 get_compose_metadata "$COMPOSE_ID"
 
+# Kill the journal monitor immediately and remove the trap
+sudo pkill -P ${WORKER_JOURNAL_PID}
+trap - EXIT
+
 # Did the compose finish with success?
 if [[ $COMPOSE_STATUS != FINISHED ]]; then
     echo "Something went wrong with the compose. 😢"


### PR DESCRIPTION
3a8c6c8a introduced a new logic for killing journalctl. Unfortunately, it
doesn't work properly. In ostree tests, multiple journalctls are spawned
but there can be only one trap active at a time. This caused all but the last
journalctls to hang indefinitely. Unfortunately, hanging background processes
is something that causes the GitLab CI to hang indefinitely as well.

This commit modifies the logic a bit: The trap is still set. However, there's
also an explicit kill of journalctl after the compose is finished. After the
process is successfully killed, the trap is removed.