### PR TITLE
Cloud API: compose/id/metadata

### DIFF
--- a/cmd/osbuild-koji-tests/main_test.go
+++ b/cmd/osbuild-koji-tests/main_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/osbuild/osbuild-composer/internal/rpmmd"
 	"github.com/osbuild/osbuild-composer/internal/upload/koji"
 )
 
@@ -163,7 +164,7 @@ func TestKojiImport(t *testing.T) {
 				Arch: "noarch",
 			},
 			Tools: []koji.Tool{},
-			RPMs:  []koji.RPM{},
+			RPMs:  []rpmmd.RPM{},
 		},
 	}
 	output := []koji.Image{
@@ -175,7 +176,7 @@ func TestKojiImport(t *testing.T) {
 			ChecksumType: "md5",
 			MD5:          hash,
 			Type:         "image",
-			RPMs:         []koji.RPM{},
+			RPMs:         []rpmmd.RPM{},
 			Extra: koji.ImageExtra{
 				Info: koji.ImageExtraInfo{
 					Arch: "noarch",

--- a/cmd/osbuild-koji/main.go
+++ b/cmd/osbuild-koji/main.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/osbuild/osbuild-composer/internal/rpmmd"
 	"github.com/osbuild/osbuild-composer/internal/upload/koji"
 )
 
@@ -83,7 +84,7 @@ func main() {
 				Arch: arch,
 			},
 			Tools: []koji.Tool{},
-			RPMs:  []koji.RPM{},
+			RPMs:  []rpmmd.RPM{},
 		},
 	}
 	output := []koji.Image{
@@ -95,7 +96,7 @@ func main() {
 			ChecksumType: "md5",
 			MD5:          hash,
 			Type:         "image",
-			RPMs:         []koji.RPM{},
+			RPMs:         []rpmmd.RPM{},
 			Extra: koji.ImageExtra{
 				Info: koji.ImageExtraInfo{
 					Arch: arch,

--- a/cmd/osbuild-worker/jobimpl-koji-finalize.go
+++ b/cmd/osbuild-worker/jobimpl-koji-finalize.go
@@ -8,6 +8,7 @@ import (
 	"net/url"
 	"time"
 
+	"github.com/osbuild/osbuild-composer/internal/rpmmd"
 	"github.com/osbuild/osbuild-composer/internal/upload/koji"
 	"github.com/osbuild/osbuild-composer/internal/worker"
 )
@@ -146,7 +147,7 @@ func (impl *KojiFinalizeJobImpl) Run(job worker.Job) error {
 				Arch: buildArgs.Arch,
 			},
 			Tools: []koji.Tool{},
-			RPMs:  osbuildStagesToRPMs(buildArgs.OSBuildOutput.Build.Stages),
+			RPMs:  rpmmd.OSBuildStagesToRPMs(buildArgs.OSBuildOutput.Build.Stages),
 		})
 		images = append(images, koji.Image{
 			BuildRootID:  uint64(i),
@@ -156,7 +157,7 @@ func (impl *KojiFinalizeJobImpl) Run(job worker.Job) error {
 			ChecksumType: "md5",
 			MD5:          buildArgs.ImageHash,
 			Type:         "image",
-			RPMs:         osbuildStagesToRPMs(buildArgs.OSBuildOutput.Stages),
+			RPMs:         rpmmd.OSBuildStagesToRPMs(buildArgs.OSBuildOutput.Stages),
 			Extra: koji.ImageExtra{
 				Info: koji.ImageExtraInfo{
 					Arch: buildArgs.Arch,

--- a/cmd/osbuild-worker/jobimpl-osbuild.go
+++ b/cmd/osbuild-worker/jobimpl-osbuild.go
@@ -30,39 +30,6 @@ type OSBuildJobImpl struct {
 	AzureCreds  *azure.Credentials
 }
 
-func packageMetadataToSignature(pkg osbuild.RPMPackageMetadata) *string {
-	if pkg.SigGPG != "" {
-		return &pkg.SigGPG
-	} else if pkg.SigPGP != "" {
-		return &pkg.SigPGP
-	}
-	return nil
-}
-
-func osbuildStagesToRPMs(stages []osbuild.StageResult) []koji.RPM {
-	rpms := make([]koji.RPM, 0)
-	for _, stage := range stages {
-		switch metadata := stage.Metadata.(type) {
-		case *osbuild.RPMStageMetadata:
-			for _, pkg := range metadata.Packages {
-				rpms = append(rpms, koji.RPM{
-					Type:      "rpm",
-					Name:      pkg.Name,
-					Epoch:     pkg.Epoch,
-					Version:   pkg.Version,
-					Release:   pkg.Release,
-					Arch:      pkg.Arch,
-					Sigmd5:    pkg.SigMD5,
-					Signature: packageMetadataToSignature(pkg),
-				})
-			}
-		default:
-			continue
-		}
-	}
-	return rpms
-}
-
 func appendTargetError(res *worker.OSBuildJobResult, err error) {
 	errStr := err.Error()
 	log.Printf("target failed: %s", errStr)

--- a/docs/news/unreleased/cloud-api-metadata.md
+++ b/docs/news/unreleased/cloud-api-metadata.md
@@ -1,0 +1,7 @@
+# Retrieve metadata about a compose through the Cloud API
+
+A new endpoint is available in the Cloud API at `compose/id/metadata`.  This
+endpoint returns a full package list (NEVRA) for the image that was built and
+the OSTree commit ID for Edge (OSTree) image types.
+
+PR: https://github.com/osbuild/osbuild-composer/pull/1490

--- a/internal/cloudapi/openapi.yml
+++ b/internal/cloudapi/openapi.yml
@@ -63,6 +63,39 @@ paths:
             text/plain:
               schema:
                 type: string
+  /compose/{id}/metadata:
+    get:
+      summary: Get the metadata for a compose.
+      operationId: compose_metadata
+      parameters:
+        - in: path
+          name: id
+          schema:
+            type: string
+            format: uuid
+            example: 123e4567-e89b-12d3-a456-426655440000
+          required: true
+          description: ID of compose status to get
+      description: 'Get the metadata of a finished compose. The exact information returned depends on the requested image type.'
+      responses:
+        '200':
+          description: The metadata for the given compose.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ComposeMetadata'
+        '400':
+          description: Invalid compose id
+          content:
+            text/plain:
+              schema:
+                type: string
+        '404':
+          description: Unknown compose id
+          content:
+            text/plain:
+              schema:
+                type: string
   /compose:
     post:
       summary: Create compose
@@ -163,6 +196,17 @@ components:
         image_name:
           type: string
           example: 'my-image'
+    ComposeMetadata:
+      type: object
+      properties:
+        packages:
+          type: array
+          items:
+            $ref: '#/components/schemas/PackageMetadata'
+          description: 'Package list including NEVRA'
+        ostree_commit:
+          type: string
+          description: 'ID (hash) of the built commit'
     ComposeRequest:
       type: object
       required:
@@ -442,3 +486,28 @@ components:
           type: string
           format: uuid
           example: '123e4567-e89b-12d3-a456-426655440000'
+    PackageMetadata:
+      required:
+        - type
+        - name
+        - version
+        - release
+        - arch
+        - sigmd5
+      properties:
+        type:
+          type: string
+        name:
+          type: string
+        version:
+          type: string
+        release:
+          type: string
+        epoch:
+          type: string
+        arch:
+          type: string
+        sigmd5:
+          type: string
+        signature:
+          type: string

--- a/internal/cloudapi/server.go
+++ b/internal/cloudapi/server.go
@@ -609,7 +609,7 @@ func (server *Server) ComposeMetadata(w http.ResponseWriter, r *http.Request, id
 	resp := new(ComposeMetadata)
 	resp.Packages = &packages
 
-	if ostreeCommitResult != nil {
+	if ostreeCommitResult != nil && ostreeCommitResult.Metadata != nil {
 		commitMetadata, ok := ostreeCommitResult.Metadata.(*osbuild1.OSTreeCommitStageMetadata)
 		if !ok {
 			panic("Failed to convert ostree commit stage metadata")

--- a/internal/distro/distro.go
+++ b/internal/distro/distro.go
@@ -131,6 +131,26 @@ func (m *Manifest) UnmarshalJSON(payload []byte) error {
 	return nil
 }
 
+type manifestVersion struct {
+	Version string `json:"version"`
+}
+
+func (m Manifest) Version() (string, error) {
+	mver := new(manifestVersion)
+	if err := json.Unmarshal(m, mver); err != nil {
+		return "", err
+	}
+
+	switch mver.Version {
+	case "":
+		return "1", nil
+	case "2":
+		return "2", nil
+	default:
+		return "", fmt.Errorf("Unsupported Manifest version %s", mver.Version)
+	}
+}
+
 func GetHostDistroName() (string, bool, bool, error) {
 	f, err := os.Open("/etc/os-release")
 	if err != nil {

--- a/internal/distro/distro_test.go
+++ b/internal/distro/distro_test.go
@@ -3,8 +3,10 @@ package distro_test
 import (
 	"testing"
 
+	"github.com/osbuild/osbuild-composer/internal/distro"
 	"github.com/osbuild/osbuild-composer/internal/distro/distro_test_common"
 	"github.com/osbuild/osbuild-composer/internal/distroregistry"
+	"github.com/stretchr/testify/require"
 )
 
 func TestDistro_Manifest(t *testing.T) {
@@ -15,4 +17,82 @@ func TestDistro_Manifest(t *testing.T) {
 		"*",
 		distroregistry.NewDefault(),
 	)
+}
+
+var (
+	v1manifests = []string{
+		`{}`,
+		`
+{
+	"sources": {
+		"org.osbuild.files": {
+			"urls": {}
+		}
+	},
+	"pipeline": {
+		"build": {
+			"pipeline": {
+				"stages": []
+			},
+			"runner": "org.osbuild.rhel84"
+		},
+		"stages": [],
+		"assembler": {
+			"name": "org.osbuild.qemu",
+			"options": {}
+		}
+	}
+}`,
+	}
+
+	v2manifests = []string{
+		`{"version": "2"}`,
+		`
+{
+	"version": "2",
+	"pipelines": [
+		{
+			"name": "build",
+			"runner": "org.osbuild.rhel84",
+			"stages": []
+		}
+	],
+	"sources": {
+		"org.osbuild.curl": {
+			"items": {}
+		}
+	}
+}`,
+	}
+)
+
+func TestDistro_Version(t *testing.T) {
+	require := require.New(t)
+	expectedVersion := "1"
+	for idx, rawManifest := range v1manifests {
+		manifest := distro.Manifest(rawManifest)
+		detectedVersion, err := manifest.Version()
+		require.NoError(err, "Could not detect Manifest version for %d: %v", idx, err)
+		require.Equal(expectedVersion, detectedVersion, "in manifest %d", idx)
+	}
+
+	expectedVersion = "2"
+	for idx, rawManifest := range v2manifests {
+		manifest := distro.Manifest(rawManifest)
+		detectedVersion, err := manifest.Version()
+		require.NoError(err, "Could not detect Manifest version for %d: %v", idx, err)
+		require.Equal(expectedVersion, detectedVersion, "in manifest %d", idx)
+	}
+
+	{
+		manifest := distro.Manifest("")
+		_, err := manifest.Version()
+		require.Error(err, "Empty manifest did not return an error")
+	}
+
+	{
+		manifest := distro.Manifest("{")
+		_, err := manifest.Version()
+		require.Error(err, "Invalid manifest did not return an error")
+	}
 }

--- a/internal/osbuild1/ostree_commit_assembler.go
+++ b/internal/osbuild1/ostree_commit_assembler.go
@@ -23,19 +23,21 @@ func NewOSTreeCommitAssembler(options *OSTreeCommitAssemblerOptions) *Assembler 
 }
 
 type OSTreeCommitStageMetadata struct {
-	Compose struct {
-		Ref                       string `json:"ref"`
-		OSTreeNMetadataTotal      int    `json:"ostree-n-metadata-total"`
-		OSTreeNMetadataWritten    int    `json:"ostree-n-metadata-written"`
-		OSTreeNContentTotal       int    `json:"ostree-n-content-total"`
-		OSTreeNContentWritten     int    `json:"ostree-n-content-written"`
-		OSTreeNCacheHits          int    `json:"ostree-n-cache-hits"`
-		OSTreeContentBytesWritten int    `json:"ostree-content-bytes-written"`
-		OSTreeCommit              string `json:"ostree-commit"`
-		OSTreeContentChecksum     string `json:"ostree-content-checksum"`
-		OSTreeTimestamp           string `json:"ostree-timestamp"`
-		RPMOSTreeInputHash        string `json:"rpm-ostree-inputhash"`
-	} `json:"compose"`
+	Compose OSTreeCommitStageMetadataCompose `json:"compose"`
+}
+
+type OSTreeCommitStageMetadataCompose struct {
+	Ref                       string `json:"ref"`
+	OSTreeNMetadataTotal      int    `json:"ostree-n-metadata-total"`
+	OSTreeNMetadataWritten    int    `json:"ostree-n-metadata-written"`
+	OSTreeNContentTotal       int    `json:"ostree-n-content-total"`
+	OSTreeNContentWritten     int    `json:"ostree-n-content-written"`
+	OSTreeNCacheHits          int    `json:"ostree-n-cache-hits"`
+	OSTreeContentBytesWritten int    `json:"ostree-content-bytes-written"`
+	OSTreeCommit              string `json:"ostree-commit"`
+	OSTreeContentChecksum     string `json:"ostree-content-checksum"`
+	OSTreeTimestamp           string `json:"ostree-timestamp"`
+	RPMOSTreeInputHash        string `json:"rpm-ostree-inputhash"`
 }
 
 func (OSTreeCommitStageMetadata) isStageMetadata() {}

--- a/internal/osbuild1/ostree_commit_assembler.go
+++ b/internal/osbuild1/ostree_commit_assembler.go
@@ -21,3 +21,21 @@ func NewOSTreeCommitAssembler(options *OSTreeCommitAssemblerOptions) *Assembler 
 		Options: options,
 	}
 }
+
+type OSTreeCommitStageMetadata struct {
+	Compose struct {
+		Ref                       string `json:"ref"`
+		OSTreeNMetadataTotal      int    `json:"ostree-n-metadata-total"`
+		OSTreeNMetadataWritten    int    `json:"ostree-n-metadata-written"`
+		OSTreeNContentTotal       int    `json:"ostree-n-content-total"`
+		OSTreeNContentWritten     int    `json:"ostree-n-content-written"`
+		OSTreeNCacheHits          int    `json:"ostree-n-cache-hits"`
+		OSTreeContentBytesWritten int    `json:"ostree-content-bytes-written"`
+		OSTreeCommit              string `json:"ostree-commit"`
+		OSTreeContentChecksum     string `json:"ostree-content-checksum"`
+		OSTreeTimestamp           string `json:"ostree-timestamp"`
+		RPMOSTreeInputHash        string `json:"rpm-ostree-inputhash"`
+	} `json:"compose"`
+}
+
+func (OSTreeCommitStageMetadata) isStageMetadata() {}

--- a/internal/osbuild1/result_test.go
+++ b/internal/osbuild1/result_test.go
@@ -3,6 +3,7 @@ package osbuild1
 import (
 	"bytes"
 	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -119,6 +120,19 @@ func TestUnmarshalV2Success(t *testing.T) {
 	assert.Len(t, result.Stages, 16)
 	assert.True(t, result.Stages[15].Success)
 	assert.NotEmpty(t, result.Stages[0].Name)
+
+	// check metadata
+	for _, stage := range result.Stages {
+		if strings.HasSuffix(stage.Name, "org.osbuild.rpm") {
+			rpmMd, convOk := stage.Metadata.(RPMStageMetadata)
+			assert.True(t, convOk)
+			assert.Greater(t, len(rpmMd.Packages), 0)
+		} else if strings.HasSuffix(stage.Name, "org.osbuild.ostree.commit") {
+			commitMd, convOk := stage.Metadata.(OSTreeCommitStageMetadata)
+			assert.True(t, convOk)
+			assert.NotEmpty(t, commitMd.Compose.Ref)
+		}
+	}
 }
 
 func TestUnmarshalV2Failure(t *testing.T) {

--- a/internal/osbuild1/result_test.go
+++ b/internal/osbuild1/result_test.go
@@ -170,7 +170,7 @@ func TestWriteFull(t *testing.T) {
 		Success: true,
 	}
 
-	testAssembler := rawAssemblerResult{
+	testAssembler := StageResult{
 		Name:    "testAssembler",
 		Options: []byte(testOptions),
 		Success: true,

--- a/internal/osbuild2/ostree_commit_stage.go
+++ b/internal/osbuild2/ostree_commit_stage.go
@@ -39,3 +39,23 @@ func NewOSTreeCommitStage(options *OSTreeCommitStageOptions, inputs *OSTreeCommi
 		Inputs:  inputs,
 	}
 }
+
+type OSTreeCommitStageMetadata struct {
+	Compose OSTreeCommitStageMetadataCompose `json:"compose"`
+}
+
+type OSTreeCommitStageMetadataCompose struct {
+	Ref                       string `json:"ref"`
+	OSTreeNMetadataTotal      int    `json:"ostree-n-metadata-total"`
+	OSTreeNMetadataWritten    int    `json:"ostree-n-metadata-written"`
+	OSTreeNContentTotal       int    `json:"ostree-n-content-total"`
+	OSTreeNContentWritten     int    `json:"ostree-n-content-written"`
+	OSTreeNCacheHits          int    `json:"ostree-n-cache-hits"`
+	OSTreeContentBytesWritten int    `json:"ostree-content-bytes-written"`
+	OSTreeCommit              string `json:"ostree-commit"`
+	OSTreeContentChecksum     string `json:"ostree-content-checksum"`
+	OSTreeTimestamp           string `json:"ostree-timestamp"`
+	RPMOSTreeInputHash        string `json:"rpm-ostree-inputhash"`
+}
+
+func (OSTreeCommitStageMetadata) isStageMetadata() {}

--- a/internal/osbuild2/rpm_stage.go
+++ b/internal/osbuild2/rpm_stage.go
@@ -51,3 +51,22 @@ func NewRPMStage(options *RPMStageOptions, inputs *RPMStageInputs) *Stage {
 		Options: options,
 	}
 }
+
+// RPMStageMetadata gives the set of packages installed by the RPM stage
+type RPMStageMetadata struct {
+	Packages []RPMPackageMetadata `json:"packages"`
+}
+
+// RPMPackageMetadata contains the metadata extracted from one RPM header
+type RPMPackageMetadata struct {
+	Name    string  `json:"name"`
+	Version string  `json:"version"`
+	Release string  `json:"release"`
+	Epoch   *string `json:"epoch"`
+	Arch    string  `json:"arch"`
+	SigMD5  string  `json:"sigmd5"`
+	SigPGP  string  `json:"sigpgp"`
+	SigGPG  string  `json:"siggpg"`
+}
+
+func (RPMStageMetadata) isStageMetadata() {}

--- a/internal/rpmmd/metadata.go
+++ b/internal/rpmmd/metadata.go
@@ -1,0 +1,49 @@
+package rpmmd
+
+import (
+	osbuild "github.com/osbuild/osbuild-composer/internal/osbuild1"
+)
+
+type RPM struct {
+	Type      string  `json:"type"` // must be 'rpm'
+	Name      string  `json:"name"`
+	Version   string  `json:"version"`
+	Release   string  `json:"release"`
+	Epoch     *string `json:"epoch,omitempty"`
+	Arch      string  `json:"arch"`
+	Sigmd5    string  `json:"sigmd5"`
+	Signature *string `json:"signature"`
+}
+
+func OSBuildStagesToRPMs(stages []osbuild.StageResult) []RPM {
+	rpms := make([]RPM, 0)
+	for _, stage := range stages {
+		switch metadata := stage.Metadata.(type) {
+		case *osbuild.RPMStageMetadata:
+			for _, pkg := range metadata.Packages {
+				rpms = append(rpms, RPM{
+					Type:      "rpm",
+					Name:      pkg.Name,
+					Epoch:     pkg.Epoch,
+					Version:   pkg.Version,
+					Release:   pkg.Release,
+					Arch:      pkg.Arch,
+					Sigmd5:    pkg.SigMD5,
+					Signature: packageMetadataToSignature(pkg),
+				})
+			}
+		default:
+			continue
+		}
+	}
+	return rpms
+}
+
+func packageMetadataToSignature(pkg osbuild.RPMPackageMetadata) *string {
+	if pkg.SigGPG != "" {
+		return &pkg.SigGPG
+	} else if pkg.SigPGP != "" {
+		return &pkg.SigPGP
+	}
+	return nil
+}

--- a/internal/rpmmd/metadata_test.go
+++ b/internal/rpmmd/metadata_test.go
@@ -1,11 +1,11 @@
-package main
+package rpmmd
 
 import (
 	"encoding/json"
-	osbuild "github.com/osbuild/osbuild-composer/internal/osbuild1"
-	"github.com/osbuild/osbuild-composer/internal/upload/koji"
-	"github.com/stretchr/testify/require"
 	"testing"
+
+	osbuild "github.com/osbuild/osbuild-composer/internal/osbuild1"
+	"github.com/stretchr/testify/require"
 )
 
 func Test_osbuildStagesToRPMs(t *testing.T) {
@@ -76,12 +76,12 @@ func Test_osbuildStagesToRPMs(t *testing.T) {
 	err := json.Unmarshal([]byte(raw), &stageResults)
 	require.NoError(t, err)
 
-	rpms := osbuildStagesToRPMs(stageResults)
+	rpms := OSBuildStagesToRPMs(stageResults)
 
 	require.Len(t, rpms, 3)
 
 	signature1 := "89023304000108001d162104963a2beb02009608fe67ea4249fd77499570ff3105025f5a272b000a091049fd77499570ff31ccdb0ffe38b95a55ebf3c021526b3cd4f2358c7e23f7767d1f5ce4b7cccef7b33653c6a96a23022313a818fbaf7abeb41837910f0d3ac15664e02838d5939d38ff459aa0076e248728a032d3ae09ddfaec955f941601081a2e3f9bbd49586fd65c1bc1b31685aeb0405687d1791471eab7359ccf00d5584ddef680e99ebc8a4846316391b9baa68ac8ed8ad696ee16fd625d847f8edd92517df3ea6920a46b77b4f119715a0f619f38835d25e0bd0eb5cfad08cd9c796eace6a2b28f4d3dee552e6068255d9748dc2a1906c951e0ba8aed9922ab24e1f659413a06083f8a0bfea56cfff14bddef23bced449f36bcd369da72f90ddf0512e7b0801ba5a0c8eaa8eb0582c630815e992192042cfb0a7c7239f76219197c2fdf18b6553260c105280806d4f037d7b04bdf3da9fd7e9a207db5c71f7e548f4288928f047c989c4cb9cbb8088eec7bd2fa5c252e693f51a3cfc660f666af6a255a5ca0fd2216d5ccd66cbd9c11afa61067d7f615ec8d0dc0c879b5fe633d8c9443f97285da597e4da8a3993af36f0be06acfa9b8058ec70bbc78b876e4c6c5d2108fb05c15a74ba48a3d7ded697cbc1748c228d77d1e0794a41fd5240fa67c3ed745fe47555a47c3d6163d8ce95fd6c2d0d6fa48f8e5b411e571e442109b1cb200d9a8117ee08bfe645f96aca34f7b7559622bbab75143dcad59f126ae0d319e6668ebba417e725638c4febf2e"
-	require.Equal(t, koji.RPM{
+	require.Equal(t, RPM{
 		Type:      "rpm",
 		Name:      "libgcc",
 		Version:   "10.0.1",

--- a/internal/upload/koji/koji.go
+++ b/internal/upload/koji/koji.go
@@ -14,6 +14,7 @@ import (
 	"os"
 
 	"github.com/kolo/xmlrpc"
+	"github.com/osbuild/osbuild-composer/internal/rpmmd"
 	"github.com/ubccr/kerby/khttp"
 )
 
@@ -63,24 +64,13 @@ type Tool struct {
 	Version string `json:"version"`
 }
 
-type RPM struct {
-	Type      string  `json:"type"` // must be 'rpm'
-	Name      string  `json:"name"`
-	Version   string  `json:"version"`
-	Release   string  `json:"release"`
-	Epoch     *string `json:"epoch,omitempty"`
-	Arch      string  `json:"arch"`
-	Sigmd5    string  `json:"sigmd5"`
-	Signature *string `json:"signature"`
-}
-
 type BuildRoot struct {
 	ID               uint64           `json:"id"`
 	Host             Host             `json:"host"`
 	ContentGenerator ContentGenerator `json:"content_generator"`
 	Container        Container        `json:"container"`
 	Tools            []Tool           `json:"tools"`
-	RPMs             []RPM            `json:"components"`
+	RPMs             []rpmmd.RPM      `json:"components"`
 }
 
 type ImageExtraInfo struct {
@@ -93,15 +83,15 @@ type ImageExtra struct {
 }
 
 type Image struct {
-	BuildRootID  uint64     `json:"buildroot_id"`
-	Filename     string     `json:"filename"`
-	FileSize     uint64     `json:"filesize"`
-	Arch         string     `json:"arch"`
-	ChecksumType string     `json:"checksum_type"` // must be 'md5'
-	MD5          string     `json:"checksum"`
-	Type         string     `json:"type"`
-	RPMs         []RPM      `json:"components"`
-	Extra        ImageExtra `json:"extra"`
+	BuildRootID  uint64      `json:"buildroot_id"`
+	Filename     string      `json:"filename"`
+	FileSize     uint64      `json:"filesize"`
+	Arch         string      `json:"arch"`
+	ChecksumType string      `json:"checksum_type"` // must be 'md5'
+	MD5          string      `json:"checksum"`
+	Type         string      `json:"type"`
+	RPMs         []rpmmd.RPM `json:"components"`
+	Extra        ImageExtra  `json:"extra"`
 }
 
 type Metadata struct {


### PR DESCRIPTION
This pull request includes:

- [x] adequate testing for the new functionality or fixed issue
- [x] adequate documentation informing people about the change such as
  - [x] create a file in [news/unreleased](https://github.com/osbuild/osbuild-composer/tree/main/docs/news/unreleased) directory if this change should be mentioned in the release news
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

For user-visible changes, "adequate documentation" is an entry describing the
change for users in docs/news. Please refer to docs/news/README.md for details.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`
-->

_Followup to #1439_

Added a new Cloud API endpoint that returns metadata about a finished build.  Currently the metadata contains full package list (NEVRA) for the built image and, where available, the commit ID (hash) for the created Edge commit.

## Internal changes
- Utility functions for extracting and structuring the RPM metadata was moved to an internal package to be reused.
- Added a small utility function that reads the schema version from a raw Manifest.
- Metadata returned from stages was previously only stored for the RPM stage.  Now all metadata from all stages is stored.  Metadata from the `org.osbuild.ostree.commit` stage are also structured.

See individual commit messages for more details.