### PR TITLE
Test all manifests with depsolved package sets 

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -137,6 +137,27 @@ Base:
       - "*.repo"
     when: always
 
+Manifests:
+  stage: test
+  extends: .terraform
+  rules:
+    - if: '$CI_PIPELINE_SOURCE != "schedule"'
+    - if: '$CI_PIPELINE_SOURCE == "schedule" && $RUNNER =~ /[\S]+rhel-9.0-[^ga][\S]+/ && $NIGHTLY == "true" && $RHEL_MAJOR == "9"'
+    - if: '$CI_PIPELINE_SOURCE == "schedule" && $RUNNER =~ /[\S]+rhel-8.6-[^ga][\S]+/ && $NIGHTLY == "true" && $RHEL_MAJOR == "8"'
+  script:
+    - schutzbot/deploy.sh
+    - /usr/libexec/tests/osbuild-composer/manifest_tests.sh
+  parallel:
+    matrix:
+      - RUNNER:
+          - aws/rhel-9.0-nightly-x86_64
+        INTERNAL_NETWORK: ["true"]
+  artifacts:
+    paths:
+      - journal-log.gpg
+      - "*.repo"
+    when: always
+
 Regression:
   stage: test
   extends: .terraform

--- a/Makefile
+++ b/Makefile
@@ -123,6 +123,7 @@ build:
 	go test -c -tags=integration -o bin/osbuild-auth-tests ./cmd/osbuild-auth-tests/
 	go test -c -tags=integration -o bin/osbuild-koji-tests ./cmd/osbuild-koji-tests/
 	go test -c -tags=integration -o bin/osbuild-composer-dbjobqueue-tests ./cmd/osbuild-composer-dbjobqueue-tests/
+	go test -c -tags=integration -o bin/osbuild-composer-manifest-tests ./cmd/osbuild-composer-manifest-tests/
 
 .PHONY: install
 install:

--- a/cmd/osbuild-composer-manifest-tests/main_test.go
+++ b/cmd/osbuild-composer-manifest-tests/main_test.go
@@ -1,0 +1,39 @@
+// +build integration
+
+package main
+
+import (
+	"flag"
+	"os"
+	"testing"
+
+	"github.com/osbuild/osbuild-composer/internal/distro/distro_test_common"
+	"github.com/osbuild/osbuild-composer/internal/distroregistry"
+	"github.com/stretchr/testify/require"
+)
+
+var manifestsPath string
+var dnfJsonPath string
+var testCaseGlob string
+
+func init() {
+	flag.StringVar(&manifestsPath, "manifests-path", "/usr/share/tests/osbuild-composer/manifests", "path to a directory with *.json files containing image test cases")
+	flag.StringVar(&dnfJsonPath, "dnf-json-path", "/usr/libexec/osbuild-composer/dnf-json", "path to the 'dnf-json' executable")
+	flag.StringVar(&testCaseGlob, "test-case-glob", "*", "glob pattern to select image test cases to verify")
+}
+
+func TestManifests(t *testing.T) {
+	cacheDirPath := "/var/tmp/osbuild-composer-manifest-tests/rpmmd"
+	err := os.MkdirAll(cacheDirPath, 0755)
+	require.Nilf(t, err, "failed to create RPMMD cache directory %q", cacheDirPath)
+
+	distro_test_common.TestDistro_Manifest(
+		t,
+		manifestsPath,
+		testCaseGlob,
+		distroregistry.NewDefault(),
+		true,
+		cacheDirPath,
+		dnfJsonPath,
+	)
+}

--- a/internal/distro/distro_test.go
+++ b/internal/distro/distro_test.go
@@ -16,6 +16,9 @@ func TestDistro_Manifest(t *testing.T) {
 		"../../test/data/manifests/",
 		"*",
 		distroregistry.NewDefault(),
+		false, // This test case does not check for changes in the imageType package sets!
+		"",
+		"",
 	)
 }
 

--- a/internal/distro/rhel86/package_sets.go
+++ b/internal/distro/rhel86/package_sets.go
@@ -498,7 +498,7 @@ func bareMetalPackageSet(t *imageType) rpmmd.PackageSet {
 			"subscription-manager-cockpit", "tar", "tcpdump", "yum",
 		},
 		Exclude: nil,
-	}.Append(bootPackageSet(t)).Append(distroBuildPackageSet(t))
+	}.Append(bootPackageSet(t)).Append(distroSpecificPackageSet(t))
 }
 
 // packages that are only in some (sub)-distributions

