### PR TITLE
customizations: add support for fs sizes in MB and GB

### DIFF
--- a/internal/blueprint/customizations.go
+++ b/internal/blueprint/customizations.go
@@ -3,6 +3,8 @@ package blueprint
 import (
 	"fmt"
 	"reflect"
+
+	"github.com/osbuild/osbuild-composer/internal/common"
 )
 
 type Customizations struct {
@@ -73,7 +75,7 @@ type ServicesCustomization struct {
 
 type FilesystemCustomization struct {
 	Mountpoint string `json:"mountpoint,omitempty" toml:"mountpoint,omitempty"`
-	MinSize    uint64 `json:"minsize,omitempty" toml:"size,omitempty"`
+	MinSize    string `json:"minsize,omitempty" toml:"size,omitempty"`
 }
 
 type CustomizationError struct {
@@ -260,7 +262,7 @@ func (c *Customizations) GetFilesystemsMinSize() uint64 {
 	}
 	var agg uint64
 	for _, m := range c.Filesystem {
-		agg += m.MinSize
+		agg += m.GetMinSize()
 	}
 	// This ensures that file system customization `size` is a multiple of
 	// sector size (512)
@@ -276,4 +278,14 @@ func (c *Customizations) GetInstallationDevice() string {
 		return defaultDevice
 	}
 	return c.InstallationDevice
+}
+
+func (fs *FilesystemCustomization) GetMinSize() uint64 {
+	min_size := common.FsSizeToUint64(fs.MinSize)
+	if min_size != nil {
+		return *min_size
+	}
+
+	// The string must be validated in the Weldr API
+	panic("Invalid filesystem size")
 }

--- a/internal/blueprint/customizations_test.go
+++ b/internal/blueprint/customizations_test.go
@@ -314,7 +314,7 @@ func TestGetFilesystems(t *testing.T) {
 
 	expectedFilesystems := []FilesystemCustomization{
 		{
-			MinSize:    1024,
+			MinSize:    "1024",
 			Mountpoint: "/",
 		},
 	}
@@ -332,11 +332,11 @@ func TestGetFilesystemsMinSize(t *testing.T) {
 
 	expectedFilesystems := []FilesystemCustomization{
 		{
-			MinSize:    1024,
+			MinSize:    "1024",
 			Mountpoint: "/",
 		},
 		{
-			MinSize:    4096,
+			MinSize:    "4096",
 			Mountpoint: "/var",
 		},
 	}
@@ -354,11 +354,11 @@ func TestGetFilesystemsMinSizeNonSectorSize(t *testing.T) {
 
 	expectedFilesystems := []FilesystemCustomization{
 		{
-			MinSize:    1025,
+			MinSize:    "1025",
 			Mountpoint: "/",
 		},
 		{
-			MinSize:    4097,
+			MinSize:    "4097",
 			Mountpoint: "/var",
 		},
 	}

--- a/internal/client/compose_test.go
+++ b/internal/client/compose_test.go
@@ -460,7 +460,7 @@ func TestComposeSupportedMountPointV0(t *testing.T) {
 		version="0.0.1"
 		[[customizations.filesystem]]
 		mountpoint = "/"
-		size = 4294967296
+		size = "4294967296"
 		`
 	resp, err := PostTOMLBlueprintV0(testState.socket, bp)
 	require.NoError(t, err, "failed with a client error")
@@ -526,7 +526,7 @@ func TestComposeUnsupportedMountPointV0(t *testing.T) {
 		version="0.0.1"
 		[[customizations.filesystem]]
 		mountpoint = "/boot"
-		size = 4294967296
+		size = "4294967296"
 		`
 	resp, err := PostTOMLBlueprintV0(testState.socket, bp)
 	require.NoError(t, err, "failed with a client error")

--- a/internal/common/helpers.go
+++ b/internal/common/helpers.go
@@ -1,8 +1,10 @@
 package common
 
 import (
+	"regexp"
 	"runtime"
 	"sort"
+	"strconv"
 )
 
 var RuntimeGOARCH = runtime.GOARCH
@@ -35,4 +37,32 @@ func IsStringInSortedSlice(slice []string, s string) bool {
 		return true
 	}
 	return false
+}
+
+func FsSizeToUint64(size string) *uint64 {
+	// Read the number in the string
+	plain_number := regexp.MustCompile(`[[:digit:]]+`)
+	numbers_as_str := plain_number.FindAllString(size, 1)
+	number, err := strconv.ParseInt(numbers_as_str[0], 10, 64)
+	if err != nil {
+		return nil
+	}
+	return_size := uint64(number)
+
+	mega_byte := regexp.MustCompile(`[[:digit:]]+\s*(m|M)(b|B)?`)
+	giga_byte := regexp.MustCompile(`[[:digit:]]+\s*(g|G)(b|B)?`)
+
+	if plain_number.MatchString(size) {
+		return &return_size
+	}
+	if mega_byte.MatchString(size) {
+		return_size *= 1000000
+		return &return_size
+	}
+	if giga_byte.MatchString(size) {
+		return_size *= 1000000000
+		return &return_size
+	}
+
+	return nil
 }

--- a/internal/disk/customizations.go
+++ b/internal/disk/customizations.go
@@ -38,7 +38,7 @@ func CreatePartitionTable(
 
 	for _, m := range mountpoints {
 		if m.Mountpoint != "/" {
-			partitionSize := m.MinSize / sectorSize
+			partitionSize := m.GetMinSize() / sectorSize
 			partition := basePartitionTable.createPartition(m.Mountpoint, partitionSize, rng)
 			basePartitionTable.Partitions = append(basePartitionTable.Partitions, partition)
 		}

--- a/internal/disk/disk_test.go
+++ b/internal/disk/disk_test.go
@@ -12,7 +12,7 @@ import (
 func TestDisk_DynamicallyResizePartitionTable(t *testing.T) {
 	mountpoints := []blueprint.FilesystemCustomization{
 		{
-			MinSize:    2147483648,
+			MinSize:    "2147483648",
 			Mountpoint: "/usr",
 		},
 	}

--- a/internal/distro/fedora33/distro_test.go
+++ b/internal/distro/fedora33/distro_test.go
@@ -386,7 +386,7 @@ func TestDistro_CustomFileSystemManifestError(t *testing.T) {
 		Customizations: &blueprint.Customizations{
 			Filesystem: []blueprint.FilesystemCustomization{
 				{
-					MinSize:    1024,
+					MinSize:    "1024",
 					Mountpoint: "/boot",
 				},
 			},
@@ -412,7 +412,7 @@ func TestDistro_TestRootMountPoint(t *testing.T) {
 		Customizations: &blueprint.Customizations{
 			Filesystem: []blueprint.FilesystemCustomization{
 				{
-					MinSize:    1024,
+					MinSize:    "1024",
 					Mountpoint: "/",
 				},
 			},

--- a/internal/distro/rhel8/distro_test.go
+++ b/internal/distro/rhel8/distro_test.go
@@ -387,7 +387,7 @@ func TestDistro_CustomFileSystemManifestError(t *testing.T) {
 		Customizations: &blueprint.Customizations{
 			Filesystem: []blueprint.FilesystemCustomization{
 				{
-					MinSize:    1024,
+					MinSize:    "1024",
 					Mountpoint: "/boot",
 				},
 			},
@@ -413,7 +413,7 @@ func TestDistro_TestRootMountPoint(t *testing.T) {
 		Customizations: &blueprint.Customizations{
 			Filesystem: []blueprint.FilesystemCustomization{
 				{
-					MinSize:    1024,
+					MinSize:    "1024",
 					Mountpoint: "/",
 				},
 			},

--- a/internal/distro/rhel84/distro_test.go
+++ b/internal/distro/rhel84/distro_test.go
@@ -596,7 +596,7 @@ func TestDistro_CustomFileSystemManifestError(t *testing.T) {
 		Customizations: &blueprint.Customizations{
 			Filesystem: []blueprint.FilesystemCustomization{
 				{
-					MinSize:    1024,
+					MinSize:    "1024",
 					Mountpoint: "/boot",
 				},
 			},
@@ -632,7 +632,7 @@ func TestDistro_TestRootMountPoint(t *testing.T) {
 		Customizations: &blueprint.Customizations{
 			Filesystem: []blueprint.FilesystemCustomization{
 				{
-					MinSize:    1024,
+					MinSize:    "1024",
 					Mountpoint: "/",
 				},
 			},

--- a/internal/distro/rhel85/distro.go
+++ b/internal/distro/rhel85/distro.go
@@ -441,8 +441,8 @@ func (t *imageType) checkOptions(customizations *blueprint.Customizations, optio
 
 	invalidMountpoints := []string{}
 	for _, m := range mountpoints {
-		if m.Mountpoint == "/usr" && m.MinSize < 2147483648 {
-			m.MinSize = 2147483648
+		if m.Mountpoint == "/usr" && m.GetMinSize() < 2147483648 {
+			m.MinSize = "2147483648"
 		}
 		if !isMountpointAllowed(m.Mountpoint) {
 			invalidMountpoints = append(invalidMountpoints, m.Mountpoint)

--- a/internal/distro/rhel85/distro_internal_test.go
+++ b/internal/distro/rhel85/distro_internal_test.go
@@ -23,7 +23,7 @@ var testEc2ImageType = imageType{
 
 var mountpoints = []blueprint.FilesystemCustomization{
 	{
-		MinSize:    1024,
+		MinSize:    "1024",
 		Mountpoint: "/usr",
 	},
 }

--- a/internal/distro/rhel85/distro_test.go
+++ b/internal/distro/rhel85/distro_test.go
@@ -569,7 +569,7 @@ func TestDistro_CustomFileSystemManifestError(t *testing.T) {
 		Customizations: &blueprint.Customizations{
 			Filesystem: []blueprint.FilesystemCustomization{
 				{
-					MinSize:    1024,
+					MinSize:    "1024",
 					Mountpoint: "/boot",
 				},
 			},
@@ -597,7 +597,7 @@ func TestDistro_TestRootMountPoint(t *testing.T) {
 		Customizations: &blueprint.Customizations{
 			Filesystem: []blueprint.FilesystemCustomization{
 				{
-					MinSize:    1024,
+					MinSize:    "1024",
 					Mountpoint: "/",
 				},
 			},
@@ -625,11 +625,11 @@ func TestDistro_CustomFileSystemSubDirectories(t *testing.T) {
 		Customizations: &blueprint.Customizations{
 			Filesystem: []blueprint.FilesystemCustomization{
 				{
-					MinSize:    1024,
+					MinSize:    "1024",
 					Mountpoint: "/var/log",
 				},
 				{
-					MinSize:    1024,
+					MinSize:    "1024",
 					Mountpoint: "/var/log/audit",
 				},
 			},
@@ -655,19 +655,19 @@ func TestDistro_MountpointsWithArbitraryDepthAllowed(t *testing.T) {
 		Customizations: &blueprint.Customizations{
 			Filesystem: []blueprint.FilesystemCustomization{
 				{
-					MinSize:    1024,
+					MinSize:    "1024",
 					Mountpoint: "/var/a",
 				},
 				{
-					MinSize:    1024,
+					MinSize:    "1024",
 					Mountpoint: "/var/a/b",
 				},
 				{
-					MinSize:    1024,
+					MinSize:    "1024",
 					Mountpoint: "/var/a/b/c",
 				},
 				{
-					MinSize:    1024,
+					MinSize:    "1024",
 					Mountpoint: "/var/a/b/c/d",
 				},
 			},
@@ -693,15 +693,15 @@ func TestDistro_DirtyMountpointsNotAllowed(t *testing.T) {
 		Customizations: &blueprint.Customizations{
 			Filesystem: []blueprint.FilesystemCustomization{
 				{
-					MinSize:    1024,
+					MinSize:    "1024",
 					Mountpoint: "//",
 				},
 				{
-					MinSize:    1024,
+					MinSize:    "1024",
 					Mountpoint: "/var//",
 				},
 				{
-					MinSize:    1024,
+					MinSize:    "1024",
 					Mountpoint: "/var//log/audit/",
 				},
 			},
@@ -727,11 +727,11 @@ func TestDistro_CustomFileSystemPatternMatching(t *testing.T) {
 		Customizations: &blueprint.Customizations{
 			Filesystem: []blueprint.FilesystemCustomization{
 				{
-					MinSize:    1024,
+					MinSize:    "1024",
 					Mountpoint: "/variable",
 				},
 				{
-					MinSize:    1024,
+					MinSize:    "1024",
 					Mountpoint: "/variable/log/audit",
 				},
 			},
@@ -759,7 +759,7 @@ func TestDistro_CustomUsrPartitionNotLargeEnough(t *testing.T) {
 		Customizations: &blueprint.Customizations{
 			Filesystem: []blueprint.FilesystemCustomization{
 				{
-					MinSize:    1024,
+					MinSize:    "1024",
 					Mountpoint: "/usr",
 				},
 			},

--- a/internal/distro/rhel86/distro.go
+++ b/internal/distro/rhel86/distro.go
@@ -442,8 +442,8 @@ func (t *imageType) checkOptions(customizations *blueprint.Customizations, optio
 
 	invalidMountpoints := []string{}
 	for _, m := range mountpoints {
-		if m.Mountpoint == "/usr" && m.MinSize < 2147483648 {
-			m.MinSize = 2147483648
+		if m.Mountpoint == "/usr" && m.GetMinSize() < 2147483648 {
+			m.MinSize = "2147483648"
 		}
 		if !isMountpointAllowed(m.Mountpoint) {
 			invalidMountpoints = append(invalidMountpoints, m.Mountpoint)

--- a/internal/distro/rhel86/distro_internal_test.go
+++ b/internal/distro/rhel86/distro_internal_test.go
@@ -23,7 +23,7 @@ var testEc2ImageType = imageType{
 
 var mountpoints = []blueprint.FilesystemCustomization{
 	{
-		MinSize:    1024,
+		MinSize:    "1024",
 		Mountpoint: "/usr",
 	},
 }

--- a/internal/distro/rhel86/distro_test.go
+++ b/internal/distro/rhel86/distro_test.go
@@ -579,7 +579,7 @@ func TestDistro_CustomFileSystemManifestError(t *testing.T) {
 		Customizations: &blueprint.Customizations{
 			Filesystem: []blueprint.FilesystemCustomization{
 				{
-					MinSize:    1024,
+					MinSize:    "1024",
 					Mountpoint: "/boot",
 				},
 			},
@@ -607,7 +607,7 @@ func TestDistro_TestRootMountPoint(t *testing.T) {
 		Customizations: &blueprint.Customizations{
 			Filesystem: []blueprint.FilesystemCustomization{
 				{
-					MinSize:    1024,
+					MinSize:    "1024",
 					Mountpoint: "/",
 				},
 			},
@@ -635,11 +635,11 @@ func TestDistro_CustomFileSystemSubDirectories(t *testing.T) {
 		Customizations: &blueprint.Customizations{
 			Filesystem: []blueprint.FilesystemCustomization{
 				{
-					MinSize:    1024,
+					MinSize:    "1024",
 					Mountpoint: "/var/log",
 				},
 				{
-					MinSize:    1024,
+					MinSize:    "1024",
 					Mountpoint: "/var/log/audit",
 				},
 			},
@@ -665,19 +665,19 @@ func TestDistro_MountpointsWithArbitraryDepthAllowed(t *testing.T) {
 		Customizations: &blueprint.Customizations{
 			Filesystem: []blueprint.FilesystemCustomization{
 				{
-					MinSize:    1024,
+					MinSize:    "1024",
 					Mountpoint: "/var/a",
 				},
 				{
-					MinSize:    1024,
+					MinSize:    "1024",
 					Mountpoint: "/var/a/b",
 				},
 				{
-					MinSize:    1024,
+					MinSize:    "1024",
 					Mountpoint: "/var/a/b/c",
 				},
 				{
-					MinSize:    1024,
+					MinSize:    "1024",
 					Mountpoint: "/var/a/b/c/d",
 				},
 			},
@@ -703,15 +703,15 @@ func TestDistro_DirtyMountpointsNotAllowed(t *testing.T) {
 		Customizations: &blueprint.Customizations{
 			Filesystem: []blueprint.FilesystemCustomization{
 				{
-					MinSize:    1024,
+					MinSize:    "1024",
 					Mountpoint: "//",
 				},
 				{
-					MinSize:    1024,
+					MinSize:    "1024",
 					Mountpoint: "/var//",
 				},
 				{
-					MinSize:    1024,
+					MinSize:    "1024",
 					Mountpoint: "/var//log/audit/",
 				},
 			},
@@ -737,11 +737,11 @@ func TestDistro_CustomFileSystemPatternMatching(t *testing.T) {
 		Customizations: &blueprint.Customizations{
 			Filesystem: []blueprint.FilesystemCustomization{
 				{
-					MinSize:    1024,
+					MinSize:    "1024",
 					Mountpoint: "/variable",
 				},
 				{
-					MinSize:    1024,
+					MinSize:    "1024",
 					Mountpoint: "/variable/log/audit",
 				},
 			},
@@ -769,7 +769,7 @@ func TestDistro_CustomUsrPartitionNotLargeEnough(t *testing.T) {
 		Customizations: &blueprint.Customizations{
 			Filesystem: []blueprint.FilesystemCustomization{
 				{
-					MinSize:    1024,
+					MinSize:    "1024",
 					Mountpoint: "/usr",
 				},
 			},

--- a/internal/distro/rhel90beta/distro.go
+++ b/internal/distro/rhel90beta/distro.go
@@ -468,8 +468,8 @@ func (t *imageType) checkOptions(customizations *blueprint.Customizations, optio
 
 	invalidMountpoints := []string{}
 	for _, m := range mountpoints {
-		if m.Mountpoint == "/usr" && m.MinSize < 2147483648 {
-			m.MinSize = 2147483648
+		if m.Mountpoint == "/usr" && m.GetMinSize() < 2147483648 {
+			m.MinSize = "2147483648"
 		}
 		if !isMountpointAllowed(m.Mountpoint) {
 			invalidMountpoints = append(invalidMountpoints, m.Mountpoint)

--- a/internal/distro/rhel90beta/distro_test.go
+++ b/internal/distro/rhel90beta/distro_test.go
@@ -577,7 +577,7 @@ func TestDistro_CustomFileSystemManifestError(t *testing.T) {
 		Customizations: &blueprint.Customizations{
 			Filesystem: []blueprint.FilesystemCustomization{
 				{
-					MinSize:    1024,
+					MinSize:    "1024",
 					Mountpoint: "/boot",
 				},
 			},
@@ -605,7 +605,7 @@ func TestDistro_TestRootMountPoint(t *testing.T) {
 		Customizations: &blueprint.Customizations{
 			Filesystem: []blueprint.FilesystemCustomization{
 				{
-					MinSize:    1024,
+					MinSize:    "1024",
 					Mountpoint: "/",
 				},
 			},
@@ -633,11 +633,11 @@ func TestDistro_CustomFileSystemSubDirectories(t *testing.T) {
 		Customizations: &blueprint.Customizations{
 			Filesystem: []blueprint.FilesystemCustomization{
 				{
-					MinSize:    1024,
+					MinSize:    "1024",
 					Mountpoint: "/var/log",
 				},
 				{
-					MinSize:    1024,
+					MinSize:    "1024",
 					Mountpoint: "/var/log/audit",
 				},
 			},
@@ -663,19 +663,19 @@ func TestDistro_MountpointsWithArbitraryDepthAllowed(t *testing.T) {
 		Customizations: &blueprint.Customizations{
 			Filesystem: []blueprint.FilesystemCustomization{
 				{
-					MinSize:    1024,
+					MinSize:    "1024",
 					Mountpoint: "/var/a",
 				},
 				{
-					MinSize:    1024,
+					MinSize:    "1024",
 					Mountpoint: "/var/a/b",
 				},
 				{
-					MinSize:    1024,
+					MinSize:    "1024",
 					Mountpoint: "/var/a/b/c",
 				},
 				{
-					MinSize:    1024,
+					MinSize:    "1024",
 					Mountpoint: "/var/a/b/c/d",
 				},
 			},
@@ -701,15 +701,15 @@ func TestDistro_DirtyMountpointsNotAllowed(t *testing.T) {
 		Customizations: &blueprint.Customizations{
 			Filesystem: []blueprint.FilesystemCustomization{
 				{
-					MinSize:    1024,
+					MinSize:    "1024",
 					Mountpoint: "//",
 				},
 				{
-					MinSize:    1024,
+					MinSize:    "1024",
 					Mountpoint: "/var//",
 				},
 				{
-					MinSize:    1024,
+					MinSize:    "1024",
 					Mountpoint: "/var//log/audit/",
 				},
 			},
@@ -735,11 +735,11 @@ func TestDistro_CustomFileSystemPatternMatching(t *testing.T) {
 		Customizations: &blueprint.Customizations{
 			Filesystem: []blueprint.FilesystemCustomization{
 				{
-					MinSize:    1024,
+					MinSize:    "1024",
 					Mountpoint: "/variable",
 				},
 				{
-					MinSize:    1024,
+					MinSize:    "1024",
 					Mountpoint: "/variable/log/audit",
 				},
 			},
@@ -767,7 +767,7 @@ func TestDistro_CustomUsrPartitionNotLargeEnough(t *testing.T) {
 		Customizations: &blueprint.Customizations{
 			Filesystem: []blueprint.FilesystemCustomization{
 				{
-					MinSize:    1024,
+					MinSize:    "1024",
 					Mountpoint: "/usr",
 				},
 			},

--- a/test/data/manifests/rhel_85-aarch64-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_85-aarch64-qcow2_customize-boot.json
@@ -95,15 +95,15 @@
         "filesystem": [
           {
             "mountpoint": "/usr",
-            "minsize": 2147483648
+            "minsize": "2147483648"
           },
           {
             "mountpoint": "/var",
-            "minsize": 1073741824
+            "minsize": "1073741824"
           },
           {
             "mountpoint": "/",
-            "minsize": 2147483648
+            "minsize": "2147483648"
           }
         ]
       }

--- a/test/data/manifests/rhel_85-ppc64le-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_85-ppc64le-qcow2_customize-boot.json
@@ -90,15 +90,15 @@
         "filesystem": [
           {
             "mountpoint": "/usr",
-            "minsize": 2147483648
+            "minsize": "2147483648"
           },
           {
             "mountpoint": "/var",
-            "minsize": 1073741824
+            "minsize": "1073741824"
           },
           {
             "mountpoint": "/",
-            "minsize": 2147483648
+            "minsize": "2147483648"
           }
         ]
       }

--- a/test/data/manifests/rhel_85-s390x-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_85-s390x-qcow2_customize-boot.json
@@ -90,15 +90,15 @@
         "filesystem": [
           {
             "mountpoint": "/usr",
-            "minsize": 2147483648
+            "minsize": "2147483648"
           },
           {
             "mountpoint": "/var",
-            "minsize": 1073741824
+            "minsize": "1073741824"
           },
           {
             "mountpoint": "/",
-            "minsize": 2147483648
+            "minsize": "2147483648"
           }
         ]
       }

--- a/test/data/manifests/rhel_85-x86_64-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_85-x86_64-qcow2_customize-boot.json
@@ -105,15 +105,15 @@
         "filesystem": [
           {
             "mountpoint": "/usr",
-            "minsize": 2147483648
+            "minsize": "2147483648"
           },
           {
             "mountpoint": "/var",
-            "minsize": 1073741824
+            "minsize": "1073741824"
           },
           {
             "mountpoint": "/",
-            "minsize": 2147483648
+            "minsize": "2147483648"
           }
         ]
       }


### PR DESCRIPTION
It is not convenient to specify filesystem sizes in bytes every time.
Add support for parsing string with mMgG specified.

This approach has a downside, that now the filesystem size is of type
String and therefore all of the references must be strings which changes
the original behavior.

Alternative approach is to define a custom type and enable parsing of
both number and string.

TODO: input validation in Weldr API


This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] create a file in [news/unreleased](https://github.com/osbuild/osbuild-composer/tree/main/docs/news/unreleased) directory if this change should be mentioned in the release news
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

For user-visible changes, "adequate documentation" is an entry describing the
change for users in docs/news. Please refer to docs/news/README.md for details.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`
-->
