### PR TITLE
osbuild: check if result objects are nil in Write()

### DIFF
--- a/internal/osbuild1/result.go
+++ b/internal/osbuild1/result.go
@@ -81,8 +81,9 @@ func (result *StageResult) UnmarshalJSON(data []byte) error {
 }
 
 func (cr *Result) Write(writer io.Writer) error {
-	if cr.Build == nil && len(cr.Stages) == 0 && cr.Assembler == nil {
+	if cr == nil || (cr.Build == nil && len(cr.Stages) == 0 && cr.Assembler == nil) {
 		fmt.Fprintf(writer, "The compose result is empty.\n")
+		return nil
 	}
 
 	if cr.Build != nil {

--- a/internal/osbuild1/result_test.go
+++ b/internal/osbuild1/result_test.go
@@ -153,10 +153,15 @@ Done
 }
 
 func TestWriteEmpty(t *testing.T) {
+	var b bytes.Buffer
+
+	var testNilResult *Result
+	assert.NoError(t, testNilResult.Write(&b))
+	assert.Equal(t, "The compose result is empty.\n", b.String())
 
 	testComposeResult := Result{}
 
-	var b bytes.Buffer
+	b.Reset()
 	assert.NoError(t, testComposeResult.Write(&b))
 	assert.Equal(t, "The compose result is empty.\n", b.String())
 

--- a/internal/osbuild2/result.go
+++ b/internal/osbuild2/result.go
@@ -201,8 +201,9 @@ func (res *Result) fromV1(resv1 osbuild1.Result) {
 }
 
 func (res *Result) Write(writer io.Writer) error {
-	if res.Log == nil {
+	if res == nil || res.Log == nil {
 		fmt.Fprintf(writer, "The compose result is empty.\n")
+		return nil
 	}
 
 	// The pipeline results don't have a stable order

--- a/internal/osbuild2/result_test.go
+++ b/internal/osbuild2/result_test.go
@@ -323,9 +323,14 @@ Metadata:
 
 func TestWriteEmpty(t *testing.T) {
 	assert := assert.New(t)
-	result := Result{}
-
 	var b bytes.Buffer
+
+	var testNilResult *Result
+	assert.NoError(testNilResult.Write(&b))
+	assert.Equal("The compose result is empty.\n", b.String())
+
+	b.Reset()
+	result := Result{}
 	assert.NoError(result.Write(&b))
 	assert.Equal("The compose result is empty.\n", b.String())
 }


### PR DESCRIPTION
Before dereferencing the method receiver in Write(), check if the object is nil.

The result writer in osbuild1 (v1 results) isn't used anymore I think, but we should cover it until it's removed.

Fixes #2002