### PR TITLE
Return error when write_files exists in cloud-init

### DIFF
--- a/tools/gen-user-data
+++ b/tools/gen-user-data
@@ -29,6 +29,7 @@ import json
 import os
 import stat
 import sys
+import yaml
 
 
 def octal_mode_string(mode):
@@ -62,7 +63,12 @@ def main():
             })
 
     with open(f"{args.configdir}/user-data.yml") as f:
-        sys.stdout.write(f.read())
+        yml=f.read()
+        o = yaml.safe_load(yml)
+        if "write_files" in o:
+            print("Input file should not contain `write_files`", file=sys.stderr)
+            return 1
+        sys.stdout.write(yml)
     sys.stdout.write("write_files: ")
     json.dump(write_files, sys.stdout)
     sys.stdout.write("\n")

--- a/tools/gen-user-data
+++ b/tools/gen-user-data
@@ -63,7 +63,7 @@ def main():
             })
 
     with open(f"{args.configdir}/user-data.yml") as f:
-        yml=f.read()
+        yml = f.read()
         o = yaml.safe_load(yml)
         if "write_files" in o:
             print("Input file should not contain `write_files`", file=sys.stderr)


### PR DESCRIPTION
Since the script adds a `write_files` key in cloud-init user-data, it
should return error if this key already exist in the input file.


This pull request includes:

- [x] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] create a file in [news/unreleased](https://github.com/osbuild/osbuild-composer/tree/main/docs/news/unreleased) directory if this change should be mentioned in the release news
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

For user-visible changes, "adequate documentation" is an entry describing the
change for users in docs/news. Please refer to docs/news/README.md for details.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`
-->
