### PR TITLE
Add support for new osbuild stages required for RHEL EC2 SAP image

### DIFF
--- a/docs/news/unreleased/support-new-osbuild-stages.md
+++ b/docs/news/unreleased/support-new-osbuild-stages.md
@@ -1,0 +1,10 @@
+# Added support for new osbuild stages required for RHEL EC2 SAP images
+
+Added support for the following osbuild stages:
+
+- `org.osbuild.selinux.config` - configures SELinux policy state and type on the system
+- `org.osbuild.tmpfilesd` - creates tmpfiles.d configuration files
+- `org.osbuild.pam.limits.conf` - creates configuration files for pam_limits module
+- `org.osbuild.sysctld` - creates sysctl.d configuration files
+- `org.osbuild.dnf.config` - configures DNF (currently only variables)
+- `org.osbuild.tuned` - sets active tuned profile (or more profiles)

--- a/internal/osbuild2/dnf_config_stage.go
+++ b/internal/osbuild2/dnf_config_stage.go
@@ -1,0 +1,32 @@
+package osbuild2
+
+// DNFConfigStageOptions represents persistent DNF configuration.
+type DNFConfigStageOptions struct {
+	// List of DNF variables.
+	Variables []DNFVariable `json:"variables,omitempty"`
+}
+
+func (DNFConfigStageOptions) isStageOptions() {}
+
+// NewDNFConfigStageOptions creates a new DNFConfig Stage options object.
+func NewDNFConfigStageOptions(variables []DNFVariable) *DNFConfigStageOptions {
+	return &DNFConfigStageOptions{
+		Variables: variables,
+	}
+}
+
+// NewDNFConfigStage creates a new DNFConfig Stage object.
+func NewDNFConfigStage(options *DNFConfigStageOptions) *Stage {
+	return &Stage{
+		Type:    "org.osbuild.dnf.config",
+		Options: options,
+	}
+}
+
+// DNFVariable represents a single DNF variable.
+type DNFVariable struct {
+	// Name of the variable.
+	Name string `json:"name"`
+	// Value of the variable.
+	Value string `json:"value"`
+}

--- a/internal/osbuild2/dnf_config_stage_test.go
+++ b/internal/osbuild2/dnf_config_stage_test.go
@@ -1,0 +1,31 @@
+package osbuild2
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewDNFConfigStageOptions(t *testing.T) {
+	variables := []DNFVariable{
+		{
+			Name:  "release",
+			Value: "8.4",
+		},
+	}
+
+	expectedOptions := &DNFConfigStageOptions{
+		Variables: variables,
+	}
+	actualOptions := NewDNFConfigStageOptions(variables)
+	assert.Equal(t, expectedOptions, actualOptions)
+}
+
+func TestNewDNFConfigStage(t *testing.T) {
+	expectedStage := &Stage{
+		Type:    "org.osbuild.dnf.config",
+		Options: &DNFConfigStageOptions{},
+	}
+	actualStage := NewDNFConfigStage(&DNFConfigStageOptions{})
+	assert.Equal(t, expectedStage, actualStage)
+}

