### PR TITLE
cloudapi/v2: 5xx error metrics

### DIFF
--- a/internal/cloudapi/v2/errors.go
+++ b/internal/cloudapi/v2/errors.go
@@ -251,7 +251,8 @@ func (s *Server) HTTPErrorHandler(echoError error, c echo.Context) {
 		return
 	}
 
-	if he.Code == http.StatusInternalServerError {
+	internalError := he.Code >= http.StatusInternalServerError && he.Code <= http.StatusNetworkAuthenticationRequired
+	if internalError {
 		if strings.HasSuffix(c.Path(), "/compose") {
 			prometheus.ComposeFailures.Inc()
 		}


### PR DESCRIPTION
Currently error metrics are being recorded forerrors with the exact error code of 500. This
commit enables recording metrics for all 5xx errors.


This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`
-->
