### PR TITLE
`generate-test-cases`: small fix and drop `--with-customizations` option

### DIFF
--- a/tools/test-case-generators/distro-arch-imagetype-map.json
+++ b/tools/test-case-generators/distro-arch-imagetype-map.json
@@ -5,7 +5,6 @@
             "fedora-iot-commit",
             "openstack",
             "qcow2",
-            "qcow2-customize",
             "vhd",
             "vmdk"
         ],
@@ -18,7 +17,6 @@
             "ami",
             "openstack",
             "qcow2",
-            "qcow2-customize",
             "tar",
             "vhd",
             "vmdk"
@@ -32,7 +30,6 @@
             "ami",
             "openstack",
             "qcow2",
-            "qcow2-customize",
             "rhel-edge-commit",
             "tar",
             "vhd",
@@ -60,7 +57,6 @@
             "openstack",
             "tar",
             "qcow2",
-            "qcow2-customize",
             "rhel-edge-commit",
             "rhel-edge-container",
             "vhd",
@@ -90,7 +86,6 @@
             "openstack",
             "tar",
             "qcow2",
-            "qcow2-customize",
             "edge-commit",
             "edge-container",
             "image_installer",
@@ -102,19 +97,16 @@
             "ec2",
             "openstack",
             "qcow2",
-            "qcow2-customize",
             "edge-commit",
             "edge-container",
             "tar"
         ],
         "ppc64le": [
             "qcow2",
-            "qcow2-customize",
             "tar"
         ],
         "s390x": [
             "qcow2",
-            "qcow2-customize",
             "tar"
         ]
     },
@@ -125,7 +117,6 @@
             "edge-container",
             "openstack",
             "qcow2",
-            "qcow2-customize",
             "tar",
             "vhd",
             "vmdk"
@@ -136,17 +127,14 @@
             "edge-container",
             "openstack",
             "qcow2",
-            "qcow2-customize",
             "tar"
         ],
         "ppc64le": [
             "qcow2",
-            "qcow2-customize",
             "tar"
         ],
         "s390x": [
             "qcow2",
-            "qcow2-customize",
             "tar"
         ]
     }

--- a/tools/test-case-generators/format-request-map.json
+++ b/tools/test-case-generators/format-request-map.json
@@ -166,25 +166,7 @@
         }
       }
     },
-    "overrides": {
-      "rhel-8": {
-        "blueprint": {
-          "name": "openstack-boot-test",
-          "description": "Image for boot test",
-          "packages": [],
-          "modules": [],
-          "groups": [],
-          "customizations": {
-            "user": [
-              {
-                "name": "redhat",
-                "key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC61wMCjOSHwbVb4VfVyl5sn497qW4PsdQ7Ty7aD6wDNZ/QjjULkDV/yW5WjDlDQ7UqFH0Sr7vywjqDizUAqK7zM5FsUKsUXWHWwg/ehKg8j9xKcMv11AkFoUoujtfAujnKODkk58XSA9whPr7qcw3vPrmog680pnMSzf9LC7J6kXfs6lkoKfBh9VnlxusCrw2yg0qI1fHAZBLPx7mW6+me71QZsS6sVz8v8KXyrXsKTdnF50FjzHcK9HXDBtSJS5wA3fkcRYymJe0o6WMWNdgSRVpoSiWaHHmFgdMUJaYoCfhXzyl7LtNb3Q+Sveg+tJK7JaRXBLMUllOlJ6ll5Hod root@localhost"
-              }
-            ]
-          }
-        }
-      }
-    }
+    "overrides": {}
   },
   "tar": {
     "boot": {
@@ -217,30 +199,7 @@
         }
       }
     },
-    "overrides": {
-      "rhel-8": {
-        "blueprint": {
-          "name": "tar-boot-test",
-          "description": "Image for boot test",
-          "packages": [
-            {
-              "name": "openssh-server",
-              "version": "*"
-            }
-          ],
-          "modules": [],
-          "groups": [],
-          "customizations": {
-            "user": [
-              {
-                "name": "redhat",
-                "key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC61wMCjOSHwbVb4VfVyl5sn497qW4PsdQ7Ty7aD6wDNZ/QjjULkDV/yW5WjDlDQ7UqFH0Sr7vywjqDizUAqK7zM5FsUKsUXWHWwg/ehKg8j9xKcMv11AkFoUoujtfAujnKODkk58XSA9whPr7qcw3vPrmog680pnMSzf9LC7J6kXfs6lkoKfBh9VnlxusCrw2yg0qI1fHAZBLPx7mW6+me71QZsS6sVz8v8KXyrXsKTdnF50FjzHcK9HXDBtSJS5wA3fkcRYymJe0o6WMWNdgSRVpoSiWaHHmFgdMUJaYoCfhXzyl7LtNb3Q+Sveg+tJK7JaRXBLMUllOlJ6ll5Hod root@localhost"
-              }
-            ]
-          }
-        }
-      }
-    }
+    "overrides": {}
   },
   "image-installer": {
     "compose-request": {
@@ -276,25 +235,7 @@
         }
       }
     },
