### PR TITLE
README: Add a link to our developer guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@ instance, includes a
  * **Bug Tracker**: <https://github.com/osbuild/osbuild-composer/issues>
  * **IRC**: #osbuild on [Libera.Chat](https://libera.chat/)
 
+#### Contributing
+
+Please refer to the [developer guide](https://www.osbuild.org/guides/developer-guide/developer-guide.html) to learn about our workflow, code style and more.
+
 ### About
 
 Composer is a middleman between the workhorses from *osbuild* and the


### PR DESCRIPTION
As discussed in our previous "How we work" session I'm proposing to add a "Contributing" section that refers to our developer guide.

See also https://github.com/osbuild/osbuild/pull/839