### PR TITLE
Makefile: Add scratch build target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -230,6 +230,15 @@ rpm: $(RPM_SPECFILE) $(RPM_TARBALL)
 		--with tests \
 		$(RPM_SPECFILE)
 
+.PHONY: scratch
+scratch: $(RPM_SPECFILE) $(RPM_TARBALL)
+	rpmbuild -bb \
+		--define "_topdir $(CURDIR)/rpmbuild" \
+		--define "commit $(COMMIT)" \
+		--without tests \
+		--nocheck \
+		$(RPM_SPECFILE)
+
 #
 # Releasing
 #


### PR DESCRIPTION
Sometimes you want to build an rpm without the tests and without running
%check


This pull request includes none of these:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] create a file in [news/unreleased](https://github.com/osbuild/osbuild-composer/tree/main/docs/news/unreleased) directory if this change should be mentioned in the release news
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

