### PR TITLE
prepare_rhel_internal: configure s3cmd explicitly

### DIFF
--- a/schutzbot/prepare-rhel-internal.sh
+++ b/schutzbot/prepare-rhel-internal.sh
@@ -126,10 +126,14 @@ if [ -z "${REPO_URL+x}" ]; then
 
     # Remove the previous latest repo for this job.
     # Don't fail if the path is missing.
+    AWS_ACCESS_KEY_ID="$V2_AWS_ACCESS_KEY_ID" \
+    AWS_SECRET_ACCESS_KEY="$V2_AWS_SECRET_ACCESS_KEY" \
     s3cmd --recursive rm "s3://${REPO_BUCKET}/${REPO_DIR_LATEST}" || true
 
     # Upload repository to S3.
     greenprint "☁ Uploading RPMs to S3"
+    AWS_ACCESS_KEY_ID="$V2_AWS_ACCESS_KEY_ID" \
+    AWS_SECRET_ACCESS_KEY="$V2_AWS_SECRET_ACCESS_KEY" \
     s3cmd --acl-public put --recursive repo/ s3://${REPO_BUCKET}/repo/
 
     # Public URL for the S3 bucket with our artifacts.


### PR DESCRIPTION
A similar change was added in 65e429fc4aa10eed920f77b023c4dae9fc04244e so adding it here as well.


This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`
-->
