### PR TITLE
rhel90: use unified grub2 layout for pure uefi platforms

### DIFF
--- a/internal/distro/rhel90/stage_options.go
+++ b/internal/distro/rhel90/stage_options.go
@@ -332,7 +332,8 @@ func grub2StageOptions(rootPartition *disk.Partition, bootPartition *disk.Partit
 
 	if uefi {
 		stageOptions.UEFI = &osbuild.GRUB2UEFI{
-			Vendor: "redhat",
+			Vendor:  "redhat",
+			Unified: legacy == "", // force unified grub scheme for pure efi systems
 		}
 	}
 

--- a/internal/osbuild2/grub2_stage.go
+++ b/internal/osbuild2/grub2_stage.go
@@ -22,6 +22,7 @@ type GRUB2StageOptions struct {
 type GRUB2UEFI struct {
 	Vendor  string `json:"vendor"`
 	Install bool   `json:"install,omitempty"`
+	Unified bool   `json:"unified,omitempty"`
 }
 
 func (GRUB2StageOptions) isStageOptions() {}

--- a/internal/osbuild2/grub2_stage.go
+++ b/internal/osbuild2/grub2_stage.go
@@ -20,7 +20,8 @@ type GRUB2StageOptions struct {
 }
 
 type GRUB2UEFI struct {
-	Vendor string `json:"vendor"`
+	Vendor  string `json:"vendor"`
+	Install bool   `json:"install,omitempty"`
 }
 
 func (GRUB2StageOptions) isStageOptions() {}

--- a/test/data/manifests/rhel_90-aarch64-ami-boot.json
+++ b/test/data/manifests/rhel_90-aarch64-ami-boot.json
@@ -1018,6 +1018,7 @@
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
               "kernel_opts": "console=ttyS0,115200n8 console=tty0 net.ifnames=0 rd.blacklist=nouveau nvme_core.io_timeout=4294967295 iommu.strict=0 crashkernel=auto",
               "uefi": {
+                "unified": true,
                 "vendor": "redhat"
               },
               "saved_entry": "ffffffffffffffffffffffffffffffff-5.14.0-0.rc3.29.el9.aarch64"

--- a/test/data/manifests/rhel_90-aarch64-qcow2-boot.json
+++ b/test/data/manifests/rhel_90-aarch64-qcow2-boot.json
@@ -920,6 +920,7 @@
               "root_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
               "kernel_opts": "console=tty0 console=ttyS0,115200n8 no_timer_check net.ifnames=0 crashkernel=auto",
               "uefi": {
+                "unified": true,
                 "vendor": "redhat"
               },
               "saved_entry": "ffffffffffffffffffffffffffffffff-5.14.0-0.rc3.29.el9.aarch64"


### PR DESCRIPTION

Needs https://github.com/osbuild/osbuild/pull/774

Feodra 34 and thus RHEL 9 switched to a unified grub configuration, which means that the main grub config is always located in the same location, /boot/grub2/grub.cfg.[1] osbuild has used this scheme for hybrid boot on x64 but not on pure efi systems like aarch64. The new osbuild option `uefi.unified` was introduced to select that new unified grug cfg scheme also for those, pure efi, systems. Use that.

[1] https://fedoraproject.org/wiki/Changes/UnifyGrubConfig

This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as

