### PR TITLE
tests: update cloud-cleaner

### DIFF
--- a/schutzbot/run_cloud_cleaner.sh
+++ b/schutzbot/run_cloud_cleaner.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 source /etc/os-release
 DISTRO_CODE="${DISTRO_CODE:-${ID}_${VERSION_ID//./}}"
 BRANCH_NAME="${BRANCH_NAME:-${CI_COMMIT_BRANCH}}"
-BUILD_ID="${BUILD_ID:-${CI_PIPELINE_ID}}"
+BUILD_ID="${BUILD_ID:-${CI_BUILD_ID}}"
 
 CLEANER_CMD="env $(cat "${AZURE_CREDS:-/dev/null}") BRANCH_NAME=$BRANCH_NAME BUILD_ID=$BUILD_ID DISTRO_CODE=$DISTRO_CODE /usr/libexec/osbuild-composer-test/cloud-cleaner"
 


### PR DESCRIPTION
In 0680214c9b20b76f82c381fb3472d83846ca0c71 the BUILD_ID was changed in azure.sh test but not in cloud_cleaner causing cloud-cleaner to not clean up properly. This fixes that.

I hope this will reduce the ammount of leftover resources in Azure.


This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] create a file in [news/unreleased](https://github.com/osbuild/osbuild-composer/tree/main/docs/news/unreleased) directory if this change should be mentioned in the release news
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

For user-visible changes, "adequate documentation" is an entry describing the
change for users in docs/news. Please refer to docs/news/README.md for details.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`
-->
