### PR TITLE
spec: bump osbuild version to 41

### DIFF
--- a/Schutzfile
+++ b/Schutzfile
@@ -2,7 +2,7 @@
   "fedora-33": {
     "dependencies": {
       "osbuild": {
-        "commit": "662fe0feb9c3fd2843b34501900d466272aac776"
+        "commit": "f7bf23fabaae6027b1e1147b27870d90d4b1911f"
       }
     },
     "dependants": {
@@ -14,28 +14,35 @@
   "fedora-34": {
     "dependencies": {
       "osbuild": {
-        "commit": "662fe0feb9c3fd2843b34501900d466272aac776"
+        "commit": "f7bf23fabaae6027b1e1147b27870d90d4b1911f"
       }
     }
   },
   "rhel-8.4": {
     "dependencies": {
       "osbuild": {
-        "commit": "662fe0feb9c3fd2843b34501900d466272aac776"
+        "commit": "f7bf23fabaae6027b1e1147b27870d90d4b1911f"
       }
     }
   },
   "rhel-8.6": {
     "dependencies": {
       "osbuild": {
-        "commit": "2e8ef3eadddda07b4649feb2c05b62c42254d2c9"
+        "commit": "f7bf23fabaae6027b1e1147b27870d90d4b1911f"
+      }
+    }
+  },
+  "rhel-9.0": {
+    "dependencies": {
+      "osbuild": {
+        "commit": "f7bf23fabaae6027b1e1147b27870d90d4b1911f"
       }
     }
   },
   "centos-8": {
     "dependencies": {
       "osbuild": {
-        "commit": "662fe0feb9c3fd2843b34501900d466272aac776"
+        "commit": "f7bf23fabaae6027b1e1147b27870d90d4b1911f"
       }
     }
   }

--- a/osbuild-composer.spec
+++ b/osbuild-composer.spec
@@ -326,8 +326,8 @@ The core osbuild-composer binary. This is suitable both for spawning in containe
 Summary:    The worker for osbuild-composer
 Requires:   systemd
 Requires:   qemu-img
-Requires:   osbuild >= 37
-Requires:   osbuild-ostree >= 37
+Requires:   osbuild >= 41
+Requires:   osbuild-ostree >= 41
 Requires:   %{name}-dnf-json = %{version}-%{release}
 
 # remove in F34


### PR DESCRIPTION
This will be needed for new stages which are available only in osbuild
41.


This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`
-->
