### PR TITLE
ci: remove 8.5 nightly testing

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -59,8 +59,6 @@ RPM:
           - aws/centos-stream-8-x86_64
           - aws/centos-stream-8-aarch64
       - RUNNER:
-          - aws/rhel-8.5-nightly-x86_64
-          - aws/rhel-8.5-nightly-aarch64
           - aws/rhel-8.6-nightly-x86_64
           - aws/rhel-8.6-nightly-aarch64
           - aws/rhel-9.0-beta-nightly-x86_64
@@ -97,7 +95,6 @@ Prepare-rhel-internal:
       - RUNNER:
           # NOTE: 1 runner prepares for all arches b/c subsequent jobs download
           # artifacts from all previous jobs and the last one wins
-          - aws/rhel-8.5-nightly-x86_64
           - aws/rhel-8.6-nightly-x86_64
         INTERNAL_NETWORK: ["true"]
 
@@ -123,8 +120,6 @@ Base:
           - aws/centos-stream-8-x86_64
           - aws/centos-stream-8-aarch64
       - RUNNER:
-          - aws/rhel-8.5-nightly-x86_64
-          - aws/rhel-8.5-nightly-aarch64
           - aws/rhel-8.6-nightly-x86_64
           - aws/rhel-8.6-nightly-aarch64
           - aws/rhel-9.0-beta-nightly-x86_64
@@ -156,8 +151,6 @@ Regression:
       - RUNNER:
           - aws/rhel-8.4-ga-x86_64
           - aws/rhel-8.4-ga-aarch64
-          - aws/rhel-8.5-nightly-x86_64
-          - aws/rhel-8.5-nightly-aarch64
           - aws/rhel-8.6-nightly-x86_64
           - aws/rhel-8.6-nightly-aarch64
           - aws/rhel-9.0-beta-nightly-x86_64
@@ -185,7 +178,6 @@ OSTree:
           # See COMPOSER-919
           # - openstack/fedora-34-x86_64
           - openstack/rhel-8.4-ga-x86_64
-          - openstack/rhel-8.5-devel-x86_64
           - openstack/rhel-8.6-nightly-x86_64
           - openstack/rhel-9.0-beta-nightly-x86_64
           - openstack/centos-stream-8-x86_64
@@ -199,7 +191,6 @@ New OSTree:
   parallel:
     matrix:
       - RUNNER:
-          - openstack/rhel-8.5-x86_64-large
           - openstack/rhel-8.6-nightly-x86_64-large
           - openstack/centos-stream-8-x86_64
 
@@ -223,7 +214,6 @@ OSTree simplified installer:
   parallel:
     matrix:
       - RUNNER:
-          - openstack/rhel-8.5-x86_64-large
           - openstack/rhel-8.6-nightly-x86_64-large
           - openstack/centos-stream-8-x86_64
 
@@ -236,7 +226,6 @@ OSTree raw image:
   parallel:
     matrix:
       - RUNNER:
-          - openstack/rhel-8.5-devel-x86_64
           - openstack/rhel-8.6-nightly-x86_64
           - openstack/centos-stream-8-x86_64
 
@@ -275,14 +264,12 @@ Integration:
       - <<: *INTEGRATION_TESTS
         RUNNER:
           - aws/rhel-8.4-ga-x86_64
-          - aws/rhel-8.5-nightly-x86_64
           - aws/rhel-8.6-nightly-x86_64
           - aws/rhel-9.0-beta-nightly-x86_64
         INTERNAL_NETWORK: ["true"]
       - SCRIPT:
           - azure_hyperv_gen2.sh
         RUNNER:
-          - aws/rhel-8.5-nightly-x86_64
           - aws/rhel-8.6-nightly-x86_64
         INTERNAL_NETWORK: ["true"]
 
@@ -320,7 +307,6 @@ API:
       - <<: *API_TESTS
         RUNNER:
           - aws/rhel-8.4-ga-x86_64
-          - aws/rhel-8.5-nightly-x86_64
           - aws/rhel-8.6-nightly-x86_64
           - aws/rhel-9.0-beta-nightly-x86_64
         INTERNAL_NETWORK: ["true"]
@@ -341,7 +327,6 @@ libvirt:
           - openstack/centos-stream-8-x86_64
       - RUNNER:
           - openstack/rhel-8.4-ga-x86_64
-          - openstack/rhel-8.5-devel-x86_64
           - openstack/rhel-8.6-nightly-x86_64
           - openstack/rhel-9.0-beta-nightly-x86_64
         INTERNAL_NETWORK: ["true"]
@@ -390,7 +375,6 @@ Installer:
   parallel:
     matrix:
       - RUNNER:
-          - openstack/rhel-8.5-devel-x86_64
           - openstack/rhel-8.6-nightly-x86_64
           - openstack/rhel-9.0-beta-nightly-x86_64
 

--- a/Schutzfile
+++ b/Schutzfile
@@ -25,13 +25,6 @@
       }
     }
   },
