### PR TITLE
tests: enable filesystem test on RHEL-9

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -248,6 +248,7 @@ Integration:
       - SCRIPT:
           - aws.sh
           - azure.sh
+          - filesystem.sh
         RUNNER:
           - aws/rhel-9.0-beta-nightly-x86_64
         INTERNAL_NETWORK: ["true"]

--- a/test/cases/filesystem.sh
+++ b/test/cases/filesystem.sh
@@ -3,6 +3,7 @@
 #
 # Test the ability to specify custom mountpoints for RHEL8.5 and above
 #
+set -euo pipefail
 
 source /etc/os-release
 
@@ -53,8 +54,13 @@ build_image() {
 
     # Start the compose.
     greenprint "🚀 Starting compose"
-    sudo composer-cli --json compose start "$blueprint_name" "$image_type" | tee "$COMPOSE_START"
-    STATUS=$(jq -r '.status' "$COMPOSE_START")
+    # this needs "|| true" at the end for the fail case scenario
+    sudo composer-cli --json compose start "$blueprint_name" "$image_type" | tee "$COMPOSE_START" || true
+    if rpm -q --quiet weldr-client; then
+        STATUS=$(jq -r '.body.status' "$COMPOSE_START")
+    else
+        STATUS=$(jq -r '.status' "$COMPOSE_START")
+    fi
     
     if [[ $want_fail == "$STATUS" ]]; then
         echo "Something went wrong with the compose. 😢"
@@ -64,17 +70,29 @@ build_image() {
     elif [[ $want_fail == true && $STATUS == false ]]; then
         sudo pkill -P ${WORKER_JOURNAL_PID}
         trap - EXIT
-        ERROR_MSG=$(jq 'first(.errors[] | select(.id == "ManifestCreationFailed")) | .msg' "$COMPOSE_START")
+        if rpm -q --quiet weldr-client; then
+            ERROR_MSG=$(jq 'first(.body.errors[] | select(.id == "ManifestCreationFailed")) | .msg' "$COMPOSE_START")
+        else
+            ERROR_MSG=$(jq 'first(.errors[] | select(.id == "ManifestCreationFailed")) | .msg' "$COMPOSE_START")
+        fi
         return
     else
-      COMPOSE_ID=$(jq -r '.build_id' "$COMPOSE_START")
+        if rpm -q --quiet weldr-client; then
+            COMPOSE_ID=$(jq -r '.body.build_id' "$COMPOSE_START")
+        else
+            COMPOSE_ID=$(jq -r '.build_id' "$COMPOSE_START")
+        fi
     fi
 
     # Wait for the compose to finish.
     greenprint "⏱ Waiting for compose to finish: ${COMPOSE_ID}"
     while true; do
         sudo composer-cli --json compose info "${COMPOSE_ID}" | tee "$COMPOSE_INFO" > /dev/null
-        COMPOSE_STATUS=$(jq -r '.queue_status' "$COMPOSE_INFO")
+        if rpm -q --quiet weldr-client; then
+            COMPOSE_STATUS=$(jq -r '.body.queue_status' "$COMPOSE_INFO")
+        else
+            COMPOSE_STATUS=$(jq -r '.queue_status' "$COMPOSE_INFO")
+        fi
 
         # Is the compose finished?
         if [[ $COMPOSE_STATUS != RUNNING ]] && [[ $COMPOSE_STATUS != WAITING ]]; then
@@ -137,7 +155,7 @@ size = 2147483648
 
 EOF
 
-build_image "$BLUEPRINT_FILE" rhel85-custom-filesystem qcow2
+build_image "$BLUEPRINT_FILE" rhel85-custom-filesystem qcow2 false
 
 # Download the image.
 greenprint "📥 Downloading the image"


### PR DESCRIPTION
Modifications to the test to work with weldr-client along with and
adding set -euo pipefail which was missing


This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] create a file in [news/unreleased](https://github.com/osbuild/osbuild-composer/tree/main/docs/news/unreleased) directory if this change should be mentioned in the release news
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

For user-visible changes, "adequate documentation" is an entry describing the
change for users in docs/news. Please refer to docs/news/README.md for details.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`
-->
