### PR TITLE
distro/rhel90: add s390utils-core to the build pipeline for s390x

### DIFF
--- a/internal/distro/rhel90/packages.go
+++ b/internal/distro/rhel90/packages.go
@@ -64,7 +64,9 @@ var packages = struct {
 			"grub2-ppc64le",
 			"grub2-ppc64le-modules",
 		},
-		s390x: nil,
+		s390x: []string{
+			"s390utils-core",
+		},
 	},
 	Qcow2: rpmmd.PackageSet{
 		Include: []string{


### PR DESCRIPTION
A recent update to crypto-policies changed its requirements from:

Recommends: grubby

to:

Recommends: (grubby if kernel)

We don't install kernel in the build pipeline, thus grubby was now no longer
installed. This caused also s390utils-core to not be installed on s390x.
s390utils-core has to be in the build pipeline though because we use
/usr/sbin/zipl from it to install the bootloader to s390x images.

Long story short, images for s390x currently cannot be build because
/usr/sbin/zipl is no longer in the build pipeline. This commit fixes that
by explicitly adding s390utils-core to the package list for s390x.

I verified this fix on an actual s390x machine. The test manifest was
regenerated but it's actually still the same because we use an older
snapshot that doesn't contain the newest crypto-policies change.

Kudos to Tomáš Hozza for helping me out!

Signed-off-by: Ondřej Budai <ondrej@budai.cz>


This pull request includes:

- [x] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] create a file in [news/unreleased](https://github.com/osbuild/osbuild-composer/tree/main/docs/news/unreleased) directory if this change should be mentioned in the release news
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

For user-visible changes, "adequate documentation" is an entry describing the
change for users in docs/news. Please refer to docs/news/README.md for details.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`
-->
