### PR TITLE
tests/ci: enable vmware.sh, cross-distro.sh and koji.sh on rhel-9

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -261,20 +261,12 @@ Integration:
         RUNNER:
           - aws/rhel-8.4-ga-x86_64
           - aws/rhel-8.5-nightly-x86_64
+          - aws/rhel-9.0-beta-nightly-x86_64
         INTERNAL_NETWORK: ["true"]
       - SCRIPT:
           - azure_hyperv_gen2.sh
         RUNNER:
           - aws/rhel-8.5-nightly-x86_64
-        INTERNAL_NETWORK: ["true"]
-      - SCRIPT:
-          - aws.sh
-          - azure.sh
-          - filesystem.sh
-          - vmware.sh
-          - cross-distro.sh
-        RUNNER:
-          - aws/rhel-9.0-beta-nightly-x86_64
         INTERNAL_NETWORK: ["true"]
 
 .API_TESTS: &API_TESTS

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -271,6 +271,8 @@ Integration:
           - aws.sh
           - azure.sh
           - filesystem.sh
+          - vmware.sh
+          - cross-distro.sh
         RUNNER:
           - aws/rhel-9.0-beta-nightly-x86_64
         INTERNAL_NETWORK: ["true"]

--- a/test/cases/koji.sh
+++ b/test/cases/koji.sh
@@ -14,6 +14,9 @@ function greenprint {
 # Provision the software under test.
 /usr/libexec/osbuild-composer-test/provision.sh
 
+# Make sure podman-plugins are installed
+sudo dnf -y install podman-plugins
+
 greenprint "Starting containers"
 sudo /usr/libexec/osbuild-composer-test/run-koji-container.sh start
 

--- a/tools/provision.sh
+++ b/tools/provision.sh
@@ -18,9 +18,8 @@ elif [[ $ID == rhel || $ID == centos ]] && [[ ${VERSION_ID%.*} == 9 ]]; then
     curl -LO --insecure https://hdn.corp.redhat.com/rhel8-csb/RPMS/noarch/redhat-internal-cert-install-0.1-23.el7.csb.noarch.rpm
     sudo dnf install -y ./redhat-internal-cert-install-0.1-23.el7.csb.noarch.rpm dnf-plugins-core
     sudo dnf copr enable -y copr.devel.redhat.com/osbuild-team/epel-el9 "rhel-9.dev-$ARCH"
-    # koji is not available yet apparently
     # jmespath required for json_query
-    sudo dnf install -y ansible-core python3-jmespath
+    sudo dnf install -y ansible-core koji python3-jmespath
 
     # json_query filter, used in our ansible playbooks, was moved to the
     # 'community.general' collection


### PR DESCRIPTION
This pull request includes:

I forgot to add the vmware.sh test to .gitlab-ci.yml file when I updated the test and cross-distro.sh should just work as is, so adding both in this commit.

Also fixes #1634 

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] create a file in [news/unreleased](https://github.com/osbuild/osbuild-composer/tree/main/docs/news/unreleased) directory if this change should be mentioned in the release news
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

For user-visible changes, "adequate documentation" is an entry describing the
change for users in docs/news. Please refer to docs/news/README.md for details.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`
-->
