### PR TITLE
cloudapi/v1: Return status created in compose handler

### DIFF
--- a/internal/cloudapi/v1/v1.go
+++ b/internal/cloudapi/v1/v1.go
@@ -384,7 +384,7 @@ func (h *apiHandlers) Compose(ctx echo.Context) error {
 	var response ComposeResult
 	response.Id = id.String()
 
-	return ctx.JSON(http.StatusOK, response)
+	return ctx.JSON(http.StatusCreated, response)
 }
 
 // ComposeStatus handles a /compose/{id} GET request

--- a/test/cases/api.sh
+++ b/test/cases/api.sh
@@ -639,7 +639,8 @@ function collectMetrics(){
 }
 
 function sendCompose() {
-    OUTPUT=$(curl \
+    OUTPUT=$(mktemp)
+    HTTPSTATUS=$(curl \
                  --silent \
                  --show-error \
                  --cacert /etc/osbuild-composer/ca-crt.pem \
@@ -648,9 +649,12 @@ function sendCompose() {
                  --header 'Content-Type: application/json' \
                  --request POST \
                  --data @"$REQUEST_FILE" \
+                 --write-out '%{http_code}' \
+                 --output "$OUTPUT" \
                  https://localhost/api/composer/v1/compose)
 
-    COMPOSE_ID=$(echo "$OUTPUT" | jq -r '.id')
+    test "$HTTPSTATUS" = "201"
+    COMPOSE_ID=$(jq -r '.id' "$OUTPUT")
 }
 
 function waitForState() {


### PR DESCRIPTION
I broke this (again) when splitting up the cloudapi in v1 and v2.
Slightly embarrassing :/  Bad rebase I guess.