### PR TITLE
distro/rhel90: re-include nss-altfiles for edge

### DIFF
--- a/internal/distro/rhel90/package_sets.go
+++ b/internal/distro/rhel90/package_sets.go
@@ -233,7 +233,7 @@ func edgeCommitPackageSet() rpmmd.PackageSet {
 	return rpmmd.PackageSet{
 		Include: []string{
 			"redhat-release", "glibc", "glibc-minimal-langpack",
-			/*"nss-altfiles", see rhbz#1916260 */ "dracut-config-generic", "dracut-network",
+			"nss-altfiles", "dracut-config-generic", "dracut-network",
 			"basesystem", "bash", "platform-python", "shadow-utils", "chrony",
 			"setup", "shadow-utils", "sudo", "systemd", "coreutils",
 			"util-linux", "curl", "vim-minimal", "rpm", "rpm-ostree", "polkit",

--- a/test/data/manifests/rhel_90-aarch64-edge_commit-boot.json
+++ b/test/data/manifests/rhel_90-aarch64-edge_commit-boot.json
@@ -615,6 +615,7 @@
                   "sha256:48f54283e14169425e68b87180435123af1906bd12c6631895d48106f5e841c9",
                   "sha256:7f3874f19f5af6867d7d9ff0a34442f4d92c153c139a1c0a058c7e3ae4ce1e7a",
                   "sha256:8a46cffbaee57de4881ef8c746195cb4da090ae0544bf90cf346dcfe3f322f4d",
+                  "sha256:d12649d69a0a7088ee0663735ce9aa6f05ae710aefe1391004cb1cb424dbdf40",
                   "sha256:785dba3e8f6c225e5a6eb5ae410c03e19c890573d010a368b754bb83e606ce94",
                   "sha256:2a399fa929245800ed68c8febee80ca2e1c20a08e92f9cd8c73e2cdd3aa04490",
                   "sha256:0f72fb02c99abc767b209829f3ebba2fe62c908a5d58317d3243f17ebd183709",
@@ -1830,6 +1831,9 @@
           },
           "sha256:d0b15c7dbe30b7890b86d77dcde6034409c9604809ff103ab54597f4a09aff28": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-appstream-n9.0-20210827/Packages/libblockdev-fs-2.25-7.el9.aarch64.rpm"
+          },
+          "sha256:d12649d69a0a7088ee0663735ce9aa6f05ae710aefe1391004cb1cb424dbdf40": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-appstream-n9.0-20210827/Packages/nss-altfiles-2.18.1-20.el9.aarch64.rpm"
           },
           "sha256:d165d14d89664d4e60cadc3625d5a76735a8c47043d9da3e3808ed44a90aeeeb": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20210827/Packages/python3-libs-3.9.6-6.el9.aarch64.rpm"
@@ -7950,6 +7954,15 @@
         "checksum": "sha256:8a46cffbaee57de4881ef8c746195cb4da090ae0544bf90cf346dcfe3f322f4d"
       },
       {
+        "name": "nss-altfiles",
+        "epoch": 0,
+        "version": "2.18.1",
+        "release": "20.el9",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-appstream-n9.0-20210827/Packages/nss-altfiles-2.18.1-20.el9.aarch64.rpm",
+        "checksum": "sha256:d12649d69a0a7088ee0663735ce9aa6f05ae710aefe1391004cb1cb424dbdf40"
+      },
+      {
         "name": "nss-softokn",
         "epoch": 0,
         "version": "3.67.0",
@@ -8575,6 +8588,7 @@
       "npth-1.6-8.el9.aarch64",
       "nspr-4.31.0-5.el9.aarch64",
       "nss-3.67.0-8.el9.aarch64",
+      "nss-altfiles-2.18.1-20.el9.aarch64",
       "nss-softokn-3.67.0-8.el9.aarch64",
       "nss-softokn-freebl-3.67.0-8.el9.aarch64",
       "nss-sysinit-3.67.0-8.el9.aarch64",

--- a/test/data/manifests/rhel_90-x86_64-edge_commit-boot.json
+++ b/test/data/manifests/rhel_90-x86_64-edge_commit-boot.json
@@ -650,6 +650,7 @@
                   "sha256:731b91b14eb7bc79961d02940db4fe2f8644c6c5d5005bd3c62cc3830443b692",
                   "sha256:22bee502caf00522d7e3733699502e9d109d1a884c3006ee212e900101b07231",
                   "sha256:ad91a2693eae9b8159810a59526a22e0f9518d79d4845f81531331dd6cbac36d",
+                  "sha256:0178538e8a7935d1418e78f74c58880239ad3e8eab94638af562a128ad133e20",
                   "sha256:f31d17d77b9b35e6907b1803e47cede1d3d552d5cb45d46d940d4bd57d28dac5",
                   "sha256:925973b321b7f87ddba9ca957f75ba6585d95a1b2604fe880a05ef1d3621c50a",
                   "sha256:6e5a2b51da0bfecbbc0f11fc023eb17f4fcaf70f23ada1294ba4be8b33bda125",
@@ -914,6 +915,9 @@
           },
           "sha256:01619e0b96181bff3b990016a5857b9d8859b7a4887d8c120b6f60c688bac526": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20210827/Packages/npth-1.6-8.el9.x86_64.rpm"
