### PR TITLE
osbuild2: selinux stage - introduce force_autorelabel option

### DIFF
--- a/internal/osbuild2/selinux_stage.go
+++ b/internal/osbuild2/selinux_stage.go
@@ -5,8 +5,9 @@ package osbuild2
 // A file contexts configuration file is sepcified that describes
 // the filesystem labels to apply to the image.
 type SELinuxStageOptions struct {
-	FileContexts string            `json:"file_contexts"`
-	Labels       map[string]string `json:"labels,omitempty"`
+	FileContexts     string            `json:"file_contexts"`
+	Labels           map[string]string `json:"labels,omitempty"`
+	ForceAutorelabel *bool             `json:"force_autorelabel,omitempty"`
 }
 
 func (SELinuxStageOptions) isStageOptions() {}

--- a/internal/osbuild2/stage_test.go
+++ b/internal/osbuild2/stage_test.go
@@ -453,6 +453,18 @@ func TestStage_UnmarshalJSON(t *testing.T) {
 			},
 		},
 		{
+			name: "selinux-force_autorelabel",
+			fields: fields{
+				Type: "org.osbuild.selinux",
+				Options: &SELinuxStageOptions{
+					ForceAutorelabel: common.BoolToPtr(true),
+				},
+			},
+			args: args{
+				data: []byte(`{"type":"org.osbuild.selinux","options":{"file_contexts":"","force_autorelabel":true}}`),
+			},
+		},
+		{
 			name: "selinux.config-empty",
 			fields: fields{
 				Type:    "org.osbuild.selinux.config",


### PR DESCRIPTION
This was added in osbuild: https://github.com/osbuild/osbuild/pull/875

Introduce the same option in composer and make it optional by specifying
it as a pointer to bool value. It would work the same even if it was
there every time, but as it should be an edge case, don't use it
everywhere. Also osbuild doesn't require it to be present, so it seems
like the right thing to do.


This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`
-->
