### PR TITLE
tests: skip Openstack image boot testing on aarch64

### DIFF
--- a/cmd/osbuild-image-tests/main_test.go
+++ b/cmd/osbuild-image-tests/main_test.go
@@ -389,9 +389,13 @@ func testBootUsingAzure(t *testing.T, imagePath string) {
 
 func testBootUsingOpenStack(t *testing.T, imagePath string) {
 	creds, err := openstack.AuthOptionsFromEnv()
+	currentArch := common.CurrentArch()
 
-	// if no credentials are given, fall back to qemu
-	if (creds == gophercloud.AuthOptions{}) {
+	// skip on aarch64 because we don't have aarch64 openstack or kvm machines
+	if currentArch == "aarch64" {
+		t.Skip("Openstack boot test is skipped on aarch64.")
+		// if no credentials are given, fall back to qemu
+	} else if (creds == gophercloud.AuthOptions{}) {
 		log.Print("No OpenStack credentials given, falling back to booting using qemu")
 		testBootUsingQemu(t, imagePath)
 		return


### PR DESCRIPTION
We don't have aarch64 machines in Openstack so fallback to qemu when running on aarch64.

This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`
-->
