### PR TITLE
[CI] Schedule dependabot checks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+      time: "04:00"
     open-pull-requests-limit: 5
 
   # Maintain dependencies for Go
@@ -15,4 +16,5 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+      time: "04:00"
     open-pull-requests-limit: 5


### PR DESCRIPTION
schedule checks so they happen at 4:00am UTC. This way gitlab CI doesn't get
blocked during working hours.

This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] create a file in [news/unreleased](https://github.com/osbuild/osbuild-composer/tree/main/docs/news/unreleased) directory if this change should be mentioned in the release news
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/
