### PR TITLE
tests: Don't overwrite CI statuses on main for nightly pipelines

### DIFF
--- a/schutzbot/update_github_status.sh
+++ b/schutzbot/update_github_status.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
 
+
+# Don't overwrite CI statuses on GitHub branches for nightly pipelines
+if [[ "$CI_PIPELINE_SOURCE" == "schedule" ]]; then
+    exit 0
+fi
+
 if [[ $1 == "start" ]]; then
   GITHUB_NEW_STATE="pending"
   GITHUB_NEW_DESC="I'm currently testing this commit, be patient."


### PR DESCRIPTION
Closes #1527.

