### PR TITLE
tools: improve deploy-openstack script

### DIFF
--- a/tools/deploy-openstack
+++ b/tools/deploy-openstack
@@ -25,6 +25,20 @@ scriptdir=$(dirname "$0")
 config=$1
 userdata=$2
 
+if [ ! -f "$config" ]; then
+  echo "first parameter should be a file"
+  exit 1
+fi
+
+if [ -d "$(dirname "$config")/../.git" ]; then
+  if [ "$(git status --porcelain -uno | wc -l)" -gt 0 ] || [ "$(git branch --show-current)" != "main" ]; then
+    read -p "Are you sure you want to deploy from git repo with non-main branch or dirty files ? " -n 1 -r
+    if [[ $REPLY =~ ^[Nn]$ ]]; then
+      exit 1
+    fi
+  fi
+fi
+
 # Verify that an openstackrc file has been sourced. This will fail when the
 # variables do not exist.
 printenv OS_PROJECT_NAME OS_USERNAME > /dev/null


### PR DESCRIPTION
Check first parameter and check for a dirty git repo


This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] create a file in [news/unreleased](https://github.com/osbuild/osbuild-composer/tree/main/docs/news/unreleased) directory if this change should be mentioned in the release news
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

For user-visible changes, "adequate documentation" is an entry describing the
change for users in docs/news. Please refer to docs/news/README.md for details.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`
-->
