### PR TITLE
osbuild2: support 'install' command in the modprobe stage and rework data validation

### DIFF
--- a/internal/osbuild2/modprobe_stage.go
+++ b/internal/osbuild2/modprobe_stage.go
@@ -55,6 +55,16 @@ func (configFile *ModprobeConfigCmdList) UnmarshalJSON(data []byte) error {
 				return fmt.Errorf("'modulename' item should be string, not %T", configCmdMap["modulename"])
 			}
 			modprobeCmd = NewModprobeConfigCmdBlacklist(modulename)
+		case "install":
+			modulename, ok := configCmdMap["modulename"].(string)
+			if !ok {
+				return fmt.Errorf("'modulename' item should be string, not %T", configCmdMap["modulename"])
+			}
+			cmdline, ok := configCmdMap["cmdline"].(string)
+			if !ok {
+				return fmt.Errorf("'cmdline' item should be string, not %T", configCmdMap["cmdline"])
+			}
+			modprobeCmd = NewModprobeConfigCmdInstall(modulename, cmdline)
 		default:
 			return fmt.Errorf("unexpected modprobe command: %s", command)
 		}
@@ -88,5 +98,25 @@ func NewModprobeConfigCmdBlacklist(modulename string) *ModprobeConfigCmdBlacklis
 	return &ModprobeConfigCmdBlacklist{
 		Command:    "blacklist",
 		Modulename: modulename,
+	}
+}
+
+// ModprobeConfigCmdInstall represents the 'install' command in the
+// modprobe configuration.
+type ModprobeConfigCmdInstall struct {
+	Command    string `json:"command"`
+	Modulename string `json:"modulename"`
+	Cmdline    string `json:"cmdline"`
+}
+
+func (ModprobeConfigCmdInstall) isModprobeConfigCmd() {}
+
+// NewModprobeConfigCmdInstall creates a new instance of ModprobeConfigCmdInstall
+// for the provided modulename.
+func NewModprobeConfigCmdInstall(modulename, cmdline string) *ModprobeConfigCmdInstall {
+	return &ModprobeConfigCmdInstall{
+		Command:    "install",
+		Modulename: modulename,
+		Cmdline:    cmdline,
 	}
 }

