### PR TITLE
SPEC: Exclude `armv7hl` architecture

### DIFF
--- a/osbuild-composer.spec
+++ b/osbuild-composer.spec
@@ -20,9 +20,8 @@ Name:           osbuild-composer
 Release:        1%{?dist}
 Summary:        An image building service based on osbuild
 
-# osbuild-composer doesn't have support for building i686 images
-# and also RHEL and Fedora has now only limited support for this arch.
-ExcludeArch:    i686
+# osbuild-composer doesn't have support for building i686 and armv7hl images
+ExcludeArch:    i686 armv7hl
 
 # Upstream license specification: Apache-2.0
 License:        ASL 2.0


### PR DESCRIPTION
Exclude the `armv7hl` architecture, since osbuild-composer does not
support building images for it.

Tested manually with scratch build on Fedora (https://koji.fedoraproject.org/koji/taskinfo?taskID=76923499)

Fix #1839

Signed-off-by: Tomas Hozza <thozza@redhat.com>


This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] create a file in [news/unreleased](https://github.com/osbuild/osbuild-composer/tree/main/docs/news/unreleased) directory if this change should be mentioned in the release news
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

For user-visible changes, "adequate documentation" is an entry describing the
change for users in docs/news. Please refer to docs/news/README.md for details.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`
-->
