### PR TITLE
NEWS: Drop title line

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,3 @@
-# OSBuild Composer - Operating System Image Composition Services
-
 ## CHANGES WITH 34:
 
   * Support temporary AWS credentials


### PR DESCRIPTION
Make the NEWS.md file more consistent with osbuild's NEWS.md, which
makes it easier to update it in an automated fashion.

This issue was not handled in the release script so far.