### PR TITLE
osbuild2: new stage sshd config

### DIFF
--- a/internal/osbuild2/sshd_config_stage.go
+++ b/internal/osbuild2/sshd_config_stage.go
@@ -1,0 +1,20 @@
+package osbuild2
+
+type SshdConfigConfig struct {
+	PasswordAuthentication          *bool `json:"PasswordAuthentication,omitempty"`
+	ChallengeResponseAuthentication *bool `json:"ChallengeResponseAuthentication,omitempty"`
+	ClientAliveInterval             *int  `json:"ClientAliveInterval,omitempty"`
+}
+
+type SshdConfigStageOptions struct {
+	Config SshdConfigConfig `json:"config"`
+}
+
+func (SshdConfigStageOptions) isStageOptions() {}
+
+func NewSshdConfigStage(options *SshdConfigStageOptions) *Stage {
+	return &Stage{
+		Type:    "org.osbuild.sshd.config",
+		Options: options,
+	}
+}

--- a/internal/osbuild2/sshd_config_stage_test.go
+++ b/internal/osbuild2/sshd_config_stage_test.go
@@ -1,0 +1,53 @@
+package osbuild2
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+
+	"github.com/osbuild/osbuild-composer/internal/common"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewSshdConfigStage(t *testing.T) {
+	expectedStage := &Stage{
+		Type:    "org.osbuild.sshd.config",
+		Options: &SshdConfigStageOptions{},
+	}
+	actualStage := NewSshdConfigStage(&SshdConfigStageOptions{})
+	assert.Equal(t, expectedStage, actualStage)
+}
+
+func TestJsonSshdConfigStage(t *testing.T) {
+	// First test that the JSON can be parsed into the expected structure.
+	expectedOptions := SshdConfigStageOptions{
+		Config: SshdConfigConfig{
+			PasswordAuthentication:          common.BoolToPtr(false),
+			ChallengeResponseAuthentication: common.BoolToPtr(false),
+			ClientAliveInterval:             common.IntToPtr(180),
+		},
+	}
+	inputString := `{
+		"config": {
+		  "PasswordAuthentication": false,
+		  "ChallengeResponseAuthentication": false,
+		  "ClientAliveInterval": 180
+		}
+	  }`
+	var inputOptions SshdConfigStageOptions
+	err := json.Unmarshal([]byte(inputString), &inputOptions)
+	assert.NoError(t, err, "failed to parse JSON into sshd config")
+	assert.True(t, reflect.DeepEqual(expectedOptions, inputOptions))
+
+	// Second try the other way around with stress on missing values
+	// for those parameters that the user didn't specify.
+	inputOptions = SshdConfigStageOptions{
+		Config: SshdConfigConfig{
+			PasswordAuthentication: common.BoolToPtr(true),
+		},
+	}
+	expectedString := `{"config":{"PasswordAuthentication":true}}`
+	inputBytes, err := json.Marshal(inputOptions)
+	assert.NoError(t, err, "failed to marshal sshd config into JSON")
+	assert.Equal(t, expectedString, string(inputBytes))
+}

--- a/internal/osbuild2/stage.go
+++ b/internal/osbuild2/stage.go
@@ -146,6 +146,8 @@ func (stage *Stage) UnmarshalJSON(data []byte) error {
 		// The stage accepts also source input, but we need to rework all inputs first to handle this nicely here.
 		// Only files input is used by the XZ stage at this moment.
 		inputs = new(FilesInputs)
+	case "org.osbuild.sshd.config":
+		options = new(SshdConfigStageOptions)
 	default:
 		return fmt.Errorf("unexpected stage type: %s", rawStage.Type)
 	}

--- a/internal/osbuild2/stage_test.go
+++ b/internal/osbuild2/stage_test.go
@@ -637,6 +637,16 @@ func TestStage_UnmarshalJSON(t *testing.T) {
 				data: []byte(`{"type":"org.osbuild.users","options":{"users":null}}`),
 			},
 		},
+		{
+			name: "sshd.config",
+			fields: fields{
+				Type:    "org.osbuild.sshd.config",
+				Options: &SshdConfigStageOptions{},
+			},
+			args: args{
+				data: []byte(`{"type":"org.osbuild.sshd.config","options":{"config":{}}}`),
+			},
+		},
 	}
 	for idx, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
This stage was introduced in osbuild 41. Add support into
osbuild-composer and a test using test data from osbuild repo.


This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`
-->
