### PR TITLE
tests: Run some libvirt tests in openstack

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -153,7 +153,6 @@ New OSTree:
 .INTEGRATION_TESTS: &INTEGRATION_TESTS
   SCRIPT:
     - koji.sh
-    - libvirt.sh
     - aws.sh
     - azure.sh
     - vmware.sh
@@ -174,14 +173,14 @@ Integration:
           - aws/fedora-33-x86_64
           # See COMPOSER-919
           # - aws/fedora-34-x86_64
-          - openstack/centos-stream-8-x86_64
+          - aws/centos-stream-8-x86_64
       - <<: *INTEGRATION_TESTS
         RUNNER:
           - aws/rhel-8-x86_64
           - aws/rhel-8.4-x86_64
         INTERNAL_NETWORK: ["true"]
       - SCRIPT:
-         - azure_hyperv_gen2.sh
+          - azure_hyperv_gen2.sh
         RUNNER:
           - aws/rhel-8.4-x86_64
         INTERNAL_NETWORK: ["true"]
@@ -190,6 +189,17 @@ Integration:
           - aws/rhel-8-x86_64
         INTERNAL_NETWORK: ["true"]
         DISTRO_CODE: ["rhel_90"]
+      - SCRIPT:
+          - libvirt.sh
+        RUNNER:
+          - aws/fedora-33-x86_64
+          - openstack/centos-stream-8-x86_64
+      - SCRIPT:
+          - libvirt.sh
+        RUNNER:
+          - aws/rhel-8-x86_64
+          - aws/rhel-8.4-x86_64
+        INTERNAL_NETWORK: ["true"]
 
 .API_TESTS: &API_TESTS
   TARGET:


### PR DESCRIPTION
This is just me trying to run just libvirt tests on Openstack.

There are two reasons for this:
1) TCG is not supported downstream meaning we can't expect booting qcow images without kvm to work.
2) We don't want to move all integration testing to Openstack as it's severely slowing down the CI as can be seen now when we moved Centos stream 8 integration testing.

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] create a file in [news/unreleased](https://github.com/osbuild/osbuild-composer/tree/main/docs/news/unreleased) directory if this change should be mentioned in the release news
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

For user-visible changes, "adequate documentation" is an entry describing the
change for users in docs/news. Please refer to docs/news/README.md for details.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`
-->
