### PR TITLE
ci: drop all remaining 8.4 nightly jobs

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -47,8 +47,6 @@ RPM:
           - aws/centos-stream-8-x86_64
           - aws/centos-stream-8-aarch64
       - RUNNER:
-          - aws/rhel-8.4-x86_64
-          - aws/rhel-8.4-aarch64
           - aws/rhel-8.5-x86_64
           - aws/rhel-8.5-aarch64
           - aws/rhel-9.0-beta-nightly-x86_64
@@ -205,7 +203,6 @@ Integration:
       - SCRIPT:
           - azure_hyperv_gen2.sh
         RUNNER:
-          - aws/rhel-8.4-x86_64
           - aws/rhel-8.5-x86_64
         INTERNAL_NETWORK: ["true"]
       - <<: *INTEGRATION_TESTS


### PR DESCRIPTION
RHEL 8.4 is GA for a long time so we no longer need 8.4 nightly jobs.

Signed-off-by: Ondřej Budai <ondrej@budai.cz>


This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] create a file in [news/unreleased](https://github.com/osbuild/osbuild-composer/tree/main/docs/news/unreleased) directory if this change should be mentioned in the release news
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

For user-visible changes, "adequate documentation" is an entry describing the
change for users in docs/news. Please refer to docs/news/README.md for details.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`
-->
