### PR TITLE
add test case for http boot of simplified installer

### DIFF
--- a/osbuild-composer.spec
+++ b/osbuild-composer.spec
@@ -348,6 +348,7 @@ Requires:   python3-lxml
 Requires:   httpd
 Requires:   mod_ssl
 Requires:   openssl
+Requires:   firewalld
 # see https://bugzilla.redhat.com/show_bug.cgi?id=1986333
 %if 0%{?rhel} && 0%{?rhel} != 9
 Requires:   podman-plugins


### PR DESCRIPTION
This pull request includes:
added test case to test the http boot of simplified installer

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] create a file in [news/unreleased](https://github.com/osbuild/osbuild-composer/tree/main/docs/news/unreleased) directory if this change should be mentioned in the release news
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

For user-visible changes, "adequate documentation" is an entry describing the
change for users in docs/news. Please refer to docs/news/README.md for details.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`
-->
