### PR TITLE
Fix-ups and missing documentation for PR#1525

### DIFF
--- a/docs/news/unreleased/new-osbuild-stages.md
+++ b/docs/news/unreleased/new-osbuild-stages.md
@@ -1,0 +1,16 @@
+# Add support for new / extended osbuild stages
+
+Add support for the following new osbuild stages:
+
+- `org.osbuild.modprobe` - allows to configure modprobe using configuration files
+- `org.osbuild.dracut.conf` - allows to create dracut configuration files
+- `org.osbuild.systemd-logind` - allows to create system-logind configuration drop-ins
+- `org.osbuild.cloud-init` - allows to configure cloud-init
+- `org.osbuild.authselect` - allows to set system identity and auth sources using authselect
+
+Add support for new functionality of existing osbuild stages:
+
+- `org.osbuild.sysconfig` - allows to create network-scripts ifcfg files
+- `org.osbuild.systemd` - allows to create `.service` file drop-ins
+- `org.osbuild.chrony` - allows to configure NTP `servers` with lower level configuration options
+- `org.osbuild.keymap` - allows to configure X11 keyboard layout

--- a/internal/osbuild2/authselect_stage.go
+++ b/internal/osbuild2/authselect_stage.go
@@ -1,7 +1,7 @@
 package osbuild2
 
 type AuthselectStageOptions struct {
-	Profile  string   `json:"profile_id"`
+	Profile  string   `json:"profile"`
 	Features []string `json:"features,omitempty"`
 }
 

--- a/internal/osbuild2/chrony_stage.go
+++ b/internal/osbuild2/chrony_stage.go
@@ -22,11 +22,8 @@ type ChronyConfigServer struct {
 	Prefer   *bool  `json:"prefer,omitempty"`
 }
 
