### PR TITLE
random fixes for tools/deploy-qemu

### DIFF
--- a/tools/deploy-qemu
+++ b/tools/deploy-qemu
@@ -24,7 +24,7 @@ its content as additional arguments to qemu."""
 
 if len(sys.argv) != 3:
     print(HELP_TEXT)
-    exit(1)
+    sys.exit(1)
 
 script_dir = os.path.dirname(os.path.realpath(__file__))
 image = sys.argv[1]

--- a/tools/deploy-qemu
+++ b/tools/deploy-qemu
@@ -33,7 +33,7 @@ userdata = sys.argv[2]
 qemu_extra_args = os.getenv("QEMU_EXTRA_ARGS")
 qemu_extra_args = qemu_extra_args.split(' ') if qemu_extra_args is not None else []
 
-with tempfile.TemporaryDirectory(prefix="qemu-tmp-", dir=script_dir) as workdir:
+with tempfile.TemporaryDirectory(prefix="qemu-tmp-") as workdir:
     os.mkdir(os.path.join(workdir, "cidata"))
 
     if os.path.isdir(userdata):


### PR DESCRIPTION
Two fixes for `tools/deploy-qemu`:
- Previously, the temporary directory was created in the script dir. It just
imo created unnecessary and confusing files in my git checkout. Let's just
use the default temporary directory because we don't really have special
needs for it.
- exit is just a helper for the interactive shell, see:
  https://stackoverflow.com/questions/6501121/difference-between-exit-and-sys-exit-in-python