### PR TITLE
api/cloud: Move depsolving to workers

### DIFF
--- a/cmd/osbuild-worker/jobimpl-depsolve.go
+++ b/cmd/osbuild-worker/jobimpl-depsolve.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/osbuild/osbuild-composer/internal/rpmmd"
+	"github.com/osbuild/osbuild-composer/internal/worker"
+)
+
+type DepsolveJobImpl struct {
+	RPMMD rpmmd.RPMMD
+}
+
+func (impl *DepsolveJobImpl) depsolve(packageSets map[string]rpmmd.PackageSet, repos []rpmmd.RepoConfig, modulePlatformID, arch, releasever string) (map[string][]rpmmd.PackageSpec, error) {
+	packageSpecs := make(map[string][]rpmmd.PackageSpec)
+	for name, packageSet := range packageSets {
+		packageSpec, _, err := impl.RPMMD.Depsolve(packageSet, repos, modulePlatformID, arch, releasever)
+		if err != nil {
+			return nil, err
+		}
+		packageSpecs[name] = packageSpec
+	}
+	return packageSpecs, nil
+}
+
+func (impl *DepsolveJobImpl) Run(job worker.Job) error {
+	var args worker.DepsolveJob
+	err := job.Args(&args)
+	if err != nil {
+		return err
+	}
+
+	var result worker.DepsolveJobResult
+	result.PackageSpecs, err = impl.depsolve(args.PackageSets, args.Repos, args.ModulePlatformID, args.Arch, args.Releasever)
+	if err != nil {
+		result.Error = err.Error()
+	}
+
+	err = job.Update(&result)
+	if err != nil {
+		return fmt.Errorf("Error reporting job result: %v", err)
+	}
+
+	return nil
+}

