### PR TITLE
RHEL-85/90: modify the x86_64 EC2 images dracut configuration

### DIFF
--- a/internal/distro/rhel85/pipelines.go
+++ b/internal/distro/rhel85/pipelines.go
@@ -389,11 +389,13 @@ func ec2X86_64BaseTreePipeline(repos []rpmmd.RepoConfig, packages []rpmmd.Packag
 	}
 
 	// EC2 x86_64-specific stages
+	// Add 'nvme' driver to handle the case when initramfs is getting forcefully
+	// rebuild on a Xen instance (and not able to boot on Nitro after that).
 	treePipeline.AddStage(osbuild.NewDracutConfStage(&osbuild.DracutConfStageOptions{
-		Filename: "xen.conf",
+		Filename: "ec2.conf",
 		Config: osbuild.DracutConfigFile{
 			AddDrivers: []string{
-				"xen-netfront",
+				"nvme",
 				"xen-blkfront",
 			},
 		},

--- a/internal/distro/rhel90/pipelines.go
+++ b/internal/distro/rhel90/pipelines.go
@@ -370,11 +370,13 @@ func ec2X86_64BaseTreePipeline(repos []rpmmd.RepoConfig, packages []rpmmd.Packag
 	}
 
 	// EC2 x86_64-specific stages
+	// Add 'nvme' driver to handle the case when initramfs is getting forcefully
+	// rebuild on a Xen instance (and not able to boot on Nitro after that).
 	treePipeline.AddStage(osbuild.NewDracutConfStage(&osbuild.DracutConfStageOptions{
-		Filename: "xen.conf",
+		Filename: "ec2.conf",
 		Config: osbuild.DracutConfigFile{
 			AddDrivers: []string{
-				"xen-netfront",
+				"nvme",
 				"xen-blkfront",
 			},
 		},

--- a/test/data/manifests/rhel_85-x86_64-ami-boot.json
+++ b/test/data/manifests/rhel_85-x86_64-ami-boot.json
@@ -1073,10 +1073,10 @@
           {
             "type": "org.osbuild.dracut.conf",
             "options": {
-              "filename": "xen.conf",
+              "filename": "ec2.conf",
               "config": {
                 "add_drivers": [
-                  "xen-netfront",
+                  "nvme",
                   "xen-blkfront"
                 ]
               }

--- a/test/data/manifests/rhel_85-x86_64-ec2-boot.json
+++ b/test/data/manifests/rhel_85-x86_64-ec2-boot.json
@@ -1077,10 +1077,10 @@
           {
             "type": "org.osbuild.dracut.conf",
             "options": {
-              "filename": "xen.conf",
+              "filename": "ec2.conf",
               "config": {
                 "add_drivers": [
-                  "xen-netfront",
+                  "nvme",
                   "xen-blkfront"
                 ]
               }

--- a/test/data/manifests/rhel_85-x86_64-ec2_ha-boot.json
+++ b/test/data/manifests/rhel_85-x86_64-ec2_ha-boot.json
@@ -1251,10 +1251,10 @@
           {
             "type": "org.osbuild.dracut.conf",
             "options": {
-              "filename": "xen.conf",
+              "filename": "ec2.conf",
               "config": {
                 "add_drivers": [
-                  "xen-netfront",
+                  "nvme",
                   "xen-blkfront"
                 ]
               }

--- a/test/data/manifests/rhel_90-x86_64-ami-boot.json
+++ b/test/data/manifests/rhel_90-x86_64-ami-boot.json
@@ -973,10 +973,10 @@
           {
             "type": "org.osbuild.dracut.conf",
             "options": {
-              "filename": "xen.conf",
+              "filename": "ec2.conf",
               "config": {
                 "add_drivers": [
-                  "xen-netfront",
+                  "nvme",
                   "xen-blkfront"
                 ]
               }


### PR DESCRIPTION
Change the x86_64-specific dracut configuration of RHEL-8.5 and RHEL-9.0 EC2 and AMI images to not include `xen-netfront` driver and add `nvme` driver, which was previously not included. Since the configuration is no
longer Xen-specific, rename the configuration file to `ec2.conf`.

Justification:
There is no reason to put `xen-netfront` to initramfs as EC2 images don't boot from network root. In addition, add `nvme` driver to handle the case when initramfs is getting forcefully rebuild on a Xen instance (and not able to boot on Nitro after that).

Related to https://issues.redhat.com/browse/COMPOSER-1096.

Signed-off-by: Tomas Hozza <thozza@redhat.com>


This pull request includes:

- [x] adequate testing for the new functionality or fixed issue
  - image test cases were modified 
- [ ] adequate documentation informing people about the change such as
  - [ ] create a file in [news/unreleased](https://github.com/osbuild/osbuild-composer/tree/main/docs/news/unreleased) directory if this change should be mentioned in the release news
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

For user-visible changes, "adequate documentation" is an entry describing the
change for users in docs/news. Please refer to docs/news/README.md for details.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`
-->
