### PR TITLE
Cloud API test: randomize used GCP zone from the region

### DIFF
--- a/internal/cloud/gcp/compute.go
+++ b/internal/cloud/gcp/compute.go
@@ -87,7 +87,7 @@ func (g *GCP) ComputeImageImport(ctx context.Context, bucket, object, imageName,
 		// regions than what can potentially fit into int32.
 		gceRegion := gceRegions[int(gceRegionIndex.Int64())]
 
-		availableZones, err := g.computeZonesInRegion(ctx, gceRegion)
+		availableZones, err := g.ComputeZonesInRegion(ctx, gceRegion)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get available GCE Zones within Region '%s': %v", region, err)
 		}
@@ -396,11 +396,11 @@ func (g *GCP) storageRegionToComputeRegions(ctx context.Context, region string) 
 	}
 }
 
-// computeZonesInRegion returns list of zones within the given GCE Region, which are "UP".
+// ComputeZonesInRegion returns list of zones within the given GCE Region, which are "UP".
 //
 // Uses:
 //  - Compute Engine API
-func (g *GCP) computeZonesInRegion(ctx context.Context, region string) ([]string, error) {
+func (g *GCP) ComputeZonesInRegion(ctx context.Context, region string) ([]string, error) {
 	var zones []string
 
 	computeService, err := compute.NewService(ctx, option.WithCredentials(g.creds))

--- a/test/cases/api.sh
+++ b/test/cases/api.sh
@@ -318,12 +318,12 @@ ARCH=$(uname -m)
 SSH_USER=
 
 # Generate a string, which can be used as a predictable resource name,
-# especially when running the test in Jenkins where we may need to clean up
+# especially when running the test in CI where we may need to clean up
 # resources in case the test unexpectedly fails or is canceled
-JENKINS_HOME="${JENKINS_HOME:-}"
-if [[ -n "$JENKINS_HOME" ]]; then
-  # in Jenkins, imitate GenerateCIArtifactName() from internal/test/helpers.go
-  TEST_ID="$DISTRO_CODE-$ARCH-$BRANCH_NAME-$BUILD_ID"
+CI="${CI:-false}"
+if [[ "$CI" == true ]]; then
+  # in CI, imitate GenerateCIArtifactName() from internal/test/helpers.go
+  TEST_ID="$DISTRO_CODE-$ARCH-$CI_COMMIT_BRANCH-$CI_BUILD_ID"
 else
   # if not running in Jenkins, generate ID not relying on specific env variables
   TEST_ID=$(uuidgen);


### PR DESCRIPTION
The `api.sh` test currently always defaults to `<REGION>-a` zone when creating instance using the built image. The resources in a zone may get exhausted and the solution is to use a different zone. Currently even a CI job retry won't help with mitigation of such error during a CI run.

Modify `api.sh` to pick random GCP zone for a given region when creating a compute instance. Use only GCP zones which are "UP".

The `cloud-cleaner` relied on the behavior of `api.sh` to always choose the "<REGION>-a" zone. Guessing the chosen zone in `cloud-cleaner` is not viable, but thankfully the instance name is by default unique for the whole GCP project. Modify `cloud-cleaner` to iterate over all available zones in the used region and try to delete the specific instance in each of them.

Make `ComputeZonesInRegion` method from the `internal/cloud/gcp` package exported and use it in `cloud-cleaner` for getting the list of available zones in a region.

Fix generation of predictable `TEST_ID` by `api.sh` test case in GitLab CI.

This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] create a file in [news/unreleased](https://github.com/osbuild/osbuild-composer/tree/main/docs/news/unreleased) directory if this change should be mentioned in the release news
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

For user-visible changes, "adequate documentation" is an entry describing the
change for users in docs/news. Please refer to docs/news/README.md for details.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`
-->