-  "rhel-8.5": {
-    "dependencies": {
-      "osbuild": {
-        "commit": "662fe0feb9c3fd2843b34501900d466272aac776"
-      }
-    }
-  },
   "rhel-8.6": {
     "dependencies": {
       "osbuild": {

--- a/test/cases/api.sh
+++ b/test/cases/api.sh
@@ -409,14 +409,6 @@ case "$ID-$VERSION_ID" in
       SSH_USER="cloud-user"
     fi
     ;;
-  "rhel-8.5")
-    DISTRO="rhel-85"
-    if [[ "$CLOUD_PROVIDER" == "$CLOUD_PROVIDER_AWS" ]]; then
-      SSH_USER="ec2-user"
-    else
-      SSH_USER="cloud-user"
-    fi
-    ;;
   "rhel-8.4")
     DISTRO="rhel-84"
     SSH_USER="cloud-user"

--- a/test/cases/api_v2.sh
+++ b/test/cases/api_v2.sh
@@ -265,7 +265,7 @@ case $(set +x; . /etc/os-release; echo "$ID-$VERSION_ID") in
       SSH_USER="cloud-user"
     fi
     ;;
-  "rhel-8.5")
+  "rhel-8.6")
     DISTRO="rhel-85"
     if [[ "$CLOUD_PROVIDER" == "$CLOUD_PROVIDER_AWS" ]]; then
       SSH_USER="ec2-user"

--- a/test/cases/filesystem.sh
+++ b/test/cases/filesystem.sh
@@ -1,14 +1,14 @@
 #!/usr/bin/bash
 
 #
-# Test the ability to specify custom mountpoints for RHEL8.5 and above
+# Test the ability to specify custom mountpoints
 #
 set -euo pipefail
 
 source /etc/os-release
 
-if [[ "${ID}-${VERSION_ID}" != "rhel-8.5" && "${ID}-${VERSION_ID}" != "rhel-9.0" ]]; then
-    echo "$0 is only enabled for rhel-8.5; skipping..."
+if [[ "${ID}-${VERSION_ID}" != "rhel-8.6" && "${ID}-${VERSION_ID}" != "rhel-9.0" ]]; then
+    echo "$0 is only enabled for rhel-8.6 and rhel-9.0; skipping..."
     exit 0
 fi
 
@@ -125,7 +125,7 @@ clean_up () {
 
 ##################################################
 ##
-## RHEL8.5 & RHEL9.0 custom filesystems test - success case
+## Custom filesystems test - success case
 ##
 ##################################################
 
@@ -184,7 +184,7 @@ sudo composer-cli blueprints delete rhel85-custom-filesystem > /dev/null
 
 ##################################################
 ##
-## RHEL8.5 & RHEL9.0 custom filesystems test - fail case
+## Custom filesystems test - fail case
 ##
 ##################################################
 

--- a/test/cases/ostree-ng.sh
+++ b/test/cases/ostree-ng.sh
@@ -101,7 +101,7 @@ case "${ID}-${VERSION_ID}" in
         USER_IN_UPGRADE_BP="true"
         INSTALLER_PATH="/ostree/repo"
         ;;
-    "rhel-8.5" | "rhel-8.6" | "centos-8")
+    "rhel-8.6" | "centos-8")
         CONTAINER_TYPE=edge-container
         CONTAINER_FILENAME=container.tar
         INSTALLER_TYPE=edge-installer

--- a/test/cases/ostree-raw-image.sh
+++ b/test/cases/ostree-raw-image.sh
@@ -85,7 +85,7 @@ SSH_KEY=${SSH_DATA_DIR}/id_rsa
 SSH_KEY_PUB=$(cat "${SSH_KEY}".pub)
 
 case "${ID}-${VERSION_ID}" in
-    "rhel-8.5" | "rhel-8.6" | "centos-8" | "rhel-9.0")
+    "rhel-8.6" | "centos-8" | "rhel-9.0")
         CONTAINER_TYPE=edge-container
         CONTAINER_FILENAME=container.tar
         INSTALLER_TYPE=edge-raw-image

--- a/test/cases/ostree-simplified-installer.sh
+++ b/test/cases/ostree-simplified-installer.sh
@@ -94,7 +94,7 @@ SSH_KEY=${SSH_DATA_DIR}/id_rsa
 SSH_KEY_PUB=$(cat "${SSH_KEY}".pub)
 
 case "${ID}-${VERSION_ID}" in
-    "rhel-8.5" | "rhel-8.6" | "centos-8" | "rhel-9.0")
+    "rhel-8.6" | "centos-8" | "rhel-9.0")
         CONTAINER_TYPE=edge-container
         CONTAINER_FILENAME=container.tar
         INSTALLER_TYPE=edge-simplified-installer

