### PR TITLE
ci: split nightly pipeline based on rhel version

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -84,14 +84,15 @@ Prepare-rhel-internal:
   stage: prepare-rhel-internal
   extends: .terraform
   rules:
-    - if: '$CI_PIPELINE_SOURCE == "schedule" && $NIGHTLY == "true"'
+    - if: '$CI_PIPELINE_SOURCE == "schedule" && $RUNNER =~ /[\S]+rhel-9.0-[^ga][\S]+/ && $NIGHTLY == "true" && $RHEL_MAJOR == "9"'
+    - if: '$CI_PIPELINE_SOURCE == "schedule" && $RUNNER =~ /[\S]+rhel-8.6-[^ga][\S]+/ && $NIGHTLY == "true" && $RHEL_MAJOR == "8"'
   script:
     - schutzbot/prepare-rhel-internal.sh
   artifacts:
     paths:
-      - rhel-8.json
-      - rhel8internal.repo
-      - rhel-8-beta.json
+      - rhel-${RHEL_MAJOR}.json
+      - rhel${RHEL_MAJOR}internal.repo
+      - rhel-${RHEL_MAJOR}-beta.json
       - COMPOSE_ID
   parallel:
     matrix:
@@ -99,6 +100,7 @@ Prepare-rhel-internal:
           # NOTE: 1 runner prepares for all arches b/c subsequent jobs download
           # artifacts from all previous jobs and the last one wins
           - aws/rhel-8.6-nightly-x86_64
+          - aws/rhel-9.0-nightly-x86_64
         INTERNAL_NETWORK: ["true"]
 
 Base:
@@ -106,7 +108,8 @@ Base:
   extends: .terraform
   rules:
     - if: '$CI_PIPELINE_SOURCE != "schedule"'
-    - if: '$CI_PIPELINE_SOURCE == "schedule" && $RUNNER =~ /[\S]+rhel-[8-9]\.[0-9]-[^ga][\S]+/ && $NIGHTLY == "true"'
+    - if: '$CI_PIPELINE_SOURCE == "schedule" && $RUNNER =~ /[\S]+rhel-9.0-[^ga][\S]+/ && $NIGHTLY == "true" && $RHEL_MAJOR == "9"'
+    - if: '$CI_PIPELINE_SOURCE == "schedule" && $RUNNER =~ /[\S]+rhel-8.6-[^ga][\S]+/ && $NIGHTLY == "true" && $RHEL_MAJOR == "8"'
   script:
     - schutzbot/deploy.sh
     - /usr/libexec/tests/osbuild-composer/base_tests.sh
@@ -139,7 +142,8 @@ Regression:
   extends: .terraform
   rules:
     - if: '$CI_PIPELINE_SOURCE != "schedule"'
-    - if: '$CI_PIPELINE_SOURCE == "schedule" && $RUNNER =~ /[\S]+rhel-[8-9]\.[0-9]-[^ga][\S]+/ && $NIGHTLY == "true"'
+    - if: '$CI_PIPELINE_SOURCE == "schedule" && $RUNNER =~ /[\S]+rhel-9.0-[^ga][\S]+/ && $NIGHTLY == "true" && $RHEL_MAJOR == "9"'
+    - if: '$CI_PIPELINE_SOURCE == "schedule" && $RUNNER =~ /[\S]+rhel-8.6-[^ga][\S]+/ && $NIGHTLY == "true" && $RHEL_MAJOR == "8"'
   script:
     - schutzbot/deploy.sh
     - /usr/libexec/tests/osbuild-composer/regression.sh
@@ -170,7 +174,8 @@ OSTree:
   extends: .terraform/openstack
   rules:
     - if: '$CI_PIPELINE_SOURCE != "schedule"'
