### PR TITLE
Filesystem config

### DIFF
--- a/internal/blueprint/customizations.go
+++ b/internal/blueprint/customizations.go
@@ -1,15 +1,16 @@
 package blueprint
 
 type Customizations struct {
-	Hostname *string                `json:"hostname,omitempty" toml:"hostname,omitempty"`
-	Kernel   *KernelCustomization   `json:"kernel,omitempty" toml:"kernel,omitempty"`
-	SSHKey   []SSHKeyCustomization  `json:"sshkey,omitempty" toml:"sshkey,omitempty"`
-	User     []UserCustomization    `json:"user,omitempty" toml:"user,omitempty"`
-	Group    []GroupCustomization   `json:"group,omitempty" toml:"group,omitempty"`
-	Timezone *TimezoneCustomization `json:"timezone,omitempty" toml:"timezone,omitempty"`
-	Locale   *LocaleCustomization   `json:"locale,omitempty" toml:"locale,omitempty"`
-	Firewall *FirewallCustomization `json:"firewall,omitempty" toml:"firewall,omitempty"`
-	Services *ServicesCustomization `json:"services,omitempty" toml:"services,omitempty"`
+	Hostname   *string                   `json:"hostname,omitempty" toml:"hostname,omitempty"`
+	Kernel     *KernelCustomization      `json:"kernel,omitempty" toml:"kernel,omitempty"`
+	SSHKey     []SSHKeyCustomization     `json:"sshkey,omitempty" toml:"sshkey,omitempty"`
+	User       []UserCustomization       `json:"user,omitempty" toml:"user,omitempty"`
+	Group      []GroupCustomization      `json:"group,omitempty" toml:"group,omitempty"`
+	Timezone   *TimezoneCustomization    `json:"timezone,omitempty" toml:"timezone,omitempty"`
+	Locale     *LocaleCustomization      `json:"locale,omitempty" toml:"locale,omitempty"`
+	Firewall   *FirewallCustomization    `json:"firewall,omitempty" toml:"firewall,omitempty"`
+	Services   *ServicesCustomization    `json:"services,omitempty" toml:"services,omitempty"`
+	Filesystem []FilesystemCustomization `json:"filesystem,omitempty" toml:"filesystem,omitempty"`
 }
 
 type KernelCustomization struct {
@@ -62,6 +63,11 @@ type FirewallServicesCustomization struct {
 type ServicesCustomization struct {
 	Enabled  []string `json:"enabled,omitempty" toml:"enabled,omitempty"`
 	Disabled []string `json:"disabled,omitempty" toml:"disabled,omitempty"`
+}
+
+type FilesystemCustomization struct {
+	Mountpoint string `json:"mountpoint,omitempty" toml:"mountpoint,omitempty"`
+	MinSize    int    `json:"minsize,omitempty" toml:"size,omitempty"`
 }
 
 type CustomizationError struct {
@@ -186,4 +192,11 @@ func (c *Customizations) GetServices() *ServicesCustomization {
 	}
 
 	return c.Services
+}
+
+func (c *Customizations) GetFilesystems() []FilesystemCustomization {
+	if c == nil {
+		return nil
+	}
+	return c.Filesystem
 }

--- a/internal/blueprint/customizations.go
+++ b/internal/blueprint/customizations.go
@@ -200,3 +200,19 @@ func (c *Customizations) GetFilesystems() []FilesystemCustomization {
 	}
 	return c.Filesystem
 }
+
+func (c *Customizations) GetFilesystemsMinSize() uint64 {
+	if c == nil {
+		return 0
+	}
+	agg := 0
+	for _, m := range c.Filesystem {
+		agg += m.MinSize
+	}
+	// This ensures that file system customization `size` is a multiple of
+	// sector size (512)
+	if agg%512 != 0 {
+		agg = (agg/512 + 1) * 512
+	}
+	return uint64(agg)
+}

--- a/internal/blueprint/customizations_test.go
+++ b/internal/blueprint/customizations_test.go
@@ -267,3 +267,21 @@ func TestNilGetTimezoneSettings(t *testing.T) {
 	assert.Nil(t, retTimezone)
 	assert.Nil(t, retNTPServers)
 }
+
+func TestGetFilesystems(t *testing.T) {
+
+	expectedFilesystems := []FilesystemCustomization{
+		{
+			MinSize:    1024,
+			Mountpoint: "/",
+		},
+	}
+
+	TestCustomizations := Customizations{
+		Filesystem: expectedFilesystems,
+	}
+
+	retFilesystems := TestCustomizations.GetFilesystems()
+
+	assert.ElementsMatch(t, expectedFilesystems, retFilesystems)
+}

--- a/internal/blueprint/customizations_test.go
+++ b/internal/blueprint/customizations_test.go
@@ -285,3 +285,47 @@ func TestGetFilesystems(t *testing.T) {
 
 	assert.ElementsMatch(t, expectedFilesystems, retFilesystems)
 }
+
+func TestGetFilesystemsMinSize(t *testing.T) {
+
+	expectedFilesystems := []FilesystemCustomization{
+		{
+			MinSize:    1024,
+			Mountpoint: "/",
+		},
+		{
+			MinSize:    4096,
+			Mountpoint: "/var",
+		},
+	}
+
+	TestCustomizations := Customizations{
+		Filesystem: expectedFilesystems,
+	}
+
+	retFilesystemsSize := TestCustomizations.GetFilesystemsMinSize()
+
+	assert.EqualValues(t, uint64(5120), retFilesystemsSize)
+}
+
+func TestGetFilesystemsMinSizeNonSectorSize(t *testing.T) {
+
+	expectedFilesystems := []FilesystemCustomization{
+		{
+			MinSize:    1025,
+			Mountpoint: "/",
+		},
+		{
+			MinSize:    4097,
+			Mountpoint: "/var",
+		},
+	}
+
+	TestCustomizations := Customizations{
+		Filesystem: expectedFilesystems,
+	}
+
+	retFilesystemsSize := TestCustomizations.GetFilesystemsMinSize()
+
+	assert.EqualValues(t, uint64(5632), retFilesystemsSize)
+}

--- a/internal/distro/fedora33/distro.go
+++ b/internal/distro/fedora33/distro.go
@@ -289,6 +289,23 @@ func (t *imageType) pipeline(c *blueprint.Customizations, options distro.ImageOp
 		return nil, fmt.Errorf("kernel boot parameter customizations are not supported for ostree types")
 	}
 
+	mountpoints := c.GetFilesystems()
+
+	if mountpoints != nil && t.rpmOstree {
+		return nil, fmt.Errorf("Custom mountpoints are not supported for ostree types")
+	}
+
+	invalidMountpoints := []string{}
+	for _, m := range mountpoints {
+		if m.Mountpoint != "/" {
+			invalidMountpoints = append(invalidMountpoints, m.Mountpoint)
+		}
+	}
+
+	if len(invalidMountpoints) > 0 {
+		return nil, fmt.Errorf("The following custom mountpoints are not supported %+q", invalidMountpoints)
+	}
+
 	p := &osbuild.Pipeline{}
 	p.SetBuild(t.buildPipeline(repos, *t.arch, buildPackageSpecs), "org.osbuild.fedora33")
 

--- a/internal/distro/rhel8/distro.go
+++ b/internal/distro/rhel8/distro.go
@@ -288,6 +288,26 @@ func (t *imageType) pipeline(c *blueprint.Customizations, options distro.ImageOp
 		return nil, fmt.Errorf("kernel boot parameter customizations are not supported for ostree types")
 	}
 
+	mountpoints := c.GetFilesystems()
+
+	if mountpoints != nil && t.rpmOstree {
+		return nil, fmt.Errorf("Custom mountpoints are not supported for ostree types")
+	}
+
+	// create a slice for storing
+	// invalid mountpoints in order to return
+	// a detailed message
+	invalidMountpoints := []string{}
+	for _, m := range mountpoints {
+		if m.Mountpoint != "/" {
+			invalidMountpoints = append(invalidMountpoints, m.Mountpoint)
+		}
+	}
+
+	if len(invalidMountpoints) > 0 {
+		return nil, fmt.Errorf("The following custom mountpoints are not supported %+q", invalidMountpoints)
+	}
+
 	p := &osbuild.Pipeline{}
 	p.SetBuild(t.buildPipeline(repos, *t.arch, buildPackageSpecs), "org.osbuild.rhel82")
 

--- a/internal/distro/rhel8/distro_test.go
+++ b/internal/distro/rhel8/distro_test.go
@@ -401,7 +401,7 @@ func TestDistro_CustomFileSystemManifestError(t *testing.T) {
 			if imgTypeName == "rhel-edge-commit" {
 				assert.EqualError(t, err, "Custom mountpoints are not supported for ostree types")
 			} else {
-				assert.EqualError(t, err, "The following custom mountpoints are not supported [\"/var\"]")
+				assert.EqualError(t, err, "The following custom mountpoints are not supported [\"/boot\"]")
 			}
 		}
 	}

