### PR TITLE
repositories: exclude downstream from upstream

### DIFF
--- a/cmd/osbuild-dnf-json-tests/main_test.go
+++ b/cmd/osbuild-dnf-json-tests/main_test.go
@@ -48,7 +48,7 @@ func TestFetchChecksum(t *testing.T) {
 // this should run cross-arch dependency solving N-1 times.
 func TestCrossArchDepsolve(t *testing.T) {
 	// Load repositories from the definition we provide in the RPM package
-	repoDir := "/usr/share/osbuild-composer"
+	repoDir := "/usr/share/tests/osbuild-composer"
 
 	// NOTE: we can add RHEL, but don't make it hard requirement because it will fail outside of VPN
 	for _, distroStruct := range []distro.Distro{fedora33.New()} {

--- a/osbuild-composer.spec
+++ b/osbuild-composer.spec
@@ -156,7 +156,16 @@ install -m 0755 -vp _bin/osbuild-worker                         %{buildroot}%{_l
 install -m 0755 -vp dnf-json                                    %{buildroot}%{_libexecdir}/osbuild-composer/
 
 install -m 0755 -vd                                             %{buildroot}%{_datadir}/osbuild-composer/repositories
-install -m 0644 -vp repositories/*                              %{buildroot}%{_datadir}/osbuild-composer/repositories/
+install -m 0644 -vp repositories/rhel-8*                        %{buildroot}%{_datadir}/osbuild-composer/repositories/
+%if 0%{?rhel} >= 9
+install -m 0644 -vp repositories/rhel-9*                        %{buildroot}%{_datadir}/osbuild-composer/repositories/
+%endif
+%if 0%{?centos} || 0%{?fedora}
+install -m 0644 -vp repositories/centos-*                       %{buildroot}%{_datadir}/osbuild-composer/repositories/
+%endif
+%if 0%{?fedora}
+install -m 0644 -vp repositories/fedora-*                       %{buildroot}%{_datadir}/osbuild-composer/repositories/
+%endif
 
 install -m 0755 -vd                                             %{buildroot}%{_unitdir}
 install -m 0644 -vp distribution/*.{service,socket}             %{buildroot}%{_unitdir}/


### PR DESCRIPTION
We don't want to give the impression we support building Fedora on RHEL or
CentOS Stream, or CentOS Stream on RHEL, so drop these repositories from
the package.

This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue (this is about dropping untested/unsupported functionality)