--- a/internal/osbuild2/pam_limits_conf_stage.go
+++ b/internal/osbuild2/pam_limits_conf_stage.go
@@ -1,0 +1,155 @@
+package osbuild2
+
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+)
+
+// PamLimitsConfStageOptions represents a single pam_limits module configuration file.
+type PamLimitsConfStageOptions struct {
+	// Filename of the configuration file to be created. Must end with '.conf'.
+	Filename string `json:"filename"`
+	// List of configuration directives. The list must contain at least one item.
+	Config []PamLimitsConfigLine `json:"config"`
+}
+
+func (PamLimitsConfStageOptions) isStageOptions() {}
+
+// NewPamLimitsConfStageOptions creates a new PamLimitsConf Stage options object.
+func NewPamLimitsConfStageOptions(filename string, config []PamLimitsConfigLine) *PamLimitsConfStageOptions {
+	return &PamLimitsConfStageOptions{
+		Filename: filename,
+		Config:   config,
+	}
+}
+
+// Unexported alias for use in PamLimitsConfStageOptions's MarshalJSON() to prevent recursion
+type pamLimitsConfStageOptions PamLimitsConfStageOptions
+
+func (o PamLimitsConfStageOptions) MarshalJSON() ([]byte, error) {
+	if len(o.Config) == 0 {
+		return nil, fmt.Errorf("the 'Config' list must contain at least one item")
+	}
+	options := pamLimitsConfStageOptions(o)
+	return json.Marshal(options)
+}
+
+// NewPamLimitsConfStage creates a new PamLimitsConf Stage object.
+func NewPamLimitsConfStage(options *PamLimitsConfStageOptions) *Stage {
+	return &Stage{
+		Type:    "org.osbuild.pam.limits.conf",
+		Options: options,
+	}
+}
+
+type PamLimitsType string
+
+// Valid 'Type' values for the use with the PamLimitsConfigLine structure.
+const (
+	PamLimitsTypeHard PamLimitsType = "hard"
+	PamLimitsTypeSoft PamLimitsType = "soft"
+	PamLimitsTypeBoth PamLimitsType = "-"
+)
+
+type PamLimitsItem string
+
+// Valid 'Item' values for the use with the PamLimitsConfigLine structure.
+const (
+	PamLimitsItemCore         PamLimitsItem = "core"
+	PamLimitsItemData         PamLimitsItem = "data"
+	PamLimitsItemFsize        PamLimitsItem = "fsize"
+	PamLimitsItemMemlock      PamLimitsItem = "memlock"
+	PamLimitsItemNofile       PamLimitsItem = "nofile"
+	PamLimitsItemRss          PamLimitsItem = "rss"
+	PamLimitsItemStack        PamLimitsItem = "stack"
+	PamLimitsItemCpu          PamLimitsItem = "cpu"
+	PamLimitsItemNproc        PamLimitsItem = "nproc"
+	PamLimitsItemAs           PamLimitsItem = "as"
+	PamLimitsItemMaxlogins    PamLimitsItem = "maxlogins"
+	PamLimitsItemMaxsyslogins PamLimitsItem = "maxsyslogins"
+	PamLimitsItemNonewprivs   PamLimitsItem = "nonewprivs"
+	PamLimitsItemPriority     PamLimitsItem = "priority"
+	PamLimitsItemLocks        PamLimitsItem = "locks"
+	PamLimitsItemSigpending   PamLimitsItem = "sigpending"
+	PamLimitsItemMsgqueue     PamLimitsItem = "msgqueue"
+	PamLimitsItemNice         PamLimitsItem = "nice"
+	PamLimitsItemRtprio       PamLimitsItem = "rtprio"
+)
+
+// PamLimitsValue is defined to represent all valid types of the 'Value'
+// item in the PamLimitsConfigLine structure.
+type PamLimitsValue interface {
+	isPamLimitsValue()
+}
+
+// PamLimitsValueStr represents a string type of the 'Value' item in
+// the PamLimitsConfigLine structure.
+type PamLimitsValueStr string
+
+func (v PamLimitsValueStr) isPamLimitsValue() {}
+
+// Valid string values which can be used for the 'Value' item in
+// the PamLimitsConfigLine structure.
+const (
+	PamLimitsValueUnlimited PamLimitsValueStr = "unlimited"
+	PamLimitsValueInfinity  PamLimitsValueStr = "infinity"
+)
+
+// PamLimitsValueInt represents an integer type of the 'Value' item in
+// the PamLimitsConfigLine structure.
+type PamLimitsValueInt int
+
+func (v PamLimitsValueInt) isPamLimitsValue() {}
+
+// PamLimitsConfigLine represents a single line in a pam_limits module configuration.
+type PamLimitsConfigLine struct {
+	// Domain to which the limit applies. E.g. username, groupname, etc.
+	Domain string `json:"domain"`
+	// Type of the limit.
+	Type PamLimitsType `json:"type"`
+	// The resource type, which is being limited.
+	Item PamLimitsItem `json:"item"`
+	// The limit value.
+	Value PamLimitsValue `json:"value"`
+}
+
+// Unexported struct used for Unmarshalling of PamLimitsConfigLine due to
+// 'value' being an integer or a string.
+type rawPamLimitsConfigLine struct {
+	// Domain to which the limit applies. E.g. username, groupname, etc.
+	Domain string `json:"domain"`
+	// Type of the limit.
+	Type PamLimitsType `json:"type"`
+	// The resource type, which is being limited.
+	Item PamLimitsItem `json:"item"`
+	// The limit value.
+	Value interface{} `json:"value"`
+}
+
+func (l *PamLimitsConfigLine) UnmarshalJSON(data []byte) error {
+	var rawLine rawPamLimitsConfigLine
+	if err := json.Unmarshal(data, &rawLine); err != nil {
+		return err
+	}
+
+	var value PamLimitsValue
+	switch valueType := reflect.TypeOf(rawLine.Value); valueType.Kind() {
+	// json.Unmarshal() uses float64 for JSON numbers
+	// https://pkg.go.dev/encoding/json#Unmarshal
+	// However the expected value is only integer.
+	case reflect.Float64:
+		value = PamLimitsValueInt(rawLine.Value.(float64))
+	case reflect.String:
+		value = PamLimitsValueStr(rawLine.Value.(string))
+	default:
+		return fmt.Errorf("the 'value' item has unsupported type %q", valueType)
+	}
+
+	l.Domain = rawLine.Domain
+	l.Type = rawLine.Type
+	l.Item = rawLine.Item
+	l.Value = value
+
+	return nil
+}