--- a/internal/distro/rhel84/distro.go
+++ b/internal/distro/rhel84/distro.go
@@ -317,6 +317,23 @@ func (t *imageType) pipeline(c *blueprint.Customizations, options distro.ImageOp
 		return nil, fmt.Errorf("kernel boot parameter customizations are not supported for ostree types")
 	}
 
+	mountpoints := c.GetFilesystems()
+
+	if mountpoints != nil && t.rpmOstree {
+		return nil, fmt.Errorf("Custom mountpoints are not supported for ostree types")
+	}
+
+	invalidMountpoints := []string{}
+	for _, m := range mountpoints {
+		if m.Mountpoint != "/" {
+			invalidMountpoints = append(invalidMountpoints, m.Mountpoint)
+		}
+	}
+
+	if len(invalidMountpoints) > 0 {
+		return nil, fmt.Errorf("The following custom mountpoints are not supported %+q", invalidMountpoints)
+	}
+
 	var pt *disk.PartitionTable
 	if t.partitionTableGenerator != nil {
 		table := t.partitionTableGenerator(options, t.arch, rng)

--- a/internal/distro/rhel84/distro_v2.go
+++ b/internal/distro/rhel84/distro_v2.go
@@ -206,6 +206,23 @@ func (t *imageTypeS2) pipelines(customizations *blueprint.Customizations, option
 		return nil, fmt.Errorf("kernel boot parameter customizations are not supported for ostree types")
 	}
 
+	mountpoints := customizations.GetFilesystems()
+
+	if mountpoints != nil && t.rpmOstree {
+		return nil, fmt.Errorf("Custom mountpoints are not supported for ostree types")
+	}
+
+	invalidMountpoints := []string{}
+	for _, m := range mountpoints {
+		if m.Mountpoint != "/" {
+			invalidMountpoints = append(invalidMountpoints, m.Mountpoint)
+		}
+	}
+
+	if len(invalidMountpoints) > 0 {
+		return nil, fmt.Errorf("The following custom mountpoints are not supported %+q", invalidMountpoints)
+	}
+
 	pipelines := make([]osbuild.Pipeline, 0)
 
 	pipelines = append(pipelines, *t.buildPipeline(repos, packageSetSpecs["build-packages"]))

--- a/internal/distro/rhel85/distro.go
+++ b/internal/distro/rhel85/distro.go
@@ -368,6 +368,24 @@ func (t *imageType) checkOptions(customizations *blueprint.Customizations, optio
 		return fmt.Errorf("kernel boot parameter customizations are not supported for ostree types")
 	}
 
+	mountpoints := customizations.GetFilesystems()
+
+	if mountpoints != nil && t.rpmOstree {
+		return fmt.Errorf("Custom mountpoints are not supported for ostree types")
+	}
+
+	// only allow root mountpoint for the time-being
+	invalidMountpoints := []string{}
+	for _, m := range mountpoints {
+		if m.Mountpoint != "/" {
+			invalidMountpoints = append(invalidMountpoints, m.Mountpoint)
+		}
+	}
+
+	if len(invalidMountpoints) > 0 {
+		return fmt.Errorf("The following custom mountpoints are not supported %+q", invalidMountpoints)
+	}
+
 	return nil
 }
 

