### PR TITLE
distribution: Use After=network.target instead of multi-user

### DIFF
--- a/distribution/osbuild-composer.service
+++ b/distribution/osbuild-composer.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=OSBuild Composer
-After=multi-user.target
+After=network.target
 
 # Weldr API needs a local worker by default.
 # Run `systemctl mask osbuild-worker@1.service`

--- a/distribution/osbuild-remote-worker@.service
+++ b/distribution/osbuild-remote-worker@.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=OSBuild Composer Remote Worker (%i)
-After=multi-user.target
+After=network.target
 
 [Service]
 Type=simple

--- a/distribution/osbuild-worker@.service
+++ b/distribution/osbuild-worker@.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=OSBuild Composer Worker (%i)
 Requires=osbuild-local-worker.socket
-After=multi-user.target osbuild-local-worker.socket
+After=network.target osbuild-local-worker.socket
 
 [Service]
 Type=simple


### PR DESCRIPTION
There is no need for osbuild-composer to wait until the whole multi-user
target is completed. It can be started earlier as it doesn't have any
dependencies in the target.

This can be a problem if there is a unit in the target that is not starting
and still is unrelated to osbuild-composer. There was a bug like this
with Plymouth where the service didn't finish and it was hanging. That
prevented osbuild-composer from starting and the user was left with
working SSH connection and shell, but composer-cli and systemctl start
osbuild-composer.service were both unresponsive.

Replace After=multi-user.target with After=network.target to start
osbuild-composer earlier.


This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] create a file in [news/unreleased](https://github.com/osbuild/osbuild-composer/tree/main/docs/news/unreleased) directory if this change should be mentioned in the release news
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

For user-visible changes, "adequate documentation" is an entry describing the
change for users in docs/news. Please refer to docs/news/README.md for details.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`
-->
