### PR TITLE
Revert "Revert "cloudapi/v1: Move depsolving to workers""

### DIFF
--- a/test/cases/api.sh
+++ b/test/cases/api.sh
@@ -706,17 +706,9 @@ function waitForState() {
     done
 }
 
-# a pending shouldn't state shouldn't trip up the heartbeats
-sudo systemctl stop "osbuild-worker@*"
 sendCompose
-waitForState "pending"
-# jobs time out after 2 minutes, so 180 seconds gives ample time to make sure it
-# doesn't time out for pending jobs
-sleep 180
-waitForState "pending"
 
 # crashed/stopped/killed worker should result in a failed state
-sudo systemctl start "osbuild-worker@1"
 waitForState "building"
 sudo systemctl stop "osbuild-worker@*"
 waitForState "failure"
@@ -734,8 +726,8 @@ test "$UPLOAD_STATUS" = "success"
 test "$UPLOAD_TYPE" = "$CLOUD_PROVIDER"
 test $((INIT_COMPOSES+1)) = "$SUBS_COMPOSES"
 
-# Make sure we get 1 job entry in the db per compose
-sudo podman exec osbuild-composer-db psql -U postgres -d osbuildcomposer -c "SELECT * FROM jobs;" | grep "2 rows"
+# Make sure we get 2 job entries in the db per compose (depsolve + build)
+sudo podman exec osbuild-composer-db psql -U postgres -d osbuildcomposer -c "SELECT * FROM jobs;" | grep "4 rows"
 
 #
 # Save the Manifest from the osbuild-composer store


### PR DESCRIPTION
Workers now depsolve in parallel to image builds, so we can
again move depsolivng to the workers. This will help us deal
with increases in traffic as we currently only have one
depsolve handler per pod. It would also avoid any issues with
composer running out of disk space due to dnf metadata caches.

This reverts PR #1908.
