### PR TITLE
Image tests: skip `rpm-ostree-1-autovar.conf` tmpfiles.d config on Fedora

### DIFF
--- a/test/cases/image_tests.sh
+++ b/test/cases/image_tests.sh
@@ -26,6 +26,13 @@ if [[ "${DISTRO_CODE}" =~ "rhel-84" ]]; then
     IMAGE_TEST_CASE_RUNNER="${IMAGE_TEST_CASE_RUNNER} -skip-selinux-ctx-check"
 fi
 
+# Skip the /usr/lib/tmpfiles.d/rpm-ostree-1-autovar.conf file form the 'tmpfiles.d'
+# section of the image-info report. The content of the file is dynamically generated
+# and lines are not deterministically sorted, thus the diff often fails.
+if [[ "${DISTRO_CODE}" =~ "fedora" ]]; then
+    IMAGE_TEST_CASE_RUNNER="${IMAGE_TEST_CASE_RUNNER} -skip-tmpfilesd-path /usr/lib/tmpfiles.d/rpm-ostree-1-autovar.conf"
+fi
+
 PASSED_TESTS=()
 FAILED_TESTS=()
 


### PR DESCRIPTION
The content of `/usr/lib/tmpfiles.d/rpm-ostree-1-autovar.conf` is
dynamically created and its lines are not ordered deterministically.
This causes the rpm-ostree based image test cases to fail often on
Fedora, because the diff of the expected and actual image-info report
always produces some different lines.

Add a new option `-skip-tmpfilesd-path` to `osbuild-image-tests`
accepting a tmpfiles.d configuration path, which should be ignored when
comparing the expected and actual image-info report. The option can be
specified multiple times and all paths will be ignored.

Modify the `image_tests.sh` test case to use the new option and ignore the
`/usr/lib/tmpfiles.d/rpm-ostree-1-autovar.conf` file when testing Fedora
images.

Signed-off-by: Tomas Hozza <thozza@redhat.com>


This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] create a file in [news/unreleased](https://github.com/osbuild/osbuild-composer/tree/main/docs/news/unreleased) directory if this change should be mentioned in the release news
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

For user-visible changes, "adequate documentation" is an entry describing the
change for users in docs/news. Please refer to docs/news/README.md for details.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`
-->
