### PR TITLE
distribution: The composer-api listens on 9196

### DIFF
--- a/distribution/osbuild-composer-clouddot-template.yml
+++ b/distribution/osbuild-composer-clouddot-template.yml
@@ -38,7 +38,7 @@ objects:
           name: osbuild-composer
           ports:
           - name: api
-            containerPort: 443
+            containerPort: 9196
             protocol: TCP
           - name: workers
             containerPort: 8700
@@ -67,7 +67,7 @@ objects:
       - name: composer-api
         protocol: TCP
         port: ${{API_LISTENER_PORT}}
-        targetPort: 443
+        targetPort: 9196
     selector:
       name: osbuild-composer
 


### PR DESCRIPTION
Getting bad gateway errors, missed that I changed the entrypoint to

```
ENTRYPOINT ["python3", "/opt/entrypoint.py", "--remote-worker-api", "--composer-api", "--composer-api-port", "9196"]
```

We could reset it to 443, but since it's http, and not https, let's try to pick something else.