### PR TITLE
Various clean-ups for RHEL 9 tests

### DIFF
--- a/osbuild-composer.spec
+++ b/osbuild-composer.spec
@@ -345,7 +345,10 @@ Requires:   python3-lxml
 Requires:   httpd
 Requires:   mod_ssl
 Requires:   openssl
+# see https://bugzilla.redhat.com/show_bug.cgi?id=1986333
+%if 0%{?rhel} && 0%{?rhel} != 9
 Requires:   podman-plugins
+%endif
 Requires:   dnf-plugins-core
 Requires:   skopeo
 %if 0%{?fedora}

--- a/test/cases/api.sh
+++ b/test/cases/api.sh
@@ -387,6 +387,10 @@ else
 fi
 
 case $(set +x; . /etc/os-release; echo "$ID-$VERSION_ID") in
+  "rhel-9.0")
+    DISTRO="rhel-90"
+    SSH_USER="cloud-user"
+    ;;
   "rhel-8.5")
     DISTRO="rhel-85"
     if [[ "$CLOUD_PROVIDER" == "$CLOUD_PROVIDER_AWS" ]]; then

--- a/test/cases/api.sh
+++ b/test/cases/api.sh
@@ -20,12 +20,6 @@ mkdir -p "${ARTIFACTS}"
 source /etc/os-release
 DISTRO_CODE="${DISTRO_CODE:-${ID}_${VERSION_ID//./}}"
 
-#TODO: remove this once there is rhel9 support for necessary image types
-if [[ $DISTRO_CODE == rhel_90 ]]; then
-    echo "Skipped"
-    exit 0
-fi
-
 #
 # Provision the software under test.
 #

--- a/test/cases/aws.sh
+++ b/test/cases/aws.sh
@@ -9,12 +9,6 @@ function greenprint {
     echo -e "\033[1;32m${1}\033[0m"
 }
 
-#TODO: Remove this once there is rhel9 support for AMI image type
-if [[ $DISTRO_CODE == rhel_90 ]]; then
-    greenprint "Skipped"
-    exit 0
-fi
-
 # Provision the software under test.
 /usr/libexec/osbuild-composer-test/provision.sh
 

--- a/test/cases/azure.sh
+++ b/test/cases/azure.sh
@@ -12,12 +12,6 @@ function greenprint {
     echo -e "\033[1;32m${1}\033[0m"
 }
 
-#TODO: Remove this once there is rhel9 support for Azure image type
-if [[ $DISTRO_CODE == rhel_90 ]]; then
-    greenprint "Skipped"
-    exit 0
-fi
-
 # Provision the software under test.
 /usr/libexec/osbuild-composer-test/provision.sh
 

--- a/test/cases/libvirt.sh
+++ b/test/cases/libvirt.sh
@@ -11,10 +11,7 @@ DISTRO_CODE="${DISTRO_CODE:-${ID}_${VERSION_ID//./}}"
 # Test the images
 /usr/libexec/osbuild-composer-test/libvirt_test.sh qcow2
 
-#TODO: remove this condition once there is rhel9 support for openstack and vhd image types
-if [[ "$DISTRO_CODE" != rhel_90 ]]; then
-  /usr/libexec/osbuild-composer-test/libvirt_test.sh openstack
-fi
+/usr/libexec/osbuild-composer-test/libvirt_test.sh openstack
 
 # RHEL 8.4 and Centos Stream 8 images also supports uefi, check that
 if [[ "$DISTRO_CODE" == "rhel_84" || "$DISTRO_CODE" == "rhel_85" || "$DISTRO_CODE" == "centos_8"  || "$DISTRO_CODE" == "rhel_90" ]]; then

--- a/test/cases/libvirt.sh
+++ b/test/cases/libvirt.sh
@@ -17,7 +17,7 @@ if [[ "$DISTRO_CODE" != rhel_90 ]]; then
 fi
 
 # RHEL 8.4 and Centos Stream 8 images also supports uefi, check that
