### PR TITLE
customizations: add support for fs sizes with custom units

### DIFF
--- a/internal/blueprint/blueprint_test.go
+++ b/internal/blueprint/blueprint_test.go
@@ -3,9 +3,33 @@ package blueprint
 import (
 	"testing"
 
+	"github.com/BurntSushi/toml"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestBlueprintParse(t *testing.T) {
+	blueprint := `
+name = "test"
+description = "Test"
+version = "0.0.0"
+
+[[packages]]
+name = "httpd"
+version = "2.4.*"
+
+[[customizations.filesystem]]
+mountpoint = "/var"
+size = 2147483648
+`
+
+	var bp Blueprint
+	err := toml.Unmarshal([]byte(blueprint), &bp)
+	require.Nil(t, err)
+	assert.Equal(t, bp.Name, "test")
+	assert.Equal(t, "/var", bp.Customizations.Filesystem[0].Mountpoint)
+	assert.Equal(t, uint64(2147483648), bp.Customizations.Filesystem[0].MinSize)
+}
 
 func TestDeepCopy(t *testing.T) {
 	bpOrig := Blueprint{

--- a/internal/blueprint/customizations.go
+++ b/internal/blueprint/customizations.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"reflect"
+
+	"github.com/osbuild/osbuild-composer/internal/common"
 )
 
 type Customizations struct {
@@ -90,8 +92,14 @@ func (fsc *FilesystemCustomization) UnmarshalTOML(data interface{}) error {
 	switch d["size"].(type) {
 	case int64:
 		fsc.MinSize = uint64(d["size"].(int64))
+	case string:
+		size, err := common.DataSizeToUint64(d["size"].(string))
+		if err != nil {
+			return fmt.Errorf("TOML unmarshal: size is not valid filesystem size (%w)", err)
+		}
+		fsc.MinSize = size
 	default:
-		return fmt.Errorf("TOML unmarshal: size must be integer, got %v of type %T", d["size"], d["size"])
+		return fmt.Errorf("TOML unmarshal: size must be integer or string, got %v of type %T", d["size"], d["size"])
 	}
 
 	return nil
@@ -116,8 +124,14 @@ func (fsc *FilesystemCustomization) UnmarshalJSON(data []byte) error {
 	case float64:
 		// Note that it uses different key than the TOML version
 		fsc.MinSize = uint64(d["minsize"].(float64))
+	case string:
+		size, err := common.DataSizeToUint64(d["minsize"].(string))
+		if err != nil {
+			return fmt.Errorf("JSON unmarshal: size is not valid filesystem size (%w)", err)
+		}
+		fsc.MinSize = size
 	default:
-		return fmt.Errorf("JSON unmarshal: minsize must be float64 number, got %v of type %T", d["minsize"], d["minsize"])
+		return fmt.Errorf("JSON unmarshal: minsize must be float64 number or string, got %v of type %T", d["minsize"], d["minsize"])
 	}
 
 	return nil

--- a/internal/common/helpers_test.go
+++ b/internal/common/helpers_test.go
@@ -2,8 +2,10 @@ package common
 
 import (
 	"errors"
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestCurrentArchAMD64(t *testing.T) {
@@ -51,4 +53,41 @@ func TestIsStringInSortedSlice(t *testing.T) {
 	assert.False(t, IsStringInSortedSlice([]string{"bart", "lisa", "marge"}, "homer"))
 	assert.False(t, IsStringInSortedSlice([]string{"bart", "lisa", "marge"}, ""))
 	assert.False(t, IsStringInSortedSlice([]string{}, "homer"))
+}
+
+func TestDataSizeToUint64(t *testing.T) {
+	cases := []struct {
+		input   string
+		success bool
+		output  uint64
+	}{
+		{"123", true, 123},
+		{"123 kB", true, 123000},
+		{"123 KiB", true, 123 * 1024},
+		{"123 MB", true, 123 * 1000 * 1000},
+		{"123 MiB", true, 123 * 1024 * 1024},
+		{"123 GB", true, 123 * 1000 * 1000 * 1000},
+		{"123 GiB", true, 123 * 1024 * 1024 * 1024},
+		{"123 TB", true, 123 * 1000 * 1000 * 1000 * 1000},
+		{"123 TiB", true, 123 * 1024 * 1024 * 1024 * 1024},
+		{"123kB", true, 123000},
+		{"123KiB", true, 123 * 1024},
+		{" 123  ", true, 123},
+		{"  123kB  ", true, 123000},
+		{"  123KiB  ", true, 123 * 1024},
+		{"123 KB", false, 0},
+		{"123 mb", false, 0},
+		{"123 PB", false, 0},
+		{"123 PiB", false, 0},
+	}
+
+	for _, c := range cases {
+		result, err := DataSizeToUint64(c.input)
+		if c.success {
+			require.Nil(t, err)
+			assert.EqualValues(t, c.output, result)
+		} else {
+			assert.NotNil(t, err)
+		}
+	}
 }


### PR DESCRIPTION
Replaces: #1907

This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] create a file in [news/unreleased](https://github.com/osbuild/osbuild-composer/tree/main/docs/news/unreleased) directory if this change should be mentioned in the release news
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

For user-visible changes, "adequate documentation" is an entry describing the
change for users in docs/news. Please refer to docs/news/README.md for details.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`
-->
