### PR TITLE
ci: run only koji.sh for rhel_90 distro

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -208,11 +208,6 @@ Integration:
           - aws/rhel-8.4-x86_64
           - aws/rhel-8.5-x86_64
         INTERNAL_NETWORK: ["true"]
-      - <<: *INTEGRATION_TESTS
-        RUNNER:
-          - aws/rhel-8-x86_64
-        INTERNAL_NETWORK: ["true"]
-        DISTRO_CODE: ["rhel_90"]
       - SCRIPT:
           - libvirt.sh
         RUNNER:
@@ -254,11 +249,19 @@ API:
           - aws/rhel-8-x86_64
           - aws/rhel-8.5-x86_64
         INTERNAL_NETWORK: ["true"]
-      - <<: *API_TESTS
-        RUNNER:
-          - aws/rhel-8-x86_64
-        INTERNAL_NETWORK: ["true"]
-        DISTRO_CODE: ["rhel_90"]
+
+RHEL 9 on 8:
+  stage: test
+  extends: .terraform
+  rules:
+    - if: '$CI_PIPELINE_SOURCE != "schedule"'
+  script:
+    - schutzbot/deploy.sh
+    - /usr/libexec/tests/osbuild-composer/koji.sh
+  variables:
+    RUNNER: aws/rhel-8-x86_64
+    INTERNAL_NETWORK: "true"
+    DISTRO_CODE: rhel-90
 
 NIGHTLY_FAIL:
   stage: finish


### PR DESCRIPTION
Previously, all sorts of tests that provided no value were run for RHEL 9.0.
This commit limits its testing to the only test that makes sense: koji.sh.
See #1461 for more details.

Fixes #1461

Signed-off-by: Ondřej Budai <ondrej@budai.cz>


This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] create a file in [news/unreleased](https://github.com/osbuild/osbuild-composer/tree/main/docs/news/unreleased) directory if this change should be mentioned in the release news
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

For user-visible changes, "adequate documentation" is an entry describing the
change for users in docs/news. Please refer to docs/news/README.md for details.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`
-->