--- a/internal/osbuild2/pam_limits_conf_stage_test.go
+++ b/internal/osbuild2/pam_limits_conf_stage_test.go
@@ -1,0 +1,52 @@
+package osbuild2
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewPamLimitsConfStageOptions(t *testing.T) {
+	filename := "example.conf"
+	config := []PamLimitsConfigLine{{
+		Domain: "user1",
+		Type:   PamLimitsTypeHard,
+		Item:   PamLimitsItemCpu,
+		Value:  PamLimitsValueInt(123),
+	}}
+
+	expectedOptions := &PamLimitsConfStageOptions{
+		Filename: filename,
+		Config:   config,
+	}
+	actualOptions := NewPamLimitsConfStageOptions(filename, config)
+	assert.Equal(t, expectedOptions, actualOptions)
+}
+
+func TestNewPamLimitsConfStage(t *testing.T) {
+	expectedStage := &Stage{
+		Type:    "org.osbuild.pam.limits.conf",
+		Options: &PamLimitsConfStageOptions{},
+	}
+	actualStage := NewPamLimitsConfStage(&PamLimitsConfStageOptions{})
+	assert.Equal(t, expectedStage, actualStage)
+}
+
+func TestPamLimitsConfStageOptions_MarshalJSON_Invalid(t *testing.T) {
+	tests := []struct {
+		name    string
+		options PamLimitsConfStageOptions
+	}{
+		{
+			name:    "empty-options",
+			options: PamLimitsConfStageOptions{},
+		},
+	}
+	for idx, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotBytes, err := json.Marshal(tt.options)
+			assert.NotNilf(t, err, "json.Marshal() didn't return an error, but: %s [idx: %d]", string(gotBytes), idx)
+		})
+	}
+}

--- a/internal/osbuild2/selinux_config_stage.go
+++ b/internal/osbuild2/selinux_config_stage.go
@@ -1,0 +1,36 @@
+package osbuild2
+
+// The SELinuxConfigStageOptions describe the desired SELinux policy state
+// and type on the system.
+type SELinuxConfigStageOptions struct {
+	State SELinuxPolicyState `json:"state,omitempty"`
+	Type  SELinuxPolicyType  `json:"type,omitempty"`
+}
+
+func (SELinuxConfigStageOptions) isStageOptions() {}
+
+// Valid SELinux Policy states
+type SELinuxPolicyState string
+
+const (
+	SELinuxStateEnforcing  SELinuxPolicyState = "enforcing"
+	SELinuxStatePermissive SELinuxPolicyState = "permissive"
+	SELinuxStateDisabled   SELinuxPolicyState = "disabled"
+)
+
+// Valid SELinux Policy types
+type SELinuxPolicyType string
+
+const (
+	SELinuxTypeTargeted SELinuxPolicyType = "targeted"
+	SELinuxTypeMinimum  SELinuxPolicyType = "minimum"
+	SELinuxTypeMLS      SELinuxPolicyType = "mls"
+)
+
+// NewSELinuxConfigStage creates a new SELinuxConfig Stage object.
+func NewSELinuxConfigStage(options *SELinuxConfigStageOptions) *Stage {
+	return &Stage{
+		Type:    "org.osbuild.selinux.config",
+		Options: options,
+	}
+}

--- a/internal/osbuild2/selinux_config_stage_test.go
+++ b/internal/osbuild2/selinux_config_stage_test.go
@@ -1,0 +1,16 @@
+package osbuild2
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewSELinuxConfigStage(t *testing.T) {
+	expectedStage := &Stage{
+		Type:    "org.osbuild.selinux.config",
+		Options: &SELinuxConfigStageOptions{},
+	}
+	actualStage := NewSELinuxConfigStage(&SELinuxConfigStageOptions{})
+	assert.Equal(t, expectedStage, actualStage)
+}

