### PR TITLE
devcontainer: introduce VSCode dev container

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,17 @@
+FROM fedora:34
+
+# Install few packages for convenient usage.
+# Inspired by the devcontainer in osbuild.
+RUN dnf install -y \
+    fish \
+    fd-find \
+    ripgrep \
+    jq
+# We build composer using RPM, install the tooling
+RUN dnf install fedora-packager rpmdevtools go-srpm-macros -y
+# The list of requirements is specified in the spec file.
+# To install them, dnf needs the "builddep" command.
+RUN dnf install 'dnf-command(builddep)' -y
+# Copy the specfile and install the dependencies.
+COPY osbuild-composer.spec /tmp/osbuild-composer.spec
+RUN dnf builddep /tmp/osbuild-composer.spec -y

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,11 @@
+{
+  "name": "ComposerBuilder",
+  "build": {
+    "dockerfile": "Dockerfile",
+    "context": ".."
+  },
+  "extensions": [
+    "laurenttreguier.rpm-spec",
+    "golang.Go"
+  ]
+}


### PR DESCRIPTION
Introduce Dockerfile and devcontainer.json specifying how to build and
run a containerized development environment in VSCode.

The configuration is inspired by the osbuild repo where a similar
configuration directory already exists.


This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] create a file in [news/unreleased](https://github.com/osbuild/osbuild-composer/tree/main/docs/news/unreleased) directory if this change should be mentioned in the release news
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

For user-visible changes, "adequate documentation" is an entry describing the
change for users in docs/news. Please refer to docs/news/README.md for details.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`
-->
