### PR TITLE
distro/rhel85: specify an ostree remote for edge installer 

### DIFF
--- a/internal/distro/rhel85/stage_options.go
+++ b/internal/distro/rhel85/stage_options.go
@@ -258,6 +258,7 @@ func ostreeKickstartStageOptions(ostreeURL, ostreeRef string) *osbuild.Kickstart
 			OSName: "rhel",
 			URL:    ostreeURL,
 			Ref:    ostreeRef,
+			Remote: "rhel-edge",
 			GPG:    false,
 		},
 	}

--- a/internal/osbuild2/kickstart_stage.go
+++ b/internal/osbuild2/kickstart_stage.go
@@ -17,6 +17,7 @@ type OSTreeOptions struct {
 	OSName string `json:"osname"`
 	URL    string `json:"url"`
 	Ref    string `json:"ref"`
+	Remote string `json:"remote,omitempty"`
 	GPG    bool   `json:"gpg"`
 }
 


### PR DESCRIPTION
Hard code a remote, called `rhel-edge` when creating the kickstart so that the deployed commit is tied to a remote, which can then be used to fetch updates from.

This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] create a file in [news/unreleased](https://github.com/osbuild/osbuild-composer/tree/main/docs/news/unreleased) directory if this change should be mentioned in the release news
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/