### PR TITLE
Filesystem implementation follow up PR

### DIFF
--- a/internal/distro/rhel85/distro.go
+++ b/internal/distro/rhel85/distro.go
@@ -55,7 +55,11 @@ const (
 
 type basePartitionTableMap map[string]disk.PartitionTable
 
-var mountpointAllowList = []string{"/", "/var", "/var/*", "/home", "/opt", "/srv", "/usr"}
+var mountpointAllowList = []string{
+	"/", "/var", "/var/*", "/home", "/home/*", "/opt", "/opt/*",
+	"/srv", "/srv/*", "/usr", "/usr/*", "/app", "/app/*",
+	"/data", "/data/*",
+}
 
 type distribution struct {
 	name             string

--- a/internal/distro/rhel85/distro_internal_test.go
+++ b/internal/distro/rhel85/distro_internal_test.go
@@ -1,0 +1,85 @@
+package rhel85
+
+import (
+	"math/rand"
+	"testing"
+
+	"github.com/osbuild/osbuild-composer/internal/blueprint"
+	"github.com/osbuild/osbuild-composer/internal/disk"
+	"github.com/osbuild/osbuild-composer/internal/distro"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var testBasicImageType = imageType{
+	name:                "test",
+	basePartitionTables: defaultBasePartitionTables,
+}
+
+var testEc2ImageType = imageType{
+	name:                "test_ec2",
+	basePartitionTables: ec2BasePartitionTables,
+}
+
+var mountpoints = []blueprint.FilesystemCustomization{
+	{
+		MinSize:    1024,
+		Mountpoint: "/usr",
+	},
+}
+
+var rng = rand.New(rand.NewSource(0))
+
+func containsMountpoint(expected []disk.Partition, mountpoint string) bool {
+	for _, p := range expected {
+		if p.Filesystem == nil {
+			continue
+		}
+		if p.Filesystem.Mountpoint == mountpoint {
+			return true
+		}
+	}
+	return false
+}
+
+func TestDistro_UnsupportedArch(t *testing.T) {
+	testBasicImageType.arch = &architecture{
+		name: "unsupported_arch",
+	}
+	_, err := testBasicImageType.getPartitionTable(mountpoints, distro.ImageOptions{}, rng)
+	require.EqualError(t, err, "unknown arch: "+testBasicImageType.arch.name)
+}
+
+func TestDistro_DefaultPartitionTables(t *testing.T) {
+	rhel8distro := New()
+	for _, archName := range rhel8distro.ListArches() {
+		testBasicImageType.arch = &architecture{
+			name: archName,
+		}
+		pt, err := testBasicImageType.getPartitionTable(mountpoints, distro.ImageOptions{}, rng)
+		require.Nil(t, err)
+		for _, m := range mountpoints {
+			contains := containsMountpoint(pt.Partitions, m.Mountpoint)
+			assert.True(t, contains)
+		}
+	}
+}
+
+func TestDistro_Ec2PartitionTables(t *testing.T) {
+	rhel8distro := New()
+	for _, archName := range rhel8distro.ListArches() {
+		testEc2ImageType.arch = &architecture{
+			name: archName,
+		}
+		pt, err := testEc2ImageType.getPartitionTable(mountpoints, distro.ImageOptions{}, rng)
+		if _, exists := testEc2ImageType.basePartitionTables[archName]; exists {
+			require.Nil(t, err)
+			for _, m := range mountpoints {
+				contains := containsMountpoint(pt.Partitions, m.Mountpoint)
+				assert.True(t, contains)
+			}
+		} else {
+			require.EqualError(t, err, "unknown arch: "+testEc2ImageType.arch.name)
+		}
+	}
+}


### PR DESCRIPTION
This pull request includes support for the following mount points and sub mounts (as per COMPOSER-1018):
- [x] /home
- [x] /opt
- [x] /srv
- [x] /usr
- [x] /var

And the following mountpoints (as per COMPOSER-1016):
- [x] /app
- [x] /data
  
Additionally, integration filesystem integration test was improved to test the fail case where not allowed mountpoints are set in the blueprint filesystem customizations.

- [x] adequate testing for the new functionality or fixed issue
- [x] adequate documentation informing people about the change such as
  - [x] create a file in [news/unreleased](https://github.com/osbuild/osbuild-composer/tree/main/docs/news/unreleased) directory if this change should be mentioned in the release news
  - [x] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

For user-visible changes, "adequate documentation" is an entry describing the
change for users in docs/news. Please refer to docs/news/README.md for details.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`
-->
