### PR TITLE
test: Enable OSTree simplified installer test on RHEL 9

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -209,8 +209,7 @@ OSTree simplified installer:
       - RUNNER:
           - openstack/rhel-8.6-nightly-x86_64-large
           - openstack/centos-stream-8-x86_64
-          # NOTE: coreos-installer not yet available in RHEL 9.0
-          # - openstack/rhel-9.0-nightly-x86_64
+          - openstack/rhel-9.0-nightly-x86_64
 
 OSTree raw image:
   stage: test


### PR DESCRIPTION
[coreos-installer-0.10.1-2.el9.x86_64.rpm](http://download-node-02.eng.bos.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.0.0/compose/AppStream/x86_64/os/Packages/coreos-installer-0.10.1-2.el9.x86_64.rpm) is available on RHEL 9 nightly, it's time to enable OSTree simplified installer test