-    - if: '$CI_PIPELINE_SOURCE == "schedule" && $RUNNER =~ /[\S]+rhel-[8-9]\.[0-9]-[^ga][\S]+/ && $NIGHTLY == "true"'
+    - if: '$CI_PIPELINE_SOURCE == "schedule" && $RUNNER =~ /[\S]+rhel-9.0-[^ga][\S]+/ && $NIGHTLY == "true" && $RHEL_MAJOR == "9"'
+    - if: '$CI_PIPELINE_SOURCE == "schedule" && $RUNNER =~ /[\S]+rhel-8.6-[^ga][\S]+/ && $NIGHTLY == "true" && $RHEL_MAJOR == "8"'
   script:
     - schutzbot/deploy.sh
     - /usr/libexec/tests/osbuild-composer/ostree.sh
@@ -239,7 +244,8 @@ Integration:
   extends: .terraform
   rules:
     - if: '$CI_PIPELINE_SOURCE != "schedule"'
-    - if: '$CI_PIPELINE_SOURCE == "schedule" && $RUNNER =~ /[\S]+rhel-[8-9]\.[0-9]-[^ga][\S]+/ && $NIGHTLY == "true"'
+    - if: '$CI_PIPELINE_SOURCE == "schedule" && $RUNNER =~ /[\S]+rhel-9.0-[^ga][\S]+/ && $NIGHTLY == "true" && $RHEL_MAJOR == "9"'
+    - if: '$CI_PIPELINE_SOURCE == "schedule" && $RUNNER =~ /[\S]+rhel-8.6-[^ga][\S]+/ && $NIGHTLY == "true" && $RHEL_MAJOR == "8"'
   script:
     - schutzbot/deploy.sh
     - /usr/libexec/tests/osbuild-composer/${SCRIPT}
@@ -281,7 +287,8 @@ API:
   extends: .terraform
   rules:
     - if: '$CI_PIPELINE_SOURCE != "schedule"'
-    - if: '$CI_PIPELINE_SOURCE == "schedule" && $RUNNER =~ /[\S]+rhel-[8-9]\.[0-9]-[^ga][\S]+/ && $NIGHTLY == "true"'
+    - if: '$CI_PIPELINE_SOURCE == "schedule" && $RUNNER =~ /[\S]+rhel-9.0-[^ga][\S]+/ && $NIGHTLY == "true" && $RHEL_MAJOR == "9"'
+    - if: '$CI_PIPELINE_SOURCE == "schedule" && $RUNNER =~ /[\S]+rhel-8.6-[^ga][\S]+/ && $NIGHTLY == "true" && $RHEL_MAJOR == "8"'
   script:
     - schutzbot/deploy.sh
     - /usr/libexec/tests/osbuild-composer/api.sh ${TARGET}
@@ -312,7 +319,8 @@ libvirt:
   extends: .terraform/openstack
   rules:
     - if: '$CI_PIPELINE_SOURCE != "schedule"'
-    - if: '$CI_PIPELINE_SOURCE == "schedule" && $RUNNER =~ /[\S]+rhel-[8-9]\.[0-9]-[^ga][\S]+/ && $NIGHTLY == "true"'
+    - if: '$CI_PIPELINE_SOURCE == "schedule" && $RUNNER =~ /[\S]+rhel-9.0-[^ga][\S]+/ && $NIGHTLY == "true" && $RHEL_MAJOR == "9"'
+    - if: '$CI_PIPELINE_SOURCE == "schedule" && $RUNNER =~ /[\S]+rhel-8.6-[^ga][\S]+/ && $NIGHTLY == "true" && $RHEL_MAJOR == "8"'
   script:
     - schutzbot/deploy.sh
     - /usr/libexec/tests/osbuild-composer/libvirt.sh
@@ -364,7 +372,8 @@ Installer:
   extends: .terraform/openstack
   rules:
     - if: '$CI_PIPELINE_SOURCE != "schedule"'
