### PR TITLE
templates: bump max postgres connections to 10

### DIFF
--- a/cmd/osbuild-composer/composer.go
+++ b/cmd/osbuild-composer/composer.go
@@ -15,6 +15,8 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 
+	logrus "github.com/sirupsen/logrus"
+
 	"github.com/osbuild/osbuild-composer/internal/auth"
 	"github.com/osbuild/osbuild-composer/internal/cloudapi"
 	"github.com/osbuild/osbuild-composer/internal/distroregistry"
@@ -25,7 +27,6 @@ import (
 	"github.com/osbuild/osbuild-composer/internal/rpmmd"
 	"github.com/osbuild/osbuild-composer/internal/weldr"
 	"github.com/osbuild/osbuild-composer/internal/worker"
-	logrus "github.com/sirupsen/logrus"
 )
 
 type Composer struct {
@@ -77,6 +78,11 @@ func NewComposer(config *ComposerConfigFile, stateDir, cacheDir string) (*Compos
 			config.Worker.PGDatabase,
 			config.Worker.PGSSLMode,
 		)
+
+		if config.Worker.PGMaxConns > 0 {
+			dbURL += fmt.Sprintf("&pool_max_conns=%d", config.Worker.PGMaxConns)
+		}
+
 		jobs, err = dbjobqueue.New(dbURL)
 		if err != nil {
 			return nil, fmt.Errorf("cannot create jobqueue: %v", err)

--- a/cmd/osbuild-composer/config.go
+++ b/cmd/osbuild-composer/config.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"os"
 	"reflect"
+	"strconv"
 
 	"github.com/BurntSushi/toml"
 )
@@ -44,6 +45,7 @@ type WorkerAPIConfig struct {
 	PGUser            string   `toml:"pg_user" env:"PGUSER"`
 	PGPassword        string   `toml:"pg_password" env:"PGPASSWORD"`
 	PGSSLMode         string   `toml:"pg_ssl_mode" env:"PGSSLMODE"`
+	PGMaxConns        int      `toml:"pg_max_conns" env:"PGMAXCONNS"`
 	EnableTLS         bool     `toml:"enable_tls"`
 	EnableMTLS        bool     `toml:"enable_mtls"`
 	EnableJWT         bool     `toml:"enable_jwt"`
@@ -143,6 +145,20 @@ func loadConfigFromEnv(intf interface{}) error {
 				continue
 			}
 			fieldV.SetString(confV)
+		case reflect.Int:
+			key, ok := fieldT.Tag.Lookup("env")
+			if !ok {
+				continue
+			}
+			confV, ok := os.LookupEnv(key)
+			if !ok {
+				continue
+			}
+			value, err := strconv.ParseInt(confV, 10, 64)
+			if err != nil {
+				return err
+			}
+			fieldV.SetInt(value)
 		case reflect.Bool:
 			// no-op
 			continue

--- a/templates/composer.yml
+++ b/templates/composer.yml
@@ -92,6 +92,8 @@ objects:
                 key: db.password
           - name: PGSSLMODE
             value: "${PGSSLMODE}"
+          - name: PGMAXCONNS
+            value: "${PGMAXCONNS}"
           ports:
           - name: composer-api
             protocol: TCP
@@ -229,6 +231,9 @@ parameters:
   - description: postgres sslmode to use when connecting to the db
     name: PGSSLMODE
     value: "require"
+  - description: postgres maximum connections per pod
+    name: PGMAXCONNS
+    value: "10"
   - description: base sso url
     name: SSO_BASE_URL
     required: true

--- a/test/cases/api.sh
+++ b/test/cases/api.sh
@@ -79,6 +79,7 @@ pg_database = "osbuildcomposer"
 pg_user = "postgres"
 pg_password = "foobar"
 pg_ssl_mode = "disable"
+pg_max_conns = 10
 EOF
 
 sudo systemctl restart osbuild-composer


### PR DESCRIPTION
By default, pgxpool.Pool has 4 connections (or number of cpus if higher).
Currently, we have 3 replicas, that means max 3*4=12 DB connections.

The dequeue operation is actually blocking - when a worker is waiting for
a job, one connection is blocked. My theory is that with 16 workers, we just
don't have enough connections that causes all sorts of weird slowdowns.

This commit bumps the number of connection from one replica to 10, therefore
we should be at 30 connections in total.

Signed-off-by: Ondřej Budai <ondrej@budai.cz>

This pull request includes:

- [x] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`
-->
