### PR TITLE
test: Update ostree test scripts to support different ostree refs

### DIFF
--- a/test/cases/ostree-ng.sh
+++ b/test/cases/ostree-ng.sh
@@ -72,8 +72,6 @@ polkit.addRule(function(action, subject) {
 EOF
 
 # Set up variables.
-OSTREE_REF="test/rhel/8/${ARCH}/edge"
-OS_VARIANT="rhel8-unknown"
 TEST_UUID=$(uuidgen)
 IMAGE_KEY="osbuild-composer-ostree-test-${TEST_UUID}"
 BIOS_GUEST_ADDRESS=192.168.100.50
@@ -87,6 +85,11 @@ QUAY_REPO_TAG=$(tr -dc a-z0-9 < /dev/urandom | head -c 4 ; echo '')
 STAGE_OCP4_SERVER_NAME="edge-stage-server"
 STAGE_OCP4_REPO_URL="http://${STAGE_OCP4_SERVER_NAME}-${QUAY_REPO_TAG}-frontdoor.apps.ocp.ci.centos.org/repo/"
 ARTIFACTS="ci-artifacts"
+# For CS8, CS9, RHEL 8.5 and above
+CONTAINER_TYPE=edge-container
+CONTAINER_FILENAME=container.tar
+INSTALLER_TYPE=edge-installer
+INSTALLER_FILENAME=installer.iso
 mkdir -p "${ARTIFACTS}"
 
 # Set up temporary files.
@@ -104,6 +107,8 @@ SSH_KEY_PUB=$(cat "${SSH_KEY}".pub)
 
 case "${ID}-${VERSION_ID}" in
     "rhel-8.4")
+        OSTREE_REF="test/rhel/8/${ARCH}/edge"
+        OS_VARIANT="rhel8-unknown"
         CONTAINER_TYPE=rhel-edge-container
         CONTAINER_FILENAME=rhel84-container.tar
         INSTALLER_TYPE=rhel-edge-installer
@@ -111,11 +116,27 @@ case "${ID}-${VERSION_ID}" in
         USER_IN_UPGRADE_BP="true"
         INSTALLER_PATH="/ostree/repo"
         ;;
-    "rhel-8.6" | "centos-8" | "rhel-9.0" | "centos-9")
-        CONTAINER_TYPE=edge-container
-        CONTAINER_FILENAME=container.tar
-        INSTALLER_TYPE=edge-installer
-        INSTALLER_FILENAME=installer.iso
+    "rhel-8.6")
+        OSTREE_REF="test/rhel/8/${ARCH}/edge"
+        OS_VARIANT="rhel8-unknown"
+        USER_IN_UPGRADE_BP="false"
+        INSTALLER_PATH="/run/install/repo/ostree/repo"
+        ;;
+    "rhel-9.0")
+        OSTREE_REF="test/rhel/9/${ARCH}/edge"
+        OS_VARIANT="rhel9-unknown"
+        USER_IN_UPGRADE_BP="false"
+        INSTALLER_PATH="/run/install/repo/ostree/repo"
+        ;;
+    "centos-8")
+        OSTREE_REF="test/centos/8/${ARCH}/edge"
+        OS_VARIANT="centos8"
+        USER_IN_UPGRADE_BP="false"
+        INSTALLER_PATH="/run/install/repo/ostree/repo"
+        ;;
+    "centos-9")
+        OSTREE_REF="test/centos/9/${ARCH}/edge"
+        OS_VARIANT="centos9"
         USER_IN_UPGRADE_BP="false"
         INSTALLER_PATH="/run/install/repo/ostree/repo"
         ;;

--- a/test/cases/ostree-raw-image.sh
+++ b/test/cases/ostree-raw-image.sh
@@ -68,8 +68,6 @@ polkit.addRule(function(action, subject) {
 EOF
 
 # Set up variables.
-OSTREE_REF="rhel/8/${ARCH}/edge"
-OS_VARIANT="rhel8-unknown"
 TEST_UUID=$(uuidgen)
 IMAGE_KEY="edge-${TEST_UUID}"
 BIOS_GUEST_ADDRESS=192.168.100.50
@@ -79,6 +77,10 @@ PROD_REPO=/var/www/html/repo
 STAGE_REPO_ADDRESS=192.168.200.1
 STAGE_REPO_URL="http://${STAGE_REPO_ADDRESS}:8080/repo/"
 ARTIFACTS="ci-artifacts"
+CONTAINER_TYPE=edge-container
+CONTAINER_FILENAME=container.tar
+INSTALLER_TYPE=edge-raw-image
+INSTALLER_FILENAME=image.raw.xz
 mkdir -p "${ARTIFACTS}"
 
 # Set up temporary files.
@@ -94,11 +96,21 @@ SSH_KEY=${SSH_DATA_DIR}/id_rsa
 SSH_KEY_PUB=$(cat "${SSH_KEY}".pub)
 
 case "${ID}-${VERSION_ID}" in
-    "rhel-8.6" | "centos-8" | "rhel-9.0" | "centos-9")
-        CONTAINER_TYPE=edge-container
-        CONTAINER_FILENAME=container.tar
-        INSTALLER_TYPE=edge-raw-image
-        INSTALLER_FILENAME=image.raw.xz
+    "rhel-8.6")
+        OSTREE_REF="rhel/8/${ARCH}/edge"
+        OS_VARIANT="rhel8-unknown"
+        ;;
+    "rhel-9.0")
+        OSTREE_REF="rhel/9/${ARCH}/edge"
+        OS_VARIANT="rhel9-unknown"
+        ;;
+    "centos-8")
+        OSTREE_REF="centos/8/${ARCH}/edge"
+        OS_VARIANT="centos8"
+        ;;
+    "centos-9")
+        OSTREE_REF="centos/9/${ARCH}/edge"
+        OS_VARIANT="centos9"
         ;;
     *)
         echo "unsupported distro: ${ID}-${VERSION_ID}"