--- a/internal/distro/rhel90/distro.go
+++ b/internal/distro/rhel90/distro.go
@@ -288,6 +288,21 @@ func sources(packages []rpmmd.PackageSpec) *osbuild.Sources {
 }
 
 func (t *imageType) pipeline(c *blueprint.Customizations, options distro.ImageOptions, repos []rpmmd.RepoConfig, packageSpecs, buildPackageSpecs []rpmmd.PackageSpec, rng *rand.Rand) (*osbuild.Pipeline, error) {
+
+	mountpoints := c.GetFilesystems()
+
+	// only allow root mountpoint for the time-being
+	invalidMountpoints := []string{}
+	for _, m := range mountpoints {
+		if m.Mountpoint != "/" {
+			invalidMountpoints = append(invalidMountpoints, m.Mountpoint)
+		}
+	}
+
+	if len(invalidMountpoints) > 0 {
+		return nil, fmt.Errorf("The following custom mountpoints are not supported %+q", invalidMountpoints)
+	}
+
 	var pt *disk.PartitionTable
 	if t.partitionTableGenerator != nil {
 		table := t.partitionTableGenerator(options, t.arch, rng)

--- a/internal/distro/rhel90/distro_test.go
+++ b/internal/distro/rhel90/distro_test.go
@@ -378,3 +378,47 @@ func TestRhel84_ModulePlatformID(t *testing.T) {
 func TestRhel90_KernelOption(t *testing.T) {
 	distro_test_common.TestDistro_KernelOption(t, rhel90.New())
 }
+
+func TestDistro_CustomFileSystemManifestError(t *testing.T) {
+	r9distro := rhel90.New()
+	bp := blueprint.Blueprint{
+		Customizations: &blueprint.Customizations{
+			Filesystem: []blueprint.FilesystemCustomization{
+				{
+					MinSize:    1024,
+					Mountpoint: "/boot",
+				},
+			},
+		},
+	}
+	for _, archName := range r9distro.ListArches() {
+		arch, _ := r9distro.GetArch(archName)
+		for _, imgTypeName := range arch.ListImageTypes() {
+			imgType, _ := arch.GetImageType(imgTypeName)
+			_, err := imgType.Manifest(bp.Customizations, distro.ImageOptions{}, nil, nil, 0)
+			assert.EqualError(t, err, "The following custom mountpoints are not supported [\"/boot\"]")
+		}
+	}
+}
+
+func TestDistro_TestRootMountPoint(t *testing.T) {
+	r9distro := rhel90.New()
+	bp := blueprint.Blueprint{
+		Customizations: &blueprint.Customizations{
+			Filesystem: []blueprint.FilesystemCustomization{
+				{
+					MinSize:    1024,
+					Mountpoint: "/",
+				},
+			},
+		},
+	}
+	for _, archName := range r9distro.ListArches() {
+		arch, _ := r9distro.GetArch(archName)
+		for _, imgTypeName := range arch.ListImageTypes() {
+			imgType, _ := arch.GetImageType(imgTypeName)
+			_, err := imgType.Manifest(bp.Customizations, distro.ImageOptions{}, nil, nil, 0)
+			assert.NoError(t, err)
+		}
+	}
+}

--- a/internal/distro/test_distro/distro.go
+++ b/internal/distro/test_distro/distro.go
@@ -3,6 +3,7 @@ package test_distro
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"sort"
 
 	"github.com/osbuild/osbuild-composer/internal/blueprint"
@@ -165,6 +166,19 @@ func (t *TestImageType) Exports() []string {
 }
 
 func (t *TestImageType) Manifest(b *blueprint.Customizations, options distro.ImageOptions, repos []rpmmd.RepoConfig, packageSpecSets map[string][]rpmmd.PackageSpec, seed int64) (distro.Manifest, error) {
+	mountpoints := b.GetFilesystems()
+
+	invalidMountpoints := []string{}
+	for _, m := range mountpoints {
+		if m.Mountpoint != "/" {
+			invalidMountpoints = append(invalidMountpoints, m.Mountpoint)
+		}
+	}
+
+	if len(invalidMountpoints) > 0 {
+		return nil, fmt.Errorf("The following custom mountpoints are not supported %+q", invalidMountpoints)
+	}
+
 	return json.Marshal(
 		osbuild.Manifest{
 			Sources:  osbuild.Sources{},

--- a/internal/weldr/api.go
+++ b/internal/weldr/api.go
@@ -2227,7 +2227,16 @@ func (api *API) composeHandler(writer http.ResponseWriter, request *http.Request
 		return
 	}
 
-	size := imageType.Size(cr.Size)
+	var size uint64
+
+	// check if filesytem customizations have been set.
+	// if compose size parameter is set, take the larger of
+	// the two values
+	if minSize := bp.Customizations.GetFilesystemsMinSize(); bp.Customizations != nil && minSize > 0 && minSize > cr.Size {
+		size = imageType.Size(minSize)
+	} else {
+		size = imageType.Size(cr.Size)
+	}
 
 	bigSeed, err := rand.Int(rand.Reader, big.NewInt(math.MaxInt64))
 	if err != nil {


### PR DESCRIPTION
I am extending the weldr api to accept filesystem customisations. Any existing images will only support the `'/'` mountpoint.
Existing images will through structured errors if an unsupported filesystem configuration has been specified.

I have added
  * the ability to specify filesystem customisations in blueprints file, with `name`, `mountpoint` and `minSize` parameters
  * errors for OSTree types for rhel8 and testing for the rhel8 distro
  * errors for unsupported mountpoints on rhel8 (only '/' supported) and added testing
  
Any feedback on the approach taken, suggestions for improvement would be greatly appreciated. I will then extend the other distro types after this.

This pull request includes:

- [x] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] create a file in [news/unreleased](https://github.com/osbuild/osbuild-composer/tree/main/docs/news/unreleased) directory if this change should be mentioned in the release news
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

For user-visible changes, "adequate documentation" is an entry describing the
change for users in docs/news. Please refer to docs/news/README.md for details.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`
-->