-    - if: '$CI_PIPELINE_SOURCE == "schedule" && $RUNNER =~ /[\S]+rhel-[8-9]\.[0-9]-[^ga][\S]+/ && $NIGHTLY == "true"'
+    - if: '$CI_PIPELINE_SOURCE == "schedule" && $RUNNER =~ /[\S]+rhel-9\.[0-9]-[^ga][\S]+/ && $NIGHTLY == "true" && $RHEL_MAJOR == "9"'
+    - if: '$CI_PIPELINE_SOURCE == "schedule" && $RUNNER =~ /[\S]+rhel-8\.[0-9]-[^ga][\S]+/ && $NIGHTLY == "true" && $RHEL_MAJOR == "8"'
   script:
     - schutzbot/deploy.sh
     - /usr/libexec/tests/osbuild-composer/installers.sh

--- a/schutzbot/deploy.sh
+++ b/schutzbot/deploy.sh
@@ -107,9 +107,9 @@ if [[ "$PROJECT" != "osbuild-composer" ]]; then
   fi
 fi
 
-if [ -f "rhel8internal.repo" ]; then
+if [ -f "rhel${VERSION_ID%.*}internal.repo" ]; then
     greenprint "Preparing repos for internal build testing"
-    sudo mv rhel8internal.repo /etc/yum.repos.d/
+    sudo mv rhel"${VERSION_ID%.*}"internal.repo /etc/yum.repos.d/
     # Use osbuild from schutzfile if desired for testing custom osbuild-composer packages
     # specified by $REPO_URL in ENV and used in prepare-rhel-internal.sh
     if [ "${SCHUTZ_OSBUILD:=false}" == true ]; then

--- a/test/cases/ostree.sh
+++ b/test/cases/ostree.sh
@@ -1,10 +1,13 @@
 #!/bin/bash
 set -euo pipefail
 
-source /usr/libexec/osbuild-composer-test/define-compose-url.sh
-
 # Get OS data.
 source /usr/libexec/osbuild-composer-test/set-env-variables.sh
+
+# Get compose url if it's running on unsubscried RHEL
+if [[ ${ID} == "rhel" ]] && ! sudo subscription-manager status; then
+    source /usr/libexec/osbuild-composer-test/define-compose-url.sh
+fi
 
 # Provision the software under test.
 /usr/libexec/osbuild-composer-test/provision.sh
@@ -30,28 +33,29 @@ case "${ID}-${VERSION_ID}" in
         OSTREE_REF="rhel/8/${ARCH}/edge"
         OS_VARIANT="rhel8-unknown"
         USER_IN_COMMIT="true"
-        BOOT_LOCATION="$COMPOSE_URL/compose/BaseOS/x86_64/os/"
+        BOOT_LOCATION="${COMPOSE_URL:-}/compose/BaseOS/x86_64/os/"
         ;;
     "rhel-9.0")
         IMAGE_TYPE=edge-commit
         OSTREE_REF="rhel/9/${ARCH}/edge"
         OS_VARIANT="rhel9.0"
         USER_IN_COMMIT="true"
-        BOOT_LOCATION="$COMPOSE_URL/compose/BaseOS/x86_64/os/"
+        BOOT_LOCATION="${COMPOSE_URL:-}/compose/BaseOS/x86_64/os/"
         ;;
     "centos-8")
         IMAGE_TYPE=edge-commit
         OSTREE_REF="centos/8/${ARCH}/edge"
         OS_VARIANT="centos8"
         USER_IN_COMMIT="true"
-        BOOT_LOCATION="$COMPOSE_URL/compose/BaseOS/x86_64/os/"
+        BOOT_LOCATION="http://mirror.centos.org/centos/8-stream/BaseOS/x86_64/os/"
         ;;
     "centos-9")
         IMAGE_TYPE=edge-commit
         OSTREE_REF="centos/9/${ARCH}/edge"
         OS_VARIANT="centos9"
         USER_IN_COMMIT="true"
-        BOOT_LOCATION="$COMPOSE_URL/compose/BaseOS/x86_64/os/"
+        # This should be changed once we get centos-9 runners
+        BOOT_LOCATION="${COMPOSE_URL:-}/compose/BaseOS/x86_64/os/"
         ;;
     *)
         echo "unsupported distro: ${ID}-${VERSION_ID}"

