### PR TITLE
internal/rpmmd: log repository files loaded during composer startup

### DIFF
--- a/internal/rpmmd/repository.go
+++ b/internal/rpmmd/repository.go
@@ -267,10 +267,13 @@ func LoadAllRepositories(confPaths []string) (DistrosRepoConfigs, error) {
 					continue
 				}
 
-				distroRepos, err := loadRepositoriesFromFile(filepath.Join(reposPath, fileEntry.Name()))
+				configFile := filepath.Join(reposPath, fileEntry.Name())
+				distroRepos, err := loadRepositoriesFromFile(configFile)
 				if err != nil {
 					return nil, err
 				}
+
+				log.Println("Loaded repository configuration file:", configFile)
 
 				distrosRepoConfigs[distro] = distroRepos
 			}


### PR DESCRIPTION
This is a confusing part of the startup process. We have changed the naming
and we also added the cross distro building feature. It is unclear which
files are loaded and from where (if /etc or /usr).

Log the files that are loaded so every user can clearly see what
configuration osbuild-composer uses. This complements the log of loaded
configuration.


This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] create a file in [news/unreleased](https://github.com/osbuild/osbuild-composer/tree/main/docs/news/unreleased) directory if this change should be mentioned in the release news
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

For user-visible changes, "adequate documentation" is an entry describing the
change for users in docs/news. Please refer to docs/news/README.md for details.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`
-->
