### PR TITLE
Revert ".gitlabci.yml: Reduce api test runners"

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -296,8 +296,23 @@ API:
     matrix:
       - <<: *API_TESTS
         RUNNER:
+          - aws/fedora-33-x86_64
+          # See COMPOSER-919
+          # - aws/fedora-34-x86_64
+          # See COMPOSER-1118
+          # - aws/centos-stream-8-x86_64
+      - TARGET:
+          - aws
+          - gcp
+          - aws.s3
+        RUNNER:
           - aws/centos-stream-8-x86_64
+      - <<: *API_TESTS
+        RUNNER:
           - aws/rhel-8.4-ga-x86_64
+          - aws/rhel-8.6-nightly-x86_64
+          - aws/rhel-9.0-nightly-x86_64
+        INTERNAL_NETWORK: ["true"]
 
 libvirt:
   stage: test

--- a/internal/cloudapi/v2/v2.go
+++ b/internal/cloudapi/v2/v2.go
@@ -372,6 +372,10 @@ func (h *apiHandlers) PostCompose(ctx echo.Context) error {
 	id, err := h.server.workers.EnqueueOSBuildAsDependency(arch.Name(), &worker.OSBuildJob{
 		Targets: []*target.Target{irTarget},
 		Exports: imageType.Exports(),
+		PipelineNames: &worker.PipelineNames{
+			Build:   imageType.BuildPipelines(),
+			Payload: imageType.PayloadPipelines(),
+		},
 	}, manifestJobID)
 	if err != nil {
 		return HTTPErrorWithInternal(ErrorEnqueueingJob, err)


### PR DESCRIPTION
We need rhel8.5+ testing.

This reverts commit ac39dacfae8c6e74429da258aed18a788a129c34.