--- a/internal/osbuild2/stage.go
+++ b/internal/osbuild2/stage.go
@@ -114,6 +114,8 @@ func (stage *Stage) UnmarshalJSON(data []byte) error {
 		options = new(OSTreeInitStageOptions)
 	case "org.osbuild.ostree.preptree":
 		options = new(OSTreePrepTreeStageOptions)
+	case "org.osbuild.pam.limits.conf":
+		options = new(PamLimitsConfStageOptions)
 	case "org.osbuild.truncate":
 		options = new(TruncateStageOptions)
 	case "org.osbuild.sfdisk":

--- a/internal/osbuild2/stage.go
+++ b/internal/osbuild2/stage.go
@@ -91,6 +91,8 @@ func (stage *Stage) UnmarshalJSON(data []byte) error {
 		options = new(ScriptStageOptions)
 	case "org.osbuild.sysconfig":
 		options = new(SysconfigStageOptions)
+	case "org.osbuild.tmpfilesd":
+		options = new(TmpfilesdStageOptions)
 	case "org.osbuild.kernel-cmdline":
 		options = new(KernelCmdlineStageOptions)
 	case "org.osbuild.rpm":

--- a/internal/osbuild2/stage.go
+++ b/internal/osbuild2/stage.go
@@ -55,6 +55,8 @@ func (stage *Stage) UnmarshalJSON(data []byte) error {
 		options = new(LocaleStageOptions)
 	case "org.osbuild.selinux":
 		options = new(SELinuxStageOptions)
+	case "org.osbuild.selinux.config":
+		options = new(SELinuxConfigStageOptions)
 	case "org.osbuild.hostname":
 		options = new(HostnameStageOptions)
 	case "org.osbuild.users":

--- a/internal/osbuild2/stage.go
+++ b/internal/osbuild2/stage.go
@@ -122,6 +122,8 @@ func (stage *Stage) UnmarshalJSON(data []byte) error {
 		options = new(PamLimitsConfStageOptions)
 	case "org.osbuild.truncate":
 		options = new(TruncateStageOptions)
+	case "org.osbuild.tuned":
+		options = new(TunedStageOptions)
 	case "org.osbuild.sfdisk":
 		options = new(SfdiskStageOptions)
 	case "org.osbuild.copy":

--- a/internal/osbuild2/stage.go
+++ b/internal/osbuild2/stage.go
@@ -91,6 +91,8 @@ func (stage *Stage) UnmarshalJSON(data []byte) error {
 		options = new(ScriptStageOptions)
 	case "org.osbuild.sysconfig":
 		options = new(SysconfigStageOptions)
+	case "org.osbuild.sysctld":
+		options = new(SysctldStageOptions)
 	case "org.osbuild.tmpfilesd":
 		options = new(TmpfilesdStageOptions)
 	case "org.osbuild.kernel-cmdline":

--- a/internal/osbuild2/stage.go
+++ b/internal/osbuild2/stage.go
@@ -69,6 +69,8 @@ func (stage *Stage) UnmarshalJSON(data []byte) error {
 		options = new(CloudInitStageOptions)
 	case "org.osbuild.chrony":
 		options = new(ChronyStageOptions)
+	case "org.osbuild.dnf.config":
+		options = new(DNFConfigStageOptions)
 	case "org.osbuild.dracut":
 		options = new(DracutStageOptions)
 	case "org.osbuild.dracut.conf":

--- a/internal/osbuild2/stage_test.go
+++ b/internal/osbuild2/stage_test.go
@@ -500,6 +500,27 @@ func TestStage_UnmarshalJSON(t *testing.T) {
 			},
 		},
 		{
+			name: "sysctld",
+			fields: fields{
+				Type: "org.osbuild.sysctld",
+				Options: &SysctldStageOptions{
+					Filename: "example.conf",
+					Config: []SysctldConfigLine{
+						{
+							Key:   "net.ipv4.conf.*.rp_filter",
+							Value: "2",
+						},
+						{
+							Key: "-net.ipv4.conf.all.rp_filter",
+						},
+					},
+				},
+			},
+			args: args{
+				data: []byte(`{"type":"org.osbuild.sysctld","options":{"filename":"example.conf","config":[{"key":"net.ipv4.conf.*.rp_filter","value":"2"},{"key":"-net.ipv4.conf.all.rp_filter"}]}}`),
+			},
+		},
+		{
 			name: "systemd",
 			fields: fields{
 				Type:    "org.osbuild.systemd",

--- a/internal/osbuild2/stage_test.go
+++ b/internal/osbuild2/stage_test.go
@@ -386,6 +386,29 @@ func TestStage_UnmarshalJSON(t *testing.T) {
 			},
 		},
 		{
+			name: "selinux.config-empty",
+			fields: fields{
+				Type:    "org.osbuild.selinux.config",
+				Options: &SELinuxConfigStageOptions{},
+			},
+			args: args{
+				data: []byte(`{"type":"org.osbuild.selinux.config","options":{}}`),
+			},
+		},
+		{
+			name: "selinux.config",
+			fields: fields{
+				Type: "org.osbuild.selinux.config",
+				Options: &SELinuxConfigStageOptions{
+					State: SELinuxStatePermissive,
+					Type:  SELinuxTypeMinimum,
+				},
+			},
+			args: args{
+				data: []byte(`{"type":"org.osbuild.selinux.config","options":{"state":"permissive","type":"minimum"}}`),
+			},
+		},
+		{
 			name: "sysconfig",
 			fields: fields{
 				Type:    "org.osbuild.sysconfig",

--- a/internal/osbuild2/stage_test.go
+++ b/internal/osbuild2/stage_test.go
@@ -137,6 +137,16 @@ func TestStage_UnmarshalJSON(t *testing.T) {
 			},
 		},
 		{
+			name: "dnf-config",
+			fields: fields{
+				Type:    "org.osbuild.dnf.config",
+				Options: &DNFConfigStageOptions{},
+			},
+			args: args{
+				data: []byte(`{"type":"org.osbuild.dnf.config","options":{}}`),
+			},
+		},
+		{
 			name: "dracut",
 			fields: fields{
 				Type:    "org.osbuild.dracut",

--- a/internal/osbuild2/stage_test.go
+++ b/internal/osbuild2/stage_test.go
@@ -329,6 +329,46 @@ func TestStage_UnmarshalJSON(t *testing.T) {
 			},
 		},
 		{
+			name: "pam-limits-conf-str",
+			fields: fields{
+				Type: "org.osbuild.pam.limits.conf",
+				Options: &PamLimitsConfStageOptions{
+					Filename: "example.conf",
+					Config: []PamLimitsConfigLine{
+						{
+							Domain: "user1",
+							Type:   PamLimitsTypeHard,
+							Item:   PamLimitsItemNofile,
+							Value:  PamLimitsValueUnlimited,
+						},
+					},
+				},
+			},
+			args: args{
+				data: []byte(`{"type":"org.osbuild.pam.limits.conf","options":{"filename":"example.conf","config":[{"domain":"user1","type":"hard","item":"nofile","value":"unlimited"}]}}`),
+			},
+		},
+		{
+			name: "pam-limits-conf-int",
+			fields: fields{
+				Type: "org.osbuild.pam.limits.conf",
+				Options: &PamLimitsConfStageOptions{
+					Filename: "example.conf",
+					Config: []PamLimitsConfigLine{
+						{
+							Domain: "user1",
+							Type:   PamLimitsTypeHard,
+							Item:   PamLimitsItemNofile,
+							Value:  PamLimitsValueInt(-1),
+						},
+					},
+				},
+			},
+			args: args{
+				data: []byte(`{"type":"org.osbuild.pam.limits.conf","options":{"filename":"example.conf","config":[{"domain":"user1","type":"hard","item":"nofile","value":-1}]}}`),
+			},
+		},
+		{
 			name: "rhsm-empty",
 			fields: fields{
 				Type:    "org.osbuild.rhsm",

--- a/internal/osbuild2/stage_test.go
+++ b/internal/osbuild2/stage_test.go
@@ -379,6 +379,18 @@ func TestStage_UnmarshalJSON(t *testing.T) {
 			},
 		},
 		{
+			name: "tuned",
+			fields: fields{
+				Type: "org.osbuild.tuned",
+				Options: &TunedStageOptions{
+					Profiles: []string{"sap-hana"},
+				},
+			},
+			args: args{
+				data: []byte(`{"type":"org.osbuild.tuned","options":{"profiles":["sap-hana"]}}`),
+			},
+		},
+		{
 			name: "rhsm-empty",
 			fields: fields{
 				Type:    "org.osbuild.rhsm",

--- a/internal/osbuild2/stage_test.go
+++ b/internal/osbuild2/stage_test.go
@@ -527,6 +527,24 @@ func TestStage_UnmarshalJSON(t *testing.T) {
 			},
 		},
 		{
+			name: "tmpfilesd",
+			fields: fields{
+				Type: "org.osbuild.tmpfilesd",
+				Options: &TmpfilesdStageOptions{
+					Filename: "example.conf",
+					Config: []TmpfilesdConfigLine{
+						{
+							Type: "d",
+							Path: "/tmp/my-example-path",
+						},
+					},
+				},
+			},
+			args: args{
+				data: []byte(`{"type":"org.osbuild.tmpfilesd","options":{"filename":"example.conf","config":[{"type":"d","path":"/tmp/my-example-path"}]}}`),
+			},
+		},
+		{
 			name: "users",
 			fields: fields{
 				Type:    "org.osbuild.users",

--- a/internal/osbuild2/sysctld_stage.go
+++ b/internal/osbuild2/sysctld_stage.go
@@ -1,0 +1,66 @@
+package osbuild2
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// SysctldStageOptions represents a single sysctl.d configuration file.
+type SysctldStageOptions struct {
+	// Filename of the configuration file to be created. Must end with '.conf'.
+	Filename string `json:"filename"`
+	// List of configuration directives. The list must contain at least one item.
+	Config []SysctldConfigLine `json:"config"`
+}
+
+func (SysctldStageOptions) isStageOptions() {}
+
+// NewSysctldStageOptions creates a new PamLimitsConf Stage options object.
+func NewSysctldStageOptions(filename string, config []SysctldConfigLine) *SysctldStageOptions {
+	return &SysctldStageOptions{
+		Filename: filename,
+		Config:   config,
+	}
+}
+
+// Unexported alias for use in SysctldStageOptions's MarshalJSON() to prevent recursion
+type sysctldStageOptions SysctldStageOptions
+
+func (o SysctldStageOptions) MarshalJSON() ([]byte, error) {
+	if len(o.Config) == 0 {
+		return nil, fmt.Errorf("the 'Config' list must contain at least one item")
+	}
+	options := sysctldStageOptions(o)
+	return json.Marshal(options)
+}
+
+// NewSysctldStage creates a new Sysctld Stage object.
+func NewSysctldStage(options *SysctldStageOptions) *Stage {
+	return &Stage{
+		Type:    "org.osbuild.sysctld",
+		Options: options,
+	}
+}
+
+// SysctldConfigLine represents a single line in a sysctl.d configuration.
+type SysctldConfigLine struct {
+	// Kernel parameter name.
+	// If the string starts with "-" and the Value is not set,
+	// then the key is excluded from being set by a matching glob.
+	Key string `json:"key"`
+	// Kernel parameter value.
+	// Must be set, unless the Key value starts with "-".
+	Value string `json:"value,omitempty"`
+}
+
+// Unexported alias for use in SysctldConfigLine's MarshalJSON() to prevent recursion.
+type sysctldConfigLine SysctldConfigLine
+
+func (l SysctldConfigLine) MarshalJSON() ([]byte, error) {
+	if l.Value == "" && !strings.HasPrefix(l.Key, "-") {
+		return nil, fmt.Errorf("only Keys starting with '-' can have an empty Value")
+	}
+	line := sysctldConfigLine(l)
+	return json.Marshal(line)
+}

--- a/internal/osbuild2/sysctld_stage_test.go
+++ b/internal/osbuild2/sysctld_stage_test.go
@@ -1,0 +1,70 @@
+package osbuild2
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewSysctldStageOptions(t *testing.T) {
+	filename := "example.conf"
+	config := []SysctldConfigLine{{
+		Key:   "net.ipv4.conf.default.rp_filter",
+		Value: "2",
+	}}
+
+	expectedOptions := &SysctldStageOptions{
+		Filename: filename,
+		Config:   config,
+	}
+	actualOptions := NewSysctldStageOptions(filename, config)
+	assert.Equal(t, expectedOptions, actualOptions)
+}
+
+func TestNewSysctldStage(t *testing.T) {
+	expectedStage := &Stage{
+		Type:    "org.osbuild.sysctld",
+		Options: &SysctldStageOptions{},
+	}
+	actualStage := NewSysctldStage(&SysctldStageOptions{})
+	assert.Equal(t, expectedStage, actualStage)
+}
+
+func TestSysctldStageOptions_MarshalJSON_Invalid(t *testing.T) {
+	tests := []struct {
+		name    string
+		options SysctldStageOptions
+	}{
+		{
+			name:    "empty-options",
+			options: SysctldStageOptions{},
+		},
+	}
+	for idx, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotBytes, err := json.Marshal(tt.options)
+			assert.NotNilf(t, err, "json.Marshal() didn't return an error, but: %s [idx: %d]", string(gotBytes), idx)
+		})
+	}
+}
+
+func TestSysctldConfigLine_MarshalJSON_Invalid(t *testing.T) {
+	tests := []struct {
+		name    string
+		options SysctldConfigLine
+	}{
+		{
+			name: "no-value-without-prefix",
+			options: SysctldConfigLine{
+				Key: "key-without-prefix",
+			},
+		},
+	}
+	for idx, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotBytes, err := json.Marshal(tt.options)
+			assert.NotNilf(t, err, "json.Marshal() didn't return an error, but: %s [idx: %d]", string(gotBytes), idx)
+		})
+	}
+}

--- a/internal/osbuild2/tmpfilesd_stage.go
+++ b/internal/osbuild2/tmpfilesd_stage.go
@@ -1,0 +1,61 @@
+package osbuild2
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// TmpfilesdStageOptions represents a single tmpfiles.d configuration file.
+type TmpfilesdStageOptions struct {
+	// Filename of the configuration file to be created. Must end with '.conf'.
+	Filename string `json:"filename"`
+	// List of configuration directives. The list must contain at least one item.
+	Config []TmpfilesdConfigLine `json:"config"`
+}
+
+func (TmpfilesdStageOptions) isStageOptions() {}
+
+// NewTmpfilesdStageOptions creates a new Tmpfilesd Stage options object.
+func NewTmpfilesdStageOptions(filename string, config []TmpfilesdConfigLine) *TmpfilesdStageOptions {
+	return &TmpfilesdStageOptions{
+		Filename: filename,
+		Config:   config,
+	}
+}
+
+// Unexported alias for use in TmpfilesdStageOptions's MarshalJSON() to prevent recursion
+type tmpfilesdStageOptions TmpfilesdStageOptions
+
+func (o TmpfilesdStageOptions) MarshalJSON() ([]byte, error) {
+	if len(o.Config) == 0 {
+		return nil, fmt.Errorf("the 'Config' list must contain at least one item")
+	}
+	options := tmpfilesdStageOptions(o)
+	return json.Marshal(options)
+}
+
+// NewTmpfilesdStage creates a new Tmpfilesd Stage object.
+func NewTmpfilesdStage(options *TmpfilesdStageOptions) *Stage {
+	return &Stage{
+		Type:    "org.osbuild.tmpfilesd",
+		Options: options,
+	}
+}
+
+// TmpfilesdConfigLine represents a single line in a tmpfiles.d configuration.
+type TmpfilesdConfigLine struct {
+	// The file system path type
+	Type string `json:"type"`
+	// Absolute file system path
+	Path string `json:"path"`
+	// The file access mode when creating the file or directory
+	Mode string `json:"mode,omitempty"`
+	// The user to use for the file or directory
+	User string `json:"user,omitempty"`
+	// The group to use for the file or directory
+	Group string `json:"group,omitempty"`
+	// Date field used to decide what files to delete when cleaning
+	Age string `json:"age,omitempty"`
+	// Argument with its meaning being specific to the path type
+	Argument string `json:"argument,omitempty"`
+}

--- a/internal/osbuild2/tmpfilesd_stage_test.go
+++ b/internal/osbuild2/tmpfilesd_stage_test.go
@@ -1,0 +1,50 @@
+package osbuild2
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewTmpfilesdStageOptions(t *testing.T) {
+	filename := "example.conf"
+	config := []TmpfilesdConfigLine{{
+		Type: "d",
+		Path: "/tmp/my-example-path",
+	}}
+
+	expectedOptions := &TmpfilesdStageOptions{
+		Filename: filename,
+		Config:   config,
+	}
+	actualOptions := NewTmpfilesdStageOptions(filename, config)
+	assert.Equal(t, expectedOptions, actualOptions)
+}
+
+func TestNewTmpfilesdStage(t *testing.T) {
+	expectedStage := &Stage{
+		Type:    "org.osbuild.tmpfilesd",
+		Options: &TmpfilesdStageOptions{},
+	}
+	actualStage := NewTmpfilesdStage(&TmpfilesdStageOptions{})
+	assert.Equal(t, expectedStage, actualStage)
+}
+
+func TestTmpfilesdStageOptions_MarshalJSON_Invalid(t *testing.T) {
+	tests := []struct {
+		name    string
+		options TmpfilesdStageOptions
+	}{
+		{
+			name:    "empty-options",
+			options: TmpfilesdStageOptions{},
+		},
+	}
+	for idx, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotBytes, err := json.Marshal(tt.options)
+			assert.NotNilf(t, err, "json.Marshal() didn't return an error, but: %s [idx: %d]", string(gotBytes), idx)
+		})
+	}
+}

--- a/internal/osbuild2/tuned_stage.go
+++ b/internal/osbuild2/tuned_stage.go
@@ -1,0 +1,40 @@
+package osbuild2
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// TunedStageOptions represents manually set TuneD profiles.
+type TunedStageOptions struct {
+	// List of TuneD profiles to apply.
+	Profiles []string `json:"profiles"`
+}
+
+func (TunedStageOptions) isStageOptions() {}
+
+// NewTunedStageOptions creates a new TuneD Stage options object.
+func NewTunedStageOptions(profiles ...string) *TunedStageOptions {
+	return &TunedStageOptions{
+		Profiles: profiles,
+	}
+}
+
+// Unexported alias for use in TunedStageOptions's MarshalJSON() to prevent recursion
+type tunedStageOptions TunedStageOptions
+
+func (o TunedStageOptions) MarshalJSON() ([]byte, error) {
+	if len(o.Profiles) == 0 {
+		return nil, fmt.Errorf("at least one Profile must be provided")
+	}
+	options := tunedStageOptions(o)
+	return json.Marshal(options)
+}
+
+// NewTunedStage creates a new TuneD Stage object.
+func NewTunedStage(options *TunedStageOptions) *Stage {
+	return &Stage{
+		Type:    "org.osbuild.tuned",
+		Options: options,
+	}
+}

--- a/internal/osbuild2/tuned_stage_test.go
+++ b/internal/osbuild2/tuned_stage_test.go
@@ -1,0 +1,59 @@
+package osbuild2
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewTunedStageOptions(t *testing.T) {
+	tests := []struct {
+		profiles        []string
+		expectedOptions *TunedStageOptions
+	}{
+		{
+			profiles:        []string{"balanced"},
+			expectedOptions: &TunedStageOptions{Profiles: []string{"balanced"}},
+		},
+		{
+			profiles:        []string{"balanced", "sap-hana"},
+			expectedOptions: &TunedStageOptions{Profiles: []string{"balanced", "sap-hana"}},
+		},
+	}
+
+	for idx, tt := range tests {
+		t.Run(fmt.Sprint(idx), func(t *testing.T) {
+			actualOptions := NewTunedStageOptions(tt.profiles...)
+			assert.Equalf(t, tt.expectedOptions, actualOptions, "NewTunedStageOptions() failed [idx: %d]", idx)
+		})
+	}
+}
+
+func TestNewTunedStage(t *testing.T) {
+	expectedStage := &Stage{
+		Type:    "org.osbuild.tuned",
+		Options: &TunedStageOptions{},
+	}
+	actualStage := NewTunedStage(&TunedStageOptions{})
+	assert.Equal(t, expectedStage, actualStage)
+}
+
+func TestTunedStageOptions_MarshalJSON_Invalid(t *testing.T) {
+	tests := []struct {
+		name    string
+		options TunedStageOptions
+	}{
+		{
+			name:    "empty-options",
+			options: TunedStageOptions{},
+		},
+	}
+	for idx, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotBytes, err := json.Marshal(tt.options)
+			assert.NotNilf(t, err, "json.Marshal() didn't return an error, but: %s [idx: %d]", string(gotBytes), idx)
+		})
+	}
+}


### PR DESCRIPTION
Add support for the following osbuild stages:
- `org.osbuild.selinux.config` - https://github.com/osbuild/osbuild/pull/799
- `org.osbuild.tmpfilesd` - https://github.com/osbuild/osbuild/pull/801
- `org.osbuild.pam.limits.conf` - https://github.com/osbuild/osbuild/pull/802, https://github.com/osbuild/osbuild/pull/807
- `org.osbuild.sysctld` - https://github.com/osbuild/osbuild/pull/804
- `org.osbuild.dnf.config` - https://github.com/osbuild/osbuild/pull/798
- `org.osbuild.tuned` - https://github.com/osbuild/osbuild/pull/797

**The required osbuild version in SPEC file was not updated, because the new stages are not yet used by any image type.**

This pull request includes:

- [x] adequate testing for the new functionality or fixed issue
  - added unit tests for all new stages
- [x] adequate documentation informing people about the change such as
  - [x] create a file in [news/unreleased](https://github.com/osbuild/osbuild-composer/tree/main/docs/news/unreleased) directory if this change should be mentioned in the release news
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

For user-visible changes, "adequate documentation" is an entry describing the
change for users in docs/news. Please refer to docs/news/README.md for details.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`
-->
