### PR TITLE
ci: remove EXTRA_REPO_PATH_SEGMENT

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -29,8 +29,6 @@ RPM:
   extends: .terraform
   rules:
     - if: '$CI_PIPELINE_SOURCE != "schedule"'
-  variables:
-    EXTRA_REPO_PATH_SEGMENT: "gitlab/"
   script:
     - sh "schutzbot/mockbuild.sh"
   after_script:
@@ -57,8 +55,6 @@ Container:
   extends: .terraform
   rules:
     - if: '$CI_PIPELINE_SOURCE != "schedule"'
-  variables:
-    EXTRA_REPO_PATH_SEGMENT: "gitlab/"
   script:
     - sh "schutzbot/containerbuild.sh"
   parallel:
@@ -71,8 +67,6 @@ Prepare-rhel-internal:
   extends: .terraform
   rules:
     - if: '$CI_PIPELINE_SOURCE == "schedule"'
-  variables:
-    EXTRA_REPO_PATH_SEGMENT: "gitlab/"
   script:
     - schutzbot/prepare-rhel-internal.sh
   artifacts:
@@ -93,8 +87,6 @@ Base:
   rules:
     - if: '$CI_PIPELINE_SOURCE != "schedule"'
     - if: '$CI_PIPELINE_SOURCE == "schedule" && $RUNNER =~ /[\S]+rhel-[8-9]\.[\S]+/'
-  variables:
-    EXTRA_REPO_PATH_SEGMENT: "gitlab/"
   script:
     - schutzbot/deploy.sh
     - /usr/libexec/tests/osbuild-composer/base_tests.sh
@@ -128,8 +120,6 @@ OSTree:
   rules:
     - if: '$CI_PIPELINE_SOURCE != "schedule"'
     - if: '$CI_PIPELINE_SOURCE == "schedule" && $RUNNER =~ /[\S]+rhel-[8-9]\.[\S]+/'
-  variables:
-    EXTRA_REPO_PATH_SEGMENT: "gitlab/"
   script:
     - schutzbot/deploy.sh
     - /usr/libexec/tests/osbuild-composer/ostree.sh
@@ -170,8 +160,6 @@ Integration:
   rules:
     - if: '$CI_PIPELINE_SOURCE != "schedule"'
     - if: '$CI_PIPELINE_SOURCE == "schedule" && $RUNNER =~ /[\S]+rhel-[8-9]\.[\S]+/'
-  variables:
-    EXTRA_REPO_PATH_SEGMENT: "gitlab/"
   script:
     - schutzbot/deploy.sh
     - /usr/libexec/tests/osbuild-composer/${SCRIPT}
@@ -212,8 +200,6 @@ API:
   rules:
     - if: '$CI_PIPELINE_SOURCE != "schedule"'
     - if: '$CI_PIPELINE_SOURCE == "schedule" && $RUNNER =~ /[\S]+rhel-[8-9]\.[\S]+/'
-  variables:
-    EXTRA_REPO_PATH_SEGMENT: "gitlab/"
   script:
     - schutzbot/deploy.sh
     - /usr/libexec/tests/osbuild-composer/api.sh ${TARGET}

--- a/schutzbot/deploy.sh
+++ b/schutzbot/deploy.sh
@@ -35,19 +35,11 @@ function setup_repo {
   local project=$1
   local commit=$2
   local priority=${3:-10}
-
-  local extra_repo_path_segment=""
-  if [[ "$project" == "osbuild-composer" ]]; then
-    # Used in the gitlab CI proof of concept so it can upload its rpms to
-    # a different location.
-    extra_repo_path_segment="${EXTRA_REPO_PATH_SEGMENT:-}"
-  fi
-
   greenprint "Setting up dnf repository for ${project} ${commit}"
   sudo tee "/etc/yum.repos.d/${project}.repo" << EOF
 [${project}]
 name=${project} ${commit}
-baseurl=http://osbuild-composer-repos.s3-website.us-east-2.amazonaws.com/${extra_repo_path_segment}${project}/${ID}-${VERSION_ID}/${ARCH}/${commit}
+baseurl=http://osbuild-composer-repos.s3-website.us-east-2.amazonaws.com/${project}/${ID}-${VERSION_ID}/${ARCH}/${commit}
 enabled=1
 gpgcheck=0
 priority=${priority}

--- a/schutzbot/mockbuild.sh
+++ b/schutzbot/mockbuild.sh
@@ -26,13 +26,9 @@ REPO_BUCKET=osbuild-composer-repos
 # Public URL for the S3 bucket with our artifacts.
 MOCK_REPO_BASE_URL="http://osbuild-composer-repos.s3-website.us-east-2.amazonaws.com"
 
-# Used in the gitlab CI proof of concept so it can upload its rpms to
-# a different location.
-EXTRA_REPO_PATH_SEGMENT="${EXTRA_REPO_PATH_SEGMENT:-}"
-
 # Relative path of the repository – used for constructing both the local and
 # remote paths below, so that they're consistent.
-REPO_PATH=${EXTRA_REPO_PATH_SEGMENT}osbuild-composer/${ID}-${VERSION_ID}/${ARCH}/${COMMIT}
+REPO_PATH=osbuild-composer/${ID}-${VERSION_ID}/${ARCH}/${COMMIT}
 
 # Directory to hold the RPMs temporarily before we upload them.
 REPO_DIR=repo/${REPO_PATH}


### PR DESCRIPTION
EXTRA_REPO_PATH_SEGMENT was needed when both Jenkins and Gitlab CI
were running in parallel (so they don't override their artifacts).

Jenkins is now decommissioned so we can drop the variable.