### PR TITLE
config: don't fail LoadConfig when file doesn't exist

### DIFF
--- a/cmd/osbuild-composer/config.go
+++ b/cmd/osbuild-composer/config.go
@@ -97,7 +97,7 @@ func GetDefaultConfig() *ComposerConfigFile {
 func LoadConfig(name string) (*ComposerConfigFile, error) {
 	c := GetDefaultConfig()
 	_, err := toml.DecodeFile(name, c)
-	if err != nil {
+	if err != nil && !os.IsNotExist(err) {
 		return nil, err
 	}
 	err = loadConfigFromEnv(c)

--- a/cmd/osbuild-composer/config_test.go
+++ b/cmd/osbuild-composer/config_test.go
@@ -16,9 +16,8 @@ func TestEmpty(t *testing.T) {
 
 func TestNonExisting(t *testing.T) {
 	config, err := LoadConfig("testdata/non-existing-config.toml")
-	require.Error(t, err)
-	require.True(t, os.IsNotExist(err))
-	require.Nil(t, config)
+	require.Nil(t, err)
+	require.Equal(t, config, GetDefaultConfig())
 }
 
 func TestDefaultConfig(t *testing.T) {

--- a/cmd/osbuild-composer/main.go
+++ b/cmd/osbuild-composer/main.go
@@ -32,11 +32,7 @@ func main() {
 
 	config, err := LoadConfig(configFile)
 	if err != nil {
-		if os.IsNotExist(err) {
-			config = &ComposerConfigFile{}
-		} else {
-			logrus.Fatalf("Error loading configuration: %v", err)
-		}
+		logrus.Fatalf("Error loading configuration: %v", err)
 	}
 
 	logrus.SetOutput(os.Stdout)


### PR DESCRIPTION
When the config file doesn't exist, don't return because we need to keep the default and also load from env.


This pull request includes:

- [x] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] create a file in [news/unreleased](https://github.com/osbuild/osbuild-composer/tree/main/docs/news/unreleased) directory if this change should be mentioned in the release news
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

For user-visible changes, "adequate documentation" is an entry describing the
change for users in docs/news. Please refer to docs/news/README.md for details.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`
-->
