### PR TITLE
image-info: cover situation when `/boot` is on a separate partition

### DIFF
--- a/tools/image-info
+++ b/tools/image-info
@@ -1845,6 +1845,10 @@ def append_partitions(report, device, loctl):
                 if esp and os.path.exists(f"{tree}/boot/efi"):
                     with mount_at(devices[esp_id], f"{tree}/boot/efi", options=['umask=077']):
                         append_filesystem(report, tree)
+                # situation when /boot is on a separate partition
+                elif esp and os.path.exists(f"{tree}/efi"):
+                    with mount_at(devices[esp_id], f"{tree}/efi", options=['umask=077']):
+                        append_filesystem(report, tree)
                 else:
                     append_filesystem(report, tree)
 


### PR DESCRIPTION
Some images with ESP, e.g. the `rhel-ec2-aarch64`, have the `/boot` on
a separate partition. `image-info` currently produces traceback on such
images, e.g.:
```
Traceback (most recent call last):
  File "/home/thozza/devel/osbuild-composer/./tools/image-info", line 1997, in <module>
    main()
  File "/home/thozza/devel/osbuild-composer/./tools/image-info", line 1991, in main
    report = analyse_image(target)
  File "/home/thozza/devel/osbuild-composer/./tools/image-info", line 1863, in analyse_image
    append_partitions(report, device, loctl)
  File "/home/thozza/devel/osbuild-composer/./tools/image-info", line 1849, in append_partitions
    append_filesystem(report, tree)
  File "/home/thozza/devel/osbuild-composer/./tools/image-info", line 1809, in append_filesystem
    with open(f"{tree}/grub2/grubenv") as f:
FileNotFoundError: [Errno 2] No such file or directory: '/tmp/tmp3i__6m1w/grub2/grubenv'
```
The reason is that `grub2/grubenv` on the `/boot` partition is a symlink
to `../efi/EFI/redhat/grubenv`. However the `efi` directory on the
`/boot` partition is empty and the ESP must be mounted to it for the
expected path to exist.

Modify `image-info` to mount the ESP to `efi` directory if it exists on
the inspected partition.

This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] create a file in [news/unreleased](https://github.com/osbuild/osbuild-composer/tree/main/docs/news/unreleased) directory if this change should be mentioned in the release news
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

For user-visible changes, "adequate documentation" is an entry describing the
change for users in docs/news. Please refer to docs/news/README.md for details.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`
-->
