### PR TITLE
CI: Journal-log is accessible and encrypted

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -9,13 +9,13 @@ stages:
 .base:
   after_script:
     - schutzbot/update_github_status.sh update
-#     - schutzbot/save_journal.sh
+    - schutzbot/save_journal.sh
     - schutzbot/run_cloud_cleaner.sh
   tags:
     - terraform
   artifacts:
     paths:
-      # - journal-log
+      - journal-log.gpg
       - ci-artifacts
     when: always
 
@@ -46,7 +46,10 @@ RPM:
     - sh "schutzbot/mockbuild.sh"
   after_script:
     - schutzbot/update_github_status.sh update
-#     - schutzbot/save_journal.sh
+    - schutzbot/save_journal.sh
+  artifacts:
+    paths:
+      - journal-log.gpg
   parallel:
     matrix:
       - RUNNER:
@@ -123,7 +126,7 @@ Base:
         INTERNAL_NETWORK: ["true"]
   artifacts:
     paths:
-      - journal-log
+      - journal-log.gpg
       - "*.repo"
     when: always
 
@@ -152,7 +155,7 @@ Regression:
         INTERNAL_NETWORK: ["true"]
   artifacts:
     paths:
-      - journal-log
+      - journal-log.gpg
       - "*.repo"
     when: always
 

--- a/schutzbot/save_journal.sh
+++ b/schutzbot/save_journal.sh
@@ -2,3 +2,8 @@
 
 # use tee, otherwise shellcheck complains
 sudo journalctl --boot | tee journal-log >/dev/null
+
+# As it might contain sensitive information and is important for debugging
+# purposes, encrypt journal-log with a symmetric passphrase.
+gpg --batch --yes --passphrase "$GPG_SYMMETRIC_PASSPHRASE" -o journal-log.gpg --symmetric journal-log
+rm journal-log


### PR DESCRIPTION
This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`
-->