--- a/internal/distro/rhel90/package_sets.go
+++ b/internal/distro/rhel90/package_sets.go
@@ -381,7 +381,6 @@ func rhelEc2SapPackageSet(t *imageType) rpmmd.PackageSet {
 		"rhel-system-roles-sap",
 		// RHBZ#1959813
 		"bind-utils",
-		"compat-sap-c++-9",
 		"nfs-utils",
 		"tcsh",
 		// RHBZ#1959955

--- a/osbuild-composer.spec
+++ b/osbuild-composer.spec
@@ -159,6 +159,7 @@ go test -c -tags=integration -ldflags="${TEST_LDFLAGS}" -o _bin/osbuild-image-te
 go test -c -tags=integration -ldflags="${TEST_LDFLAGS}" -o _bin/osbuild-auth-tests %{goipath}/cmd/osbuild-auth-tests
 go test -c -tags=integration -ldflags="${TEST_LDFLAGS}" -o _bin/osbuild-koji-tests %{goipath}/cmd/osbuild-koji-tests
 go test -c -tags=integration -ldflags="${TEST_LDFLAGS}" -o _bin/osbuild-composer-dbjobqueue-tests %{goipath}/cmd/osbuild-composer-dbjobqueue-tests
+go test -c -tags=integration -ldflags="${TEST_LDFLAGS}" -o _bin/osbuild-composer-manifest-tests %{goipath}/cmd/osbuild-composer-manifest-tests
 go build -tags=integration -ldflags="${TEST_LDFLAGS}" -o _bin/cloud-cleaner %{goipath}/cmd/cloud-cleaner
 go build -tags=integration -ldflags="${TEST_LDFLAGS}" -o _bin/osbuild-mock-openid-provider %{goipath}/cmd/osbuild-mock-openid-provider
 
@@ -224,6 +225,7 @@ install -m 0755 -vp _bin/osbuild-image-tests                    %{buildroot}%{_l
 install -m 0755 -vp _bin/osbuild-auth-tests                     %{buildroot}%{_libexecdir}/osbuild-composer-test/
 install -m 0755 -vp _bin/osbuild-koji-tests                     %{buildroot}%{_libexecdir}/osbuild-composer-test/
 install -m 0755 -vp _bin/osbuild-composer-dbjobqueue-tests      %{buildroot}%{_libexecdir}/osbuild-composer-test/
+install -m 0755 -vp _bin/osbuild-composer-manifest-tests        %{buildroot}%{_libexecdir}/osbuild-composer-test/
 install -m 0755 -vp _bin/cloud-cleaner                          %{buildroot}%{_libexecdir}/osbuild-composer-test/
 install -m 0755 -vp _bin/osbuild-mock-openid-provider           %{buildroot}%{_libexecdir}/osbuild-composer-test/
 install -m 0755 -vp tools/define-compose-url.sh                 %{buildroot}%{_libexecdir}/osbuild-composer-test/

--- a/test/cases/manifest_tests.sh
+++ b/test/cases/manifest_tests.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+set -euo pipefail
+
+MANIFEST_TESTS_RUNNER="/usr/libexec/osbuild-composer-test/osbuild-composer-manifest-tests"
+DNF_JSON_PATH="/usr/libexec/osbuild-composer/dnf-json"
+IMAGE_TEST_CASES_PATH="/usr/share/tests/osbuild-composer/manifests"
+
+WORKING_DIRECTORY=/usr/libexec/osbuild-composer
+mkdir --parents /tmp/logs
+LOGS_DIRECTORY=$(mktemp --directory --tmpdir=/tmp/logs)
+
+# Print out a nice test divider so we know when tests stop and start.
+test_divider () {
+    printf "%0.s-" {1..78} && echo
+}
+
+# Provision the software under test.
+/usr/libexec/osbuild-composer-test/provision.sh
+
+# Change to the working directory.
+cd $WORKING_DIRECTORY
+
+# Run test case.
+TEST_NAME=$(basename "$MANIFEST_TESTS_RUNNER")
+echo
+test_divider
+echo "🏃🏻 Running test: ${TEST_NAME}"
+test_divider
+
+if sudo "$MANIFEST_TESTS_RUNNER" -test.v -manifests-path "$IMAGE_TEST_CASES_PATH" -dnf-json-path "$DNF_JSON_PATH" | tee "${LOGS_DIRECTORY}"/"${TEST_NAME}".log; then
+    echo "🎉  Test passed."
+    exit 0
+else
+    echo "🔥 Test failed."
+    exit 1
+fi


### PR DESCRIPTION
- Introduce a new test case checking manifests of all supported combinations of image types against manifests which are part of image test cases, including depsolving of default image's package sets. Depsolving is important to catch unintentional changes in image's package sets. Run the test case in CI. all manifests are verified on a single runner within a single job, because the depsolving should not care about the system distribution. However if needed, the test case could be split to verify manifests of a specific distribution on the same distribution. The single CI job currently take a little over 12 minutes to finish (the test itself takes approximately 419 seconds).
- Fix one issue in the `rhel-86` `image-installer` image type, found by the new test case.
- Fix one issue in the `rhel-90` `ec2-sap` image type, found by the new test case.

This pull request includes:

- [x] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`
-->
