### PR TITLE
weldr: Get the host distro using distroregistry

### DIFF
--- a/internal/weldr/api.go
+++ b/internal/weldr/api.go
@@ -141,13 +141,9 @@ func New(repoPaths []string, stateDir string, rpm rpmmd.RPMMD, dr *distroregistr
 		logger = log.New(os.Stdout, "", 0)
 	}
 
-	hostDistroName, _, _, err := distro.GetHostDistroName()
-	if err != nil {
-		return nil, fmt.Errorf("host distro is not supported")
-	}
 	archName := common.CurrentArch()
 
-	hostDistro := dr.GetDistro(hostDistroName)
+	hostDistro := dr.FromHost()
 	hostArch, err := hostDistro.GetArch(archName)
 	if err != nil {
 		return nil, fmt.Errorf("Host distro does not support host architecture: %v", err)


### PR DESCRIPTION
Currently the host name needs to be mangled, so let distroregistry do
all the hard work and get the distro from it.

Fixes #1576


This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] create a file in [news/unreleased](https://github.com/osbuild/osbuild-composer/tree/main/docs/news/unreleased) directory if this change should be mentioned in the release news
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/
