### PR TITLE
internal/osbuild2: add stages for raw images and grub iso

### DIFF
--- a/internal/osbuild2/grub_iso_stage.go
+++ b/internal/osbuild2/grub_iso_stage.go
@@ -1,0 +1,25 @@
+package osbuild2
+
+type GrubISOStageOptions struct {
+	Product Product `json:"product"`
+
+	Kernel string `json:"kernel"`
+
+	ISOLabel string `json:"isolabel"`
+
+	// taken from bootiso.mono, when that goes away we'll move it here
+	EFI EFI `json:"efi,omitempty"`
+
+	// Additional kernel boot options
+	KernelOpts string `json:"kernel_opts,omitempty"`
+}
+
+func (GrubISOStageOptions) isStageOptions() {}
+
+// Assemble a file system tree for a bootable ISO
+func NewGrubISOStage(options *BootISOMonoStageOptions) *Stage {
+	return &Stage{
+		Type:    "org.osbuild.grub.iso",
+		Options: options,
+	}
+}

--- a/internal/osbuild2/mkdir_stage.go
+++ b/internal/osbuild2/mkdir_stage.go
@@ -1,0 +1,24 @@
+package osbuild2
+
+import "os"
+
+// Options for the org.osbuild.mkdir stage.
+type MkdirStageOptions struct {
+	Paths []Path `json:"paths"`
+}
+
+type Path struct {
+	Path string `json:"path"`
+
+	Mode os.FileMode `json:"mode"`
+}
+
+func (MkdirStageOptions) isStageOptions() {}
+
+// A new org.osbuild.ostree.init stage to create an OSTree repository
+func NewMkdirStage(options *MkdirStageOptions) *Stage {
+	return &Stage{
+		Type:    "org.osbuild.mkdir",
+		Options: options,
+	}
+}

--- a/internal/osbuild2/ostree_config_stage.go
+++ b/internal/osbuild2/ostree_config_stage.go
@@ -1,0 +1,27 @@
+package osbuild2
+
+type OSTreeConfigOptions struct {
+	Sysroot SysrootOptions `json:"sysroot"`
+}
+
+type SysrootOptions struct {
+	ReadOnly bool `json:"readonly"`
+}
+
+// Options for the org.osbuild.ostree.config stage.
+type OSTreeConfigStageOptions struct {
+	// Location of the ostree repo
+	Repo string `json:"repo"`
+
+	Config OSTreeConfigOptions `json:"config"`
+}
+
+func (OSTreeConfigStageOptions) isStageOptions() {}
+
+// A new org.osbuild.ostree.init stage to create an OSTree repository
+func NewOSTreeConfigStage(options *OSTreeConfigStageOptions) *Stage {
+	return &Stage{
+		Type:    "org.osbuild.ostree.config",
+		Options: options,
+	}
+}

--- a/internal/osbuild2/ostree_deploy_stage.go
+++ b/internal/osbuild2/ostree_deploy_stage.go
@@ -1,0 +1,28 @@
+package osbuild2
+
+// Options for the org.osbuild.ostree.deploy stage.
+type OSTreeDeployStageOptions struct {
+	OsName string `json:"osname"`
+
+	Ref string `json:"ref"`
+
+	Mounts []string `json:"mounts,omitempty"`
+
+	Rootfs Rootfs `json:"rootfs"`
+
+	KernelOpts []string `json:"kernel_opts,omitempty"`
+}
+
+type Rootfs struct {
+	Label string `json:"label"`
+}
+
+func (OSTreeDeployStageOptions) isStageOptions() {}
+
+// A new org.osbuild.ostree.init stage to create an OSTree repository
+func NewOSTreeDeployStage(options *OSTreeDeployStageOptions) *Stage {
+	return &Stage{
+		Type:    "org.osbuild.ostree.deploy",
+		Options: options,
+	}
+}

--- a/internal/osbuild2/ostree_fillvar_stage.go
+++ b/internal/osbuild2/ostree_fillvar_stage.go
@@ -1,0 +1,22 @@
+package osbuild2
+
+// Options for the org.osbuild.ostree.fillvar stage.
+type OSTreeFillvarStageOptions struct {
+	Deployment OSTreeDeployment `json:"deployment"`
+}
+
+type OSTreeDeployment struct {
+	OsName string `json:"osname"`
+
+	Ref string `json:"ref"`
+}
+
+func (OSTreeFillvarStageOptions) isStageOptions() {}
+
+// A new org.osbuild.ostree.init stage to create an OSTree repository
+func NewOSTreeFillvarStage(options *OSTreeFillvarStageOptions) *Stage {
+	return &Stage{
+		Type:    "org.osbuild.ostree.fillvar",
+		Options: options,
+	}
+}

--- a/internal/osbuild2/ostree_init_fs_stage.go
+++ b/internal/osbuild2/ostree_init_fs_stage.go
@@ -1,0 +1,8 @@
+package osbuild2
+
+// A new org.osbuild.ostree.init stage to create an OSTree repository
+func OSTreeInitFsStage() *Stage {
+	return &Stage{
+		Type: "org.osbuild.ostree.init-fs",
+	}
+}

--- a/internal/osbuild2/ostree_os_init_stage.go
+++ b/internal/osbuild2/ostree_os_init_stage.go
@@ -1,0 +1,17 @@
+package osbuild2
+
+// Options for the org.osbuild.ostree.os-init stage.
+type OSTreeOsInitStageOptions struct {
+	// Name of the OS
+	OsName string `json:"osname,omitempty"`
+}
+
+func (OSTreeOsInitStageOptions) isStageOptions() {}
+
+// A new org.osbuild.ostree.init stage to create an OSTree repository
+func NewOSTreeOsInitStage(options *OSTreeOsInitStageOptions) *Stage {
+	return &Stage{
+		Type:    "org.osbuild.ostree.os-init",
+		Options: options,
+	}
+}

--- a/internal/osbuild2/ostree_selinux_stage.go
+++ b/internal/osbuild2/ostree_selinux_stage.go
@@ -1,0 +1,17 @@
+package osbuild2
+
+// Options for the org.osbuild.ostree.selinux stage.
+type OSTreeSelinuxStageOptions struct {
+	// shared with ostree.fillvar
+	Deployment OSTreeDeployment `json:"deployment"`
+}
+
+func (OSTreeSelinuxStageOptions) isStageOptions() {}
+
+// A new org.osbuild.ostree.init stage to create an OSTree repository
+func NewOSTreeSelinuxStage(options *OSTreeSelinuxStageOptions) *Stage {
+	return &Stage{
+		Type:    "org.osbuild.ostree.selinux",
+		Options: options,
+	}
+}


### PR DESCRIPTION
Signed-off-by: Antonio Murdaca <runcom@linux.com>


This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] create a file in [news/unreleased](https://github.com/osbuild/osbuild-composer/tree/main/docs/news/unreleased) directory if this change should be mentioned in the release news
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/


This PR implements all the needed stages to create raw images and the new grub.iso stage needed for the new edge simplified installer. I'll follow up with a PR to create the pipelines (I think it's easier to review like this)

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

For user-visible changes, "adequate documentation" is an entry describing the
change for users in docs/news. Please refer to docs/news/README.md for details.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`
-->
