### PR TITLE
Reflect changes made to some osbuild stages before the v30 release

### DIFF
--- a/internal/osbuild2/cloud_init_stage.go
+++ b/internal/osbuild2/cloud_init_stage.go
@@ -6,7 +6,8 @@ import (
 )
 
 type CloudInitStageOptions struct {
-	ConfigFiles map[string]CloudInitConfigFile `json:"configuration_files,omitempty"`
+	Filename string              `json:"filename"`
+	Config   CloudInitConfigFile `json:"config"`
 }
 
 func (CloudInitStageOptions) isStageOptions() {}

--- a/internal/osbuild2/cloud_init_stage_test.go
+++ b/internal/osbuild2/cloud_init_stage_test.go
@@ -22,31 +22,32 @@ func TestCloudInitStage_MarshalJSON_Invalid(t *testing.T) {
 		options CloudInitStageOptions
 	}{
 		{
+			name:    "empty-options",
+			options: CloudInitStageOptions{},
+		},
+		{
 			name: "no-config-file-section",
 			options: CloudInitStageOptions{
-				ConfigFiles: map[string]CloudInitConfigFile{
-					"00-default_user.cfg": {},
-				},
+				Filename: "00-default_user.cfg",
+				Config:   CloudInitConfigFile{},
 			},
 		},
 		{
 			name: "no-system-info-section-option",
 			options: CloudInitStageOptions{
-				ConfigFiles: map[string]CloudInitConfigFile{
-					"00-default_user.cfg": {
-						SystemInfo: &CloudInitConfigSystemInfo{},
-					},
+				Filename: "00-default_user.cfg",
+				Config: CloudInitConfigFile{
+					SystemInfo: &CloudInitConfigSystemInfo{},
 				},
 			},
 		},
 		{
 			name: "no-default-user-section-option",
 			options: CloudInitStageOptions{
-				ConfigFiles: map[string]CloudInitConfigFile{
-					"00-default_user.cfg": {
-						SystemInfo: &CloudInitConfigSystemInfo{
-							DefaultUser: &CloudInitConfigDefaultUser{},
-						},
+				Filename: "00-default_user.cfg",
+				Config: CloudInitConfigFile{
+					SystemInfo: &CloudInitConfigSystemInfo{
+						DefaultUser: &CloudInitConfigDefaultUser{},
 					},
 				},
 			},

--- a/internal/osbuild2/dracut_conf_stage.go
+++ b/internal/osbuild2/dracut_conf_stage.go
@@ -6,7 +6,8 @@ import (
 )
 
 type DracutConfStageOptions struct {
-	ConfigFiles map[string]DracutConfigFile `json:"configuration_files,omitempty"`
+	Filename string           `json:"filename"`
+	Config   DracutConfigFile `json:"config"`
 }
 
 func (DracutConfStageOptions) isStageOptions() {}

--- a/internal/osbuild2/dracut_conf_stage.go
+++ b/internal/osbuild2/dracut_conf_stage.go
@@ -13,7 +13,7 @@ type DracutConfStageOptions struct {
 func (DracutConfStageOptions) isStageOptions() {}
 
 // Dracut.conf stage creates dracut configuration files under /usr/lib/dracut/dracut.conf.d/
-func NewDracutConfStageOptions(options *DracutConfStageOptions) *Stage {
+func NewDracutConfStage(options *DracutConfStageOptions) *Stage {
 	return &Stage{
 		Type:    "org.osbuild.dracut.conf",
 		Options: options,

--- a/internal/osbuild2/dracut_conf_stage_test.go
+++ b/internal/osbuild2/dracut_conf_stage_test.go
@@ -22,11 +22,14 @@ func TestDracutConfStage_MarshalJSON_Invalid(t *testing.T) {
 		options DracutConfStageOptions
 	}{
 		{
+			name:    "empty-options",
+			options: DracutConfStageOptions{},
+		},
+		{
 			name: "no-options-in-config",
 			options: DracutConfStageOptions{
-				ConfigFiles: map[string]DracutConfigFile{
-					"testing.conf": {},
-				},
+				Filename: "testing.conf",
+				Config:   DracutConfigFile{},
 			},
 		},
 	}

--- a/internal/osbuild2/dracut_conf_stage_test.go
+++ b/internal/osbuild2/dracut_conf_stage_test.go
@@ -12,7 +12,7 @@ func TestNewDracutConfStage(t *testing.T) {
 		Type:    "org.osbuild.dracut.conf",
 		Options: &DracutConfStageOptions{},
 	}
-	actualStage := NewDracutConfStageOptions(&DracutConfStageOptions{})
+	actualStage := NewDracutConfStage(&DracutConfStageOptions{})
 	assert.Equal(t, expectedStage, actualStage)
 }
 

--- a/internal/osbuild2/modprobe_stage.go
+++ b/internal/osbuild2/modprobe_stage.go
@@ -6,7 +6,8 @@ import (
 )
 
 type ModprobeStageOptions struct {
-	ConfigFiles map[string]ModprobeConfigCmdList `json:"configuration_files,omitempty"`
+	Filename string                `json:"filename"`
+	Commands ModprobeConfigCmdList `json:"commands"`
 }
 
 func (ModprobeStageOptions) isStageOptions() {}

--- a/internal/osbuild2/modprobe_stage_test.go
+++ b/internal/osbuild2/modprobe_stage_test.go
@@ -22,11 +22,14 @@ func TestModprobeStage_MarshalJSON_Invalid(t *testing.T) {
 		options ModprobeStageOptions
 	}{
 		{
+			name:    "empty-options",
+			options: ModprobeStageOptions{},
+		},
+		{
 			name: "no-commands",
 			options: ModprobeStageOptions{
-				ConfigFiles: map[string]ModprobeConfigCmdList{
-					"disallow-modules.conf": {},
-				},
+				Filename: "disallow-modules.conf",
+				Commands: ModprobeConfigCmdList{},
 			},
 		},
 	}

--- a/internal/osbuild2/stage.go
+++ b/internal/osbuild2/stage.go
@@ -81,6 +81,8 @@ func (stage *Stage) UnmarshalJSON(data []byte) error {
 		options = new(RHSMStageOptions)
 	case "org.osbuild.systemd":
 		options = new(SystemdStageOptions)
+	case "org.osbuild.systemd.unit":
+		options = new(SystemdUnitStageOptions)
 	case "org.osbuild.systemd-logind":
 		options = new(SystemdLogindStageOptions)
 	case "org.osbuild.script":

--- a/internal/osbuild2/stage_test.go
+++ b/internal/osbuild2/stage_test.go
@@ -448,21 +448,19 @@ func TestStage_UnmarshalJSON(t *testing.T) {
 		{
 			name: "systemd-unit-dropins",
 			fields: fields{
-				Type: "org.osbuild.systemd",
-				Options: &SystemdStageOptions{
-					UnitDropins: map[string]SystemdServiceUnitDropins{
-						"nm-cloud-setup.service": {
-							"10-rh-enable-for-ec2.conf": {
-								Service: &SystemdUnitServiceSection{
-									Environment: "NM_CLOUD_SETUP_EC2=yes",
-								},
-							},
+				Type: "org.osbuild.systemd.unit",
+				Options: &SystemdUnitStageOptions{
+					Unit:   "nm-cloud-setup.service",
+					Dropin: "10-rh-enable-for-ec2.conf",
+					Config: SystemdServiceUnitDropin{
+						Service: &SystemdUnitServiceSection{
+							Environment: "NM_CLOUD_SETUP_EC2=yes",
 						},
 					},
 				},
 			},
 			args: args{
-				data: []byte(`{"type":"org.osbuild.systemd","options":{"unit_dropins":{"nm-cloud-setup.service":{"10-rh-enable-for-ec2.conf":{"Service":{"Environment":"NM_CLOUD_SETUP_EC2=yes"}}}}}}`),
+				data: []byte(`{"type":"org.osbuild.systemd.unit","options":{"unit":"nm-cloud-setup.service","dropin":"10-rh-enable-for-ec2.conf","config":{"Service":{"Environment":"NM_CLOUD_SETUP_EC2=yes"}}}}`),
 			},
 		},
 		{

--- a/internal/osbuild2/stage_test.go
+++ b/internal/osbuild2/stage_test.go
@@ -81,31 +81,20 @@ func TestStage_UnmarshalJSON(t *testing.T) {
 		{
 			name: "cloud-init",
 			fields: fields{
-				Type:    "org.osbuild.cloud-init",
-				Options: &CloudInitStageOptions{},
-			},
-			args: args{
-				data: []byte(`{"type":"org.osbuild.cloud-init","options":{}}`),
-			},
-		},
-		{
-			name: "cloud-init-data",
-			fields: fields{
 				Type: "org.osbuild.cloud-init",
 				Options: &CloudInitStageOptions{
-					ConfigFiles: map[string]CloudInitConfigFile{
-						"00-default_user.cfg": {
-							SystemInfo: &CloudInitConfigSystemInfo{
-								DefaultUser: &CloudInitConfigDefaultUser{
-									Name: "ec2-user",
-								},
+					Filename: "00-default_user.cfg",
+					Config: CloudInitConfigFile{
+						SystemInfo: &CloudInitConfigSystemInfo{
+							DefaultUser: &CloudInitConfigDefaultUser{
+								Name: "ec2-user",
 							},
 						},
 					},
 				},
 			},
 			args: args{
-				data: []byte(`{"type":"org.osbuild.cloud-init","options":{"configuration_files":{"00-default_user.cfg":{"system_info":{"default_user":{"name":"ec2-user"}}}}}}`),
+				data: []byte(`{"type":"org.osbuild.cloud-init","options":{"filename":"00-default_user.cfg","config":{"system_info":{"default_user":{"name":"ec2-user"}}}}}`),
 			},
 		},
 		{

--- a/internal/osbuild2/stage_test.go
+++ b/internal/osbuild2/stage_test.go
@@ -300,40 +300,23 @@ func TestStage_UnmarshalJSON(t *testing.T) {
 		{
 			name: "modprobe",
 			fields: fields{
-				Type:    "org.osbuild.modprobe",
-				Options: &ModprobeStageOptions{},
-			},
-			args: args{
-				data: []byte(`{"type":"org.osbuild.modprobe","options":{}}`),
-			},
-		},
-		{
-			name: "modprobe-data",
-			fields: fields{
 				Type: "org.osbuild.modprobe",
 				Options: &ModprobeStageOptions{
-					ConfigFiles: map[string]ModprobeConfigCmdList{
-						"disallow-modules.conf": {
-							&ModprobeConfigCmdBlacklist{
-								Command:    "blacklist",
-								Modulename: "nouveau",
-							},
-							&ModprobeConfigCmdBlacklist{
-								Command:    "blacklist",
-								Modulename: "floppy",
-							},
+					Filename: "disallow-modules.conf",
+					Commands: ModprobeConfigCmdList{
+						&ModprobeConfigCmdBlacklist{
+							Command:    "blacklist",
+							Modulename: "nouveau",
 						},
-						"disallow-additional-modules.conf": {
-							&ModprobeConfigCmdBlacklist{
-								Command:    "blacklist",
-								Modulename: "my-module",
-							},
+						&ModprobeConfigCmdBlacklist{
+							Command:    "blacklist",
+							Modulename: "floppy",
 						},
 					},
 				},
 			},
 			args: args{
-				data: []byte(`{"type":"org.osbuild.modprobe","options":{"configuration_files":{"disallow-additional-modules.conf":[{"command":"blacklist","modulename":"my-module"}],"disallow-modules.conf":[{"command":"blacklist","modulename":"nouveau"},{"command":"blacklist","modulename":"floppy"}]}}}`),
+				data: []byte(`{"type":"org.osbuild.modprobe","options":{"filename":"disallow-modules.conf","commands":[{"command":"blacklist","modulename":"nouveau"},{"command":"blacklist","modulename":"floppy"}]}}`),
 			},
 		},
 		{

--- a/internal/osbuild2/stage_test.go
+++ b/internal/osbuild2/stage_test.go
@@ -468,29 +468,18 @@ func TestStage_UnmarshalJSON(t *testing.T) {
 		{
 			name: "systemd-logind",
 			fields: fields{
-				Type:    "org.osbuild.systemd-logind",
-				Options: &SystemdLogindStageOptions{},
-			},
-			args: args{
-				data: []byte(`{"type":"org.osbuild.systemd-logind","options":{}}`),
-			},
-		},
-		{
-			name: "systemd-logind-data",
-			fields: fields{
 				Type: "org.osbuild.systemd-logind",
 				Options: &SystemdLogindStageOptions{
-					ConfigDropins: map[string]SystemdLogindConfigDropin{
-						"10-ec2-getty-fix.conf": {
-							Login: SystemdLogindConfigLoginSection{
-								NAutoVT: common.IntToPtr(0),
-							},
+					Filename: "10-ec2-getty-fix.conf",
+					Config: SystemdLogindConfigDropin{
+						Login: SystemdLogindConfigLoginSection{
+							NAutoVT: common.IntToPtr(0),
 						},
 					},
 				},
 			},
 			args: args{
-				data: []byte(`{"type":"org.osbuild.systemd-logind","options":{"configuration_dropins":{"10-ec2-getty-fix.conf":{"Login":{"NAutoVT":0}}}}}`),
+				data: []byte(`{"type":"org.osbuild.systemd-logind","options":{"filename":"10-ec2-getty-fix.conf","config":{"Login":{"NAutoVT":0}}}}`),
 			},
 		},
 		{

--- a/internal/osbuild2/stage_test.go
+++ b/internal/osbuild2/stage_test.go
@@ -148,38 +148,24 @@ func TestStage_UnmarshalJSON(t *testing.T) {
 		{
 			name: "dracut.conf",
 			fields: fields{
-				Type:    "org.osbuild.dracut.conf",
-				Options: &DracutConfStageOptions{},
-			},
-			args: args{
-				data: []byte(`{"type":"org.osbuild.dracut.conf","options":{}}`),
-			},
-		},
-		{
-			name: "dracut.conf-data",
-			fields: fields{
 				Type: "org.osbuild.dracut.conf",
 				Options: &DracutConfStageOptions{
-					ConfigFiles: map[string]DracutConfigFile{
-						"sgdisk.conf": {
-							Install: []string{"sgdisk"},
-						},
-						"testing.conf": {
-							Compress:       "xz",
-							AddModules:     []string{"floppy"},
-							OmitModules:    []string{"nouveau"},
-							AddDrivers:     []string{"driver1"},
-							ForceDrivers:   []string{"driver2"},
-							Filesystems:    []string{"ext4"},
-							Install:        []string{"file1"},
-							EarlyMicrocode: common.BoolToPtr(false),
-							Reproducible:   common.BoolToPtr(false),
-						},
+					Filename: "testing.conf",
+					Config: DracutConfigFile{
+						Compress:       "xz",
+						AddModules:     []string{"floppy"},
+						OmitModules:    []string{"nouveau"},
+						AddDrivers:     []string{"driver1"},
+						ForceDrivers:   []string{"driver2"},
+						Filesystems:    []string{"ext4"},
+						Install:        []string{"file1"},
+						EarlyMicrocode: common.BoolToPtr(false),
+						Reproducible:   common.BoolToPtr(false),
 					},
 				},
 			},
 			args: args{
-				data: []byte(`{"type":"org.osbuild.dracut.conf","options":{"configuration_files":{"sgdisk.conf":{"install_items":["sgdisk"]},"testing.conf":{"compress":"xz","add_dracutmodules":["floppy"],"omit_dracutmodules":["nouveau"],"add_drivers":["driver1"],"force_drivers":["driver2"],"filesystems":["ext4"],"install_items":["file1"],"early_microcode":false,"reproducible":false}}}}`),
+				data: []byte(`{"type":"org.osbuild.dracut.conf","options":{"filename":"testing.conf","config":{"compress":"xz","add_dracutmodules":["floppy"],"omit_dracutmodules":["nouveau"],"add_drivers":["driver1"],"force_drivers":["driver2"],"filesystems":["ext4"],"install_items":["file1"],"early_microcode":false,"reproducible":false}}}`),
 			},
 		},
 		{

--- a/internal/osbuild2/systemd_logind_stage.go
+++ b/internal/osbuild2/systemd_logind_stage.go
@@ -6,7 +6,8 @@ import (
 )
 
 type SystemdLogindStageOptions struct {
-	ConfigDropins map[string]SystemdLogindConfigDropin `json:"configuration_dropins,omitempty"`
+	Filename string                    `json:"filename"`
+	Config   SystemdLogindConfigDropin `json:"config"`
 }
 
 func (SystemdLogindStageOptions) isStageOptions() {}

--- a/internal/osbuild2/systemd_logind_stage_test.go
+++ b/internal/osbuild2/systemd_logind_stage_test.go
@@ -22,12 +22,15 @@ func TestSystemdLogindStage_MarshalJSON_Invalid(t *testing.T) {
 		options SystemdLogindStageOptions
 	}{
 		{
+			name:    "empty-options",
+			options: SystemdLogindStageOptions{},
+		},
+		{
 			name: "no-section-options",
 			options: SystemdLogindStageOptions{
-				ConfigDropins: map[string]SystemdLogindConfigDropin{
-					"10-ec2-getty-fix.conf": {
-						Login: SystemdLogindConfigLoginSection{},
-					},
+				Filename: "10-ec2-getty-fix.conf",
+				Config: SystemdLogindConfigDropin{
+					Login: SystemdLogindConfigLoginSection{},
 				},
 			},
 		},

--- a/internal/osbuild2/systemd_stage.go
+++ b/internal/osbuild2/systemd_stage.go
@@ -4,9 +4,6 @@ type SystemdStageOptions struct {
 	EnabledServices  []string `json:"enabled_services,omitempty"`
 	DisabledServices []string `json:"disabled_services,omitempty"`
 	DefaultTarget    string   `json:"default_target,omitempty"`
-
-	// For now we support only .service drop-ins, but this may change in the future
-	UnitDropins map[string]SystemdServiceUnitDropins `json:"unit_dropins,omitempty"`
 }
 
 func (SystemdStageOptions) isStageOptions() {}
@@ -16,18 +13,4 @@ func NewSystemdStage(options *SystemdStageOptions) *Stage {
 		Type:    "org.osbuild.systemd",
 		Options: options,
 	}
-}
-
-// Drop-in configurations for a '.service' unit
-type SystemdServiceUnitDropins map[string]SystemdServiceUnitDropin
-
-// Drop-in configuration for a '.service' unit
-type SystemdServiceUnitDropin struct {
-	Service *SystemdUnitServiceSection `json:"Service,omitempty"`
-}
-
-// 'Service' configuration section of a unit file
-type SystemdUnitServiceSection struct {
-	// Sets environment variables for executed process
-	Environment string `json:"Environment,omitempty"`
 }

--- a/internal/osbuild2/systemd_unit_stage.go
+++ b/internal/osbuild2/systemd_unit_stage.go
@@ -1,0 +1,27 @@
+package osbuild2
+
+type SystemdUnitStageOptions struct {
+	Unit   string                   `json:"unit"`
+	Dropin string                   `json:"dropin"`
+	Config SystemdServiceUnitDropin `json:"config"`
+}
+
+func (SystemdUnitStageOptions) isStageOptions() {}
+
+func NewSystemdUnitStage(options *SystemdUnitStageOptions) *Stage {
+	return &Stage{
+		Type:    "org.osbuild.systemd.unit",
+		Options: options,
+	}
+}
+
+// Drop-in configuration for a '.service' unit
+type SystemdServiceUnitDropin struct {
+	Service *SystemdUnitServiceSection `json:"Service,omitempty"`
+}
+
+// 'Service' configuration section of a unit file
+type SystemdUnitServiceSection struct {
+	// Sets environment variables for executed process
+	Environment string `json:"Environment,omitempty"`
+}

--- a/internal/osbuild2/systemd_unit_stage_test.go
+++ b/internal/osbuild2/systemd_unit_stage_test.go
@@ -1,0 +1,16 @@
+package osbuild2
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewSystemdUnitStage(t *testing.T) {
+	expectedStage := &Stage{
+		Type:    "org.osbuild.systemd.unit",
+		Options: &SystemdUnitStageOptions{},
+	}
+	actualStage := NewSystemdUnitStage(&SystemdUnitStageOptions{})
+	assert.Equal(t, expectedStage, actualStage)
+}


### PR DESCRIPTION
This Pull Request reflects changes made to some osbuild stages before the v30 release (https://github.com/osbuild/osbuild/pull/739):
- change the following stages from creating multiple configuration files to just a single file:
  - `cloud-init`
  - `modprobe`
  - `dracut.conf`
  - `systemd-logind`
- the functionality to create Systemd unit drop-ins was extracted from the `systemd` stage to a new `systemd.unit` stage

This pull request includes:

- [x] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] create a file in [news/unreleased](https://github.com/osbuild/osbuild-composer/tree/main/docs/news/unreleased) directory if this change should be mentioned in the release news
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

For user-visible changes, "adequate documentation" is an entry describing the
change for users in docs/news. Please refer to docs/news/README.md for details.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`
-->