-    "overrides": {
-      "rhel-8": {
-        "blueprint": {
-          "name": "qcow2-boot-test",
-          "description": "Image for boot test",
-          "packages": [],
-          "modules": [],
-          "groups": [],
-          "customizations": {
-            "user": [
-              {
-                "name": "redhat",
-                "key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC61wMCjOSHwbVb4VfVyl5sn497qW4PsdQ7Ty7aD6wDNZ/QjjULkDV/yW5WjDlDQ7UqFH0Sr7vywjqDizUAqK7zM5FsUKsUXWHWwg/ehKg8j9xKcMv11AkFoUoujtfAujnKODkk58XSA9whPr7qcw3vPrmog680pnMSzf9LC7J6kXfs6lkoKfBh9VnlxusCrw2yg0qI1fHAZBLPx7mW6+me71QZsS6sVz8v8KXyrXsKTdnF50FjzHcK9HXDBtSJS5wA3fkcRYymJe0o6WMWNdgSRVpoSiWaHHmFgdMUJaYoCfhXzyl7LtNb3Q+Sveg+tJK7JaRXBLMUllOlJ6ll5Hod root@localhost"
-              }
-            ]
-          }
-        }
-      }
-    }
+    "overrides": {}
   },
   "vhd": {
     "compose-request": {
@@ -319,25 +260,7 @@
         }
       }
     },
-    "overrides": {
-      "rhel-8": {
-        "blueprint": {
-          "name": "vhd-boot-test",
-          "description": "Image for boot test",
-          "packages": [],
-          "modules": [],
-          "groups": [],
-          "customizations": {
-            "user": [
-              {
-                "name": "redhat",
-                "key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC61wMCjOSHwbVb4VfVyl5sn497qW4PsdQ7Ty7aD6wDNZ/QjjULkDV/yW5WjDlDQ7UqFH0Sr7vywjqDizUAqK7zM5FsUKsUXWHWwg/ehKg8j9xKcMv11AkFoUoujtfAujnKODkk58XSA9whPr7qcw3vPrmog680pnMSzf9LC7J6kXfs6lkoKfBh9VnlxusCrw2yg0qI1fHAZBLPx7mW6+me71QZsS6sVz8v8KXyrXsKTdnF50FjzHcK9HXDBtSJS5wA3fkcRYymJe0o6WMWNdgSRVpoSiWaHHmFgdMUJaYoCfhXzyl7LtNb3Q+Sveg+tJK7JaRXBLMUllOlJ6ll5Hod root@localhost"
-              }
-            ]
-          }
-        }
-      }
-    }
+    "overrides": {}
   },
   "vmdk": {
     "compose-request": {
@@ -361,24 +284,6 @@
         }
       }
     },
-    "overrides": {
-      "rhel-8": {
-        "blueprint": {
-          "name": "vhd-boot-test",
-          "description": "Image for boot test",
-          "packages": [],
-          "modules": [],
-          "groups": [],
-          "customizations": {
-            "user": [
-              {
-                "name": "redhat",
-                "key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC61wMCjOSHwbVb4VfVyl5sn497qW4PsdQ7Ty7aD6wDNZ/QjjULkDV/yW5WjDlDQ7UqFH0Sr7vywjqDizUAqK7zM5FsUKsUXWHWwg/ehKg8j9xKcMv11AkFoUoujtfAujnKODkk58XSA9whPr7qcw3vPrmog680pnMSzf9LC7J6kXfs6lkoKfBh9VnlxusCrw2yg0qI1fHAZBLPx7mW6+me71QZsS6sVz8v8KXyrXsKTdnF50FjzHcK9HXDBtSJS5wA3fkcRYymJe0o6WMWNdgSRVpoSiWaHHmFgdMUJaYoCfhXzyl7LtNb3Q+Sveg+tJK7JaRXBLMUllOlJ6ll5Hod root@localhost"
-              }
-            ]
-          }
-        }
-      }
-    }
+    "overrides": {}
   }
 }