--- a/internal/osbuild2/modprobe_stage_test.go
+++ b/internal/osbuild2/modprobe_stage_test.go
@@ -1,29 +1,36 @@
 package osbuild2
 
 import (
-	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
 
 func TestNewModprobeStage(t *testing.T) {
+	stageOptions := &ModprobeStageOptions{
+		Filename: "testing.conf",
+		Commands: ModprobeConfigCmdList{
+			NewModprobeConfigCmdBlacklist("testing_module"),
+		},
+	}
 	expectedStage := &Stage{
 		Type:    "org.osbuild.modprobe",
-		Options: &ModprobeStageOptions{},
+		Options: stageOptions,
 	}
-	actualStage := NewModprobeStage(&ModprobeStageOptions{})
+	actualStage := NewModprobeStage(stageOptions)
 	assert.Equal(t, expectedStage, actualStage)
 }
 
-func TestModprobeStage_MarshalJSON_Invalid(t *testing.T) {
+func TestModprobeStageOptionsValidate(t *testing.T) {
 	tests := []struct {
 		name    string
 		options ModprobeStageOptions
+		err     bool
 	}{
 		{
 			name:    "empty-options",
 			options: ModprobeStageOptions{},
+			err:     true,
 		},
 		{
 			name: "no-commands",
@@ -31,12 +38,110 @@ func TestModprobeStage_MarshalJSON_Invalid(t *testing.T) {
 				Filename: "disallow-modules.conf",
 				Commands: ModprobeConfigCmdList{},
 			},
+			err: true,
+		},
+		{
+			name: "no-filename",
+			options: ModprobeStageOptions{
+				Commands: ModprobeConfigCmdList{NewModprobeConfigCmdBlacklist("module_name")},
+			},
+			err: true,
+		},
+		{
+			name: "incorrect-filename",
+			options: ModprobeStageOptions{
+				Filename: "disallow-modules.ccoonnff",
+				Commands: ModprobeConfigCmdList{NewModprobeConfigCmdBlacklist("module_name")},
+			},
+			err: true,
+		},
+		{
+			name: "good-options",
+			options: ModprobeStageOptions{
+				Filename: "disallow-modules.conf",
+				Commands: ModprobeConfigCmdList{NewModprobeConfigCmdBlacklist("module_name")},
+			},
+			err: false,
 		},
 	}
 	for idx, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotBytes, err := json.Marshal(tt.options)
-			assert.NotNilf(t, err, "json.Marshal() didn't return an error, but: %s [idx: %d]", string(gotBytes), idx)
+			if tt.err {
+				assert.Errorf(t, tt.options.validate(), "%q didn't return an error [idx: %d]", tt.name, idx)
+				assert.Panics(t, func() { NewModprobeStage(&tt.options) })
+			} else {
+				assert.NoErrorf(t, tt.options.validate(), "%q returned an error [idx: %d]", tt.name, idx)
+				assert.NotPanics(t, func() { NewModprobeStage(&tt.options) })
+			}
+		})
+	}
+}
+
+func TestNewModprobeConfigCmdBlacklist(t *testing.T) {
+	tests := []struct {
+		name       string
+		modulename string
+		err        bool
+	}{
+		{
+			name:       "empty-modulename",
+			modulename: "",
+			err:        true,
+		},
+		{
+			name:       "non-empty-modulename",
+			modulename: "module_name",
+			err:        false,
+		},
+	}
+	for idx, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.err {
+				assert.Errorf(t, ModprobeConfigCmdBlacklist{Command: "blacklist", Modulename: tt.modulename}.validate(), "%q didn't return an error [idx: %d]", tt.name, idx)
+				assert.Panics(t, func() { NewModprobeConfigCmdBlacklist(tt.modulename) })
+			} else {
+				assert.NoErrorf(t, ModprobeConfigCmdBlacklist{Command: "blacklist", Modulename: tt.modulename}.validate(), "%q returned an error [idx: %d]", tt.name, idx)
+				assert.NotPanics(t, func() { NewModprobeConfigCmdBlacklist(tt.modulename) })
+			}
+		})
+	}
+}
+
+func TestNewModprobeConfigCmdInstall(t *testing.T) {
+	tests := []struct {
+		name       string
+		modulename string
+		cmdline    string
+		err        bool
+	}{
+		{
+			name:       "empty-modulename",
+			modulename: "",
+			cmdline:    "/usr/bin/true",
+			err:        true,
+		},
+		{
+			name:       "empty-cmdline",
+			modulename: "module_name",
+			cmdline:    "",
+			err:        true,
+		},
+		{
+			name:       "non-empty-modulename",
+			modulename: "module_name",
+			cmdline:    "/usr/bin/true",
+			err:        false,
+		},
+	}
+	for idx, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.err {
+				assert.Errorf(t, ModprobeConfigCmdInstall{Command: "install", Modulename: tt.modulename, Cmdline: tt.cmdline}.validate(), "%q didn't return an error [idx: %d]", tt.name, idx)
+				assert.Panics(t, func() { NewModprobeConfigCmdInstall(tt.modulename, tt.cmdline) })
+			} else {
+				assert.NoErrorf(t, ModprobeConfigCmdInstall{Command: "install", Modulename: tt.modulename, Cmdline: tt.cmdline}.validate(), "%q returned an error [idx: %d]", tt.name, idx)
+				assert.NotPanics(t, func() { NewModprobeConfigCmdInstall(tt.modulename, tt.cmdline) })
+			}
 		})
 	}
 }

--- a/internal/osbuild2/stage_test.go
+++ b/internal/osbuild2/stage_test.go
@@ -321,11 +321,16 @@ func TestStage_UnmarshalJSON(t *testing.T) {
 							Command:    "blacklist",
 							Modulename: "floppy",
 						},
+						&ModprobeConfigCmdInstall{
+							Command:    "install",
+							Modulename: "nf_conntrack",
+							Cmdline:    "/usr/sbin/modprobe --ignore-install nf_conntrack $CMDLINE_OPTS && /usr/sbin/sysctl --quiet --pattern 'net[.]netfilter[.]nf_conntrack.*' --system",
+						},
 					},
 				},
 			},
 			args: args{
-				data: []byte(`{"type":"org.osbuild.modprobe","options":{"filename":"disallow-modules.conf","commands":[{"command":"blacklist","modulename":"nouveau"},{"command":"blacklist","modulename":"floppy"}]}}`),
+				data: []byte(`{"type":"org.osbuild.modprobe","options":{"filename":"disallow-modules.conf","commands":[{"command":"blacklist","modulename":"nouveau"},{"command":"blacklist","modulename":"floppy"},{"command":"install","modulename":"nf_conntrack","cmdline":"/usr/sbin/modprobe --ignore-install nf_conntrack $CMDLINE_OPTS \u0026\u0026 /usr/sbin/sysctl --quiet --pattern 'net[.]netfilter[.]nf_conntrack.*' --system"}]}}`),
 			},
 		},
 		{


### PR DESCRIPTION
- osbuild2: support 'install' command in the modprobe stage
  - Related to osbuild/osbuild#867
- osbuild2/modprobe: extend and rework stage options validation
  -  Related to issue #1785.

This pull request includes:

- [x] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`
-->
