### PR TITLE
RHEL 85: Image installer

### DIFF
--- a/internal/distro/rhel85/distro.go
+++ b/internal/distro/rhel85/distro.go
@@ -765,11 +765,8 @@ func newDistro(name, modulePlatformID, ostreeRef string) distro.Distro {
 		filename: "installer.iso",
 		mimeType: "application/x-iso9660-image",
 		packageSets: map[string]rpmmd.PackageSet{
-			buildPkgsKey: x8664InstallerBuildPackageSet(),
-			osPkgsKey: {
-				Include: []string{"lvm2", "policycoreutils", "selinux-policy-targeted"},
-				Exclude: []string{"rng-tools"},
-			},
+			buildPkgsKey:     x8664InstallerBuildPackageSet(),
+			osPkgsKey:        bareMetalPackageSet(),
 			installerPkgsKey: installerPackageSet(),
 		},
 		rpmOstree: false,

--- a/internal/distro/rhel85/distro.go
+++ b/internal/distro/rhel85/distro.go
@@ -761,7 +761,7 @@ func newDistro(name, modulePlatformID, ostreeRef string) distro.Distro {
 		exports:   []string{"root-tar"},
 	}
 	tarInstallerImgTypeX86_64 := imageType{
-		name:     "tar-installer",
+		name:     "image-installer",
 		filename: "installer.iso",
 		mimeType: "application/x-iso9660-image",
 		packageSets: map[string]rpmmd.PackageSet{

--- a/internal/distro/rhel85/distro_test.go
+++ b/internal/distro/rhel85/distro_test.go
@@ -104,8 +104,8 @@ func TestFilenameFromType(t *testing.T) {
 			},
 		},
 		{
-			name: "tar-installer",
-			args: args{"tar-installer"},
+			name: "image-installer",
+			args: args{"image-installer"},
 			want: wantResult{
 				filename: "installer.iso",
 				mimeType: "application/x-iso9660-image",
@@ -264,7 +264,7 @@ func TestImageType_Name(t *testing.T) {
 				"edge-container",
 				"edge-installer",
 				"tar",
-				"tar-installer",
+				"image-installer",
 			},
 		},
 		{
@@ -446,7 +446,7 @@ func TestArchitecture_ListImageTypes(t *testing.T) {
 				"edge-container",
 				"edge-installer",
 				"tar",
-				"tar-installer",
+				"image-installer",
 			},
 		},
 		{

--- a/internal/distro/rhel85/package_sets.go
+++ b/internal/distro/rhel85/package_sets.go
@@ -276,6 +276,27 @@ func aarch64EdgeCommitPackageSet() rpmmd.PackageSet {
 	}
 }
 
+func bareMetalPackageSet() rpmmd.PackageSet {
+	return rpmmd.PackageSet{
+		Include: []string{
+			"authselect-compat", "chrony", "cockpit-system", "cockpit-ws",
+			"@core", "dhcp-client", "dnf", "dnf-utils", "dosfstools",
+			"dracut-norescue", "insights-client", "iwl1000-firmware",
+			"iwl100-firmware", "iwl105-firmware", "iwl135-firmware",
+			"iwl2000-firmware", "iwl2030-firmware", "iwl3160-firmware",
+			"iwl3945-firmware", "iwl4965-firmware", "iwl5000-firmware",
+			"iwl5150-firmware", "iwl6000-firmware", "iwl6000g2a-firmware",
+			"iwl6000g2b-firmware", "iwl6050-firmware", "iwl7260-firmware",
+			"lvm2", "net-tools", "NetworkManager", "nfs-utils", "oddjob",
+			"oddjob-mkhomedir", "policycoreutils", "psmisc",
+			"python3-jsonschema", "qemu-guest-agent", "redhat-release",
+			"redhat-release-eula", "rsync", "selinux-policy-targeted",
+			"subscription-manager-cockpit", "tar", "tcpdump", "yum",
+		},
+		Exclude: nil,
+	}
+}
+
 // INSTALLER PACKAGE SET
 func installerPackageSet() rpmmd.PackageSet {
 	// TODO: simplify

--- a/internal/store/json.go
+++ b/internal/store/json.go
@@ -356,7 +356,7 @@ var imageTypeCompatMapping = map[string]string{
 	"edge-commit":         "edge-commit",
 	"edge-container":      "edge-container",
 	"edge-installer":      "edge-installer",
-	"tar-installer":       "tar-installer",
+	"image-installer":     "image-installer",
 	"test_type":           "test_type",         // used only in json_test.go
 	"test_type_invalid":   "test_type_invalid", // used only in json_test.go
 	"ec2":                 "ec2",

--- a/test/cases/installers.sh
+++ b/test/cases/installers.sh
@@ -251,10 +251,6 @@ modules = []
 groups = []
 
 [[packages]]
-name = "@core"
-version = "*"
-
-[[packages]]
 name = "vim-enhanced"
 version = "*"
 
@@ -268,54 +264,6 @@ version = "*"
 
 [[packages]]
 name = "openssh-server"
-version = "*"
-
-[[packages]]
-name = "dhcp-client"
-version = "*"
-
-[[packages]]
-name = "dnf"
-version = "*"
-
-[[packages]]
-name = "dnf-utils"
-version = "*"
-
-[[packages]]
-name = "dosfstools"
-version = "*"
-
-[[packages]]
-name = "dracut-norescue"
-version = "*"
-
-[[packages]]
-name = "NetworkManager"
-version = "*"
-
-[[packages]]
-name = "net-tools"
-version = "*"
-
-[[packages]]
-name = "nfs-utils"
-version = "*"
-
-[[packages]]
-name = "python3-jsonschema"
-version = "*"
-
-[[packages]]
-name = "qemu-guest-agent"
-version = "*"
-
-[[packages]]
-name = "tar"
-version = "*"
-
-[[packages]]
-name = "yum"
 version = "*"
 
 [[packages]]

--- a/test/cases/installers.sh
+++ b/test/cases/installers.sh
@@ -340,7 +340,7 @@ sudo composer-cli blueprints push "$BLUEPRINT_FILE"
 sudo composer-cli blueprints depsolve installer
 
 # Build installer image.
-build_image installer tar-installer
+build_image installer image-installer
 
 # Download the image
 greenprint "📥 Downloading the installer image"

--- a/test/data/manifests/rhel_85-x86_64-image_installer-boot.json
+++ b/test/data/manifests/rhel_85-x86_64-image_installer-boot.json
@@ -2,7 +2,7 @@
   "compose-request": {
     "distro": "rhel-85",
     "arch": "x86_64",
-    "image-type": "tar-installer",
+    "image-type": "image-installer",
     "repositories": [
       {
         "name": "baseos",

--- a/tools/test-case-generators/format-request-map.json
+++ b/tools/test-case-generators/format-request-map.json
@@ -240,11 +240,11 @@
       }
     }
   },
-  "tar-installer": {
+  "image-installer": {
     "compose-request": {
       "distro": "",
       "arch": "",
-      "image-type": "tar-installer",
+      "image-type": "image-installer",
       "repositories": [],
       "filename": "installer.iso",
       "blueprint": {}


### PR DESCRIPTION
Renamed tar-installer to image-installer.
This is a more appropriate name:
- It disassociates the image type from the "tar" image type. The two  should not be assumed to be connected.
- It's more descriptive. The format of the payload (tar)  isn't relevant to the purpose or role of the image type.

The package set of the payload has changed to be closer to a default RHEL install.

This pull request includes:

- [x] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] create a file in [news/unreleased](https://github.com/osbuild/osbuild-composer/tree/main/docs/news/unreleased) directory if this change should be mentioned in the release news
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

For user-visible changes, "adequate documentation" is an entry describing the
change for users in docs/news. Please refer to docs/news/README.md for details.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`
-->
