### PR TITLE
Worker: report stages status after RunOSBuild

### DIFF
--- a/cmd/osbuild-worker/jobimpl-osbuild.go
+++ b/cmd/osbuild-worker/jobimpl-osbuild.go
@@ -96,6 +96,37 @@ func (impl *OSBuildJobImpl) Run(job worker.Job) error {
 	if err != nil {
 		return err
 	}
+
+	log.Println("Build stages results:")
+
+	// Include the build stages output inside the worker's logs.
+	for _, stage := range osbuildJobResult.OSBuildOutput.Build.Stages {
+		if stage.Success {
+			log.Println(stage.Name, " success")
+		} else {
+			log.Printf("%s failure:\n", stage.Name)
+			stageOutput := strings.Split(stage.Output, "\n")
+			for _, line := range stageOutput {
+				log.Printf("	%s", line)
+			}
+		}
+	}
+
+	log.Println("Stages results:")
+
+	// Include the stages output inside the worker's logs.
+	for _, stage := range osbuildJobResult.OSBuildOutput.Stages {
+		if stage.Success {
+			log.Println(stage.Name, " success")
+		} else {
+			log.Printf("%s failure:\n", stage.Name)
+			stageOutput := strings.Split(stage.Output, "\n")
+			for _, line := range stageOutput {
+				log.Printf("	%s", line)
+			}
+		}
+	}
+
 	// Second handle the case when the build failed, but osbuild finished successfully
 	if !osbuildJobResult.OSBuildOutput.Success {
 		return nil


### PR DESCRIPTION
To help along with debugging, this commit makes the worker able to print
the status of the different stages with a oneliner for each successfull
stages and a detailed message for failed ones.

Sample output:
Jul 23[..]: Build stages results:
Jul 23[..]: org.osbuild.rpm  success
Jul 23[..]: org.osbuild.selinux  success
Jul 23[..]: Stages results:
Jul 23[..]: org.osbuild.rpm  success
Jul 23[..]: org.osbuild.fix-bls  success
Jul 23[..]: org.osbuild.fstab  success
Jul 23[..]: org.osbuild.grub2  success
Jul 23[..]: org.osbuild.locale  success
Jul 23[..]: org.osbuild.timezone  success
Jul 23[..]: org.osbuild.users failure:
Jul 23[..]:  [/usr/lib/tmpfiles.d/journal-nocow.conf:26] Failed to resolve specifier: uninitialized /etc detected, skipping
Jul 23[..]: All rules containing unresolvable specifiers will be skipped.
Jul 23[..]: Failed to create file /sys/fs/selinux/checkreqprot: Read-only file system
Jul 23[..]: useradd: group 'toto' does not exist

Fixes #1584


This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] create a file in [news/unreleased](https://github.com/osbuild/osbuild-composer/tree/main/docs/news/unreleased) directory if this change should be mentioned in the release news
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

For user-visible changes, "adequate documentation" is an entry describing the
change for users in docs/news. Please refer to docs/news/README.md for details.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`
-->