--- a/tools/test-case-generators/format-request-map.json
+++ b/tools/test-case-generators/format-request-map.json
@@ -237,6 +237,179 @@
     },
     "overrides": {}
   },
+  "qcow2-customize": {
+    "compose-request": {
+      "distro": "",
+      "arch": "",
+      "image-type": "qcow2",
+      "repositories": [],
+      "filename": "disk.qcow2",
+      "blueprint": {
+        "name": "qcow2-customize-boot-test",
+        "description": "Image for boot test",
+        "packages": [
+          {
+            "name": "bash",
+            "version": "*"
+          }
+        ],
+        "modules": [],
+        "groups": [
+          {
+            "name": "core"
+          }
+        ],
+        "customizations": {
+          "hostname": "my-host",
+          "kernel": {
+            "append": "debug"
+          },
+          "sshkey": [
+            {
+              "user": "user1",
+              "key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC61wMCjOSHwbVb4VfVyl5sn497qW4PsdQ7Ty7aD6wDNZ/QjjULkDV/yW5WjDlDQ7UqFH0Sr7vywjqDizUAqK7zM5FsUKsUXWHWwg/ehKg8j9xKcMv11AkFoUoujtfAujnKODkk58XSA9whPr7qcw3vPrmog680pnMSzf9LC7J6kXfs6lkoKfBh9VnlxusCrw2yg0qI1fHAZBLPx7mW6+me71QZsS6sVz8v8KXyrXsKTdnF50FjzHcK9HXDBtSJS5wA3fkcRYymJe0o6WMWNdgSRVpoSiWaHHmFgdMUJaYoCfhXzyl7LtNb3Q+Sveg+tJK7JaRXBLMUllOlJ6ll5Hod root@localhost"
+            }
+          ],
+          "user": [
+            {
+              "name": "user2",
+              "description": "description 2",
+              "password": "$6$BhyxFBgrEFh0VrPJ$MllG8auiU26x2pmzL4.1maHzPHrA.4gTdCvlATFp8HJU9UPee4zCS9BVl2HOzKaUYD/zEm8r/OF05F2icWB0K/",
+              "key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC61wMCjOSHwbVb4VfVyl5sn497qW4PsdQ7Ty7aD6wDNZ/QjjULkDV/yW5WjDlDQ7UqFH0Sr7vywjqDizUAqK7zM5FsUKsUXWHWwg/ehKg8j9xKcMv11AkFoUoujtfAujnKODkk58XSA9whPr7qcw3vPrmog680pnMSzf9LC7J6kXfs6lkoKfBh9VnlxusCrw2yg0qI1fHAZBLPx7mW6+me71QZsS6sVz8v8KXyrXsKTdnF50FjzHcK9HXDBtSJS5wA3fkcRYymJe0o6WMWNdgSRVpoSiWaHHmFgdMUJaYoCfhXzyl7LtNb3Q+Sveg+tJK7JaRXBLMUllOlJ6ll5Hod root@localhost",
+              "home": "/home/home2",
+              "shell": "/bin/sh",
+              "groups": [
+                "group1"
+              ],
+              "uid": 1020,
+              "gid": 1050
+            }
+          ],
+          "group": [
+            {
+              "name": "group1",
+              "gid": 1030
+            },
+            {
+              "name": "group2",
+              "gid": 1050
+            }
+          ],
+          "timezone": {
+            "timezone": "Europe/London",
+            "ntpservers": [
+              "time.example.com"
+            ]
+          },
+          "locale": {
+            "languages": [
+              "el_CY.UTF-8"
+            ],
+            "keyboard": "dvorak"
+          },
+          "services": {
+            "enabled": [
+              "sshd.socket"
+            ],
+            "disabled": [
+              "bluetooth.service"
+            ]
+          }
+        }
+      }
+    },
+    "overrides": {
+      "rhel-85": {
+        "blueprint": {
+          "name": "qcow2-customize-boot-test",
+          "description": "Image for boot test",
+          "packages": [
+            {
+              "name": "bash",
+              "version": "*"
+            }
+          ],
+          "modules": [],
+          "groups": [
+            {
+              "name": "core"
+            }
+          ],
+          "customizations": {
+            "hostname": "my-host",
+            "kernel": {
+              "append": "debug"
+            },
+            "sshkey": [
+              {
+                "user": "user1",
+                "key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC61wMCjOSHwbVb4VfVyl5sn497qW4PsdQ7Ty7aD6wDNZ/QjjULkDV/yW5WjDlDQ7UqFH0Sr7vywjqDizUAqK7zM5FsUKsUXWHWwg/ehKg8j9xKcMv11AkFoUoujtfAujnKODkk58XSA9whPr7qcw3vPrmog680pnMSzf9LC7J6kXfs6lkoKfBh9VnlxusCrw2yg0qI1fHAZBLPx7mW6+me71QZsS6sVz8v8KXyrXsKTdnF50FjzHcK9HXDBtSJS5wA3fkcRYymJe0o6WMWNdgSRVpoSiWaHHmFgdMUJaYoCfhXzyl7LtNb3Q+Sveg+tJK7JaRXBLMUllOlJ6ll5Hod root@localhost"
+              }
+            ],
+            "user": [
+              {
+                "name": "user2",
+                "description": "description 2",
+                "password": "$6$BhyxFBgrEFh0VrPJ$MllG8auiU26x2pmzL4.1maHzPHrA.4gTdCvlATFp8HJU9UPee4zCS9BVl2HOzKaUYD/zEm8r/OF05F2icWB0K/",
+                "key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC61wMCjOSHwbVb4VfVyl5sn497qW4PsdQ7Ty7aD6wDNZ/QjjULkDV/yW5WjDlDQ7UqFH0Sr7vywjqDizUAqK7zM5FsUKsUXWHWwg/ehKg8j9xKcMv11AkFoUoujtfAujnKODkk58XSA9whPr7qcw3vPrmog680pnMSzf9LC7J6kXfs6lkoKfBh9VnlxusCrw2yg0qI1fHAZBLPx7mW6+me71QZsS6sVz8v8KXyrXsKTdnF50FjzHcK9HXDBtSJS5wA3fkcRYymJe0o6WMWNdgSRVpoSiWaHHmFgdMUJaYoCfhXzyl7LtNb3Q+Sveg+tJK7JaRXBLMUllOlJ6ll5Hod root@localhost",
+                "home": "/home/home2",
+                "shell": "/bin/sh",
+                "groups": [
+                  "group1"
+                ],
+                "uid": 1020,
+                "gid": 1050
+              }
+            ],
+            "group": [
+              {
+                "name": "group1",
+                "gid": 1030
+              },
+              {
+                "name": "group2",
+                "gid": 1050
+              }
+            ],
+            "timezone": {
+              "timezone": "Europe/London",
+              "ntpservers": [
+                "time.example.com"
+              ]
+            },
+            "locale": {
+              "languages": [
+                "el_CY.UTF-8"
+              ],
+              "keyboard": "dvorak"
+            },
+            "services": {
+              "enabled": [
+                "sshd.socket"
+              ],
+              "disabled": [
+                "bluetooth.service"
+              ]
+            },
+            "filesystem": [
+              {
+                "mountpoint": "/usr",
+                "minsize": 2147483648
+              },
+              {
+                "mountpoint": "/var",
+                "minsize": 1073741824
+              },
+              {
+                "mountpoint": "/",
+                "minsize": 2147483648
+              }
+            ]
+          }
+        }
+      }
+    }
+  },
   "vhd": {
     "compose-request": {
       "distro": "",

--- a/tools/test-case-generators/generate-all-test-cases
+++ b/tools/test-case-generators/generate-all-test-cases
@@ -849,18 +849,9 @@ class BaseTestCaseMatrixGenerator(contextlib.AbstractContextManager):
                 for image_type in img_type_list:
                     log.info("Generating test case for '%s' '%s' image on '%s'", distro, image_type, arch)
 
-                    # is the image with customizations?
-                    if image_type.endswith("-customize"):
-                        with_customizations = True
-                        image_type = image_type.rstrip("-customize")
-                    else:
-                        with_customizations = False
-
                     gen_test_cases_cmd = f"cd {runner_sources_dir}; sudo tools/test-case-generators/generate-test-cases" + \
                         f" --distro {distro} --arch {arch} --image-types {image_type}" + \
                         f" --store {runner_osbuild_store_dir} --output {runner_output_dir}"
-                    if with_customizations:
-                        gen_test_cases_cmd += " --with-customizations"
 
                     # allow fixed number of retries if the command fails for a specific reason
                     for i in range(1, go_tls_timeout_retries+1):

--- a/tools/test-case-generators/generate-test-cases
+++ b/tools/test-case-generators/generate-test-cases
@@ -108,134 +108,11 @@ def generate_test_case(test_type, distro, arch, output_format, test_case_request
         case_file.write("\n")
 
 
-CUSTOMIZATIONS_BLUEPRINT =  {
-    "packages": [
-        {
-            "name": "bash",
-            "version": "*"
-        }
-    ],
-    "groups": [
-        {
-            "name": "core"
-        }
-    ],
-    "customizations": {
-        "hostname": "my-host",
-        "kernel": {
-            "append": "debug"
-        },
-        "sshkey": [
-            {
-                "user": "user1",
-                "key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC61wMCjOSHwbVb4VfVyl5sn497qW4PsdQ7Ty7aD6wDNZ/QjjULkDV/yW5WjDlDQ7UqFH0Sr7vywjqDizUAqK7zM5FsUKsUXWHWwg/ehKg8j9xKcMv11AkFoUoujtfAujnKODkk58XSA9whPr7qcw3vPrmog680pnMSzf9LC7J6kXfs6lkoKfBh9VnlxusCrw2yg0qI1fHAZBLPx7mW6+me71QZsS6sVz8v8KXyrXsKTdnF50FjzHcK9HXDBtSJS5wA3fkcRYymJe0o6WMWNdgSRVpoSiWaHHmFgdMUJaYoCfhXzyl7LtNb3Q+Sveg+tJK7JaRXBLMUllOlJ6ll5Hod root@localhost"
-            }
-        ],
-        "user": [
-            {
-                "name": "user2",
-                "description": "description 2",
-                "password": "$6$BhyxFBgrEFh0VrPJ$MllG8auiU26x2pmzL4.1maHzPHrA.4gTdCvlATFp8HJU9UPee4zCS9BVl2HOzKaUYD/zEm8r/OF05F2icWB0K/",
-                "key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC61wMCjOSHwbVb4VfVyl5sn497qW4PsdQ7Ty7aD6wDNZ/QjjULkDV/yW5WjDlDQ7UqFH0Sr7vywjqDizUAqK7zM5FsUKsUXWHWwg/ehKg8j9xKcMv11AkFoUoujtfAujnKODkk58XSA9whPr7qcw3vPrmog680pnMSzf9LC7J6kXfs6lkoKfBh9VnlxusCrw2yg0qI1fHAZBLPx7mW6+me71QZsS6sVz8v8KXyrXsKTdnF50FjzHcK9HXDBtSJS5wA3fkcRYymJe0o6WMWNdgSRVpoSiWaHHmFgdMUJaYoCfhXzyl7LtNb3Q+Sveg+tJK7JaRXBLMUllOlJ6ll5Hod root@localhost",
-                "home": "/home/home2",
-                "shell": "/bin/sh",
-                "groups": [
-                    "group1"
-                ],
-                "uid": 1020,
-                "gid": 1050,
-            }
-        ],
-        "group": [
-            {
-                "name": "group1",
-                "gid": 1030
-            },
-            {
-                "name": "group2",
-                "gid": 1050
-            }
-        ],
-        "timezone": {
-            "timezone": "Europe/London",
-            "ntpservers": [
-                "time.example.com"
-            ]
-        },
-        "locale": {
-            "languages": [
-                "el_CY.UTF-8"
-            ],
-            "keyboard": "dvorak"
-        },
-#       "firewall": {
-#           "ports": [
-#               "25:tcp"
-#           ],
-#           "services": {
-#               "enabled": [
-#                   "cockpit"
-#               ],
-#               "disabled": [
-#                   "ssh"
-#               ]
-#           }
-#       },
-        "services": {
-            "enabled": [
-                "sshd.socket"
-            ],
-            "disabled": [
-                "bluetooth.service"
-            ]
-        }
-    }
-}
-
-FILESYSTEM_CUSTOMIZATIONS = [
-  {
-    "mountpoint": "/usr",
-    "minsize": 2147483648
-  },
-  {
-    "mountpoint": "/var",
-    "minsize": 1073741824
-  },
-  {
-    "mountpoint": "/",
-    "minsize": 2147483648
-  }
-]
-
-
-
-def main(distro, arch, image_types, keep_image_info, store, output, with_customizations):
+def main(distro, arch, image_types, keep_image_info, store, output):
     with open("tools/test-case-generators/format-request-map.json") as format_request_json:
         format_request_dict = json.load(format_request_json)
     with open("tools/test-case-generators/repos.json") as repos_json:
         repos_dict = json.load(repos_json)
-
-    # Apply all customizations from the CUSTOMIZATIONS_BLUEPRINT dictionary
-    if with_customizations:
-        if len(image_types) > 1 or image_types[0] != "qcow2":
-            print("Customizations are only available for qcow2 image type")
-            sys.exit(1)
-
-        if distro == "rhel-85":
-            CUSTOMIZATIONS_BLUEPRINT["customizations"]["filesystem"] = FILESYSTEM_CUSTOMIZATIONS
-
-        test_case_request = {
-            "compose-request": {
-                "distro": distro,
-                "arch": arch,
-                "repositories": repos_dict[distro][arch],
-                "image-type": "qcow2",
-                "filename": "disk.qcow2",
-                "blueprint": CUSTOMIZATIONS_BLUEPRINT,
-            }
-        }
-        generate_test_case("customize", distro, arch, "qcow2", test_case_request, keep_image_info, store, output)
-        return
 
     filtered_test_case_request_items = [
         "overrides",
@@ -270,8 +147,7 @@ if __name__ == '__main__':
     parser.add_argument("--keep-image-info", action='store_true', help="skip image info (re)generation, but keep the one found in the existing test case")
     parser.add_argument("--store", metavar="STORE_DIRECTORY", type=os.path.abspath, help="path to the osbuild store", required=True)
     parser.add_argument("--output", metavar="OUTPUT_DIRECTORY", type=os.path.abspath, help="path to the output directory", required=True)
-    parser.add_argument("--with-customizations", action='store_true', help="apply all currently supported customizations to the image (qcow2 only)")
     args = parser.parse_args()
 
-    main(args.distro, args.arch, args.image_types, args.keep_image_info, args.store, args.output, args.with_customizations)
+    main(args.distro, args.arch, args.image_types, args.keep_image_info, args.store, args.output)
     sys.exit()

--- a/tools/test-case-generators/generate-test-cases
+++ b/tools/test-case-generators/generate-test-cases
@@ -237,14 +237,18 @@ def main(distro, arch, image_types, keep_image_info, store, output, with_customi
         generate_test_case("customize", distro, arch, "qcow2", test_case_request, keep_image_info, store, output)
         return
 
+    filtered_test_case_request_items = [
+        "overrides",
+        "supported_arches"
+    ]
     for output_format, test_case_request in format_request_dict.items():
-        filtered_request = dict(filter(lambda i: i[0] != "overrides", test_case_request.items()))
+        filtered_request = dict(filter(lambda i: i[0] not in filtered_test_case_request_items, test_case_request.items()))
         if filtered_request["compose-request"]["image-type"] not in image_types:
                 continue
         filtered_request["compose-request"]["distro"] = distro
         # if the compose-request has specified supported arches, then generate
         # the test case only if the requested arch is in the list
-        supported_arches = filtered_request.get("supported_arches")
+        supported_arches = test_case_request.get("supported_arches")
         if supported_arches is not None and arch not in supported_arches:
             continue
         filtered_request["compose-request"]["arch"] = arch


### PR DESCRIPTION
Generating image test case with all possible blueprint customizations is supported only for `qcow2` image type. Generating `qcow2` images with customizations was not a lot of fun. One had to use a special CLI option
for this case.

To streamline the generation of image test cases, drop the `--with-customizations` option from the `generate-test-cases` script and move the functionality to `format-request-map.json` by defining a new `qcow2-customize` test case. This is very similar to what `*edge-rt` test case already uses. This mean that when the test case for `qcow2` image type is being generated, actually two test cases will be generated. The filesystem customizations since RHEL-8.5 are handled through distro-specific `overrides`.

In addition:
- Ensure that the `supported_arches` from `format-request-map.json` does not leak to the generated image test case, since it is relevant only for the generator script.
- remove redundant overrides from `format-request-map.json`

This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] create a file in [news/unreleased](https://github.com/osbuild/osbuild-composer/tree/main/docs/news/unreleased) directory if this change should be mentioned in the release news
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

For user-visible changes, "adequate documentation" is an entry describing the
change for users in docs/news. Please refer to docs/news/README.md for details.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`
-->
