### PR TITLE
Container: minor fixes

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -83,7 +83,7 @@ should be the same location as the `$CONTAINER_CONFIG_DIR` described above
 The services also require a config file each which they expect to be in the
 same directory. The following test files can be copied into it:
 
-    cp ./test/data/composer/osbuild-composer.toml ./test/data/composer/osbuild-worker.toml ./containers/config/
+    cp ./test/data/composer/osbuild-composer.toml ./test/data/worker/osbuild-worker.toml ./containers/config/
 
 The `$CONTAINER_CONFIG_DIR` (default `containers/config`) directory will be mounted inside both containers (see
 the [`docker-composer.yml`](./distribution/docker-compose.yml) file).

--- a/containers/osbuild-composer/entrypoint.py
+++ b/containers/osbuild-composer/entrypoint.py
@@ -213,7 +213,7 @@ class Cli(contextlib.AbstractContextManager):
     def _spawn_composer(sockets):
         cmd = [
             "/usr/libexec/osbuild-composer/osbuild-composer",
-            "-v",
+            "-verbose",
         ]
 
         # Prepare the environment for osbuild-composer. Note that we cannot use

--- a/distribution/docker-compose.yml
+++ b/distribution/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       context: ..
       dockerfile: ./distribution/Dockerfile-worker
     # override the entrypoint to specify composer hostname and port
-    entrypoint: /usr/libexec/osbuild-composer/osbuild-worker composer:8700
+    entrypoint: ["/usr/libexec/osbuild-composer/osbuild-worker" "https://composer:8700"]
     volumes:
       - ${CONTAINER_CONFIG_DIR}/:/etc/osbuild-composer
     environment:


### PR DESCRIPTION
Minor fixes to the containers to reflect changes to `osbuild-composer` and `osbuild-worker` commands:
- adding the `https://` protocol to the baseurl for the worker container entry point
- updating the log level flag for the `osbuild-composer` entrypoint
- minor doc fix  

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

For user-visible changes, "adequate documentation" is an entry describing the
change for users in docs/news. Please refer to docs/news/README.md for details.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`
-->
