### PR TITLE
packit: Use upstream github release description

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -9,6 +9,8 @@ synced_files:
 upstream_package_name: osbuild-composer
 downstream_package_name: osbuild-composer
 
+copy_upstream_release_description: true
+
 upstream_tag_template: v{version}
 
 actions:


### PR DESCRIPTION
Setting this option enables packit to use the Github upstream release description for the specfile instead of just using all commit messages.

See also: https://packit.dev/docs/configuration/#copy_upstream_release_description

As we're doing good GitHub release notes I hope this will make downstream release notes more consistent with upstream.

Also see the related PR for osbuild: https://github.com/osbuild/osbuild/pull/880