### PR TITLE
osbuild2: update rhsm stage

### DIFF
--- a/internal/osbuild2/rhsm_stage.go
+++ b/internal/osbuild2/rhsm_stage.go
@@ -6,6 +6,7 @@ package osbuild2
 // related components. Currently it allows only configuration of the enablement
 // state of DNF plugins used by the Subscription Manager.
 type RHSMStageOptions struct {
+	YumPlugins *RHSMStageOptionsDnfPlugins `json:"yum-plugins,omitempty"`
 	DnfPlugins *RHSMStageOptionsDnfPlugins `json:"dnf-plugins,omitempty"`
 	SubMan     *RHSMStageOptionsSubMan     `json:"subscription-manager,omitempty"`
 }

--- a/internal/osbuild2/rhsm_stage_test.go
+++ b/internal/osbuild2/rhsm_stage_test.go
@@ -1,9 +1,12 @@
 package osbuild2
 
 import (
+	"encoding/json"
+	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNewRhsmStage(t *testing.T) {
@@ -13,4 +16,57 @@ func TestNewRhsmStage(t *testing.T) {
 	}
 	actualStage := NewRHSMStage(&RHSMStageOptions{})
 	assert.Equal(t, expectedStage, actualStage)
+}
+
+func TestRhsmStageJson(t *testing.T) {
+	tests := []struct {
+		Options    RHSMStageOptions
+		JsonString string
+	}{
+		{
+			Options: RHSMStageOptions{
+				YumPlugins: &RHSMStageOptionsDnfPlugins{
+					ProductID: &RHSMStageOptionsDnfPlugin{
+						Enabled: true,
+					},
+					SubscriptionManager: &RHSMStageOptionsDnfPlugin{
+						Enabled: false,
+					},
+				},
+			},
+			JsonString: `{"yum-plugins":{"product-id":{"enabled":true},"subscription-manager":{"enabled":false}}}`,
+		},
+		{
+			Options: RHSMStageOptions{
+				DnfPlugins: &RHSMStageOptionsDnfPlugins{
+					ProductID: &RHSMStageOptionsDnfPlugin{
+						Enabled: true,
+					},
+					SubscriptionManager: &RHSMStageOptionsDnfPlugin{
+						Enabled: false,
+					},
+				},
+			},
+			JsonString: `{"dnf-plugins":{"product-id":{"enabled":true},"subscription-manager":{"enabled":false}}}`,
+		},
+		{
+			Options: RHSMStageOptions{
+				SubMan: &RHSMStageOptionsSubMan{
+					Rhsm:      &SubManConfigRHSMSection{},
+					Rhsmcertd: &SubManConfigRHSMCERTDSection{},
+				},
+			},
+			JsonString: `{"subscription-manager":{"rhsm":{},"rhsmcertd":{}}}`,
+		},
+	}
+	for _, test := range tests {
+		marshaledJson, err := json.Marshal(test.Options)
+		require.NoError(t, err, "failed to marshal JSON")
+		require.Equal(t, string(marshaledJson), test.JsonString)
+
+		var jsonOptions RHSMStageOptions
+		err = json.Unmarshal([]byte(test.JsonString), &jsonOptions)
+		require.NoError(t, err, "failed to parse JSON")
+		require.True(t, reflect.DeepEqual(test.Options, jsonOptions))
+	}
 }


### PR DESCRIPTION
The stage now allows for customizations specific to YUM or DNF. So far
it is just an alias to the same definition, meaning that composer can
use exactly the same structures for both.

Ref: https://github.com/osbuild/osbuild/pull/876


This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`
-->