--- a/test/cases/ostree.sh
+++ b/test/cases/ostree.sh
@@ -17,19 +17,13 @@ case "${ID}-${VERSION_ID}" in
         OS_VARIANT="fedora33"
         USER_IN_COMMIT="false"
         BOOT_LOCATION="https://mirrors.rit.edu/fedora/fedora/linux/releases/33/Everything/x86_64/os/";;
-    "rhel-8.3")
-        IMAGE_TYPE=rhel-edge-commit
-        OSTREE_REF="rhel/8/${ARCH}/edge"
-        OS_VARIANT="rhel8.3"
-        USER_IN_COMMIT="false"
-        BOOT_LOCATION="http://download.devel.redhat.com/released/rhel-8/RHEL-8/8.3.0/BaseOS/x86_64/os/";;
     "rhel-8.4")
         IMAGE_TYPE=rhel-edge-commit
         OSTREE_REF="rhel/8/${ARCH}/edge"
         OS_VARIANT="rhel8.4"
         USER_IN_COMMIT="false"
         BOOT_LOCATION="http://download.devel.redhat.com/released/rhel-8/RHEL-8/8.4.0/BaseOS/x86_64/os/";;
-    "rhel-8.5" | "rhel-8.6")
+    "rhel-8.6")
         IMAGE_TYPE=edge-commit
         OSTREE_REF="rhel/8/${ARCH}/edge"
         OS_VARIANT="rhel8-unknown"

--- a/test/cases/regression-excluded-dependency.sh
+++ b/test/cases/regression-excluded-dependency.sh
@@ -11,15 +11,14 @@
 #
 # Bug report: https://github.com/osbuild/osbuild-composer/issues/921
 
-# NOTE: ONLY WORKS IN RHEL 8.5 and RHEL 9.0
 # Get OS data.
 source /etc/os-release
 
 # Provision the software under test.
 /usr/libexec/osbuild-composer-test/provision.sh
 
-if [[ "${ID}-${VERSION_ID}" != "rhel-8.5" && "${ID}-${VERSION_ID}" != "rhel-9.0" ]]; then
-    echo "$0 is only enabled for rhel-8.5 and rhel-9.0; skipping..."
+if [[ "${ID}-${VERSION_ID}" != "rhel-8.6" && "${ID}-${VERSION_ID}" != "rhel-9.0" ]]; then
+    echo "$0 is only enabled for rhel-8.6 and rhel-9.0; skipping..."
     exit 0
 fi
 

--- a/tools/define-compose-url.sh
+++ b/tools/define-compose-url.sh
@@ -8,7 +8,7 @@ if [[ $ID != rhel ]]; then
 fi
 
 if [[ $ID == rhel && ${VERSION_ID%.*} == 8 ]]; then
-  COMPOSE_ID=$(curl -L http://download.devel.redhat.com/rhel-8/nightly/RHEL-8/latest-finished-RHEL-8.5/COMPOSE_ID)
+  COMPOSE_ID=$(curl -L http://download.devel.redhat.com/rhel-8/nightly/RHEL-8/latest-finished-RHEL-8.6/COMPOSE_ID)
 
   # default to a nightly tree but respect values passed from ENV so we can test rel-eng composes as well
   COMPOSE_URL="${COMPOSE_URL:-http://download.devel.redhat.com/rhel-8/nightly/RHEL-8/$COMPOSE_ID}"

--- a/tools/provision.sh
+++ b/tools/provision.sh
@@ -73,12 +73,6 @@ sudo cp /usr/share/tests/osbuild-composer/repositories/rhel-90.json "$REPODIR"
 
 # RHEL nightly repos need to be overridden
 case "${ID}-${VERSION_ID}" in
-    "rhel-8.5")
-        # Override old rhel-8.json and rhel-8-beta.json because RHEL 8.5 test needs nightly repos
-        sudo cp /usr/share/tests/osbuild-composer/repositories/rhel-85.json "$REPODIR/rhel-8.json"
-        # If multiple tests are run and call provision.sh the symlink will need to be overridden with -f
-        sudo ln -sf /etc/osbuild-composer/repositories/rhel-8.json "$REPODIR/rhel-8-beta.json"
-        ;;
     "rhel-8.6")
         # Override old rhel-8.json and rhel-8-beta.json because RHEL 8.6 test needs nightly repos
         sudo cp /usr/share/tests/osbuild-composer/repositories/rhel-86.json "$REPODIR/rhel-8.json"


### PR DESCRIPTION
It no longer makes sense because:

- we don't make any changes to 8.5
- we don't regenerate test manifests for 8.5
- osbuild-composer for 8.5 is in the rhel-8.5.0 branch

Also, the latest-8.5.0 symlink was removed, which broke the CI.

Signed-off-by: Ondřej Budai <ondrej@budai.cz>


This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] create a file in [news/unreleased](https://github.com/osbuild/osbuild-composer/tree/main/docs/news/unreleased) directory if this change should be mentioned in the release news
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

For user-visible changes, "adequate documentation" is an entry describing the
change for users in docs/news. Please refer to docs/news/README.md for details.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`
-->
