### PR TITLE
distro/rhel90*: minor code cleanup

### DIFF
--- a/internal/cloudapi/v1/v1.go
+++ b/internal/cloudapi/v1/v1.go
@@ -517,6 +517,11 @@ func (h *apiHandlers) ComposeMetadata(ctx echo.Context, id string) error {
 		return echo.NewHTTPError(http.StatusNotFound, "Job %s not found: %s", id, err)
 	}
 
+	if result.OSBuildOutput == nil || result.OSBuildOutput.Stages == nil {
+		// no data to work with; parse error
+		return echo.NewHTTPError(http.StatusInternalServerError, "Failed to read metadata for job %s", id)
+	}
+
 	var job worker.OSBuildJob
 	if _, _, _, err = h.server.workers.Job(jobId, &job); err != nil {
 		return echo.NewHTTPError(http.StatusNotFound, "Job %s not found: %s", id, err)

--- a/internal/distro/rhel90/pipelines.go
+++ b/internal/distro/rhel90/pipelines.go
@@ -91,9 +91,6 @@ func vhdPipelines(t *imageType, customizations *blueprint.Customizations, option
 	diskfile := "disk.img"
 	imagePipeline := liveImagePipeline(treePipeline.Name, diskfile, &partitionTable, t.arch, kernelVer)
 	pipelines = append(pipelines, *imagePipeline)
-	if err != nil {
-		return nil, err
-	}
 
 	qemuPipeline := qemuPipeline(imagePipeline.Name, diskfile, t.filename, "vpc", "")
 	pipelines = append(pipelines, *qemuPipeline)
@@ -123,9 +120,6 @@ func vmdkPipelines(t *imageType, customizations *blueprint.Customizations, optio
 	diskfile := "disk.img"
 	imagePipeline := liveImagePipeline(treePipeline.Name, diskfile, &partitionTable, t.arch, kernelVer)
 	pipelines = append(pipelines, *imagePipeline)
-	if err != nil {
-		return nil, err
-	}
 
 	qemuPipeline := qemuPipeline(imagePipeline.Name, diskfile, t.filename, "vmdk", "")
 	pipelines = append(pipelines, *qemuPipeline)
@@ -155,9 +149,6 @@ func openstackPipelines(t *imageType, customizations *blueprint.Customizations, 
 	diskfile := "disk.img"
 	imagePipeline := liveImagePipeline(treePipeline.Name, diskfile, &partitionTable, t.arch, kernelVer)
 	pipelines = append(pipelines, *imagePipeline)
-	if err != nil {
-		return nil, err
-	}
 
 	qemuPipeline := qemuPipeline(imagePipeline.Name, diskfile, t.filename, "qcow2", "")
 	pipelines = append(pipelines, *qemuPipeline)

--- a/internal/distro/rhel90beta/pipelines.go
+++ b/internal/distro/rhel90beta/pipelines.go
@@ -89,9 +89,6 @@ func vhdPipelines(t *imageType, customizations *blueprint.Customizations, option
 	diskfile := "disk.img"
 	imagePipeline := liveImagePipeline(treePipeline.Name, diskfile, &partitionTable, t.arch, kernelVer)
 	pipelines = append(pipelines, *imagePipeline)
-	if err != nil {
-		return nil, err
-	}
 
 	qemuPipeline := qemuPipeline(imagePipeline.Name, diskfile, t.filename, "vpc", "")
 	pipelines = append(pipelines, *qemuPipeline)
@@ -121,9 +118,6 @@ func vmdkPipelines(t *imageType, customizations *blueprint.Customizations, optio
 	diskfile := "disk.img"
 	imagePipeline := liveImagePipeline(treePipeline.Name, diskfile, &partitionTable, t.arch, kernelVer)
 	pipelines = append(pipelines, *imagePipeline)
-	if err != nil {
-		return nil, err
-	}
 
 	qemuPipeline := qemuPipeline(imagePipeline.Name, diskfile, t.filename, "vmdk", "")
 	pipelines = append(pipelines, *qemuPipeline)
@@ -152,9 +146,6 @@ func openstackPipelines(t *imageType, customizations *blueprint.Customizations, 
 	diskfile := "disk.img"
 	imagePipeline := liveImagePipeline(treePipeline.Name, diskfile, &partitionTable, t.arch, kernelVer)
 	pipelines = append(pipelines, *imagePipeline)
-	if err != nil {
-		return nil, err
-	}
 
 	qemuPipeline := qemuPipeline(imagePipeline.Name, diskfile, t.filename, "qcow2", "")
 	pipelines = append(pipelines, *qemuPipeline)


### PR DESCRIPTION
Removing extraneous error checks (unreachable code).

There's also a fix for some potential nil dereferencing.

Caught by covscan during release.  I decided to fix them immediately instead of bundling them with a feature PR so I wont forget.