--- a/test/cases/ostree-simplified-installer.sh
+++ b/test/cases/ostree-simplified-installer.sh
@@ -109,13 +109,13 @@ case "${ID}-${VERSION_ID}" in
         OSTREE_REF="rhel/8/${ARCH}/edge"
         OS_VARIANT="rhel8-unknown"
         ;;
-    "centos-8")
-        OSTREE_REF="centos/8/${ARCH}/edge"
-        OS_VARIANT="rhel8-unknown"
-        ;;
     "rhel-9.0")
         OSTREE_REF="rhel/9/${ARCH}/edge"
         OS_VARIANT="rhel9-unknown"
+        ;;
+    "centos-8")
+        OSTREE_REF="centos/8/${ARCH}/edge"
+        OS_VARIANT="rhel8-unknown"
         ;;
     "centos-9")
         OSTREE_REF="centos/9/${ARCH}/edge"

--- a/test/cases/ostree.sh
+++ b/test/cases/ostree.sh
@@ -16,31 +16,43 @@ case "${ID}-${VERSION_ID}" in
         OSTREE_REF="fedora/33/${ARCH}/iot"
         OS_VARIANT="fedora33"
         USER_IN_COMMIT="false"
-        BOOT_LOCATION="https://mirrors.rit.edu/fedora/fedora/linux/releases/33/Everything/x86_64/os/";;
+        BOOT_LOCATION="https://mirrors.rit.edu/fedora/fedora/linux/releases/33/Everything/x86_64/os/"
+        ;;
     "rhel-8.4")
         IMAGE_TYPE=rhel-edge-commit
         OSTREE_REF="rhel/8/${ARCH}/edge"
         OS_VARIANT="rhel8.4"
         USER_IN_COMMIT="false"
-        BOOT_LOCATION="http://download.devel.redhat.com/released/rhel-8/RHEL-8/8.4.0/BaseOS/x86_64/os/";;
+        BOOT_LOCATION="http://download.devel.redhat.com/released/rhel-8/RHEL-8/8.4.0/BaseOS/x86_64/os/"
+        ;;
     "rhel-8.6")
         IMAGE_TYPE=edge-commit
         OSTREE_REF="rhel/8/${ARCH}/edge"
         OS_VARIANT="rhel8-unknown"
         USER_IN_COMMIT="true"
-        BOOT_LOCATION="$COMPOSE_URL/compose/BaseOS/x86_64/os/";;
+        BOOT_LOCATION="$COMPOSE_URL/compose/BaseOS/x86_64/os/"
+        ;;
     "rhel-9.0")
         IMAGE_TYPE=edge-commit
         OSTREE_REF="rhel/9/${ARCH}/edge"
         OS_VARIANT="rhel9.0"
         USER_IN_COMMIT="true"
-        BOOT_LOCATION="$COMPOSE_URL/compose/BaseOS/x86_64/os/";;
+        BOOT_LOCATION="$COMPOSE_URL/compose/BaseOS/x86_64/os/"
+        ;;
+    "centos-8")
+        IMAGE_TYPE=edge-commit
+        OSTREE_REF="centos/8/${ARCH}/edge"
+        OS_VARIANT="centos8"
+        USER_IN_COMMIT="true"
+        BOOT_LOCATION="$COMPOSE_URL/compose/BaseOS/x86_64/os/"
+        ;;
     "centos-9")
         IMAGE_TYPE=edge-commit
         OSTREE_REF="centos/9/${ARCH}/edge"
         OS_VARIANT="centos9"
         USER_IN_COMMIT="true"
-        BOOT_LOCATION="$COMPOSE_URL/compose/BaseOS/x86_64/os/";;
+        BOOT_LOCATION="$COMPOSE_URL/compose/BaseOS/x86_64/os/"
+        ;;
     *)
         echo "unsupported distro: ${ID}-${VERSION_ID}"
         exit 1;;


### PR DESCRIPTION
Now the Edge image can be built on multi-distros, such as RHEL 8.x, RHEL 9.x, CentOS Stream 8. CentOS Stream 9 is coming soon. Different distros have different ostree refs.Test script should support ostree ref according to its distro. That's what this PR is doing.