### PR TITLE
Filesystem submounts fix

### DIFF
--- a/internal/distro/rhel85/distro.go
+++ b/internal/distro/rhel85/distro.go
@@ -7,6 +7,7 @@ import (
 	"math/rand"
 	"path"
 	"sort"
+	"strings"
 
 	"github.com/osbuild/osbuild-composer/internal/blueprint"
 	"github.com/osbuild/osbuild-composer/internal/disk"
@@ -42,9 +43,7 @@ const (
 )
 
 var mountpointAllowList = []string{
-	"/", "/var", "/var/*", "/home", "/home/*", "/opt", "/opt/*",
-	"/srv", "/srv/*", "/usr", "/usr/*", "/app", "/app/*",
-	"/data", "/data/*",
+	"/", "/var", "/opt", "/srv", "/usr", "/app", "/data", "/home",
 }
 
 type distribution struct {
@@ -394,10 +393,17 @@ func (t *imageType) sources(packages []rpmmd.PackageSpec, ostreeCommits []ostree
 
 func isMountpointAllowed(mountpoint string) bool {
 	for _, allowed := range mountpointAllowList {
-		// check if the path and its subdirectories
-		// is in the allow list
 		match, _ := path.Match(allowed, mountpoint)
-		if mountpoint == "/" || match {
+		if match {
+			return true
+		}
+		// ensure that only clean mountpoints
+		// are valid
+		if strings.Contains(mountpoint, "//") {
+			return false
+		}
+		match = strings.HasPrefix(mountpoint, allowed+"/")
+		if allowed != "/" && match {
 			return true
 		}
 	}

--- a/internal/distro/rhel90/distro_test.go
+++ b/internal/distro/rhel90/distro_test.go
@@ -2,6 +2,7 @@ package rhel90_test
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -620,6 +621,10 @@ func TestDistro_CustomFileSystemSubDirectories(t *testing.T) {
 					MinSize:    1024,
 					Mountpoint: "/var/log",
 				},
+				{
+					MinSize:    1024,
+					Mountpoint: "/var/log/audit",
+				},
 			},
 		},
 	}
@@ -628,12 +633,82 @@ func TestDistro_CustomFileSystemSubDirectories(t *testing.T) {
 		for _, imgTypeName := range arch.ListImageTypes() {
 			imgType, _ := arch.GetImageType(imgTypeName)
 			_, err := imgType.Manifest(bp.Customizations, distro.ImageOptions{}, nil, nil, 0)
-			if imgTypeName == "edge-commit" || imgTypeName == "edge-container" {
-				assert.EqualError(t, err, "Custom mountpoints are not supported for ostree types")
-			} else if imgTypeName == "edge-installer" {
+			if strings.HasPrefix(imgTypeName, "edge-") {
 				continue
 			} else {
 				assert.NoError(t, err)
+			}
+		}
+	}
+}
+
+func TestDistro_MountpointsWithArbitraryDepthAllowed(t *testing.T) {
+	r9distro := rhel90.New()
+	bp := blueprint.Blueprint{
+		Customizations: &blueprint.Customizations{
+			Filesystem: []blueprint.FilesystemCustomization{
+				{
+					MinSize:    1024,
+					Mountpoint: "/var/a",
+				},
+				{
+					MinSize:    1024,
+					Mountpoint: "/var/a/b",
+				},
+				{
+					MinSize:    1024,
+					Mountpoint: "/var/a/b/c",
+				},
+				{
+					MinSize:    1024,
+					Mountpoint: "/var/a/b/c/d",
+				},
+			},
+		},
+	}
+	for _, archName := range r9distro.ListArches() {
+		arch, _ := r9distro.GetArch(archName)
+		for _, imgTypeName := range arch.ListImageTypes() {
+			imgType, _ := arch.GetImageType(imgTypeName)
+			_, err := imgType.Manifest(bp.Customizations, distro.ImageOptions{}, nil, nil, 0)
+			if strings.HasPrefix(imgTypeName, "edge-") {
+				continue
+			} else {
+				assert.NoError(t, err)
+			}
+		}
+	}
+}
+
+func TestDistro_DirtyMountpointsNotAllowed(t *testing.T) {
+	r9distro := rhel90.New()
+	bp := blueprint.Blueprint{
+		Customizations: &blueprint.Customizations{
+			Filesystem: []blueprint.FilesystemCustomization{
+				{
+					MinSize:    1024,
+					Mountpoint: "//",
+				},
+				{
+					MinSize:    1024,
+					Mountpoint: "/var//",
+				},
+				{
+					MinSize:    1024,
+					Mountpoint: "/var//log/audit/",
+				},
+			},
+		},
+	}
+	for _, archName := range r9distro.ListArches() {
+		arch, _ := r9distro.GetArch(archName)
+		for _, imgTypeName := range arch.ListImageTypes() {
+			imgType, _ := arch.GetImageType(imgTypeName)
+			_, err := imgType.Manifest(bp.Customizations, distro.ImageOptions{}, nil, nil, 0)
+			if strings.HasPrefix(imgTypeName, "edge-") {
+				continue
+			} else {
+				assert.EqualError(t, err, "The following custom mountpoints are not supported [\"//\" \"/var//\" \"/var//log/audit/\"]")
 			}
 		}
 	}
@@ -648,6 +723,10 @@ func TestDistro_CustomFileSystemPatternMatching(t *testing.T) {
 					MinSize:    1024,
 					Mountpoint: "/variable",
 				},
+				{
+					MinSize:    1024,
+					Mountpoint: "/variable/log/audit",
+				},
 			},
 		},
 	}
@@ -661,7 +740,7 @@ func TestDistro_CustomFileSystemPatternMatching(t *testing.T) {
 			} else if imgTypeName == "edge-installer" {
 				continue
 			} else {
-				assert.EqualError(t, err, "The following custom mountpoints are not supported [\"/variable\"]")
+				assert.EqualError(t, err, "The following custom mountpoints are not supported [\"/variable\" \"/variable/log/audit\"]")
 			}
 		}
 	}

--- a/test/cases/filesystem.sh
+++ b/test/cases/filesystem.sh
@@ -132,6 +132,10 @@ mountpoint = "/var/log"
 size = 131072000
 
 [[customizations.filesystem]]
+mountpoint = "/var/log/audit"
+size = 131072000
+
+[[customizations.filesystem]]
 mountpoint = "/usr"
 size = 2147483648
 


### PR DESCRIPTION
This pull request includes:

Currently the filesystem configuration allows for mount points and their direct sub-directories to be configured as separate partitions (i.e. `/var` & `/var/log`). This pr expands this support to add an additional level to allow for grandchild-directories (i.e. `/var/log/audit`)
 

- [x] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] create a file in [news/unreleased](https://github.com/osbuild/osbuild-composer/tree/main/docs/news/unreleased) directory if this change should be mentioned in the release news
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

For user-visible changes, "adequate documentation" is an entry describing the
change for users in docs/news. Please refer to docs/news/README.md for details.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`
-->