+          },
+          "sha256:0178538e8a7935d1418e78f74c58880239ad3e8eab94638af562a128ad133e20": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20210827/Packages/nss-altfiles-2.18.1-20.el9.x86_64.rpm"
           },
           "sha256:02c6622480af52421fc2e54be42b8dd1ce6502e237c9a4e8231ae587b49767e3": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20210827/Packages/zlib-1.2.11-31.el9.x86_64.rpm"
@@ -8300,6 +8304,15 @@
         "checksum": "sha256:ad91a2693eae9b8159810a59526a22e0f9518d79d4845f81531331dd6cbac36d"
       },
       {
+        "name": "nss-altfiles",
+        "epoch": 0,
+        "version": "2.18.1",
+        "release": "20.el9",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20210827/Packages/nss-altfiles-2.18.1-20.el9.x86_64.rpm",
+        "checksum": "sha256:0178538e8a7935d1418e78f74c58880239ad3e8eab94638af562a128ad133e20"
+      },
+      {
         "name": "nss-softokn",
         "epoch": 0,
         "version": "3.67.0",
@@ -8931,6 +8944,7 @@
       "npth-1.6-8.el9.x86_64",
       "nspr-4.31.0-5.el9.x86_64",
       "nss-3.67.0-8.el9.x86_64",
+      "nss-altfiles-2.18.1-20.el9.x86_64",
       "nss-softokn-3.67.0-8.el9.x86_64",
       "nss-softokn-freebl-3.67.0-8.el9.x86_64",
       "nss-sysinit-3.67.0-8.el9.x86_64",

--- a/test/data/manifests/rhel_90-x86_64-edge_commit_rt-boot.json
+++ b/test/data/manifests/rhel_90-x86_64-edge_commit_rt-boot.json
@@ -29,6 +29,9 @@
       }
     }
   },
+  "supported_arches": [
+    "x86_64"
+  ],
   "manifest": {
     "version": "2",
     "pipelines": [
@@ -703,6 +706,7 @@
                   "sha256:731b91b14eb7bc79961d02940db4fe2f8644c6c5d5005bd3c62cc3830443b692",
                   "sha256:22bee502caf00522d7e3733699502e9d109d1a884c3006ee212e900101b07231",
                   "sha256:ad91a2693eae9b8159810a59526a22e0f9518d79d4845f81531331dd6cbac36d",
+                  "sha256:0178538e8a7935d1418e78f74c58880239ad3e8eab94638af562a128ad133e20",
                   "sha256:f31d17d77b9b35e6907b1803e47cede1d3d552d5cb45d46d940d4bd57d28dac5",
                   "sha256:925973b321b7f87ddba9ca957f75ba6585d95a1b2604fe880a05ef1d3621c50a",
                   "sha256:6e5a2b51da0bfecbbc0f11fc023eb17f4fcaf70f23ada1294ba4be8b33bda125",
@@ -1119,6 +1123,9 @@
           },
           "sha256:01619e0b96181bff3b990016a5857b9d8859b7a4887d8c120b6f60c688bac526": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20210827/Packages/npth-1.6-8.el9.x86_64.rpm"
+          },
+          "sha256:0178538e8a7935d1418e78f74c58880239ad3e8eab94638af562a128ad133e20": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20210827/Packages/nss-altfiles-2.18.1-20.el9.x86_64.rpm"
           },
           "sha256:02c6622480af52421fc2e54be42b8dd1ce6502e237c9a4e8231ae587b49767e3": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20210827/Packages/zlib-1.2.11-31.el9.x86_64.rpm"
@@ -10305,6 +10312,15 @@
         "checksum": "sha256:ad91a2693eae9b8159810a59526a22e0f9518d79d4845f81531331dd6cbac36d"
       },
       {
+        "name": "nss-altfiles",
+        "epoch": 0,
+        "version": "2.18.1",
+        "release": "20.el9",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20210827/Packages/nss-altfiles-2.18.1-20.el9.x86_64.rpm",
+        "checksum": "sha256:0178538e8a7935d1418e78f74c58880239ad3e8eab94638af562a128ad133e20"
+      },
+      {
         "name": "nss-softokn",
         "epoch": 0,
         "version": "3.67.0",
@@ -11068,6 +11084,7 @@
       "npth-1.6-8.el9.x86_64",
       "nspr-4.31.0-5.el9.x86_64",
       "nss-3.67.0-8.el9.x86_64",
+      "nss-altfiles-2.18.1-20.el9.x86_64",
       "nss-softokn-3.67.0-8.el9.x86_64",
       "nss-softokn-freebl-3.67.0-8.el9.x86_64",
       "nss-sysinit-3.67.0-8.el9.x86_64",


### PR DESCRIPTION
The `nss-altfiles` package is actually needed for OSTree based systems, since in those the user/groups database is located in the /usr/lib directory (in addition to /etc). It was removed because it was not available in RHEL 9 (rhbz#1916260). This has been fixed, so we need to re-include the package.


This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] create a file in [news/unreleased](https://github.com/osbuild/osbuild-composer/tree/main/docs/news/unreleased) directory if this change should be mentioned in the release news
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/
