### PR TITLE
CI: scheduled cloud-cleaner for Azure

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -3,6 +3,7 @@ stages:
   - rpmbuild
   - prepare-rhel-internal
   - test
+  - cleanup
   - finish
 
 .terraform:
@@ -69,7 +70,7 @@ Prepare-rhel-internal:
   stage: prepare-rhel-internal
   extends: .terraform
   rules:
-    - if: '$CI_PIPELINE_SOURCE == "schedule"'
+    - if: '$CI_PIPELINE_SOURCE == "schedule" && $NIGHTLY == "true"'
   script:
     - schutzbot/prepare-rhel-internal.sh
   artifacts:
@@ -90,7 +91,7 @@ Base:
   extends: .terraform
   rules:
     - if: '$CI_PIPELINE_SOURCE != "schedule"'
-    - if: '$CI_PIPELINE_SOURCE == "schedule" && $RUNNER =~ /[\S]+rhel-[8-9]\.[\S]+/'
+    - if: '$CI_PIPELINE_SOURCE == "schedule" && $RUNNER =~ /[\S]+rhel-[8-9]\.[\S]+/ && $NIGHTLY == "true"'
   script:
     - schutzbot/deploy.sh
     - /usr/libexec/tests/osbuild-composer/base_tests.sh
@@ -150,7 +151,7 @@ OSTree:
   extends: .terraform
   rules:
     - if: '$CI_PIPELINE_SOURCE != "schedule"'
-    - if: '$CI_PIPELINE_SOURCE == "schedule" && $RUNNER =~ /[\S]+rhel-[8-9]\.[\S]+/'
+    - if: '$CI_PIPELINE_SOURCE == "schedule" && $RUNNER =~ /[\S]+rhel-[8-9]\.[\S]+/ && $NIGHTLY == "true"'
   script:
     - schutzbot/deploy.sh
     - /usr/libexec/tests/osbuild-composer/ostree.sh
@@ -186,7 +187,7 @@ Integration:
   extends: .terraform
   rules:
     - if: '$CI_PIPELINE_SOURCE != "schedule"'
-    - if: '$CI_PIPELINE_SOURCE == "schedule" && $RUNNER =~ /[\S]+rhel-[8-9]\.[\S]+/'
+    - if: '$CI_PIPELINE_SOURCE == "schedule" && $RUNNER =~ /[\S]+rhel-[8-9]\.[\S]+/ && $NIGHTLY == "true"'
   script:
     - schutzbot/deploy.sh
     - /usr/libexec/tests/osbuild-composer/${SCRIPT}
@@ -232,7 +233,7 @@ API:
   extends: .terraform
   rules:
     - if: '$CI_PIPELINE_SOURCE != "schedule"'
-    - if: '$CI_PIPELINE_SOURCE == "schedule" && $RUNNER =~ /[\S]+rhel-[8-9]\.[\S]+/'
+    - if: '$CI_PIPELINE_SOURCE == "schedule" && $RUNNER =~ /[\S]+rhel-[8-9]\.[\S]+/ && $NIGHTLY == "true"'
   script:
     - schutzbot/deploy.sh
     - /usr/libexec/tests/osbuild-composer/api.sh ${TARGET}
@@ -268,7 +269,7 @@ NIGHTLY_FAIL:
   tags:
     - shell
   rules:
-    - if: '$CI_PIPELINE_SOURCE == "schedule"'
+    - if: '$CI_PIPELINE_SOURCE == "schedule" && $NIGHTLY == "true"'
       when: on_failure
   script:
     - schutzbot/slack_notification.sh FAILED ":big-sad:"
@@ -278,7 +279,7 @@ NIGHTLY_SUCCESS:
   tags:
     - shell
   rules:
-    - if: '$CI_PIPELINE_SOURCE == "schedule"'
+    - if: '$CI_PIPELINE_SOURCE == "schedule" && $NIGHTLY == "true"'
   script:
     - schutzbot/slack_notification.sh SUCCESS ":partymeow:"
 
