### PR TITLE
[CI] remove rhn subscriptions before registering a new one

### DIFF
--- a/schutzbot/deploy.sh
+++ b/schutzbot/deploy.sh
@@ -52,6 +52,7 @@ ARCH=$(uname -m)
 
 if [[ $ID == "rhel" && $VERSION_ID == "8.3" && -n "${RHN_REGISTRATION_SCRIPT:-}" ]] && ! sudo subscription-manager status; then
     greenprint "Registering RHEL"
+    sudo subscription-manager remove --all
     sudo chmod +x "$RHN_REGISTRATION_SCRIPT"
     sudo "$RHN_REGISTRATION_SCRIPT"
 fi

--- a/schutzbot/mockbuild.sh
+++ b/schutzbot/mockbuild.sh
@@ -13,6 +13,7 @@ ARCH=$(uname -m)
 # Register RHEL if we are provided with a registration script.
 if [[ $ID == "rhel" && $VERSION_ID == "8.3" && -n "${RHN_REGISTRATION_SCRIPT:-}" ]] && ! sudo subscription-manager status; then
     greenprint "🪙 Registering RHEL instance"
+    sudo subscription-manager remove --all
     sudo chmod +x "$RHN_REGISTRATION_SCRIPT"
     sudo "$RHN_REGISTRATION_SCRIPT"
 fi


### PR DESCRIPTION
Sometimes CI  gets to an error related to RHSM: https://issues.redhat.com/browse/COMPOSER-1037

This PR intends to solve this issue.

This pull request includes:

- [x] adequate testing for the new functionality or fixed issue
- [x] adequate documentation informing people about the change such as
  - [x] create a file in [news/unreleased](https://github.com/osbuild/osbuild-composer/tree/main/docs/news/unreleased) directory if this change should be mentioned in the release news
  - [x] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/
