### PR TITLE
rhel85: set bootloader to `none` for edge raw images

### DIFF
--- a/Schutzfile
+++ b/Schutzfile
@@ -2,7 +2,7 @@
   "fedora-33": {
     "dependencies": {
       "osbuild": {
-        "commit": "5d7316757b60645b5e0ee114614266fca297208e"
+        "commit": "662fe0feb9c3fd2843b34501900d466272aac776"
       }
     },
     "dependants": {
@@ -14,35 +14,35 @@
   "fedora-34": {
     "dependencies": {
       "osbuild": {
-        "commit": "5d7316757b60645b5e0ee114614266fca297208e"
+        "commit": "662fe0feb9c3fd2843b34501900d466272aac776"
       }
     }
   },
   "rhel-8.4": {
     "dependencies": {
       "osbuild": {
-        "commit": "5d7316757b60645b5e0ee114614266fca297208e"
+        "commit": "662fe0feb9c3fd2843b34501900d466272aac776"
       }
     }
   },
   "rhel-8.5": {
     "dependencies": {
       "osbuild": {
-        "commit": "5d7316757b60645b5e0ee114614266fca297208e"
+        "commit": "662fe0feb9c3fd2843b34501900d466272aac776"
       }
     }
   },
   "rhel-9.0": {
     "dependencies": {
       "osbuild": {
-        "commit": "5d7316757b60645b5e0ee114614266fca297208e"
+        "commit": "662fe0feb9c3fd2843b34501900d466272aac776"
       }
     }
   },
   "centos-8": {
     "dependencies": {
       "osbuild": {
-        "commit": "5d7316757b60645b5e0ee114614266fca297208e"
+        "commit": "662fe0feb9c3fd2843b34501900d466272aac776"
       }
     }
   }

--- a/internal/distro/rhel85/stage_options.go
+++ b/internal/distro/rhel85/stage_options.go
@@ -566,7 +566,8 @@ func ostreeConfigStageOptions(repo string, readOnly bool) *osbuild.OSTreeConfigS
 		Repo: repo,
 		Config: &osbuild.OSTreeConfig{
 			Sysroot: &osbuild.SysrootOptions{
-				ReadOnly: common.BoolToPtr(readOnly),
+				ReadOnly:   common.BoolToPtr(readOnly),
+				Bootloader: "none",
 			},
 		},
 	}

--- a/internal/osbuild2/ostree_config_stage.go
+++ b/internal/osbuild2/ostree_config_stage.go
@@ -19,7 +19,7 @@ type SysrootOptions struct {
 	ReadOnly *bool `json:"readonly,omitempty"`
 }
 
-// A new org.osbuild.ostree.init stage to create an OSTree repository
+// A new org.osbuild.ostree.config stage to configure an OSTree repository
 func NewOSTreeConfigStage(options *OSTreeConfigStageOptions) *Stage {
 	return &Stage{
 		Type:    "org.osbuild.ostree.config",

--- a/internal/osbuild2/ostree_config_stage.go
+++ b/internal/osbuild2/ostree_config_stage.go
@@ -16,7 +16,8 @@ type OSTreeConfig struct {
 }
 
 type SysrootOptions struct {
-	ReadOnly *bool `json:"readonly,omitempty"`
+	ReadOnly   *bool  `json:"readonly,omitempty"`
+	Bootloader string `json:"bootloader,omitempty"`
 }
 
 // A new org.osbuild.ostree.config stage to configure an OSTree repository

--- a/osbuild-composer.spec
+++ b/osbuild-composer.spec
@@ -326,8 +326,8 @@ The core osbuild-composer binary. This is suitable both for spawning in containe
 Summary:    The worker for osbuild-composer
 Requires:   systemd
 Requires:   qemu-img
-Requires:   osbuild >= 36
-Requires:   osbuild-ostree >= 36
+Requires:   osbuild >= 37
+Requires:   osbuild-ostree >= 37
 
 # remove in F34
 Obsoletes: golang-github-osbuild-composer-worker < %{version}-%{release}


### PR DESCRIPTION
Use the new bootloader config for OSTree deployments to set the bootloader backend to `none` since we use grub2 and BLS in all currentlysupported architectures. In fact, not setting it to `none`, will use the default `auto`, which will result in the run of `grub2-mkconfig`, which is not what we want and might even fail for us.

This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] create a file in [news/unreleased](https://github.com/osbuild/osbuild-composer/tree/main/docs/news/unreleased) directory if this change should be mentioned in the release news
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/
