### PR TITLE
Change filesystem minsize from int to uint64 (Fixes #1832)

### DIFF
--- a/internal/blueprint/customizations.go
+++ b/internal/blueprint/customizations.go
@@ -73,7 +73,7 @@ type ServicesCustomization struct {
 
 type FilesystemCustomization struct {
 	Mountpoint string `json:"mountpoint,omitempty" toml:"mountpoint,omitempty"`
-	MinSize    int    `json:"minsize,omitempty" toml:"size,omitempty"`
+	MinSize    uint64 `json:"minsize,omitempty" toml:"size,omitempty"`
 }
 
 type CustomizationError struct {
@@ -258,7 +258,7 @@ func (c *Customizations) GetFilesystemsMinSize() uint64 {
 	if c == nil {
 		return 0
 	}
-	agg := 0
+	var agg uint64
 	for _, m := range c.Filesystem {
 		agg += m.MinSize
 	}
@@ -267,7 +267,7 @@ func (c *Customizations) GetFilesystemsMinSize() uint64 {
 	if agg%512 != 0 {
 		agg = (agg/512 + 1) * 512
 	}
-	return uint64(agg)
+	return agg
 }
 
 func (c *Customizations) GetInstallationDevice() string {

--- a/internal/disk/customizations.go
+++ b/internal/disk/customizations.go
@@ -38,7 +38,7 @@ func CreatePartitionTable(
 
 	for _, m := range mountpoints {
 		if m.Mountpoint != "/" {
-			partitionSize := uint64(m.MinSize) / sectorSize
+			partitionSize := m.MinSize / sectorSize
 			partition := basePartitionTable.createPartition(m.Mountpoint, partitionSize, rng)
 			basePartitionTable.Partitions = append(basePartitionTable.Partitions, partition)
 		}


### PR DESCRIPTION
@thozza pointed out that `int` is platform dependent which results in a fs size that is too small for 32-bit machines. This pr changes the filesystem custimizations to use `uint64` instead of `int`.

Fix #1832

This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] create a file in [news/unreleased](https://github.com/osbuild/osbuild-composer/tree/main/docs/news/unreleased) directory if this change should be mentioned in the release news
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

For user-visible changes, "adequate documentation" is an entry describing the
change for users in docs/news. Please refer to docs/news/README.md for details.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`
-->
