### PR TITLE
regression tests: Introduce test for the RHSM fallback

### DIFF
--- a/Schutzfile
+++ b/Schutzfile
@@ -2,7 +2,7 @@
   "fedora-33": {
     "dependencies": {
       "osbuild": {
-        "commit": "35de3093a7b52569512bdc61d2105febbb9b0c7e"
+        "commit": "5d7316757b60645b5e0ee114614266fca297208e"
       }
     },
     "dependants": {
@@ -14,14 +14,14 @@
   "fedora-34": {
     "dependencies": {
       "osbuild": {
-        "commit": "35de3093a7b52569512bdc61d2105febbb9b0c7e"
+        "commit": "5d7316757b60645b5e0ee114614266fca297208e"
       }
     }
   },
   "rhel-8.3": {
     "dependencies": {
       "osbuild": {
-        "commit": "35de3093a7b52569512bdc61d2105febbb9b0c7e"
+        "commit": "5d7316757b60645b5e0ee114614266fca297208e"
       }
     },
     "dependants": {
@@ -36,7 +36,28 @@
   "rhel-8.4": {
     "dependencies": {
       "osbuild": {
-        "commit": "35de3093a7b52569512bdc61d2105febbb9b0c7e"
+        "commit": "5d7316757b60645b5e0ee114614266fca297208e"
+      }
+    }
+  },
+  "rhel-8.5": {
+    "dependencies": {
+      "osbuild": {
+        "commit": "5d7316757b60645b5e0ee114614266fca297208e"
+      }
+    }
+  },
+  "rhel-9.0": {
+    "dependencies": {
+      "osbuild": {
+        "commit": "5d7316757b60645b5e0ee114614266fca297208e"
+      }
+    }
+  },
+  "centos-8": {
+    "dependencies": {
+      "osbuild": {
+        "commit": "5d7316757b60645b5e0ee114614266fca297208e"
       }
     }
   }

--- a/osbuild-composer.spec
+++ b/osbuild-composer.spec
@@ -283,8 +283,8 @@ The core osbuild-composer binary. This is suitable both for spawning in containe
 Summary:    The worker for osbuild-composer
 Requires:   systemd
 Requires:   qemu-img
-Requires:   osbuild >= 30
-Requires:   osbuild-ostree >= 30
+Requires:   osbuild >= 36
+Requires:   osbuild-ostree >= 36
 
 # remove in F34
 Obsoletes: golang-github-osbuild-composer-worker < %{version}-%{release}


### PR DESCRIPTION
Make sure the fallback works when there is no redhat.repo file, but
there is a certificate that can be used to access the repositories.


This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] create a file in [news/unreleased](https://github.com/osbuild/osbuild-composer/tree/main/docs/news/unreleased) directory if this change should be mentioned in the release news
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

For user-visible changes, "adequate documentation" is an entry describing the
change for users in docs/news. Please refer to docs/news/README.md for details.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`
-->
