### PR TITLE
weldr: deleting an unknown source should return an error

### DIFF
--- a/internal/weldr/api.go
+++ b/internal/weldr/api.go
@@ -948,6 +948,17 @@ func (api *API) sourceDeleteHandler(writer http.ResponseWriter, request *http.Re
 		}
 	}
 
+	// Return an error for unknown sources
+	s := api.store.GetSource(name[0][1:])
+	if s == nil {
+		errors := responseError{
+			ID:  "UnknownSource",
+			Msg: name[0][1:] + " is not a valid source.",
+		}
+		statusResponseError(writer, http.StatusBadRequest, errors)
+		return
+	}
+
 	// Only delete the first name, which will have a / at the start because of the /*source route
 	if isRequestVersionAtLeast(params, 1) {
 		api.store.DeleteSourceByID(name[0][1:])

--- a/internal/weldr/api_test.go
+++ b/internal/weldr/api_test.go
@@ -1334,6 +1334,7 @@ func TestSourcesDelete(t *testing.T) {
 	}{
 		{"DELETE", "/api/v0/projects/source/delete/", ``, http.StatusNotFound, `{"status":false,"errors":[{"code":404,"id":"HTTPError","msg":"Not Found"}]}`},
 		{"DELETE", "/api/v0/projects/source/delete/fish", ``, http.StatusOK, `{"status":true}`},
+		{"DELETE", "/api/v0/projects/source/delete/unknown", ``, http.StatusBadRequest, `{"status":false,"errors":[{"id":"UnknownSource","msg":"unknown is not a valid source."}]}`},
 	}
 
 	tempdir, err := ioutil.TempDir("", "weldr-tests-")


### PR DESCRIPTION
This adds a check to see if the source is valid and returns a 400 error
if it doesn't exist.


This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] create a file in [news/unreleased](https://github.com/osbuild/osbuild-composer/tree/main/docs/news/unreleased) directory if this change should be mentioned in the release news
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/
