### PR TITLE
composer: Add metrics endpoint to auth excludes again

### DIFF
--- a/cmd/osbuild-composer/composer.go
+++ b/cmd/osbuild-composer/composer.go
@@ -250,6 +250,9 @@ func (c *Composer) Start() error {
 			mux.Handle(apiRoute+"/", c.api.V1(apiRoute))
 			mux.Handle(apiRouteV2+"/", c.api.V2(apiRouteV2))
 			mux.Handle(kojiRoute+"/", c.koji.Handler(kojiRoute))
+
+			// Metrics handler attached to api mux to avoid a
+			// separate listener/socket
 			mux.Handle("/metrics", promhttp.Handler().(http.HandlerFunc))
 
 			handler := http.Handler(mux)
@@ -262,6 +265,7 @@ func (c *Composer) Start() error {
 					[]string{
 						"/api/image-builder-composer/v2/openapi/?$",
 						"/api/image-builder-composer/v2/errors/?$",
+						"/metrics/?$",
 					}, mux)
 				if err != nil {
 					panic(err)


### PR DESCRIPTION
Mistakenly removed in 4577ac0717c8acfcc96c4917587106258fcd7d86. Composer
itself does the authentication, not the gateway, therefore we do need
the auth exclude.

Added a comment to explain why it's attached to the api socket and not a
separate listener.
