### PR TITLE
CI: limit testing for RHEL 8.5

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -107,7 +107,8 @@ Base:
           - aws/centos-stream-8-aarch64
       - RUNNER:
           - aws/rhel-8.4-x86_64
-          - aws/rhel-8.5-x86_64
+          # main image types not yet supported in 8.5
+          # - aws/rhel-8.5-x86_64
           # see COMPOSER-918
           # - aws/rhel-8.4-aarch64
         INTERNAL_NETWORK: ["true"]
@@ -225,19 +226,19 @@ API:
         INTERNAL_NETWORK: ["true"]
         DISTRO_CODE: ["rhel_90"]
 
-Installer:
-  stage: test
-  extends: .terraform
-  rules:
-    - if: '$CI_PIPELINE_SOURCE != "schedule"'
-    - if: '$CI_PIPELINE_SOURCE == "schedule" && $RUNNER =~ /[\S]+rhel-[8-9]\.[\S]+/'
-  script:
-    - schutzbot/deploy.sh
-    - /usr/libexec/tests/osbuild-composer/installers.sh
-  parallel:
-    matrix:
-      - RUNNER:
-          - openstack/rhel-8.5-x86_64
+# Installer:
+#   stage: test
+#   extends: .terraform
+#   rules:
+#     - if: '$CI_PIPELINE_SOURCE != "schedule"'
+#     - if: '$CI_PIPELINE_SOURCE == "schedule" && $RUNNER =~ /[\S]+rhel-[8-9]\.[\S]+/'
+#   script:
+#     - schutzbot/deploy.sh
+#     - /usr/libexec/tests/osbuild-composer/installers.sh
+#   parallel:
+#     matrix:
+#       - RUNNER:
+#           - openstack/rhel-8.5-x86_64
 
 finish:
   stage: finish

--- a/test/cases/installers.sh
+++ b/test/cases/installers.sh
@@ -231,7 +231,6 @@ sudo composer-cli blueprints depsolve installer
 # Build installer image.
 build_image installer tar-installer
 
-COMPOSE_ID=7108ede0-b2e4-45ae-8f1b-c1681d4ba18c
 # Download the image
 greenprint "📥 Downloading the installer image"
 sudo composer-cli compose image "${COMPOSE_ID}" > /dev/null


### PR DESCRIPTION
This PR is meant to limit the number of tests run for RHEL 8.5 to just the features and image types that are supported.

- Disable base tests on RHEL 8.5
The unit tests should be passing here but there others depend on image types that aren't supported.

This means that there will be untested features for RHEL 8.5, but that should be fixed soon with the main image types.