### PR TITLE
distro/rhel85: pre-load uid/gid database for edge

### DIFF
--- a/internal/distro/rhel85/distro.go
+++ b/internal/distro/rhel85/distro.go
@@ -380,7 +380,7 @@ func (t *imageType) Manifest(customizations *blueprint.Customizations,
 	}
 
 	var commits []ostreeCommit
-	if t.bootISO && options.OSTree.Parent != "" && options.OSTree.URL != "" {
+	if options.OSTree.Parent != "" && options.OSTree.URL != "" {
 		commits = []ostreeCommit{{Checksum: options.OSTree.Parent, URL: options.OSTree.URL}}
 	}
 	return json.Marshal(

--- a/internal/distro/rhel85/pipelines.go
+++ b/internal/distro/rhel85/pipelines.go
@@ -657,6 +657,11 @@ func ostreeTreePipeline(repos []rpmmd.RepoConfig, packages []rpmmd.PackageSpec, 
 	p.Build = "name:build"
 
 	packages = append(packages, bpPackages...)
+
+	if options.OSTree.Parent != "" && options.OSTree.URL != "" {
+		p.AddStage(osbuild2.NewOSTreePasswdStage("org.osbuild.source", options.OSTree.Parent))
+	}
+
 	p.AddStage(osbuild.NewRPMStage(rpmStageOptions(repos), rpmStageInputs(packages)))
 	p.AddStage(osbuild.NewFixBLSStage(&osbuild.FixBLSStageOptions{}))
 	language, keyboard := c.GetPrimaryLocale()

--- a/internal/osbuild2/ostree_input.go
+++ b/internal/osbuild2/ostree_input.go
@@ -13,3 +13,30 @@ func NewOSTreeInput() *OSTreeInput {
 	input.Origin = "org.osbuild.source"
 	return input
 }
+
+// Inputs of type org.osbuild.ostree.checkout
+type OSTreeCheckoutInput struct {
+	inputCommon
+	References OSTreeCheckoutReferences `json:"references"`
+}
+
+func (OSTreeCheckoutInput) isStageInput() {}
+
+type OSTreeCheckoutReferences []string
+
+func (OSTreeCheckoutReferences) isReferences() {}
+
+// NewOSTreeCommitsInput creates a new OSTreeCommitsInputs
+// where `origin` is either "org.osbuild.source" or "org.osbuild.pipeline
+// `name` is the id of the commit, i.e. its digest or the pipeline name that
+// produced it)
+func NewOSTreeCheckoutInput(origin, name string) *OSTreeCheckoutInput {
+	input := new(OSTreeCheckoutInput)
+	input.Type = "org.osbuild.ostree.checkout"
+	input.Origin = origin
+
+	inputRefs := make([]string, 1)
+	inputRefs[0] = name
+	input.References = inputRefs
+	return input
+}

--- a/internal/osbuild2/ostree_passwd_stage.go
+++ b/internal/osbuild2/ostree_passwd_stage.go
@@ -1,0 +1,21 @@
+package osbuild2
+
+// The org.osbuild.ostree.passwd stage has no options so far.
+type OSTreePasswdStageOptions struct {
+}
+
+func (s *OSTreePasswdStageOptions) isStageOptions() {}
+
+type OSTreePasswdStageInputs struct {
+	Commits *OSTreeCheckoutInput `json:"commits"`
+}
+
+func (OSTreePasswdStageInputs) isStageInputs() {}
+
+// A new org.osbuild.ostree.passwd stage to pre-fill the user and group databases
+func NewOSTreePasswdStage(origin, name string) *Stage {
+	return &Stage{
+		Type:   "org.osbuild.ostree.passwd",
+		Inputs: &OSTreePasswdStageInputs{Commits: NewOSTreeCheckoutInput(origin, name)},
+	}
+}

--- a/internal/osbuild2/stage.go
+++ b/internal/osbuild2/stage.go
@@ -100,6 +100,9 @@ func (stage *Stage) UnmarshalJSON(data []byte) error {
 	case "org.osbuild.ostree.commit":
 		options = new(OSTreeCommitStageOptions)
 		inputs = new(OSTreeCommitStageInputs)
+	case "org.osbuild.ostree.passwd":
+		options = new(OSTreePasswdStageOptions)
+		inputs = new(OSTreePasswdStageInputs)
 	case "org.osbuild.ostree.pull":
 		options = new(OSTreePullStageOptions)
 		inputs = new(OSTreePullStageInputs)


### PR DESCRIPTION
When building RHEL for Edge commits and a parent together with an URL was specified, add a `org.osbuild.ostree.passwd` stage which then will pre-load the uid/gid database with the data from the parent commit. This ensures that uids and gids do not change for the "child" commit.

NB: needs osbuild fix for the `ostree.checkout` input: https://github.com/osbuild/osbuild/pull/775

This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
