### PR TITLE
spec: Make dnf-json subpackage conflict with old composer versions

### DIFF
--- a/osbuild-composer.spec
+++ b/osbuild-composer.spec
@@ -361,6 +361,10 @@ systemctl stop "osbuild-worker@*.service" "osbuild-remote-worker@*.service"
 %package dnf-json
 Summary: The dnf-json binary used by osbuild-composer and the workers
 
+# Conflicts with older versions of composer that provide the same files
+# this can be removed when RHEL 8 and Fedora 35 reach EOL
+Conflicts: osbuild-composer <= 35
+
 %description dnf-json
 The dnf-json binary used by osbuild-composer and the workers.
 


### PR DESCRIPTION
In v36, a new subpackage was introduced: `osbuild-composer-dnf-json`.  This package provides files (namely, `dnf-json`) that were previously part of the main `osbuild-composer` package.  This causes issues when downgrading from v36 to any previous version:
```
file /usr/libexec/osbuild-composer/dnf-json from install of osbuild-composer-core-33.2-1.el8.x86_64 conflicts with file from package osbuild-composer-dnf-json-36-1.el8.x86_64
```

This PR specifies that `osbuild-composer-dnf-json` conflicts with `osbuild-composer <= 35`.  Downgrading with this rule results in:
```
Error:
Problem: package osbuild-composer-dnf-json-36-1.20211018gitf42e3e5.fc34.x86_64 conflicts with osbuild-composer <= 35 provided by osbuild-composer-35-1.20211018gitfed4b97.fc34.x86_64
- conflicting requests
- problem with installed package osbuild-composer-dnf-json-36-1.20211018gitf42e3e5.fc34.x86_64
(try to add '--allowerasing' to command line to replace conflicting packages or '--skip-broken' to skip uninstallable packages)
```

Adding `--allowerasing` correctly removes `osbuild-composer-dnf-json` during the downgrade.

Is there a more appropriate way to handle this?