### PR TITLE
internal/common: introduce constants that are set during the build time

### DIFF
--- a/internal/common/constants.go
+++ b/internal/common/constants.go
@@ -1,0 +1,27 @@
+package common
+
+import "fmt"
+
+// These constants are set during buildtime using additional
+// compiler flags. Not all of them are necessarily defined
+// because RPMs can be build from a tarball and spec file without
+// being in a git repository. On the other hand when building
+// composer inside of a container, there is no RPM layer so in
+// that case the RPM version doesn't exist at all.
+var (
+	// Git revision from which this code was built
+	GitRev = "undefined"
+
+	// RPM Version
+	RpmVersion = "undefined"
+)
+
+func BuildVersion() string {
+	if GitRev != "undefined" {
+		return fmt.Sprintf("git-rev:%s", GitRev)
+	} else if RpmVersion != "undefined" {
+		return fmt.Sprintf("NEVRA:%s", RpmVersion)
+	} else {
+		return "devel"
+	}
+}

--- a/internal/weldr/api.go
+++ b/internal/weldr/api.go
@@ -561,7 +561,7 @@ func (api *API) statusHandler(writer http.ResponseWriter, request *http.Request,
 		DBVersion:     "0",
 		SchemaVersion: "0",
 		Backend:       "osbuild-composer",
-		Build:         "devel",
+		Build:         common.BuildVersion(),
 		Messages:      make([]string, 0),
 	})
 	common.PanicOnError(err)

--- a/osbuild-composer.spec
+++ b/osbuild-composer.spec
@@ -124,6 +124,14 @@ export GOPATH=$GO_BUILD_PATH:%{gopath}
 export GOFLAGS=-mod=vendor
 %endif
 
+# Set the commit hash so that composer can report what source version
+# was used to build it. This has to be set explicitly when calling rpmbuild,
+# this script will not attempt to automatically discover it.
+%if %{?commit:1}0
+export LDFLAGS="${LDFLAGS} -X 'github.com/osbuild/osbuild-composer/internal/common.GitRev=%{commit}'"
+%endif
+export LDFLAGS="${LDFLAGS} -X 'github.com/osbuild/osbuild-composer/internal/common.RpmVersion=%{name}-%{epoch}:%{version}-%{release}.%{_arch}'"
+
 %gobuild -o _bin/osbuild-composer %{goipath}/cmd/osbuild-composer
 %gobuild -o _bin/osbuild-worker %{goipath}/cmd/osbuild-worker
 


### PR DESCRIPTION
See individual commits.

This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] create a file in [news/unreleased](https://github.com/osbuild/osbuild-composer/tree/main/docs/news/unreleased) directory if this change should be mentioned in the release news
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

For user-visible changes, "adequate documentation" is an entry describing the
change for users in docs/news. Please refer to docs/news/README.md for details.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`
-->
