### PR TITLE
packit: Propose PRs to all Fedoras

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -19,4 +19,4 @@ jobs:
   trigger: release
   metadata:
     dist_git_branches:
-      - fedora-rawhide
+      - fedora-all


### PR DESCRIPTION
As the task is the same for all Fedoras (and creating PRs in rawhide works reasonably well now) I propose we enable packit for all active Fedora releases in order to reduce the manual effort.
I could also imagine doing a second job and pushing to rawhide directly instead of just creating a PR there.

This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] create a file in [news/unreleased](https://github.com/osbuild/osbuild-composer/tree/main/docs/news/unreleased) directory if this change should be mentioned in the release news
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

For user-visible changes, "adequate documentation" is an entry describing the
change for users in docs/news. Please refer to docs/news/README.md for details.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`
-->
