### PR TITLE
osbuild: check if result objects are nil in Write()

### DIFF
--- a/internal/osbuild1/result.go
+++ b/internal/osbuild1/result.go
@@ -84,8 +84,9 @@ func (result *StageResult) UnmarshalJSON(data []byte) error {
 }
 
 func (cr *Result) Write(writer io.Writer) error {
-	if cr.Build == nil && len(cr.Stages) == 0 && cr.Assembler == nil {
+	if cr == nil || (cr.Build == nil && len(cr.Stages) == 0 && cr.Assembler == nil) {
 		fmt.Fprintf(writer, "The compose result is empty.\n")
+		return nil
 	}
 
 	if cr.Build != nil {

--- a/internal/osbuild1/result_test.go
+++ b/internal/osbuild1/result_test.go
@@ -231,10 +231,15 @@ Done
 }
 
 func TestWriteEmpty(t *testing.T) {
+	var b bytes.Buffer
+
+	var testNilResult *Result
+	assert.NoError(t, testNilResult.Write(&b))
+	assert.Equal(t, "The compose result is empty.\n", b.String())
 
 	testComposeResult := Result{}
 
-	var b bytes.Buffer
+	b.Reset()
 	assert.NoError(t, testComposeResult.Write(&b))
 	assert.Equal(t, "The compose result is empty.\n", b.String())
 


### PR DESCRIPTION
Cherry picked fix from #2022.

osbuild2 result does not have a `Write()` method in 8.5 so only osbuild1 needs the fix.