### PR TITLE
templates: image-builder-ci access to composer

### DIFF
--- a/templates/composer.yml
+++ b/templates/composer.yml
@@ -165,7 +165,7 @@ objects:
   data:
     acl.yml: |
       - claim: user_id
-        pattern: ^(54629121|54629180|54597799)$
+        pattern: ^(54629121|54629180|54597799|54676085)$
     osbuild-composer.toml: |
       log_level = "info"
       [koji]


### PR DESCRIPTION
This should all move to app-interface, as it is configuration, and
we should distinguish between staging and production.

But for now, enable this where it is.

Signed-off-by: Tom Gundersen <teg@jklm.no>