### PR TITLE
generate-test-cases: check `supported_arches` from format-request-map.json`

### DIFF
--- a/tools/test-case-generators/format-request-map.json
+++ b/tools/test-case-generators/format-request-map.json
@@ -69,7 +69,8 @@
         }
       }
     },
-    "overrides": {}
+    "overrides": {},
+    "supported_arches": ["x86_64"]
   },
   "rhel-edge-commit": {
     "compose-request": {
@@ -108,7 +109,8 @@
         }
       }
     },
-    "overrides": {}
+    "overrides": {},
+    "supported_arches": ["x86_64"]
   },
   "fedora-iot-commit": {
     "compose-request": {

--- a/tools/test-case-generators/generate-test-cases
+++ b/tools/test-case-generators/generate-test-cases
@@ -242,6 +242,11 @@ def main(distro, arch, image_types, keep_image_info, store, output, with_customi
         if filtered_request["compose-request"]["image-type"] not in image_types:
                 continue
         filtered_request["compose-request"]["distro"] = distro
+        # if the compose-request has specified supported arches, then generate
+        # the test case only if the requested arch is in the list
+        supported_arches = filtered_request.get("supported_arches")
+        if supported_arches is not None and arch not in supported_arches:
+            continue
         filtered_request["compose-request"]["arch"] = arch
         filtered_request["compose-request"]["repositories"] = repos_dict[distro][arch]
 


### PR DESCRIPTION
Some image type test cases require additional repositories, which are
not available for all architectures. However, when an image type test
case is specified in the `format-request-map.json`, it is generated on any
architecture.

This behavior is creating issues when generating `*edge-commit` image
type test cases. This is because the `format-request-map.json` contains one
additional definition for `*edge-commit-rt`, which includes `kernel-rt`
package. However repositories with this package are available only for
x86_64. Therefore, when generating image test cases for `*edge-commit`,
the `generate-test-cases` script always generates two test cases,
but the generation of `*edge-commit-rt` always fails on non-x86_64
architectures.

Add a new optional member to the image type test case object in
`format-request-map.json`, called `supported_arches`. Its value is a
list of strings, specifying the supported architectures of the image
type test case. In case the member is not specified, the image test
case is supported on any architecture.

Extend the `generate-test-cases` script to skip image type test case
generation in case the case has the `supported_arches` specified and the
requested architecture is not in the list.

Fix #1478

Signed-off-by: Tomas Hozza <thozza@redhat.com>


This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] create a file in [news/unreleased](https://github.com/osbuild/osbuild-composer/tree/main/docs/news/unreleased) directory if this change should be mentioned in the release news
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

For user-visible changes, "adequate documentation" is an entry describing the
change for users in docs/news. Please refer to docs/news/README.md for details.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`
-->
