### PR TITLE
[CI] retry subscribing to RHN

### DIFF
--- a/schutzbot/deploy.sh
+++ b/schutzbot/deploy.sh
@@ -52,9 +52,12 @@ ARCH=$(uname -m)
 
 if [[ $ID == "rhel" && $VERSION_ID == "8.3" && -n "${RHN_REGISTRATION_SCRIPT:-}" ]] && ! sudo subscription-manager status; then
     greenprint "Registering RHEL"
-    sudo subscription-manager remove --all
     sudo chmod +x "$RHN_REGISTRATION_SCRIPT"
-    sudo "$RHN_REGISTRATION_SCRIPT"
+    for _ in {0..4}
+    do
+        sudo "$RHN_REGISTRATION_SCRIPT" && break
+    sleep 5
+    done
 fi
 
 # Distro version that this script is running on.

--- a/schutzbot/mockbuild.sh
+++ b/schutzbot/mockbuild.sh
@@ -13,9 +13,12 @@ ARCH=$(uname -m)
 # Register RHEL if we are provided with a registration script.
 if [[ $ID == "rhel" && $VERSION_ID == "8.3" && -n "${RHN_REGISTRATION_SCRIPT:-}" ]] && ! sudo subscription-manager status; then
     greenprint "🪙 Registering RHEL instance"
-    sudo subscription-manager remove --all
-    sudo chmod +x "$RHN_REGISTRATION_SCRIPT"
-    sudo "$RHN_REGISTRATION_SCRIPT"
+    sudo chmod +x "$RHN_REGISTRATION_SCRIPT" 
+    for _ in {0..4}
+    do
+    	sudo "$RHN_REGISTRATION_SCRIPT" && break
+    sleep 5
+    done
 fi
 
 # Mock configuration file to use for building RPMs.


### PR DESCRIPTION
Sometimes CI gets to an error related to RHSM: https://issues.redhat.com/browse/COMPOSER-1037

After trying to remove all subscriptions from the system (https://github.com/osbuild/osbuild-composer/pull/1657), and realising it didn't solve the issue. Now retry logic is implemented in this PR

This pull request includes:

- [x] adequate testing for the new functionality or fixed issue
- [x] adequate documentation informing people about the change such as
  - [x] create a file in [news/unreleased](https://github.com/osbuild/osbuild-composer/tree/main/docs/news/unreleased) directory if this change should be mentioned in the release news
  - [x] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

