### PR TITLE
cloudapi/v2: fix newV2Server() call in test

### DIFF
--- a/internal/cloudapi/v2/v2_test.go
+++ b/internal/cloudapi/v2/v2_test.go
@@ -411,7 +411,8 @@ func TestImageTypes(t *testing.T) {
 	dir, err := ioutil.TempDir("", "osbuild-composer-test-api-v2-")
 	require.NoError(t, err)
 	defer os.RemoveAll(dir)
-	srv, _ := newV2Server(t, dir)
+	srv, _, cancel := newV2Server(t, dir)
+	defer cancel()
 
 	test.TestRoute(t, srv.Handler("/api/image-builder-composer/v2"), false, "POST", "/api/image-builder-composer/v2/compose", fmt.Sprintf(`
 	{


### PR DESCRIPTION
Bug caused by two consecutive PR merge rebases, one that added a function call and another that changed the signature of the same function.

#1841 added a new test to internal/cloudapi/v2/v2_test.go and
#1814 changed the signature of the newV2Server() in the same file