### PR TITLE
ci: minor fixes for nightly testing

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -122,7 +122,7 @@ Regression:
   extends: .terraform
   rules:
     - if: '$CI_PIPELINE_SOURCE != "schedule"'
-    - if: '$CI_PIPELINE_SOURCE == "schedule" && $RUNNER =~ /[\S]+rhel-[8-9]\.[\S]+/'
+    - if: '$CI_PIPELINE_SOURCE == "schedule" && $RUNNER =~ /[\S]+rhel-[8-9]\.[\S]+/ && $NIGHTLY == "true"'
   script:
     - schutzbot/deploy.sh
     - /usr/libexec/tests/osbuild-composer/regression.sh
@@ -288,7 +288,7 @@ Installer:
   extends: .terraform
   rules:
     - if: '$CI_PIPELINE_SOURCE != "schedule"'
-    - if: '$CI_PIPELINE_SOURCE == "schedule" && $RUNNER =~ /[\S]+rhel-[8-9]\.[\S]+/'
+    - if: '$CI_PIPELINE_SOURCE == "schedule" && $RUNNER =~ /[\S]+rhel-[8-9]\.[\S]+/ && $NIGHTLY == "true"'
   script:
     - schutzbot/deploy.sh
     - /usr/libexec/tests/osbuild-composer/installers.sh

--- a/schutzbot/deploy.sh
+++ b/schutzbot/deploy.sh
@@ -103,7 +103,7 @@ if [ -f "rhel8internal.repo" ]; then
     sudo mv rhel8internal.repo /etc/yum.repos.d/
     # Use osbuild from schutzfile if desired for testing custom osbuild-composer packages
     # specified by $REPO_URL in ENV and used in prepare-rhel-internal.sh
-    if [ "$SCHUTZ_OSBUILD" == 1 ]; then
+    if [ "${SCHUTZ_OSBUILD:=false}" == true ]; then
         sudo rm -f /etc/yum.repos.d/osbuild-composer.repo
     else
         sudo rm -f /etc/yum.repos.d/osbuild*.repo

--- a/schutzbot/prepare-rhel-internal.sh
+++ b/schutzbot/prepare-rhel-internal.sh
@@ -64,7 +64,7 @@ cp rhel-8.json rhel-8-beta.json
 
 JOB_NAME="${JOB_NAME:-${CI_JOB_ID}}"
 # Do not create tests repo if it's provided from ENV
-if [ -z "$REPO_URL" ]; then
+if [ -z "${REPO_URL+x}" ]; then
     greenprint "📦 Installing requirements"
     sudo dnf -y install createrepo_c wget python3-pip
 


### PR DESCRIPTION
Updating rules for Installer and Regression testing and fixing failures
if certain variables are not set.


This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] create a file in [news/unreleased](https://github.com/osbuild/osbuild-composer/tree/main/docs/news/unreleased) directory if this change should be mentioned in the release news
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

For user-visible changes, "adequate documentation" is an entry describing the
change for users in docs/news. Please refer to docs/news/README.md for details.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`
-->
