### PR TITLE
packit: Push downstream instead of creating PR

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -14,6 +14,7 @@ upstream_tag_template: v{version}
 actions:
   get-current-version: bash -c "git describe --tags --abbrev=0 | sed 's|v||'"
 
+create_pr: false
 jobs:
 - job: propose_downstream
   trigger: release


### PR DESCRIPTION
packit allows for not only creating PRs for all Fedoras, it also can push directly to dist-git - or as in this case: all active branches of dist-git (https://packit.dev/docs/guide/#packit-service-handles-fedora-rawhide-updates-for-you).

In order for this to work we would have to give the packit user on src.fedoraproject the ability to push in our osbuild group.

I see the main benefit in being able to add another GH Action to use `fedpkg` to automatically creates builds in koji. If packit only creates PRs we need to wait for someone with packaging rights to merge the PRs and only then can fedpkg be called. While the release script does this now, it's still an additional manual step.
I would of course propose the same change to `osbuild` but I don't want to waste everyone's time with two PRs/reviews about the same line of code when it's not clear that this is what we want :)

I hope I'm not overlooking some pitfalls - apart from the rare case where we have a semi-broken release in Fedora, as would have happened with composer 34.