### PR TITLE
upload/aws: add support for session tokens

### DIFF
--- a/cmd/osbuild-upload-aws/main.go
+++ b/cmd/osbuild-upload-aws/main.go
@@ -5,12 +5,14 @@ import (
 	"fmt"
 
 	"github.com/aws/aws-sdk-go/aws"
+
 	"github.com/osbuild/osbuild-composer/internal/upload/awsupload"
 )
 
 func main() {
 	var accessKeyID string
 	var secretAccessKey string
+	var sessionToken string
 	var region string
 	var bucketName string
 	var keyName string
@@ -20,6 +22,7 @@ func main() {
 	var arch string
 	flag.StringVar(&accessKeyID, "access-key-id", "", "access key ID")
 	flag.StringVar(&secretAccessKey, "secret-access-key", "", "secret access key")
+	flag.StringVar(&sessionToken, "session-token", "", "session token")
 	flag.StringVar(&region, "region", "", "target region")
 	flag.StringVar(&bucketName, "bucket", "", "target S3 bucket name")
 	flag.StringVar(&keyName, "key", "", "target S3 key name")
@@ -29,7 +32,7 @@ func main() {
 	flag.StringVar(&arch, "arch", "", "arch (x86_64 or aarch64)")
 	flag.Parse()
 
-	a, err := awsupload.New(region, accessKeyID, secretAccessKey)
+	a, err := awsupload.New(region, accessKeyID, secretAccessKey, sessionToken)
 	if err != nil {
 		println(err.Error())
 		return

--- a/cmd/osbuild-worker/jobimpl-osbuild.go
+++ b/cmd/osbuild-worker/jobimpl-osbuild.go
@@ -208,7 +208,7 @@ func (impl *OSBuildJobImpl) Run(job worker.Job) error {
 			osbuildJobResult.Success = true
 			osbuildJobResult.UploadStatus = "success"
 		case *target.AWSTargetOptions:
-			a, err := awsupload.New(options.Region, options.AccessKeyID, options.SecretAccessKey)
+			a, err := awsupload.New(options.Region, options.AccessKeyID, options.SecretAccessKey, "")
 			if err != nil {
 				appendTargetError(osbuildJobResult, err)
 				return nil
@@ -244,7 +244,7 @@ func (impl *OSBuildJobImpl) Run(job worker.Job) error {
 			osbuildJobResult.Success = true
 			osbuildJobResult.UploadStatus = "success"
 		case *target.AWSS3TargetOptions:
-			a, err := awsupload.New(options.Region, options.AccessKeyID, options.SecretAccessKey)
+			a, err := awsupload.New(options.Region, options.AccessKeyID, options.SecretAccessKey, "")
 			if err != nil {
 				appendTargetError(osbuildJobResult, err)
 				return nil

--- a/internal/boot/aws.go
+++ b/internal/boot/aws.go
@@ -13,6 +13,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/ec2"
+
 	"github.com/osbuild/osbuild-composer/internal/common"
 	"github.com/osbuild/osbuild-composer/internal/upload/awsupload"
 )
@@ -89,7 +90,7 @@ func wrapErrorf(innerError error, format string, a ...interface{}) error {
 // The s3 key is never returned - the same thing is done in osbuild-composer,
 // the user has no way of getting the s3 key.
 func UploadImageToAWS(c *awsCredentials, imagePath string, imageName string) error {
-	uploader, err := awsupload.New(c.Region, c.AccessKeyId, c.SecretAccessKey)
+	uploader, err := awsupload.New(c.Region, c.AccessKeyId, c.SecretAccessKey, "")
 	if err != nil {
 		return fmt.Errorf("cannot create aws uploader: %v", err)
 	}

--- a/internal/upload/awsupload/awsupload.go
+++ b/internal/upload/awsupload/awsupload.go
@@ -21,9 +21,9 @@ type AWS struct {
 	s3       *s3.S3
 }
 
-func New(region, accessKeyID, accessKey string) (*AWS, error) {
+func New(region, accessKeyID, accessKey, sessionToken string) (*AWS, error) {
 	// Session credentials
-	creds := credentials.NewStaticCredentials(accessKeyID, accessKey, "")
+	creds := credentials.NewStaticCredentials(accessKeyID, accessKey, sessionToken)
 
 	// Create a Session with a custom region
 	sess, err := session.NewSession(&aws.Config{


### PR DESCRIPTION
If a user uses a temporary access key for login, a session token is also
needed.

This commit adds support for it to the internal aws library and also
to the osbuild-upload-aws helper. Note that this doesn't affect the main
osbuild-composer executable nor the worker. Everything here should work
as before and session tokens are not supported. Something for a follow up
if anyone needs it.

Signed-off-by: Ondřej Budai <ondrej@budai.cz>


This pull request includes:

- [x] adequate testing for the new functionality or fixed issue
  - our existing test suite covers that this change is backward compatible, no new tests are needed, this just a change to development tools
- [x] adequate documentation informing people about the change such as
  - just a change of development tools

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

For user-visible changes, "adequate documentation" is an entry describing the
change for users in docs/news. Please refer to docs/news/README.md for details.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`
-->
