### PR TITLE
templates: add service account

### DIFF
--- a/templates/composer.yml
+++ b/templates/composer.yml
@@ -35,6 +35,7 @@ objects:
         labels:
           app: composer
       spec:
+        serviceAccountName: image-builder
         containers:
         - image: "${IMAGE_NAME}:${IMAGE_TAG}"
           name: composer
@@ -124,6 +125,13 @@ objects:
                 key: db.password
           - name: PGSSLMODE
             value: "${PGSSLMODE}"
+
+- apiVersion: v1
+  kind: ServiceAccount
+  metadata:
+    name: image-builder
+  imagePullSecrets:
+  - name: quay-cloudservices-pull
 
 - apiVersion: v1
   kind: Service


### PR DESCRIPTION
Avoid using the default account, but use a dedicated one.

This follows the guidelines from AppSRE and is what was done for
image-builder.

Signed-off-by: Tom Gundersen <teg@jklm.no>