### PR TITLE
schutzbot: double quote jq argument to prevent shellcheck failures

### DIFF
--- a/schutzbot/scheduled_cloud_cleaner.sh
+++ b/schutzbot/scheduled_cloud_cleaner.sh
@@ -28,8 +28,8 @@ HOURS_BACK="${HOURS_BACK:-6}"
 DELETE_TIME=$(date -d "- $HOURS_BACK hours" +%s)
 OLD_RESOURCE_LIST_NAMES=()
 for i in $(seq 0 $(("$RESOURCE_COUNT"-1))); do
-    RESOURCE_TIME=$(echo "$RESOURCE_LIST" | jq .[$i].createdTime | tr -d '"')
-    RESOURCE_TYPE=$(echo "$RESOURCE_LIST" | jq .[$i].type | tr -d '"')
+    RESOURCE_TIME=$(echo "$RESOURCE_LIST" | jq ".[$i].createdTime" | tr -d '"')
+    RESOURCE_TYPE=$(echo "$RESOURCE_LIST" | jq ".[$i].type" | tr -d '"')
     RESOURCE_TIME_SECONDS=$(date -d "$RESOURCE_TIME" +%s)
     if [[ "$RESOURCE_TIME_SECONDS" -lt "$DELETE_TIME" && "$RESOURCE_TYPE" != Microsoft.Storage/storageAccounts ]]; then
         OLD_RESOURCE_LIST_NAMES+=("$(echo "$RESOURCE_LIST" | jq .["$i"].name | sed -e 's/^[^-]*-//' | tr -d '"')")


### PR DESCRIPTION
The argument contains a variable $i. Shellcheck complains that it must
be quoted.


This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`
-->
