### PR TITLE
Let schutzbot do the post-release version bump

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,4 +12,4 @@ jobs:
       - name: Upstream release
         uses: osbuild/release-action@main
         with:
-          token: "${{ secrets.GITHUB_TOKEN }}"
+          token: "${{ secrets.SCHUTZBOT_GITHUB_ACCESS_TOKEN }}"

--- a/osbuild-composer.spec
+++ b/osbuild-composer.spec
@@ -4,7 +4,7 @@
 
 %global goipath         github.com/osbuild/osbuild-composer
 
-Version:        37
+Version:        38
 
 %gometa
 


### PR DESCRIPTION
This PR does two things:

- bumps the version ahead of time for the next composer release
- switches over to using schutzbot's personal access token to do the post release version bump.

Related PR for osbuild: https://github.com/osbuild/osbuild/pull/863