### PR TITLE
Pre-define an ostree remote for RFE raw images (including created via simplified installer)

### DIFF
--- a/internal/osbuild2/ostree_deploy_stage.go
+++ b/internal/osbuild2/ostree_deploy_stage.go
@@ -11,6 +11,8 @@ type OSTreeDeployStageOptions struct {
 
 	Ref string `json:"ref"`
 
+	Remote string `json:"remote,omitempty"`
+
 	Mounts []string `json:"mounts"`
 
 	Rootfs Rootfs `json:"rootfs"`

--- a/internal/osbuild2/ostree_pull_stage.go
+++ b/internal/osbuild2/ostree_pull_stage.go
@@ -4,6 +4,8 @@ package osbuild2
 type OSTreePullStageOptions struct {
 	// Location of the ostree repo
 	Repo string `json:"repo"`
+	// Remote to configure for all commits
+	Remote string `json:"remote,omitempty"`
 }
 
 func (OSTreePullStageOptions) isStageOptions() {}

--- a/test/cases/ostree-raw-image.sh
+++ b/test/cases/ostree-raw-image.sh
@@ -589,11 +589,6 @@ until [ "$(sudo podman inspect -f '{{.State.Running}}' rhel-edge)" == "true" ]; 
     sleep 1;
 done;
 
-# Workaround to https://github.com/osbuild/osbuild-composer/issues/1693
-greenprint "🗳 Add external prod edge repo"
-sudo ssh "${SSH_OPTIONS[@]}" -i "${SSH_KEY}" admin@${UEFI_GUEST_ADDRESS} "echo ${EDGE_USER_PASSWORD} |sudo -S ostree remote add --no-gpg-verify --no-sign-verify rhel-edge ${PROD_REPO_URL}"
-sudo ssh "${SSH_OPTIONS[@]}" -i "${SSH_KEY}" admin@${UEFI_GUEST_ADDRESS} "echo ${EDGE_USER_PASSWORD} |sudo -S ostree admin switch rhel-edge:${OSTREE_REF}"
-
 # Pull upgrade to prod mirror
 greenprint "⛓ Pull upgrade to prod mirror"
 sudo ostree --repo="$PROD_REPO" pull --mirror edge-stage "$OSTREE_REF"

--- a/test/cases/ostree-simplified-installer.sh
+++ b/test/cases/ostree-simplified-installer.sh
@@ -518,11 +518,6 @@ until [ "$(sudo podman inspect -f '{{.State.Running}}' rhel-edge)" == "true" ]; 
     sleep 1;
 done;
 
-# Workaround to https://github.com/osbuild/osbuild-composer/issues/1693
-greenprint "🗳 Add external prod edge repo"
-sudo ssh "${SSH_OPTIONS[@]}" -i "${SSH_KEY}" admin@${UEFI_GUEST_ADDRESS} "echo ${EDGE_USER_PASSWORD} |sudo -S ostree remote add --no-gpg-verify --no-sign-verify rhel-edge ${PROD_REPO_URL}"
-sudo ssh "${SSH_OPTIONS[@]}" -i "${SSH_KEY}" admin@${UEFI_GUEST_ADDRESS} "echo ${EDGE_USER_PASSWORD} |sudo -S ostree admin switch rhel-edge:${OSTREE_REF}"
-
 # Pull upgrade to prod mirror
 greenprint "⛓ Pull upgrade to prod mirror"
 sudo ostree --repo="$PROD_REPO" pull --mirror edge-stage "$OSTREE_REF"


### PR DESCRIPTION
Preset a remote called `rhel-edge` with the URL that was used to fetch the commit, so it can be used to fetch updates.

This pull request includes:

- [x] adequate testing for the new functionality or fixed issue
