### PR TITLE
worker: add ssl authentication for worker connect kojiserver

### DIFF
--- a/cmd/osbuild-worker/jobimpl-osbuild-koji.go
+++ b/cmd/osbuild-worker/jobimpl-osbuild-koji.go
@@ -19,7 +19,7 @@ import (
 type OSBuildKojiJobImpl struct {
 	Store       string
 	Output      string
-	KojiServers map[string]koji.GSSAPICredentials
+	KojiServers map[string]koji.Credentials
 }
 
 func (impl *OSBuildKojiJobImpl) kojiUpload(file *os.File, server, directory, filename string) (string, uint64, error) {
@@ -40,7 +40,7 @@ func (impl *OSBuildKojiJobImpl) kojiUpload(file *os.File, server, directory, fil
 		return "", 0, fmt.Errorf("Koji server has not been configured: %s", serverURL.Hostname())
 	}
 
-	k, err := koji.NewFromGSSAPI(server, &creds, transport)
+	k, err := creds.NewKojiFromCreds(server)
 	if err != nil {
 		return "", 0, err
 	}

--- a/cmd/osbuild-worker/jobimpl-osbuild.go
+++ b/cmd/osbuild-worker/jobimpl-osbuild.go
@@ -25,7 +25,7 @@ import (
 type OSBuildJobImpl struct {
 	Store       string
 	Output      string
-	KojiServers map[string]koji.GSSAPICredentials
+	KojiServers map[string]koji.Credentials
 	GCPCreds    []byte
 	AzureCreds  *azure.Credentials
 	AWSCreds    string


### PR DESCRIPTION
This pull request includes:

Set the communicate of worker with koji support ssl authentication ，before it only support GSSAPI.

The related pr: [osbuild-composer#issue](https://github.com/osbuild/osbuild-composer/issues/1895)

@ondrejbudai @teg 