### PR TITLE
spec: Only run worker preun if systemd is running

### DIFF
--- a/osbuild-composer.spec
+++ b/osbuild-composer.spec
@@ -349,10 +349,11 @@ The worker for osbuild-composer
 # systemd_preun uses systemctl disable --now which doesn't work well with template services.
 # See https://github.com/systemd/systemd/issues/15620
 # The following lines mimicks its behaviour by running two commands:
-
-# disable and stop all the worker services
-systemctl --no-reload disable osbuild-worker@.service osbuild-remote-worker@.service
-systemctl stop "osbuild-worker@*.service" "osbuild-remote-worker@*.service"
+if [ -d /run/systemd/system ]; then
+    # disable and stop all the worker services
+    systemctl --no-reload disable osbuild-worker@.service osbuild-remote-worker@.service
+    systemctl stop "osbuild-worker@*.service" "osbuild-remote-worker@*.service"
+fi
 
 %postun worker
 # restart all the worker services


### PR DESCRIPTION
Fixes #1915

---

[ -d /run/systemd/system ] is used in the systemd rpm macros as well; there's also a check if /usb/bin/systemctl exists in the firstplace, is that needed as well @teg? 