### PR TITLE
templates: hook up simple probes and default limits

### DIFF
--- a/templates/composer.yml
+++ b/templates/composer.yml
@@ -38,6 +38,31 @@ objects:
         containers:
         - image: "${IMAGE_NAME}:${IMAGE_TAG}"
           name: composer
+          livenessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: ${LIVENESS_URI}
+              port: ${{COMPOSER_API_PORT}}
+              scheme: HTTP
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: ${READINESS_URI}
+              port: ${{COMPOSER_API_PORT}}
+              scheme: HTTP
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          resources:
+            requests:
+              cpu: "${CPU_REQUEST}"
+              memory: "${MEMORY_REQUEST}"
+            limits:
+              cpu: "${CPU_LIMIT}"
+              memory: "${MEMORY_LIMIT}"
           env:
           - name: PGHOST
             valueFrom:
@@ -210,3 +235,21 @@ parameters:
     name: WORKER_API_PORT
     required: true
     value: "8700"
+  - name: LIVENESS_URI
+    description: URI to query for the liveness check
+    value: "/openapi"
+  - name: READINESS_URI
+    description: URI to query for the readiness check
+    value: "/openapi"
+  - name: CPU_REQUEST
+    description: CPU request per container
+    value: "200m"
+  - name: CPU_LIMIT
+    description: CPU limit per container
+    value: "1"
+  - name: MEMORY_REQUEST
+    description: Memory request per container
+    value: "256Mi"
+  - name: MEMORY_LIMIT
+    description: Memory limit per container
+    value: "512Mi"


### PR DESCRIPTION
Use fetching the OpenAPI spec as a simple readiness/liveness, as
there is not much else we can/need to verify.

Set the default CPU and memory limits in accordance with AppSRE
requirements.

Signed-off-by: Tom Gundersen <teg@jklm.no>