### PR TITLE
RHEL-8.5/9.0: keep RHSM DNF plugins enabled on `ec2`, `ec2-ha` and `ami`

### DIFF
--- a/docs/news/unreleased/rhel-ec2-images-rhsm-dnf-plugins.md
+++ b/docs/news/unreleased/rhel-ec2-images-rhsm-dnf-plugins.md
@@ -1,0 +1,4 @@
+# RHEL-8.5 / RHEL-9.0: RHSM DNF plugins are now enabled by default on `ec2` and `ami` images
+
+The RHSM DNF plugins `product-id` and `subscription-manager` are now by default enabled
+on the RHEL-8.5 and RHEL-9.0 `ec2`, `ec2-ha` and `ami` images.

--- a/internal/distro/rhel85/pipelines.go
+++ b/internal/distro/rhel85/pipelines.go
@@ -346,15 +346,8 @@ func ec2BaseTreePipeline(repos []rpmmd.RepoConfig, packages []rpmmd.PackageSpec,
 			WaitForNetwork: true,
 		}))
 	} else {
+		// The EC2 images should keep the RHSM DNF plugins enabled (RHBZ#1996670)
 		rhsmStageOptions := &osbuild.RHSMStageOptions{
-			DnfPlugins: &osbuild.RHSMStageOptionsDnfPlugins{
-				ProductID: &osbuild.RHSMStageOptionsDnfPlugin{
-					Enabled: false,
-				},
-				SubscriptionManager: &osbuild.RHSMStageOptionsDnfPlugin{
-					Enabled: false,
-				},
-			},
 			// RHBZ#1932802
 			SubMan: &osbuild.RHSMStageOptionsSubMan{
 				Rhsmcertd: &osbuild.SubManConfigRHSMCERTDSection{

--- a/internal/distro/rhel90/pipelines.go
+++ b/internal/distro/rhel90/pipelines.go
@@ -340,15 +340,8 @@ func ec2BaseTreePipeline(repos []rpmmd.RepoConfig, packages []rpmmd.PackageSpec,
 			WaitForNetwork: true,
 		}))
 	} else {
+		// The EC2 images should keep the RHSM DNF plugins enabled (RHBZ#1996670)
 		rhsmStageOptions := &osbuild.RHSMStageOptions{
-			DnfPlugins: &osbuild.RHSMStageOptionsDnfPlugins{
-				ProductID: &osbuild.RHSMStageOptionsDnfPlugin{
-					Enabled: false,
-				},
-				SubscriptionManager: &osbuild.RHSMStageOptionsDnfPlugin{
-					Enabled: false,
-				},
-			},
 			// RHBZ#1932802
 			SubMan: &osbuild.RHSMStageOptionsSubMan{
 				Rhsmcertd: &osbuild.SubManConfigRHSMCERTDSection{

--- a/test/data/manifests/rhel_85-aarch64-ami-boot.json
+++ b/test/data/manifests/rhel_85-aarch64-ami-boot.json
@@ -1066,14 +1066,6 @@
           {
             "type": "org.osbuild.rhsm",
             "options": {
-              "dnf-plugins": {
-                "product-id": {
-                  "enabled": false
-                },
-                "subscription-manager": {
-                  "enabled": false
-                }
-              },
               "subscription-manager": {
                 "rhsmcertd": {
                   "auto_registration": true
@@ -10746,10 +10738,10 @@
     "rhsm": {
       "dnf-plugins": {
         "product-id": {
-          "enabled": false
+          "enabled": true
         },
         "subscription-manager": {
-          "enabled": false
+          "enabled": true
         }
       },
       "rhsm.conf": {
@@ -10799,8 +10791,6 @@
     "rpm-verify": {
       "changed": {
         "/etc/chrony.conf": "S.5....T.",
-        "/etc/dnf/plugins/product-id.conf": "..5....T.",
-        "/etc/dnf/plugins/subscription-manager.conf": "..5....T.",
         "/etc/machine-id": ".M.......",
         "/etc/nsswitch.conf": "....L....",
         "/etc/pam.d/fingerprint-auth": "....L....",

--- a/test/data/manifests/rhel_85-aarch64-ec2-boot.json
+++ b/test/data/manifests/rhel_85-aarch64-ec2-boot.json
@@ -1067,14 +1067,6 @@
           {
             "type": "org.osbuild.rhsm",
             "options": {
-              "dnf-plugins": {
-                "product-id": {
-                  "enabled": false
-                },
-                "subscription-manager": {
-                  "enabled": false
-                }
-              },
               "subscription-manager": {
                 "rhsm": {
                   "manage_repos": false
@@ -10786,10 +10778,10 @@
     "rhsm": {
       "dnf-plugins": {
         "product-id": {
-          "enabled": false
+          "enabled": true
         },
         "subscription-manager": {
-          "enabled": false
+          "enabled": true
         }
       },
       "rhsm.conf": {
@@ -10839,8 +10831,6 @@
     "rpm-verify": {
       "changed": {
         "/etc/chrony.conf": "S.5....T.",
-        "/etc/dnf/plugins/product-id.conf": "..5....T.",
-        "/etc/dnf/plugins/subscription-manager.conf": "..5....T.",
         "/etc/machine-id": ".M.......",
         "/etc/nsswitch.conf": "....L....",
         "/etc/pam.d/fingerprint-auth": "....L....",

--- a/test/data/manifests/rhel_85-x86_64-ami-boot.json
+++ b/test/data/manifests/rhel_85-x86_64-ami-boot.json
@@ -1055,14 +1055,6 @@
           {
             "type": "org.osbuild.rhsm",
             "options": {
-              "dnf-plugins": {
-                "product-id": {
-                  "enabled": false
-                },
-                "subscription-manager": {
-                  "enabled": false
-                }
-              },
               "subscription-manager": {
                 "rhsmcertd": {
                   "auto_registration": true
@@ -10340,10 +10332,10 @@
     "rhsm": {
       "dnf-plugins": {
         "product-id": {
-          "enabled": false
+          "enabled": true
         },
         "subscription-manager": {
-          "enabled": false
+          "enabled": true
         }
       },
       "rhsm.conf": {
@@ -10393,8 +10385,6 @@
     "rpm-verify": {
       "changed": {
         "/etc/chrony.conf": "S.5....T.",
-        "/etc/dnf/plugins/product-id.conf": "..5....T.",
-        "/etc/dnf/plugins/subscription-manager.conf": "..5....T.",
         "/etc/machine-id": ".M.......",
         "/etc/nsswitch.conf": "....L....",
         "/etc/pam.d/fingerprint-auth": "....L....",

--- a/test/data/manifests/rhel_85-x86_64-ec2-boot.json
+++ b/test/data/manifests/rhel_85-x86_64-ec2-boot.json
@@ -1056,14 +1056,6 @@
           {
             "type": "org.osbuild.rhsm",
             "options": {
-              "dnf-plugins": {
-                "product-id": {
-                  "enabled": false
-                },
-                "subscription-manager": {
-                  "enabled": false
-                }
-              },
               "subscription-manager": {
                 "rhsm": {
                   "manage_repos": false
@@ -10380,10 +10372,10 @@
     "rhsm": {
       "dnf-plugins": {
         "product-id": {
-          "enabled": false
+          "enabled": true
         },
         "subscription-manager": {
-          "enabled": false
+          "enabled": true
         }
       },
       "rhsm.conf": {
@@ -10433,8 +10425,6 @@
     "rpm-verify": {
       "changed": {
         "/etc/chrony.conf": "S.5....T.",
-        "/etc/dnf/plugins/product-id.conf": "..5....T.",
-        "/etc/dnf/plugins/subscription-manager.conf": "..5....T.",
         "/etc/machine-id": ".M.......",
         "/etc/nsswitch.conf": "....L....",
         "/etc/pam.d/fingerprint-auth": "....L....",

--- a/test/data/manifests/rhel_85-x86_64-ec2_ha-boot.json
+++ b/test/data/manifests/rhel_85-x86_64-ec2_ha-boot.json
@@ -1230,14 +1230,6 @@
           {
             "type": "org.osbuild.rhsm",
             "options": {
-              "dnf-plugins": {
-                "product-id": {
-                  "enabled": false
-                },
-                "subscription-manager": {
-                  "enabled": false
-                }
-              },
               "subscription-manager": {
                 "rhsm": {
                   "manage_repos": false
@@ -12811,10 +12803,10 @@
     "rhsm": {
       "dnf-plugins": {
         "product-id": {
-          "enabled": false
+          "enabled": true
         },
         "subscription-manager": {
-          "enabled": false
+          "enabled": true
         }
       },
       "rhsm.conf": {
@@ -12864,8 +12856,6 @@
     "rpm-verify": {
       "changed": {
         "/etc/chrony.conf": "S.5....T.",
-        "/etc/dnf/plugins/product-id.conf": "..5....T.",
-        "/etc/dnf/plugins/subscription-manager.conf": "..5....T.",
         "/etc/machine-id": ".M.......",
         "/etc/nsswitch.conf": "....L....",
         "/etc/pam.d/fingerprint-auth": "....L....",

--- a/test/data/manifests/rhel_90-aarch64-ami-boot.json
+++ b/test/data/manifests/rhel_90-aarch64-ami-boot.json
@@ -968,14 +968,6 @@
           {
             "type": "org.osbuild.rhsm",
             "options": {
-              "dnf-plugins": {
-                "product-id": {
-                  "enabled": false
-                },
-                "subscription-manager": {
-                  "enabled": false
-                }
-              },
               "subscription-manager": {
                 "rhsmcertd": {
                   "auto_registration": true
@@ -9699,10 +9691,10 @@
     "rhsm": {
       "dnf-plugins": {
         "product-id": {
-          "enabled": false
+          "enabled": true
         },
         "subscription-manager": {
-          "enabled": false
+          "enabled": true
         }
       },
       "rhsm.conf": {
@@ -9753,8 +9745,6 @@
       "changed": {
         "/boot/efi/EFI": ".M.......",
         "/etc/chrony.conf": "S.5....T.",
-        "/etc/dnf/plugins/product-id.conf": "..5....T.",
-        "/etc/dnf/plugins/subscription-manager.conf": "..5....T.",
         "/etc/nsswitch.conf": "....L....",
         "/etc/pam.d/fingerprint-auth": "....L....",
         "/etc/pam.d/password-auth": "....L....",

--- a/test/data/manifests/rhel_90-x86_64-ami-boot.json
+++ b/test/data/manifests/rhel_90-x86_64-ami-boot.json
@@ -953,14 +953,6 @@
           {
             "type": "org.osbuild.rhsm",
             "options": {
-              "dnf-plugins": {
-                "product-id": {
-                  "enabled": false
-                },
-                "subscription-manager": {
-                  "enabled": false
-                }
-              },
               "subscription-manager": {
                 "rhsmcertd": {
                   "auto_registration": true
@@ -9301,10 +9293,10 @@
     "rhsm": {
       "dnf-plugins": {
         "product-id": {
-          "enabled": false
+          "enabled": true
         },
         "subscription-manager": {
-          "enabled": false
+          "enabled": true
         }
       },
       "rhsm.conf": {
@@ -9354,8 +9346,6 @@
     "rpm-verify": {
       "changed": {
         "/etc/chrony.conf": "S.5....T.",
-        "/etc/dnf/plugins/product-id.conf": "..5....T.",
-        "/etc/dnf/plugins/subscription-manager.conf": "..5....T.",
         "/etc/nsswitch.conf": "....L....",
         "/etc/pam.d/fingerprint-auth": "....L....",
         "/etc/pam.d/password-auth": "....L....",


### PR DESCRIPTION
The RHSM DNF plugins `product-id` and `subscription-manager` are now
by default enabled on the RHEL-8.5 and RHEL-9.0 `ec2`, `ec2-ha` and
`ami` images.

The desired default state of the RHSM DNF plugins has been decided by
the RHSM team.

Related to https://bugzilla.redhat.com/show_bug.cgi?id=1996670

Signed-off-by: Tomas Hozza <thozza@redhat.com>


This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] create a file in [news/unreleased](https://github.com/osbuild/osbuild-composer/tree/main/docs/news/unreleased) directory if this change should be mentioned in the release news
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

For user-visible changes, "adequate documentation" is an entry describing the
change for users in docs/news. Please refer to docs/news/README.md for details.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`
-->