--- a/cmd/osbuild-worker/jobimpl-depsolve.go
+++ b/cmd/osbuild-worker/jobimpl-depsolve.go
@@ -33,6 +33,12 @@ func (impl *DepsolveJobImpl) Run(job worker.Job) error {
 	var result worker.DepsolveJobResult
 	result.PackageSpecs, err = impl.depsolve(args.PackageSets, args.Repos, args.ModulePlatformID, args.Arch, args.Releasever)
 	if err != nil {
+		switch err.(type) {
+		case *rpmmd.DNFError:
+			result.ErrorType = worker.DepsolveErrorType
+		case error:
+			result.ErrorType = worker.OtherErrorType
+		}
 		result.Error = err.Error()
 	}
 

--- a/cmd/osbuild-worker/main.go
+++ b/cmd/osbuild-worker/main.go
@@ -18,6 +18,7 @@ import (
 	"github.com/BurntSushi/toml"
 
 	"github.com/osbuild/osbuild-composer/internal/common"
+	"github.com/osbuild/osbuild-composer/internal/rpmmd"
 	"github.com/osbuild/osbuild-composer/internal/upload/azure"
 	"github.com/osbuild/osbuild-composer/internal/upload/koji"
 	"github.com/osbuild/osbuild-composer/internal/worker"
@@ -131,6 +132,7 @@ func main() {
 		log.Fatal("CACHE_DIRECTORY is not set. Is the service file missing CacheDirectory=?")
 	}
 	store := path.Join(cacheDirectory, "osbuild-store")
+	rpmmd_cache := path.Join(cacheDirectory, "rpmmd")
 	output := path.Join(cacheDirectory, "output")
 	_ = os.Mkdir(output, os.ModeDir)
 
@@ -236,6 +238,9 @@ func main() {
 		},
 		"koji-finalize": &KojiFinalizeJobImpl{
 			KojiServers: kojiServers,
+		},
+		"depsolve": &DepsolveJobImpl{
+			RPMMD: rpmmd.NewRPMMD(rpmmd_cache, "/usr/libexec/osbuild-composer/dnf-json"),
 		},
 	}
 

--- a/internal/cloudapi/v2/errors.go
+++ b/internal/cloudapi/v2/errors.go
@@ -51,6 +51,8 @@ const (
 	ErrorUnknownManifestVersion                   ServiceErrorCode = 1010
 	ErrorUnableToConvertOSTreeCommitStageMetadata ServiceErrorCode = 1011
 	ErrorMalformedOSBuildJobResult                ServiceErrorCode = 1012
+	ErrorGettingDepsolveJobStatus                 ServiceErrorCode = 1013
+	ErrorDepsolveJobCanceled                      ServiceErrorCode = 1014
 
 	// Errors contained within this file
 	ErrorUnspecified          ServiceErrorCode = 10000
@@ -109,6 +111,8 @@ func getServiceErrors() serviceErrors {
 		serviceError{ErrorUnknownManifestVersion, http.StatusInternalServerError, "Unknown manifest version"},
 		serviceError{ErrorUnableToConvertOSTreeCommitStageMetadata, http.StatusInternalServerError, "Unable to convert ostree commit stage metadata"},
 		serviceError{ErrorMalformedOSBuildJobResult, http.StatusInternalServerError, "OSBuildJobResult does not have expected fields set"},
+		serviceError{ErrorGettingDepsolveJobStatus, http.StatusInternalServerError, "Unable to get depsolve job status"},
+		serviceError{ErrorDepsolveJobCanceled, http.StatusInternalServerError, "Depsolve job was cancelled"},
 
 		serviceError{ErrorUnspecified, http.StatusInternalServerError, "Unspecified internal error "},
 		serviceError{ErrorNotHTTPError, http.StatusInternalServerError, "Error is not an instance of HTTPError"},

--- a/internal/cloudapi/v2/v2_test.go
+++ b/internal/cloudapi/v2/v2_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -19,7 +20,7 @@ import (
 	"github.com/osbuild/osbuild-composer/internal/worker"
 )
 
-func newV2Server(t *testing.T, dir string) (*v2.Server, *worker.Server) {
+func newV2Server(t *testing.T, dir string) (*v2.Server, *worker.Server, context.CancelFunc) {
 	rpmFixture := rpmmd_mock.BaseFixture(dir)
 	rpm := rpmmd_mock.NewRPMMDMock(rpmFixture)
 	require.NotNil(t, rpm)
@@ -31,14 +32,38 @@ func newV2Server(t *testing.T, dir string) (*v2.Server, *worker.Server) {
 	v2Server := v2.NewServer(rpmFixture.Workers, rpm, distros)
 	require.NotNil(t, v2Server)
 
-	return v2Server, rpmFixture.Workers
+	// start a routine which just completes depsolve jobs
+	depsolveContext, cancel := context.WithCancel(context.Background())
+	go func() {
+		for {
+			ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(50*time.Millisecond))
+			defer cancel()
+			_, token, _, _, _, err := rpmFixture.Workers.RequestJob(ctx, test_distro.TestDistroName, []string{"depsolve"})
+			if err != nil {
+				continue
+			}
+			rawMsg, err := json.Marshal(&worker.DepsolveJobResult{PackageSpecs: nil, Error: "", ErrorType: worker.ErrorType("")})
+			require.NoError(t, err)
+			require.NoError(t, rpmFixture.Workers.FinishJob(token, rawMsg))
+
+			select {
+			case <-depsolveContext.Done():
+				return
+			default:
+				continue
+			}
+		}
+	}()
+
+	return v2Server, rpmFixture.Workers, cancel
 }
 
 func TestUnknownRoute(t *testing.T) {
 	dir, err := ioutil.TempDir("", "osbuild-composer-test-api-v2-")
 	require.NoError(t, err)
 	defer os.RemoveAll(dir)
-	srv, _ := newV2Server(t, dir)
+	srv, _, cancel := newV2Server(t, dir)
+	defer cancel()
 
 	test.TestRoute(t, srv.Handler("/api/composer/v2"), false, "GET", "/api/composer/v2/badroute", ``, http.StatusNotFound, `
 	{
@@ -54,7 +79,8 @@ func TestGetError(t *testing.T) {
 	dir, err := ioutil.TempDir("", "osbuild-composer-test-api-v2-")
 	require.NoError(t, err)
 	defer os.RemoveAll(dir)
-	srv, _ := newV2Server(t, dir)
+	srv, _, cancel := newV2Server(t, dir)
+	defer cancel()
 
 	test.TestRoute(t, srv.Handler("/api/composer/v2"), false, "GET", "/api/composer/v2/errors/4", ``, http.StatusOK, `
 	{
@@ -79,7 +105,8 @@ func TestGetErrorList(t *testing.T) {
 	dir, err := ioutil.TempDir("", "osbuild-composer-test-api-v2-")
 	require.NoError(t, err)
 	defer os.RemoveAll(dir)
-	srv, _ := newV2Server(t, dir)
+	srv, _, cancel := newV2Server(t, dir)
+	defer cancel()
 
 	test.TestRoute(t, srv.Handler("/api/composer/v2"), false, "GET", "/api/composer/v2/errors?page=3&size=1", ``, http.StatusOK, `
 	{
@@ -100,7 +127,8 @@ func TestCompose(t *testing.T) {
 	dir, err := ioutil.TempDir("", "osbuild-composer-test-api-v2-")
 	require.NoError(t, err)
 	defer os.RemoveAll(dir)
-	srv, _ := newV2Server(t, dir)
+	srv, _, cancel := newV2Server(t, dir)
+	defer cancel()
 
 	// unsupported distribution
 	test.TestRoute(t, srv.Handler("/api/composer/v2"), false, "POST", "/api/composer/v2/compose", fmt.Sprintf(`
@@ -248,7 +276,8 @@ func TestComposeStatusSuccess(t *testing.T) {
 	dir, err := ioutil.TempDir("", "osbuild-composer-test-api-v2-")
 	require.NoError(t, err)
 	defer os.RemoveAll(dir)
-	srv, wrksrv := newV2Server(t, dir)
+	srv, wrksrv, cancel := newV2Server(t, dir)
+	defer cancel()
 
 	test.TestRoute(t, srv.Handler("/api/composer/v2"), false, "POST", "/api/composer/v2/compose", fmt.Sprintf(`
 	{
@@ -318,7 +347,8 @@ func TestComposeStatusFailure(t *testing.T) {
 	dir, err := ioutil.TempDir("", "osbuild-composer-test-api-v2-")
 	require.NoError(t, err)
 	defer os.RemoveAll(dir)
-	srv, wrksrv := newV2Server(t, dir)
+	srv, wrksrv, cancel := newV2Server(t, dir)
+	defer cancel()
 
 	test.TestRoute(t, srv.Handler("/api/composer/v2"), false, "POST", "/api/composer/v2/compose", fmt.Sprintf(`
 	{
@@ -372,7 +402,8 @@ func TestComposeCustomizations(t *testing.T) {
 	dir, err := ioutil.TempDir("", "osbuild-composer-test-api-v2-")
 	require.NoError(t, err)
 	defer os.RemoveAll(dir)
-	srv, _ := newV2Server(t, dir)
+	srv, _, cancel := newV2Server(t, dir)
+	defer cancel()
 
 	test.TestRoute(t, srv.Handler("/api/composer/v2"), false, "POST", "/api/composer/v2/compose", fmt.Sprintf(`
 	{

--- a/internal/worker/json.go
+++ b/internal/worker/json.go
@@ -81,9 +81,17 @@ type DepsolveJob struct {
 	Releasever       string                      `json:"releasever"`
 }
 
+type ErrorType string
+
+const (
+	DepsolveErrorType ErrorType = "depsolve"
+	OtherErrorType    ErrorType = "other"
+)
+
 type DepsolveJobResult struct {
 	PackageSpecs map[string][]rpmmd.PackageSpec `json:"package_specs"`
 	Error        string                         `json:"error"`
+	ErrorType    ErrorType                      `json:"error_type"`
 }
 
 //

--- a/internal/worker/json.go
+++ b/internal/worker/json.go
@@ -3,6 +3,7 @@ package worker
 import (
 	"github.com/osbuild/osbuild-composer/internal/distro"
 	osbuild "github.com/osbuild/osbuild-composer/internal/osbuild1"
+	"github.com/osbuild/osbuild-composer/internal/rpmmd"
 	"github.com/osbuild/osbuild-composer/internal/target"
 )
 
@@ -70,6 +71,19 @@ type KojiFinalizeJob struct {
 
 type KojiFinalizeJobResult struct {
 	KojiError string `json:"koji_error"`
+}
+
+type DepsolveJob struct {
+	PackageSets      map[string]rpmmd.PackageSet `json:"package_sets"`
+	Repos            []rpmmd.RepoConfig          `json:"repos"`
+	ModulePlatformID string                      `json:"module_platform_id"`
+	Arch             string                      `json:"arch"`
+	Releasever       string                      `json:"releasever"`
+}
+
+type DepsolveJobResult struct {
+	PackageSpecs map[string][]rpmmd.PackageSpec `json:"package_specs"`
+	Error        string                         `json:"error"`
 }
 
 //

--- a/internal/worker/server.go
+++ b/internal/worker/server.go
@@ -98,6 +98,10 @@ func (s *Server) EnqueueKojiFinalize(job *KojiFinalizeJob, initID uuid.UUID, bui
 	return s.jobs.Enqueue("koji-finalize", job, append([]uuid.UUID{initID}, buildIDs...))
 }
 
+func (s *Server) EnqueueDepsolve(job *DepsolveJob) (uuid.UUID, error) {
+	return s.jobs.Enqueue("depsolve", job, nil)
+}
+
 func (s *Server) JobStatus(id uuid.UUID, result interface{}) (*JobStatus, []uuid.UUID, error) {
 	rawResult, queued, started, finished, canceled, deps, err := s.jobs.JobStatus(id)
 	if err != nil {

--- a/osbuild-composer.spec
+++ b/osbuild-composer.spec
@@ -314,13 +314,13 @@ cd $PWD/_build/src/%{goipath}
 
 %package core
 Summary:    The core osbuild-composer binary
+Requires:   %{name}-dnf-json = %{version}-%{release}
 
 %description core
 The core osbuild-composer binary. This is suitable both for spawning in containers and by systemd.
 
 %files core
 %{_libexecdir}/osbuild-composer/osbuild-composer
-%{_libexecdir}/osbuild-composer/dnf-json
 %{_datadir}/osbuild-composer/
 
 %package worker
@@ -329,6 +329,7 @@ Requires:   systemd
 Requires:   qemu-img
 Requires:   osbuild >= 37
 Requires:   osbuild-ostree >= 37
+Requires:   %{name}-dnf-json = %{version}-%{release}
 
 # remove in F34
 Obsoletes: golang-github-osbuild-composer-worker < %{version}-%{release}
@@ -357,6 +358,15 @@ systemctl stop "osbuild-worker@*.service" "osbuild-remote-worker@*.service"
 %postun worker
 # restart all the worker services
 %systemd_postun_with_restart "osbuild-worker@*.service" "osbuild-remote-worker@*.service"
+
+%package dnf-json
+Summary: The dnf-json binary used by osbuild-composer and the workers
+
+%description dnf-json
+The dnf-json binary used by osbuild-composer and the workers.
+
+%files dnf-json
+%{_libexecdir}/osbuild-composer/dnf-json
 
 %if %{with tests} || 0%{?rhel}
 


### PR DESCRIPTION
Proof of concept of the simplest way to move depsolving to workers. Do not try this at home unless you are a trained professional.