### PR TITLE
tools/deploy-qemu: fix running with unset QEMU_EXTRA_ARGS

### DIFF
--- a/tools/deploy-qemu
+++ b/tools/deploy-qemu
@@ -70,4 +70,4 @@ qemu-system-x86_64 \
   -net nic,model=virtio \
   -net user,hostfwd=tcp::2222-:22,hostfwd=tcp::4430-:443 \
   -cdrom "$workdir/cloudinit.iso" \
-  "${qemu_extra_args[@]}" "$image"
+  ${qemu_extra_args[0]+"${qemu_extra_args[@]}"} "$image"


### PR DESCRIPTION
tools/deploy-qemu with an unset QEMU_EXTRA_ARGS fails with:

    line 66: qemu_extra_args[@]: unbound variable

Even though the variable is defined, it is not an array. Fix this by
using the "infamous empty array work-around" described here:

    https://lists.gnu.org/archive/html/bug-bash/2010-12/msg00136.html


This pull request includes:

- [x] adequate testing for the new functionality or fixed issue
- [x] adequate documentation informing people about the change such as
  - [ ] create a file in [news/unreleased](https://github.com/osbuild/osbuild-composer/tree/main/docs/news/unreleased) directory if this change should be mentioned in the release news
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

_I think testing and documentation are adequate, because this is a developer-only tool that's explained in the README and wasn't tested before._