### PR TITLE
[8.6/9.0] internal: mandate installation device for the simplified installer

### DIFF
--- a/internal/blueprint/customizations.go
+++ b/internal/blueprint/customizations.go
@@ -332,9 +332,8 @@ func (c *Customizations) GetFilesystemsMinSize() uint64 {
 }
 
 func (c *Customizations) GetInstallationDevice() string {
-	defaultDevice := "/dev/sda"
 	if c == nil || c.InstallationDevice == "" {
-		return defaultDevice
+		return ""
 	}
 	return c.InstallationDevice
 }

--- a/internal/distro/rhel86/distro.go
+++ b/internal/distro/rhel86/distro.go
@@ -461,6 +461,9 @@ func (t *imageType) checkOptions(customizations *blueprint.Customizations, optio
 			if err := customizations.CheckAllowed("InstallationDevice"); err != nil {
 				return fmt.Errorf("boot ISO image type %q contains unsupported blueprint customizations: %v", t.name, err)
 			}
+			if customizations.GetInstallationDevice() == "" {
+				return fmt.Errorf("boot ISO image type %q requires specifying an installation device to install to", t.name)
+			}
 		} else if customizations != nil {
 			return fmt.Errorf("boot ISO image type %q does not support blueprint customizations", t.name)
 		}

--- a/internal/distro/rhel90/distro.go
+++ b/internal/distro/rhel90/distro.go
@@ -461,6 +461,9 @@ func (t *imageType) checkOptions(customizations *blueprint.Customizations, optio
 			if err := customizations.CheckAllowed("InstallationDevice"); err != nil {
 				return fmt.Errorf("boot ISO image type %q contains unsupported blueprint customizations: %v", t.name, err)
 			}
+			if customizations.GetInstallationDevice() == "" {
+				return fmt.Errorf("boot ISO image type %q requires specifying an installation device to install to", t.name)
+			}
 		} else if customizations != nil {
 			return fmt.Errorf("boot ISO image type %q does not support blueprint customizations", t.name)
 		}


### PR DESCRIPTION
Fix https://github.com/osbuild/osbuild-composer/issues/1660

Signed-off-by: Antonio Murdaca <runcom@linux.com>


This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] create a file in [news/unreleased](https://github.com/osbuild/osbuild-composer/tree/main/docs/news/unreleased) directory if this change should be mentioned in the release news
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

For user-visible changes, "adequate documentation" is an entry describing the
change for users in docs/news. Please refer to docs/news/README.md for details.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`
-->