@@ -295,6 +296,18 @@ Installer:
     matrix:
       - RUNNER:
           - openstack/rhel-8.5-x86_64
+
+SCHEDULED_CLOUD_CLEANER:
+  stage: cleanup
+  tags:
+    - terraform
+  variables:
+    RUNNER: aws/fedora-33-x86_64
+  rules:
+    - if: '$CI_PIPELINE_SOURCE == "schedule" && $CLEANUP == "true"'
+  script:
+    - schutzbot/deploy.sh
+    - schutzbot/scheduled_cloud_cleaner.sh
 
 finish:
   stage: finish

--- a/schutzbot/scheduled_cloud_cleaner.sh
+++ b/schutzbot/scheduled_cloud_cleaner.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+
+# Azure cleanup
+if ! hash az; then
+    # this installation method is taken from the official docs:
+    # https://docs.microsoft.com/cs-cz/cli/azure/install-azure-cli-linux?pivots=dnf
+    sudo rpm --import https://packages.microsoft.com/keys/microsoft.asc
+    echo -e "[azure-cli]
+name=Azure CLI
+baseurl=https://packages.microsoft.com/yumrepos/azure-cli
+enabled=1
+gpgcheck=1
+gpgkey=https://packages.microsoft.com/keys/microsoft.asc" | sudo tee /etc/yum.repos.d/azure-cli.repo
+
+  greenprint "Installing azure-cli"
+  sudo dnf install -y azure-cli
+  az version
+fi
+
+az login --service-principal --username "${AZURE_CLIENT_ID}" --password "${AZURE_CLIENT_SECRET}" --tenant "${AZURE_TENANT_ID}"
+
+# List all resources from AZURE_RESOURCE_GROUP
+RESOURCE_LIST=$(az resource list -g "$AZURE_RESOURCE_GROUP")
+RESOURCE_COUNT=$( echo "$RESOURCE_LIST" | jq .[].name | wc -l)
+
+# filter out resources older than X hours
+DELETE_TIME=$(date -d "- $HOURS_BACK hours" +%s)
+OLD_RESOURCE_LIST_NAMES=()
+for i in $(seq 0 $(("$RESOURCE_COUNT"-1))); do
+    RESOURCE_TIME=$(echo "$RESOURCE_LIST" | jq .[$i].createdTime | tr -d '"')
+    RESOURCE_TYPE=$(echo "$RESOURCE_LIST" | jq .[$i].type | tr -d '"')
+    RESOURCE_TIME_SECONDS=$(date -d "$RESOURCE_TIME" +%s)
+    if [[ "$RESOURCE_TIME_SECONDS" -lt "$DELETE_TIME" && "$RESOURCE_TYPE" != Microsoft.Storage/storageAccounts ]]; then
+        OLD_RESOURCE_LIST_NAMES+=("$(echo "$RESOURCE_LIST" | jq .["$i"].name | sed -e 's/^[^-]*-//' | tr -d '"')")
+    fi
+done
+
+#Exit early if no there are no resources to delete
+if [ ${#OLD_RESOURCE_LIST_NAMES[@]} == 0 ]; then
+    echo "Nothing to delete."
+    exit 0
+fi
+
+# Keep only unique resource names
+mapfile -t RESOURCE_TO_DELETE_LIST  < <(printf "%s\n" "${OLD_RESOURCE_LIST_NAMES[@]}" | sort -u)
+echo "${RESOURCE_TO_DELETE_LIST[@]}"
+
+TO_DELETE_COUNT=${#RESOURCE_TO_DELETE_LIST[@]}
+echo "There are resources from $TO_DELETE_COUNT test runs to delete."
+
+for i in $(seq 0 $(("$TO_DELETE_COUNT"-1))); do
+    echo "Running cloud-cleaner in Azure for resources with TEST_ID: ${RESOURCE_TO_DELETE_LIST[$i]}"
+    TEST_ID=${RESOURCE_TO_DELETE_LIST[$i]} /usr/libexec/osbuild-composer-test/cloud-cleaner
+done
+
+echo "Azure cleanup complete!"

--- a/test/cases/api.sh
+++ b/test/cases/api.sh
@@ -561,7 +561,7 @@ EOF
 }
 
 function createReqFileAzure() {
-  AZURE_IMAGE_NAME="osbuild-composer-api-test-$(uuidgen)"
+  AZURE_IMAGE_NAME="image-$TEST_ID"
 
   cat > "$REQUEST_FILE" << EOF
 {
@@ -1003,8 +1003,30 @@ function verifyInAzure() {
   AZURE_SSH_KEY="$WORKDIR/id_azure"
   ssh-keygen -t rsa -f "$AZURE_SSH_KEY" -C "$SSH_USER" -N ""
 
+  # Create network resources with predictable names
+  $AZURE_CMD network nsg create --resource-group "$AZURE_RESOURCE_GROUP" --name "nsg-$TEST_ID" --location "$AZURE_LOCATION"
+  $AZURE_CMD network nsg rule create --resource-group "$AZURE_RESOURCE_GROUP" \
+      --nsg-name "nsg-$TEST_ID" \
+      --name SSH \
+      --priority 1001 \
+      --access Allow \
+      --protocol Tcp \
+      --destination-address-prefixes '*' \
+      --destination-port-ranges 22 \
+      --source-port-ranges '*' \
+      --source-address-prefixes '*'
+  $AZURE_CMD network vnet create --resource-group "$AZURE_RESOURCE_GROUP" --name "vnet-$TEST_ID" --subnet-name "snet-$TEST_ID" --location "$AZURE_LOCATION"
+  $AZURE_CMD network public-ip create --resource-group "$AZURE_RESOURCE_GROUP" --name "ip-$TEST_ID" --location "$AZURE_LOCATION"
+  $AZURE_CMD network nic create --resource-group "$AZURE_RESOURCE_GROUP" \
+      --name "iface-$TEST_ID" \
+      --subnet "snet-$TEST_ID" \
+      --vnet-name "vnet-$TEST_ID" \
+      --network-security-group "nsg-$TEST_ID" \
+      --public-ip-address "ip-$TEST_ID" \
+      --location "$AZURE_LOCATION" 
+
   # create the instance
-  AZURE_INSTANCE_NAME="vm-$(uuidgen)"
+  AZURE_INSTANCE_NAME="vm-$TEST_ID"
   $AZURE_CMD vm create --name "$AZURE_INSTANCE_NAME" \
     --resource-group "$AZURE_RESOURCE_GROUP" \
     --image "$AZURE_IMAGE_NAME" \
@@ -1012,7 +1034,9 @@ function verifyInAzure() {
     --admin-username "$SSH_USER" \
     --ssh-key-values "$AZURE_SSH_KEY.pub" \
     --authentication-type "ssh" \
-    --location "$AZURE_LOCATION"
+    --location "$AZURE_LOCATION" \
+    --nics "iface-$TEST_ID" \
+    --os-disk-name "disk-$TEST_ID"
   $AZURE_CMD vm show --name "$AZURE_INSTANCE_NAME" --resource-group "$AZURE_RESOURCE_GROUP" --show-details > "$WORKDIR/vm_details.json"
   HOST=$(jq -r '.publicIps' "$WORKDIR/vm_details.json")
 


### PR DESCRIPTION
This pull request includes:

I'm trying to see if it's possible to trap cloud-cleaner during test execution

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] create a file in [news/unreleased](https://github.com/osbuild/osbuild-composer/tree/main/docs/news/unreleased) directory if this change should be mentioned in the release news
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

For user-visible changes, "adequate documentation" is an entry describing the
change for users in docs/news. Please refer to docs/news/README.md for details.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`
-->
