### PR TITLE
Add .gitleaks.toml

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,5 +1,8 @@
 # Repo Specific Gitleaks Configuration
 # https://github.com/zricethezav/gitleaks/#configuration
+#
+# For info on how this is utilized
+# https://url.corp.redhat.com/2a2aaeb
 
 # Set to avoid false positives
 [allowlist]

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,3 +1,7 @@
+# Repo Specific Gitleaks Configuration
+# https://github.com/zricethezav/gitleaks/#configuration
+
+# Set to avoid false positives
 [allowlist]
   description = "Allowlist"
   paths = [

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,5 @@
+[allowlist]
+  description = "Allowlist"
+  paths = [
+    '''test/cases/''',
+  ]


### PR DESCRIPTION
I'd like to add this to help a few scanners avoid false positives. If you have an guidance on how to tune that config so that it doesn't ignore a real leak, just let me know and I can make the necessary changes. 


This pull request includes:

- [X] adequate testing for the new functionality or fixed issue
- [X] adequate documentation informing people about the change such as
  - [X] create a file in [news/unreleased](https://github.com/osbuild/osbuild-composer/tree/main/docs/news/unreleased) directory if this change should be mentioned in the release news (no need to mention in release)
  - [X] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/ (no behavior was changed)

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

For user-visible changes, "adequate documentation" is an entry describing the
change for users in docs/news. Please refer to docs/news/README.md for details.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`
-->