-if [[ "$DISTRO_CODE" == "rhel_84" || "$DISTRO_CODE" == "rhel_85" || "$DISTRO_CODE" == "centos_8" ]]; then
+if [[ "$DISTRO_CODE" == "rhel_84" || "$DISTRO_CODE" == "rhel_85" || "$DISTRO_CODE" == "centos_8"  || "$DISTRO_CODE" == "rhel_90" ]]; then
   echo "🐄 Booting qcow2 image in UEFI mode on RHEL/Centos Stream"
   /usr/libexec/osbuild-composer-test/libvirt_test.sh qcow2 uefi
 fi

--- a/test/cases/ostree-ng.sh
+++ b/test/cases/ostree-ng.sh
@@ -100,6 +100,12 @@ case "${ID}-${VERSION_ID}" in
         INSTALLER_TYPE=edge-installer
         INSTALLER_FILENAME=installer.iso
         ;;
+    "rhel-9.0")
+        CONTAINER_TYPE=edge-container
+        CONTAINER_FILENAME=container.tar
+        INSTALLER_TYPE=edge-installer
+        INSTALLER_FILENAME=installer.iso
+        ;;
     *)
         echo "unsupported distro: ${ID}-${VERSION_ID}"
         exit 1;;

--- a/test/cases/ostree.sh
+++ b/test/cases/ostree.sh
@@ -36,6 +36,12 @@ case "${ID}-${VERSION_ID}" in
         OS_VARIANT="rhel8-unknown"
         USER_IN_COMMIT="true"
         BOOT_LOCATION="$COMPOSE_URL/compose/BaseOS/x86_64/os/";;
+    "rhel-9.0")
+        IMAGE_TYPE=edge-commit
+        OSTREE_REF="rhel/9/${ARCH}/edge"
+        OS_VARIANT="rhel9.0"
+        USER_IN_COMMIT="true"
+        BOOT_LOCATION="$COMPOSE_URL/compose/BaseOS/x86_64/os/";;
     *)
         echo "unsupported distro: ${ID}-${VERSION_ID}"
         exit 1;;

--- a/tools/define-compose-url.sh
+++ b/tools/define-compose-url.sh
@@ -1,11 +1,24 @@
 #!/bin/bash
 set -euo pipefail
+source /etc/os-release
 
-curl -L http://download.devel.redhat.com/rhel-8/nightly/RHEL-8/latest-finished-RHEL-8.5/COMPOSE_ID > COMPOSE_ID
-COMPOSE_ID=$(cat COMPOSE_ID)
+# This isn't needed when not running on RHEL
+if [[ $ID != rhel ]]; then
+  exit 0
+fi
 
-# default to a nightly tree but respect values passed from ENV so we can test rel-eng composes as well
-COMPOSE_URL="${COMPOSE_URL:-http://download.devel.redhat.com/rhel-8/nightly/RHEL-8/$COMPOSE_ID}"
+if [[ $ID == rhel && ${VERSION_ID%.*} == 8 ]]; then
+  COMPOSE_ID=$(curl -L http://download.devel.redhat.com/rhel-8/nightly/RHEL-8/latest-finished-RHEL-8.5/COMPOSE_ID)
+
+  # default to a nightly tree but respect values passed from ENV so we can test rel-eng composes as well
+  COMPOSE_URL="${COMPOSE_URL:-http://download.devel.redhat.com/rhel-8/nightly/RHEL-8/$COMPOSE_ID}"
+
+elif [[ $ID == rhel && ${VERSION_ID%.*} == 9 ]]; then
+  COMPOSE_ID=$(curl -L http://download.devel.redhat.com/rhel-9/nightly/RHEL-9-Beta/latest-RHEL-9.0/COMPOSE_ID)
+
+  # default to a nightly tree but respect values passed from ENV so we can test rel-eng composes as well
+  COMPOSE_URL="${COMPOSE_URL:-http://download.devel.redhat.com/rhel-9/nightly/RHEL-9-Beta/$COMPOSE_ID}"
+fi
 
 # in case COMPOSE_URL was defined from the outside refresh COMPOSE_ID file,
 # used for slack messages in case of success/failure


### PR DESCRIPTION
This PR introduces a number of small patches that should simplify the work on enabling RHEL 9 tests. It doesn't enable anything yet but this should move us closer to it.