### PR TITLE
distribution: worker dnf-json & cache dir

### DIFF
--- a/distribution/Dockerfile-worker
+++ b/distribution/Dockerfile-worker
@@ -10,6 +10,8 @@ RUN mkdir -p "/etc/osbuild-composer/"
 RUN mkdir -p "/run/osbuild-composer/"
 RUN mkdir -p "/var/cache/osbuild-worker/"
 RUN mkdir -p "/var/lib/osbuild-composer/"
+RUN mkdir -p "/var/cache/osbuild-composer/output"
 COPY --from=builder /opt/app-root/src/go/bin/osbuild-worker /usr/libexec/osbuild-composer/
+COPY ./dnf-json /usr/libexec/osbuild-composer/
 
 ENTRYPOINT ["/usr/libexec/osbuild-composer/osbuild-worker"]


### PR DESCRIPTION
Since the depsolving has been moved to the worker, the Dockerfile for the worker needed to have the
dnf-json executable. Additionally there was a missing cache directory.


This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`
-->
