### PR TITLE
osbuild2: new stage authconfig 

### DIFF
--- a/internal/osbuild2/authconfig_stage.go
+++ b/internal/osbuild2/authconfig_stage.go
@@ -1,0 +1,13 @@
+package osbuild2
+
+type AuthconfigStageOptions struct {
+}
+
+func (AuthconfigStageOptions) isStageOptions() {}
+
+func NewAuthconfigStage(options *AuthconfigStageOptions) *Stage {
+	return &Stage{
+		Type:    "org.osbuild.authconfig",
+		Options: options,
+	}
+}

--- a/internal/osbuild2/authconfig_stage_test.go
+++ b/internal/osbuild2/authconfig_stage_test.go
@@ -1,0 +1,16 @@
+package osbuild2
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewAuthconfigStage(t *testing.T) {
+	expectedStage := &Stage{
+		Type:    "org.osbuild.authconfig",
+		Options: &AuthconfigStageOptions{},
+	}
+	actualStage := NewAuthconfigStage(&AuthconfigStageOptions{})
+	assert.Equal(t, expectedStage, actualStage)
+}

--- a/internal/osbuild2/stage.go
+++ b/internal/osbuild2/stage.go
@@ -146,6 +146,8 @@ func (stage *Stage) UnmarshalJSON(data []byte) error {
 		// The stage accepts also source input, but we need to rework all inputs first to handle this nicely here.
 		// Only files input is used by the XZ stage at this moment.
 		inputs = new(FilesInputs)
+	case "org.osbuild.authconfig":
+		options = new(AuthconfigStageOptions)
 	default:
 		return fmt.Errorf("unexpected stage type: %s", rawStage.Type)
 	}

--- a/internal/osbuild2/stage_test.go
+++ b/internal/osbuild2/stage_test.go
@@ -637,6 +637,16 @@ func TestStage_UnmarshalJSON(t *testing.T) {
 				data: []byte(`{"type":"org.osbuild.users","options":{"users":null}}`),
 			},
 		},
+		{
+			name: "authconfig",
+			fields: fields{
+				Type:    "org.osbuild.authconfig",
+				Options: &AuthconfigStageOptions{},
+			},
+			args: args{
+				data: []byte(`{"type":"org.osbuild.authconfig","options":{}}`),
+			},
+		},
 	}
 	for idx, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`
-->
