### PR TITLE
cloudapi: fix compose return value

### DIFF
--- a/internal/cloudapi/server.go
+++ b/internal/cloudapi/server.go
@@ -426,7 +426,7 @@ func (h *apiHandlers) Compose(ctx echo.Context) error {
 	var response ComposeResult
 	response.Id = id.String()
 
-	return ctx.JSON(http.StatusOK, response)
+	return ctx.JSON(http.StatusCreated, response)
 }
 
 // ComposeStatus handles a /compose/{id} GET request


### PR DESCRIPTION
Correct compose successful return status from http.StatusOK to
http.StatusCreated. Mistakenly set to http.StatusOK in previous
commit.


This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] create a file in [news/unreleased](https://github.com/osbuild/osbuild-composer/tree/main/docs/news/unreleased) directory if this change should be mentioned in the release news
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/