-// Unexported struct for use in ChronyStageOptions's MarshalJSON() to prevent recursion
-type chronyStageOptions struct {
-	Timeservers []string             `json:"timeservers,omitempty"`
-	Servers     []ChronyConfigServer `json:"servers,omitempty"`
-}
+// Unexported alias for use in ChronyStageOptions's MarshalJSON() to prevent recursion
+type chronyStageOptions ChronyStageOptions
 
 func (o ChronyStageOptions) MarshalJSON() ([]byte, error) {
 	if (len(o.Timeservers) != 0 && len(o.Servers) != 0) || (len(o.Timeservers) == 0 && len(o.Servers) == 0) {

--- a/internal/osbuild2/cloud_init_stage.go
+++ b/internal/osbuild2/cloud_init_stage.go
@@ -23,10 +23,8 @@ type CloudInitConfigFile struct {
 	SystemInfo *CloudInitConfigSystemInfo `json:"system_info,omitempty"`
 }
 
-// Unexported struct for use in CloudInitConfigFile's MarshalJSON() to prevent recursion
-type cloudInitConfigFile struct {
-	SystemInfo *CloudInitConfigSystemInfo `json:"system_info,omitempty"`
-}
+// Unexported alias for use in CloudInitConfigFile's MarshalJSON() to prevent recursion
+type cloudInitConfigFile CloudInitConfigFile
 
 func (c CloudInitConfigFile) MarshalJSON() ([]byte, error) {
 	if c.SystemInfo == nil {
@@ -41,10 +39,8 @@ type CloudInitConfigSystemInfo struct {
 	DefaultUser *CloudInitConfigDefaultUser `json:"default_user,omitempty"`
 }
 
-// Unexported struct for use in CloudInitConfigSystemInfo's MarshalJSON() to prevent recursion
-type cloudInitConfigSystemInfo struct {
-	DefaultUser *CloudInitConfigDefaultUser `json:"default_user,omitempty"`
-}
+// Unexported alias for use in CloudInitConfigSystemInfo's MarshalJSON() to prevent recursion
+type cloudInitConfigSystemInfo CloudInitConfigSystemInfo
 
 func (si CloudInitConfigSystemInfo) MarshalJSON() ([]byte, error) {
 	if si.DefaultUser == nil {
@@ -59,10 +55,8 @@ type CloudInitConfigDefaultUser struct {
 	Name string `json:"name,omitempty"`
 }
 
-// Unexported struct for use in CloudInitConfigDefaultUser's MarshalJSON() to prevent recursion
-type cloudInitConfigDefaultUser struct {
-	Name string `json:"name,omitempty"`
-}
+// Unexported alias for use in CloudInitConfigDefaultUser's MarshalJSON() to prevent recursion
+type cloudInitConfigDefaultUser CloudInitConfigDefaultUser
 
 func (du CloudInitConfigDefaultUser) MarshalJSON() ([]byte, error) {
 	if du.Name == "" {

--- a/internal/osbuild2/dracut_conf_stage.go
+++ b/internal/osbuild2/dracut_conf_stage.go
@@ -54,41 +54,8 @@ type DracutConfigFile struct {
 	Reproducible *bool `json:"reproducible,omitempty"`
 }
 
-// Unexported struct for use in DracutConfigFile MarshalJSON() to prevent recursion
-type dracutConfigFile struct {
-	// Compression method for the initramfs
-	Compress string `json:"compress,omitempty"`
-
-	// Exact list of dracut modules to use
-	Modules []string `json:"dracutmodules,omitempty"`
-
-	// Additional dracut modules to include
-	AddModules []string `json:"add_dracutmodules,omitempty"`
-
-	// Dracut modules to not include
-	OmitModules []string `json:"omit_dracutmodules,omitempty"`
-
-	// Kernel modules to exclusively include
-	Drivers []string `json:"drivers,omitempty"`
-
-	// Add a specific kernel module
-	AddDrivers []string `json:"add_drivers,omitempty"`
-
-	// Add driver and ensure that they are tried to be loaded
-	ForceDrivers []string `json:"force_drivers,omitempty"`
-
-	// Kernel filesystem modules to exclusively include
-	Filesystems []string `json:"filesystems,omitempty"`
-
-	// Install the specified files
-	Install []string `json:"install_items,omitempty"`
-
-	// Combine early microcode with the initramfs
-	EarlyMicrocode *bool `json:"early_microcode,omitempty"`
-
-	// Create reproducible images
-	Reproducible *bool `json:"reproducible,omitempty"`
-}
+// Unexported alias for use in DracutConfigFile MarshalJSON() to prevent recursion
+type dracutConfigFile DracutConfigFile
 
 func (c DracutConfigFile) MarshalJSON() ([]byte, error) {
 	if c.Compress == "" &&

--- a/internal/osbuild2/keymap_stage.go
+++ b/internal/osbuild2/keymap_stage.go
@@ -23,10 +23,8 @@ type X11KeymapOptions struct {
 	Layouts []string `json:"layouts"`
 }
 
-// Unexported struct for use in X11KeymapOptions's MarshalJSON() to prevent recursion
-type x11KeymapOptions struct {
-	Layouts []string `json:"layouts"`
-}
+// Unexported alias for use in X11KeymapOptions's MarshalJSON() to prevent recursion
+type x11KeymapOptions X11KeymapOptions
 
 func (o X11KeymapOptions) MarshalJSON() ([]byte, error) {
 	if len(o.Layouts) == 0 {

--- a/internal/osbuild2/stage_test.go
+++ b/internal/osbuild2/stage_test.go
@@ -62,7 +62,7 @@ func TestStage_UnmarshalJSON(t *testing.T) {
 				},
 			},
 			args: args{
-				data: []byte(`{"type":"org.osbuild.authselect","options":{"profile_id":"sssd"}}`),
+				data: []byte(`{"type":"org.osbuild.authselect","options":{"profile":"sssd"}}`),
 			},
 		},
 		{
@@ -75,7 +75,7 @@ func TestStage_UnmarshalJSON(t *testing.T) {
 				},
 			},
 			args: args{
-				data: []byte(`{"type":"org.osbuild.authselect","options":{"profile_id":"nis","features":["with-ecryptfs","with-mkhomedir"]}}`),
+				data: []byte(`{"type":"org.osbuild.authselect","options":{"profile":"nis","features":["with-ecryptfs","with-mkhomedir"]}}`),
 			},
 		},
 		{

--- a/internal/osbuild2/systemd_logind_stage.go
+++ b/internal/osbuild2/systemd_logind_stage.go
@@ -30,12 +30,8 @@ type SystemdLogindConfigLoginSection struct {
 	NAutoVT *int `json:"NAutoVT,omitempty"`
 }
 
-// Unexported struct for use in SystemdLogindConfigLoginSection's MarshalJSON() to prevent recursion
-type systemdLogindConfigLoginSection struct {
-	// Configures how many virtual terminals (VTs) to allocate by default
-	// The option is optional, but zero is a valid value
-	NAutoVT *int `json:"NAutoVT,omitempty"`
-}
+// Unexported alias for use in SystemdLogindConfigLoginSection's MarshalJSON() to prevent recursion
+type systemdLogindConfigLoginSection SystemdLogindConfigLoginSection
 
 func (s SystemdLogindConfigLoginSection) MarshalJSON() ([]byte, error) {
 	if s.NAutoVT == nil {


### PR DESCRIPTION
- Reflect osbuild/osbuild#729 in osbuild-composer.
- Some osbuild stages added as part of #1525 declare unexported types which are complete copies of types with custom MarshalJSON method, to prevent recursion when marshalling to JSON.
- Add news entry for changes merged as part of #1525.


This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [x] create a file in [news/unreleased](https://github.com/osbuild/osbuild-composer/tree/main/docs/news/unreleased) directory if this change should be mentioned in the release news
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

For user-visible changes, "adequate documentation" is an entry describing the
change for users in docs/news. Please refer to docs/news/README.md for details.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`
-->
