### PR TITLE
distro/rhel90: use qcow2 compat 1.1 for qcows

### DIFF
--- a/internal/distro/rhel90/pipelines.go
+++ b/internal/distro/rhel90/pipelines.go
@@ -53,7 +53,7 @@ func qcow2Pipelines(t *imageType, customizations *blueprint.Customizations, opti
 	imagePipeline := liveImagePipeline(treePipeline.Name, diskfile, &partitionTable, t.arch, kernelVer)
 	pipelines = append(pipelines, *imagePipeline)
 
-	qemuPipeline := qemuPipeline(imagePipeline.Name, diskfile, t.filename, "qcow2", "0.10")
+	qemuPipeline := qemuPipeline(imagePipeline.Name, diskfile, t.filename, "qcow2", "1.1")
 	pipelines = append(pipelines, *qemuPipeline)
 
 	return pipelines, nil

--- a/test/data/manifests/rhel_90-aarch64-qcow2-boot.json
+++ b/test/data/manifests/rhel_90-aarch64-qcow2-boot.json
@@ -1080,7 +1080,7 @@
               "filename": "disk.qcow2",
               "format": {
                 "type": "qcow2",
-                "compat": "0.10"
+                "compat": "1.1"
               }
             }
           }

--- a/test/data/manifests/rhel_90-aarch64-qcow2-customize.json
+++ b/test/data/manifests/rhel_90-aarch64-qcow2-customize.json
@@ -1415,7 +1415,7 @@
               "filename": "disk.qcow2",
               "format": {
                 "type": "qcow2",
-                "compat": "0.10"
+                "compat": "1.1"
               }
             }
           }

--- a/test/data/manifests/rhel_90-ppc64le-qcow2-boot.json
+++ b/test/data/manifests/rhel_90-ppc64le-qcow2-boot.json
@@ -1120,7 +1120,7 @@
               "filename": "disk.qcow2",
               "format": {
                 "type": "qcow2",
-                "compat": "0.10"
+                "compat": "1.1"
               }
             }
           }

--- a/test/data/manifests/rhel_90-ppc64le-qcow2-customize.json
+++ b/test/data/manifests/rhel_90-ppc64le-qcow2-customize.json
@@ -1461,7 +1461,7 @@
               "filename": "disk.qcow2",
               "format": {
                 "type": "qcow2",
-                "compat": "0.10"
+                "compat": "1.1"
               }
             }
           }

--- a/test/data/manifests/rhel_90-s390x-qcow2-boot.json
+++ b/test/data/manifests/rhel_90-s390x-qcow2-boot.json
@@ -1214,7 +1214,7 @@
               "filename": "disk.qcow2",
               "format": {
                 "type": "qcow2",
-                "compat": "0.10"
+                "compat": "1.1"
               }
             }
           }

--- a/test/data/manifests/rhel_90-s390x-qcow2-customize.json
+++ b/test/data/manifests/rhel_90-s390x-qcow2-customize.json
@@ -1539,7 +1539,7 @@
               "filename": "disk.qcow2",
               "format": {
                 "type": "qcow2",
-                "compat": "0.10"
+                "compat": "1.1"
               }
             }
           }

--- a/test/data/manifests/rhel_90-x86_64-qcow2-boot.json
+++ b/test/data/manifests/rhel_90-x86_64-qcow2-boot.json
@@ -1132,7 +1132,7 @@
               "filename": "disk.qcow2",
               "format": {
                 "type": "qcow2",
-                "compat": "0.10"
+                "compat": "1.1"
               }
             }
           }

--- a/test/data/manifests/rhel_90-x86_64-qcow2-customize.json
+++ b/test/data/manifests/rhel_90-x86_64-qcow2-customize.json
@@ -1484,7 +1484,7 @@
               "filename": "disk.qcow2",
               "format": {
                 "type": "qcow2",
-                "compat": "0.10"
+                "compat": "1.1"
               }
             }
           }


### PR DESCRIPTION
There's no reason to use 0.10 since we don't need to support running
this image on RHEL 6 anymore.
See https://bugzilla.redhat.com/show_bug.cgi?id=2008910

Signed-off-by: Ondřej Budai <ondrej@budai.cz>


This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] create a file in [news/unreleased](https://github.com/osbuild/osbuild-composer/tree/main/docs/news/unreleased) directory if this change should be mentioned in the release news
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

For user-visible changes, "adequate documentation" is an entry describing the
change for users in docs/news. Please refer to docs/news/README.md for details.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`
-->
