### PR TITLE
replace hard coded ssh keys with generated one

### DIFF
--- a/osbuild-composer.spec
+++ b/osbuild-composer.spec
@@ -179,6 +179,7 @@ install -m 0755 -vp _bin/cloud-cleaner                          %{buildroot}%{_l
 install -m 0755 -vp tools/define-compose-url.sh                 %{buildroot}%{_libexecdir}/osbuild-composer-test/
 install -m 0755 -vp tools/provision.sh                          %{buildroot}%{_libexecdir}/osbuild-composer-test/
 install -m 0755 -vp tools/gen-certs.sh                          %{buildroot}%{_libexecdir}/osbuild-composer-test/
+install -m 0755 -vp tools/gen-ssh.sh                            %{buildroot}%{_libexecdir}/osbuild-composer-test/
 install -m 0755 -vp tools/image-info                            %{buildroot}%{_libexecdir}/osbuild-composer-test/
 install -m 0755 -vp tools/run-koji-container.sh                 %{buildroot}%{_libexecdir}/osbuild-composer-test/
 install -m 0755 -vp tools/koji-compose.py                       %{buildroot}%{_libexecdir}/osbuild-composer-test/

--- a/test/cases/aws.sh
+++ b/test/cases/aws.sh
@@ -1,8 +1,6 @@
 #!/bin/bash
 set -euo pipefail
 
-OSBUILD_COMPOSER_TEST_DATA=/usr/share/tests/osbuild-composer/
-
 source /etc/os-release
 DISTRO_CODE="${DISTRO_CODE:-${ID}_${VERSION_ID//./}}"
 
@@ -48,11 +46,12 @@ AMI_DATA=${TEMPDIR}/ami-data-${IMAGE_KEY}.json
 INSTANCE_DATA=${TEMPDIR}/instance-data-${IMAGE_KEY}.json
 INSTANCE_CONSOLE=${TEMPDIR}/instance-console-${IMAGE_KEY}.json
 
+SSH_DATA_DIR=$(/usr/libexec/osbuild-composer-test/gen-ssh.sh)
+SSH_KEY=${SSH_DATA_DIR}/id_rsa
+
 # Check for the smoke test file on the AWS instance that we start.
 smoke_test_check () {
     # Ensure the ssh key has restricted permissions.
-    SSH_KEY=${OSBUILD_COMPOSER_TEST_DATA}keyring/id_rsa
-
     SMOKE_TEST=$(sudo ssh -i "${SSH_KEY}" redhat@"${1}" 'cat /etc/smoke-test.txt')
     if [[ $SMOKE_TEST == smoke-test ]]; then
         echo 1
@@ -204,7 +203,7 @@ $AWS_CMD ec2 run-instances \
     --key-name personal_servers \
     --image-id "${AMI_IMAGE_ID}" \
     --instance-type t3a.micro \
-    --user-data file://"${OSBUILD_COMPOSER_TEST_DATA}"/cloud-init/user-data \
+    --user-data file://"${SSH_DATA_DIR}"/user-data \
     --cli-input-json file://"${AWS_INSTANCE_JSON}" > /dev/null
 
 # Wait for the instance to finish building.

--- a/test/cases/azure.sh
+++ b/test/cases/azure.sh
@@ -203,9 +203,11 @@ export ARM_CLIENT_SECRET="$AZURE_CLIENT_SECRET" > /dev/null
 export ARM_SUBSCRIPTION_ID="$AZURE_SUBSCRIPTION_ID" > /dev/null
 export ARM_TENANT_ID="$AZURE_TENANT_ID" > /dev/null
 
+SSH_DATA_DIR=$(/usr/libexec/osbuild-composer-test/gen-ssh.sh)
+
 # Copy terraform main file and cloud-init to current working directory
 cp /usr/share/tests/osbuild-composer/azure/main.tf .
-cp /usr/share/tests/osbuild-composer/cloud-init/user-data .
+cp "${SSH_DATA_DIR}"/user-data .
 
 # Initialize terraform
 terraform init

--- a/test/cases/installers.sh
+++ b/test/cases/installers.sh
@@ -58,7 +58,6 @@ polkit.addRule(function(action, subject) {
 EOF
 
 # Set up variables.
-OSBUILD_COMPOSER_TEST_DATA=/usr/share/tests/osbuild-composer/
 OS_VARIANT="rhel8-unknown"
 TEST_UUID=$(uuidgen)
 IMAGE_KEY="osbuild-composer-installer-test-${TEST_UUID}"
@@ -74,7 +73,8 @@ COMPOSE_INFO=${TEMPDIR}/compose-info-${IMAGE_KEY}.json
 
 # SSH setup.
 SSH_OPTIONS=(-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=5)
-SSH_KEY=${OSBUILD_COMPOSER_TEST_DATA}keyring/id_rsa
+SSH_DATA_DIR=$(/usr/libexec/osbuild-composer-test/gen-ssh.sh)
+SSH_KEY=${SSH_DATA_DIR}/id_rsa
 
 # Get the compose log.
 get_compose_log () {

--- a/test/cases/ostree-ng.sh
+++ b/test/cases/ostree-ng.sh
@@ -59,7 +59,6 @@ polkit.addRule(function(action, subject) {
 EOF
 
 # Set up variables.
-OSBUILD_COMPOSER_TEST_DATA=/usr/share/tests/osbuild-composer/
 OSTREE_REF="test/rhel/8/${ARCH}/edge"
 OS_VARIANT="rhel8-unknown"
 TEST_UUID=$(uuidgen)
@@ -84,7 +83,9 @@ COMPOSE_INFO=${TEMPDIR}/compose-info-${IMAGE_KEY}.json
 
 # SSH setup.
 SSH_OPTIONS=(-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=5)
-SSH_KEY=${OSBUILD_COMPOSER_TEST_DATA}keyring/id_rsa
+SSH_DATA_DIR=$(/usr/libexec/osbuild-composer-test/gen-ssh.sh)
+SSH_KEY=${SSH_DATA_DIR}/id_rsa
+SSH_KEY_PUB=$(cat "${SSH_KEY}".pub)
 
 case "${ID}-${VERSION_ID}" in
     "rhel-8.4")
@@ -279,7 +280,7 @@ name = "kernel-rt"
 name = "admin"
 description = "Administrator account"
 password = "\$6\$GRmb7S0p8vsYmXzH\$o0E020S.9JQGaHkszoog4ha4AQVs3sk8q0DvLjSMxoxHBKnB2FBXGQ/OkwZQfW/76ktHd0NX5nls2LPxPuUdl."
-key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC61wMCjOSHwbVb4VfVyl5sn497qW4PsdQ7Ty7aD6wDNZ/QjjULkDV/yW5WjDlDQ7UqFH0Sr7vywjqDizUAqK7zM5FsUKsUXWHWwg/ehKg8j9xKcMv11AkFoUoujtfAujnKODkk58XSA9whPr7qcw3vPrmog680pnMSzf9LC7J6kXfs6lkoKfBh9VnlxusCrw2yg0qI1fHAZBLPx7mW6+me71QZsS6sVz8v8KXyrXsKTdnF50FjzHcK9HXDBtSJS5wA3fkcRYymJe0o6WMWNdgSRVpoSiWaHHmFgdMUJaYoCfhXzyl7LtNb3Q+Sveg+tJK7JaRXBLMUllOlJ6ll5Hod root@localhost"
+key = "${SSH_KEY_PUB}"
 home = "/home/admin/"
 groups = ["wheel"]
 EOF
@@ -551,7 +552,7 @@ name = "kernel-rt"
 name = "admin"
 description = "Administrator account"
 password = "\$6\$GRmb7S0p8vsYmXzH\$o0E020S.9JQGaHkszoog4ha4AQVs3sk8q0DvLjSMxoxHBKnB2FBXGQ/OkwZQfW/76ktHd0NX5nls2LPxPuUdl."
-key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC61wMCjOSHwbVb4VfVyl5sn497qW4PsdQ7Ty7aD6wDNZ/QjjULkDV/yW5WjDlDQ7UqFH0Sr7vywjqDizUAqK7zM5FsUKsUXWHWwg/ehKg8j9xKcMv11AkFoUoujtfAujnKODkk58XSA9whPr7qcw3vPrmog680pnMSzf9LC7J6kXfs6lkoKfBh9VnlxusCrw2yg0qI1fHAZBLPx7mW6+me71QZsS6sVz8v8KXyrXsKTdnF50FjzHcK9HXDBtSJS5wA3fkcRYymJe0o6WMWNdgSRVpoSiWaHHmFgdMUJaYoCfhXzyl7LtNb3Q+Sveg+tJK7JaRXBLMUllOlJ6ll5Hod root@localhost"
+key = "${SSH_KEY_PUB}"
 home = "/home/admin/"
 groups = ["wheel"]
 EOF

--- a/test/cases/ostree.sh
+++ b/test/cases/ostree.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 set -euo pipefail
 
-OSBUILD_COMPOSER_TEST_DATA=/usr/share/tests/osbuild-composer/
 source /usr/libexec/osbuild-composer-test/define-compose-url.sh
 
 # Get OS data.
@@ -111,7 +110,9 @@ COMPOSE_INFO=${TEMPDIR}/compose-info-${IMAGE_KEY}.json
 
 # SSH setup.
 SSH_OPTIONS=(-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=5)
-SSH_KEY=${OSBUILD_COMPOSER_TEST_DATA}keyring/id_rsa
+SSH_DATA_DIR=$(/usr/libexec/osbuild-composer-test/gen-ssh.sh)
+SSH_KEY=${SSH_DATA_DIR}/id_rsa
+SSH_KEY_PUB="$(cat "${SSH_KEY}".pub)"
 
 # Get the compose log.
 get_compose_log () {
@@ -265,7 +266,7 @@ if [[ "${USER_IN_COMMIT}" == "true" ]]; then
 name = "${SSH_USER}"
 description = "Administrator account"
 password = "\$6\$GRmb7S0p8vsYmXzH\$o0E020S.9JQGaHkszoog4ha4AQVs3sk8q0DvLjSMxoxHBKnB2FBXGQ/OkwZQfW/76ktHd0NX5nls2LPxPuUdl."
-key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC61wMCjOSHwbVb4VfVyl5sn497qW4PsdQ7Ty7aD6wDNZ/QjjULkDV/yW5WjDlDQ7UqFH0Sr7vywjqDizUAqK7zM5FsUKsUXWHWwg/ehKg8j9xKcMv11AkFoUoujtfAujnKODkk58XSA9whPr7qcw3vPrmog680pnMSzf9LC7J6kXfs6lkoKfBh9VnlxusCrw2yg0qI1fHAZBLPx7mW6+me71QZsS6sVz8v8KXyrXsKTdnF50FjzHcK9HXDBtSJS5wA3fkcRYymJe0o6WMWNdgSRVpoSiWaHHmFgdMUJaYoCfhXzyl7LtNb3Q+Sveg+tJK7JaRXBLMUllOlJ6ll5Hod root@localhost"
+key = "${SSH_KEY_PUB}"
 home = "/home/${SSH_USER}/"
 groups = ["wheel"]
 EOF
@@ -315,7 +316,7 @@ timezone --utc Etc/UTC
 selinux --enforcing
 rootpw --lock --iscrypted locked
 user --name=${SSH_USER} --groups=wheel --iscrypted --password=\$6\$1LgwKw9aOoAi/Zy9\$Pn3ErY1E8/yEanJ98evqKEW.DZp24HTuqXPJl6GYCm8uuobAmwxLv7rGCvTRZhxtcYdmC0.XnYRSR9Sh6de3p0
-sshkey --username=${SSH_USER} "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC61wMCjOSHwbVb4VfVyl5sn497qW4PsdQ7Ty7aD6wDNZ/QjjULkDV/yW5WjDlDQ7UqFH0Sr7vywjqDizUAqK7zM5FsUKsUXWHWwg/ehKg8j9xKcMv11AkFoUoujtfAujnKODkk58XSA9whPr7qcw3vPrmog680pnMSzf9LC7J6kXfs6lkoKfBh9VnlxusCrw2yg0qI1fHAZBLPx7mW6+me71QZsS6sVz8v8KXyrXsKTdnF50FjzHcK9HXDBtSJS5wA3fkcRYymJe0o6WMWNdgSRVpoSiWaHHmFgdMUJaYoCfhXzyl7LtNb3Q+Sveg+tJK7JaRXBLMUllOlJ6ll5Hod root@localhost"
+sshkey --username=${SSH_USER} "${SSH_KEY_PUB}"
 
 bootloader --timeout=1 --append="net.ifnames=0 modprobe.blacklist=vc4"
 
@@ -429,7 +430,7 @@ if [[ "${USER_IN_COMMIT}" == "true" ]]; then
 name = "${SSH_USER}"
 description = "Administrator account"
 password = "\$6\$GRmb7S0p8vsYmXzH\$o0E020S.9JQGaHkszoog4ha4AQVs3sk8q0DvLjSMxoxHBKnB2FBXGQ/OkwZQfW/76ktHd0NX5nls2LPxPuUdl."
-key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC61wMCjOSHwbVb4VfVyl5sn497qW4PsdQ7Ty7aD6wDNZ/QjjULkDV/yW5WjDlDQ7UqFH0Sr7vywjqDizUAqK7zM5FsUKsUXWHWwg/ehKg8j9xKcMv11AkFoUoujtfAujnKODkk58XSA9whPr7qcw3vPrmog680pnMSzf9LC7J6kXfs6lkoKfBh9VnlxusCrw2yg0qI1fHAZBLPx7mW6+me71QZsS6sVz8v8KXyrXsKTdnF50FjzHcK9HXDBtSJS5wA3fkcRYymJe0o6WMWNdgSRVpoSiWaHHmFgdMUJaYoCfhXzyl7LtNb3Q+Sveg+tJK7JaRXBLMUllOlJ6ll5Hod root@localhost"
+key = "${SSH_KEY_PUB}"
 home = "/home/${SSH_USER}/"
 groups = ["wheel"]
 EOF

--- a/test/cases/vmware.sh
+++ b/test/cases/vmware.sh
@@ -1,8 +1,6 @@
 #!/bin/bash
 set -euo pipefail
 
-OSBUILD_COMPOSER_TEST_DATA=/usr/share/tests/osbuild-composer
-
 source /etc/os-release
 
 # Colorful output.
@@ -56,9 +54,13 @@ BLUEPRINT_FILE=${TEMPDIR}/blueprint.toml
 COMPOSE_START=${TEMPDIR}/compose-start-${IMAGE_KEY}.json
 COMPOSE_INFO=${TEMPDIR}/compose-info-${IMAGE_KEY}.json
 
+SSH_DATA_DIR=$(/usr/libexec/osbuild-composer-test/gen-ssh.sh)
+SSH_KEY=${SSH_DATA_DIR}/id_rsa
+SSH_KEY_PUB=$(cat "$SSH_KEY".pub)
+
 # Check that the system started and is running correctly
 running_test_check () {
-    STATUS=$(sudo ssh -i $OSBUILD_COMPOSER_TEST_DATA/keyring/id_rsa redhat@"${1}" 'systemctl --wait is-system-running')
+    STATUS=$(sudo ssh -i "${SSH_KEY}" redhat@"${1}" 'systemctl --wait is-system-running')
     if [[ $STATUS == running || $STATUS == degraded ]]; then
         echo 0
     else
@@ -119,7 +121,7 @@ enabled = ["sshd"]
 
 [[customizations.user]]
 name = "redhat"
-key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC61wMCjOSHwbVb4VfVyl5sn497qW4PsdQ7Ty7aD6wDNZ/QjjULkDV/yW5WjDlDQ7UqFH0Sr7vywjqDizUAqK7zM5FsUKsUXWHWwg/ehKg8j9xKcMv11AkFoUoujtfAujnKODkk58XSA9whPr7qcw3vPrmog680pnMSzf9LC7J6kXfs6lkoKfBh9VnlxusCrw2yg0qI1fHAZBLPx7mW6+me71QZsS6sVz8v8KXyrXsKTdnF50FjzHcK9HXDBtSJS5wA3fkcRYymJe0o6WMWNdgSRVpoSiWaHHmFgdMUJaYoCfhXzyl7LtNb3Q+Sveg+tJK7JaRXBLMUllOlJ6ll5Hod root@localhost"
+key = "${SSH_KEY_PUB}"
 EOF
 
 # Prepare the blueprint for the compose.

--- a/tools/gen-ssh.sh
+++ b/tools/gen-ssh.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/bash
+
+# Create SSH key
+SSH_DATA_DIR="$(mktemp -d)"
+SSH_KEY=${SSH_DATA_DIR}/id_rsa
+ssh-keygen -f "${SSH_KEY}" -N "" -q -t rsa
+
+# Change cloud-init/user-data ssh key
+key=" - $(cat "${SSH_KEY}".pub)"
+# Temporary, will copy user data from cloud-init once
+# go test are updated
+tee "${SSH_DATA_DIR}"/user-data > /dev/null << EOF
+#cloud-config
+write_files:
+  - path: "/etc/smoke-test.txt"
+    content: "c21va2UtdGVzdAo="
+    encoding: "b64"
+    owner: "root:root"
+    permissions: "0644"
+
+user: redhat
+ssh_authorized_keys:
+${key}
+EOF
+
+# Return temp directory
+echo "${SSH_DATA_DIR}"


### PR DESCRIPTION
This pull request includes:

Trying the basic functionality just with libvirt test, i'll extend it to the other tests if it works

- [x] adequate testing for the new functionality or fixed issue
- [x] adequate documentation informing people about the change such as
  - [x] create a file in [news/unreleased](https://github.com/osbuild/osbuild-composer/tree/main/docs/news/unreleased) directory if this change should be mentioned in the release news
  - [x] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

For user-visible changes, "adequate documentation" is an entry describing the
change for users in docs/news. Please refer to docs/news/README.md for details.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`
-->
