### PR TITLE
schutzbot: disable /tmp as tmpfs on RHEL 9

### DIFF
--- a/schutzbot/deploy.sh
+++ b/schutzbot/deploy.sh
@@ -54,6 +54,15 @@ EOF
 source /etc/os-release
 ARCH=$(uname -m)
 
+if [[ $ID == "rhel" && ${VERSION_ID%.*} == "9" ]]; then
+  # There's a bug in RHEL 9 that causes /tmp to be mounted on tmpfs.
+  # Explicitly stop and mask the mount unit to prevent this.
+  # Otherwise, the tests will randomly fail because we use /tmp quite a lot.
+  # See https://bugzilla.redhat.com/show_bug.cgi?id=1959826
+  greenprint "Disabling /tmp as tmpfs on RHEL 9"
+  sudo systemctl stop tmp.mount && sudo systemctl mask tmp.mount
+fi
+
 if [[ $ID == "rhel" && $VERSION_ID == "8.3" && -n "${RHN_REGISTRATION_SCRIPT:-}" ]] && ! sudo subscription-manager status; then
     greenprint "Registering RHEL"
     sudo chmod +x "$RHN_REGISTRATION_SCRIPT"


### PR DESCRIPTION
This should fix the randomly failing test. See the comment for more
information.

Fixes #1718

Signed-off-by: Ondřej Budai <ondrej@budai.cz>


This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] create a file in [news/unreleased](https://github.com/osbuild/osbuild-composer/tree/main/docs/news/unreleased) directory if this change should be mentioned in the release news
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

For user-visible changes, "adequate documentation" is an entry describing the
change for users in docs/news. Please refer to docs/news/README.md for details.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`
-->