--- a/tools/define-compose-url.sh
+++ b/tools/define-compose-url.sh
@@ -8,16 +8,16 @@ if [[ $ID != rhel ]]; then
 fi
 
 if [[ $ID == rhel && ${VERSION_ID%.*} == 8 ]]; then
-  COMPOSE_ID=$(curl -L http://download.devel.redhat.com/rhel-8/nightly/RHEL-8/latest-finished-RHEL-8.6/COMPOSE_ID)
+  COMPOSE_ID=$(curl -L http://download.devel.redhat.com/rhel-8/nightly/RHEL-8/latest-finished-RHEL-"${VERSION_ID}"/COMPOSE_ID)
 
   # default to a nightly tree but respect values passed from ENV so we can test rel-eng composes as well
   COMPOSE_URL="${COMPOSE_URL:-http://download.devel.redhat.com/rhel-8/nightly/RHEL-8/$COMPOSE_ID}"
 
 elif [[ $ID == rhel && ${VERSION_ID%.*} == 9 ]]; then
-  COMPOSE_ID=$(curl -L http://download.devel.redhat.com/rhel-9/nightly/RHEL-9-Beta/latest-RHEL-9.0/COMPOSE_ID)
+  COMPOSE_ID=$(curl -L http://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-"${VERSION_ID}"/COMPOSE_ID)
 
   # default to a nightly tree but respect values passed from ENV so we can test rel-eng composes as well
-  COMPOSE_URL="${COMPOSE_URL:-http://download.devel.redhat.com/rhel-9/nightly/RHEL-9-Beta/$COMPOSE_ID}"
+  COMPOSE_URL="${COMPOSE_URL:-http://download.devel.redhat.com/rhel-9/nightly/RHEL-9/$COMPOSE_ID}"
 fi
 
 # in case COMPOSE_URL was defined from the outside refresh COMPOSE_ID file,

--- a/tools/define-compose-url.sh
+++ b/tools/define-compose-url.sh
@@ -4,7 +4,7 @@ source /etc/os-release
 
 # This isn't needed when not running on RHEL
 if [[ $ID != rhel ]]; then
-  exit 0
+  return 0
 fi
 
 if [[ $ID == rhel && ${VERSION_ID%.*} == 8 ]]; then

--- a/tools/provision.sh
+++ b/tools/provision.sh
@@ -90,12 +90,12 @@ esac
 
 # overrides for RHEL nightly builds testing
 VERSION_SUFFIX=$(echo "${VERSION_ID}" | tr -d ".")
-if [ -f "rhel-8.json" ]; then
-    sudo cp rhel-8.json "$REPODIR/rhel-${VERSION_SUFFIX}.json"
+if [ -f "rhel-${VERSION_ID%.*}.json" ]; then
+    sudo cp rhel-"${VERSION_ID%.*}".json "$REPODIR/rhel-${VERSION_SUFFIX}.json"
 fi
 
-if [ -f "rhel-8-beta.json" ]; then
-    sudo cp rhel-8-beta.json "$REPODIR/rhel-${VERSION_SUFFIX}-beta.json"
+if [ -f "rhel-${VERSION_ID%.*}-beta.json" ]; then
+    sudo cp rhel-"${VERSION_ID%.*}"-beta.json "$REPODIR/rhel-${VERSION_SUFFIX}-beta.json"
 fi
 
 # Generate all X.509 certificates for the tests


### PR DESCRIPTION
This pull request includes:

Just some experiments before implementing nightly pipeline for RHEL-9

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] create a file in [news/unreleased](https://github.com/osbuild/osbuild-composer/tree/main/docs/news/unreleased) directory if this change should be mentioned in the release news
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

For user-visible changes, "adequate documentation" is an entry describing the
change for users in docs/news. Please refer to docs/news/README.md for details.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`
-->
