### PR TITLE
RHEL-9.0: install and enable TuneD by default on all EC2 images

### DIFF
--- a/internal/distro/rhel90/distro.go
+++ b/internal/distro/rhel90/distro.go
@@ -757,6 +757,7 @@ func newDistro(distroName string) distro.Distro {
 		"cloud-config",
 		"cloud-final",
 		"reboot.target",
+		"tuned",
 	}
 
 	amiImgTypeX86_64 := imageType{

--- a/internal/distro/rhel90/package_sets.go
+++ b/internal/distro/rhel90/package_sets.go
@@ -335,7 +335,7 @@ func ec2CommonPackageSet(t *imageType) rpmmd.PackageSet {
 			"cloud-utils-growpart", "dhcp-client", "yum-utils",
 			"dracut-config-generic", "gdisk", "grub2",
 			"langpacks-en", "NetworkManager", "NetworkManager-cloud-setup",
-			"redhat-release", "redhat-release-eula", "rsync", "tar",
+			"redhat-release", "redhat-release-eula", "rsync", "tar", "tuned",
 			"qemu-guest-agent",
 		},
 		Exclude: []string{

--- a/test/data/manifests/rhel_90-aarch64-ami-boot.json
+++ b/test/data/manifests/rhel_90-aarch64-ami-boot.json
@@ -16,7 +16,7 @@
       },
       {
         "name": "rhui",
-        "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-rhui-3-20210930/",
+        "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-rhui-4-20211105/",
         "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBErgSTsBEACh2A4b0O9t+vzC9VrVtL1AKvUWi9OPCjkvR7Xd8DtJxeeMZ5eF\n0HtzIG58qDRybwUe89FZprB1ffuUKzdE+HcL3FbNWSSOXVjZIersdXyH3NvnLLLF\n0DNRB2ix3bXG9Rh/RXpFsNxDp2CEMdUvbYCzE79K1EnUTVh1L0Of023FtPSZXX0c\nu7Pb5DI5lX5YeoXO6RoodrIGYJsVBQWnrWw4xNTconUfNPk0EGZtEnzvH2zyPoJh\nXGF+Ncu9XwbalnYde10OCvSWAZ5zTCpoLMTvQjWpbCdWXJzCm6G+/hx9upke546H\n5IjtYm4dTIVTnc3wvDiODgBKRzOl9rEOCIgOuGtDxRxcQkjrC+xvg5Vkqn7vBUyW\n9pHedOU+PoF3DGOM+dqv+eNKBvh9YF9ugFAQBkcG7viZgvGEMGGUpzNgN7XnS1gj\n/DPo9mZESOYnKceve2tIC87p2hqjrxOHuI7fkZYeNIcAoa83rBltFXaBDYhWAKS1\nPcXS1/7JzP0ky7d0L6Xbu/If5kqWQpKwUInXtySRkuraVfuK3Bpa+X1XecWi24JY\nHVtlNX025xx1ewVzGNCTlWn1skQN2OOoQTV4C8/qFpTW6DTWYurd4+fE0OJFJZQF\nbuhfXYwmRlVOgN5i77NTIJZJQfYFj38c/Iv5vZBPokO6mffrOTv3MHWVgQARAQAB\ntDNSZWQgSGF0LCBJbmMuIChyZWxlYXNlIGtleSAyKSA8c2VjdXJpdHlAcmVkaGF0\nLmNvbT6JAjYEEwECACAFAkrgSTsCGwMGCwkIBwMCBBUCCAMEFgIDAQIeAQIXgAAK\nCRAZni+R/UMdUWzpD/9s5SFR/ZF3yjY5VLUFLMXIKUztNN3oc45fyLdTI3+UClKC\n2tEruzYjqNHhqAEXa2sN1fMrsuKec61Ll2NfvJjkLKDvgVIh7kM7aslNYVOP6BTf\nC/JJ7/ufz3UZmyViH/WDl+AYdgk3JqCIO5w5ryrC9IyBzYv2m0HqYbWfphY3uHw5\nun3ndLJcu8+BGP5F+ONQEGl+DRH58Il9Jp3HwbRa7dvkPgEhfFR+1hI+Btta2C7E\n0/2NKzCxZw7Lx3PBRcU92YKyaEihfy/aQKZCAuyfKiMvsmzs+4poIX7I9NQCJpyE\nIGfINoZ7VxqHwRn/d5mw2MZTJjbzSf+Um9YJyA0iEEyD6qjriWQRbuxpQXmlAJbh\n8okZ4gbVFv1F8MzK+4R8VvWJ0XxgtikSo72fHjwha7MAjqFnOq6eo6fEC/75g3NL\nGht5VdpGuHk0vbdENHMC8wS99e5qXGNDued3hlTavDMlEAHl34q2H9nakTGRF5Ki\nJUfNh3DVRGhg8cMIti21njiRh7gyFI2OccATY7bBSr79JhuNwelHuxLrCFpY7V25\nOFktl15jZJaMxuQBqYdBgSay2G0U6D1+7VsWufpzd/Abx1/c3oi9ZaJvW22kAggq\ndzdA27UUYjWvx42w9menJwh/0jeQcTecIUd0d0rFcw/c1pvgMMl/Q73yzKgKYw==\n=zbHE\n-----END PGP PUBLIC KEY BLOCK-----\n-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBFsy23UBEACUKSphFEIEvNpy68VeW4Dt6qv+mU6am9a2AAl10JANLj1oqWX+\noYk3en1S6cVe2qehSL5DGVa3HMUZkP3dtbD4SgzXzxPodebPcr4+0QNWigkUisri\nXGL5SCEcOP30zDhZvg+4mpO2jMi7Kc1DLPzBBkgppcX91wa0L1pQzBcvYMPyV/Dh\nKbQHR75WdkP6OA2JXdfC94nxYq+2e0iPqC1hCP3Elh+YnSkOkrawDPmoB1g4+ft/\nxsiVGVy/W0ekXmgvYEHt6si6Y8NwXgnTMqxeSXQ9YUgVIbTpsxHQKGy76T5lMlWX\n4LCOmEVomBJg1SqF6yi9Vu8TeNThaDqT4/DddYInd0OO69s0kGIXalVgGYiW2HOD\nx2q5R1VGCoJxXomz+EbOXY+HpKPOHAjU0DB9MxbU3S248LQ69nIB5uxysy0PSco1\nsdZ8sxRNQ9Dw6on0Nowx5m6Thefzs5iK3dnPGBqHTT43DHbnWc2scjQFG+eZhe98\nEll/kb6vpBoY4bG9/wCG9qu7jj9Z+BceCNKeHllbezVLCU/Hswivr7h2dnaEFvPD\nO4GqiWiwOF06XaBMVgxA8p2HRw0KtXqOpZk+o+sUvdPjsBw42BB96A1yFX4jgFNA\nPyZYnEUdP6OOv9HSjnl7k/iEkvHq/jGYMMojixlvXpGXhnt5jNyc4GSUJQARAQAB\ntDNSZWQgSGF0LCBJbmMuIChhdXhpbGlhcnkga2V5KSA8c2VjdXJpdHlAcmVkaGF0\nLmNvbT6JAjkEEwECACMFAlsy23UCGwMHCwkIBwMCAQYVCAIJCgsEFgIDAQIeAQIX\ngAAKCRD3b2bD1AgnknqOD/9fB2ASuG2aJIiap4kK58R+RmOVM4qgclAnaG57+vjI\nnKvyfV3NH/keplGNRxwqHekfPCqvkpABwhdGEXIE8ILqnPewIMr6PZNZWNJynZ9i\neSMzVuCG7jDoGyQ5/6B0f6xeBtTeBDiRl7+Alehet1twuGL1BJUYG0QuLgcEzkaE\n/gkuumeVcazLzz7L12D22nMk66GxmgXfqS5zcbqOAuZwaA6VgSEgFdV2X2JU79zS\nBQJXv7NKc+nDXFG7M7EHjY3Rma3HXkDbkT8bzh9tJV7Z7TlpT829pStWQyoxKCVq\nsEX8WsSapTKA3P9YkYCwLShgZu4HKRFvHMaIasSIZWzLu+RZH/4yyHOhj0QB7XMY\neHQ6fGSbtJ+K6SrpHOOsKQNAJ0hVbSrnA1cr5+2SDfel1RfYt0W9FA6DoH/S5gAR\ndzT1u44QVwwp3U+eFpHphFy//uzxNMtCjjdkpzhYYhOCLNkDrlRPb+bcoL/6ePSr\n016PA7eEnuC305YU1Ml2WcCn7wQV8x90o33klJmEkWtXh3X39vYtI4nCPIvZn1eP\nVy+F+wWt4vN2b8oOdlzc2paOembbCo2B+Wapv5Y9peBvlbsDSgqtJABfK8KQq/jK\nYl3h5elIa1I3uNfczeHOnf1enLOUOlq630yeM/yHizz99G1g+z/guMh5+x/OHraW\niLkCDQRbMtt1ARAA1lNsWklhS9LoBdolTVtg65FfdFJr47pzKRGYIoGLbcJ155ND\nG+P8UrM06E/ah06EEWuvu2YyyYAz1iYGsCwHAXtbEJh+1tF0iOVx2vnZPgtIGE9V\nP95V5ZvWvB3bdke1z8HadDA+/Ve7fbwXXLa/z9QhSQgsJ8NS8KYnDDjI4EvQtv0i\nPVLY8+u8z6VyiV9RJyn8UEZEJdbFDF9AZAT8103w8SEo/cvIoUbVKZLGcXdAIjCa\ny04u6jsrMp9UGHZX7+srT+9YHDzQixei4IdmxUcqtiNR2/bFHpHCu1pzYjXj968D\n8Ng2txBXDgs16BF/9l++GWKz2dOSH0jdS6sFJ/Dmg7oYnJ2xKSJEmcnV8Z0M1n4w\nXR1t/KeKZe3aR+RXCAEVC5dQ3GbRW2+WboJ6ldgFcVcOv6iOSWP9TrLzFPOpCsIr\nnHE+cMBmPHq3dUm7KeYXQ6wWWmtXlw6widf7cBcGFeELpuU9klzqdKze8qo2oMkf\nrfxIq8zdciPxZXb/75dGWs6dLHQmDpo4MdQVskw5vvwHicMpUpGpxkX7X1XAfdQf\nyIHLGT4ZXuMLIMUPdzJE0Vwt/RtJrZ+feLSv/+0CkkpGHORYroGwIBrJ2RikgcV2\nbc98V/27Kz2ngUCEwnmlhIcrY4IGAAZzUAl0GLHSevPbAREu4fDW4Y+ztOsAEQEA\nAYkCHwQYAQIACQUCWzLbdQIbDAAKCRD3b2bD1AgnkusfD/9U4sPtZfMw6cII167A\nXRZOO195G7oiAnBUw5AW6EK0SAHVZcuW0LMMXnGe9f4UsEUgCNwo5mvLWPxzKqFq\n6/G3kEZVFwZ0qrlLoJPeHNbOcfkeZ9NgD/OhzQmdylM0IwGM9DMrm2YS4EVsmm2b\n53qKIfIyysp1yAGcTnBwBbZ85osNBl2KRDIPhMs0bnmGB7IAvwlSb+xm6vWKECkO\nlwQDO5Kg8YZ8+Z3pn/oS688t/fPXvWLZYUqwR63oWfIaPJI7Ahv2jJmgw1ofL81r\n2CE3T/OydtUeGLzqWJAB8sbUgT3ug0cjtxsHuroQBSYBND3XDb/EQh5GeVVnGKKH\ngESLFAoweoNjDSXrlIu1gFjCDHF4CqBRmNYKrNQjLmhCrSfwkytXESJwlLzFKY8P\nK1yZyTpDC9YK0G7qgrk7EHmH9JAZTQ5V65pp0vR9KvqTU5ewkQDIljD2f3FIqo2B\nSKNCQE+N6NjWaTeNlU75m+yZocKObSPg0zS8FAuSJetNtzXA7ouqk34OoIMQj4gq\nUnh/i1FcZAd4U6Dtr9aRZ6PeLlm6MJ/h582L6fJLNEu136UWDtJj5eBYEzX13l+d\nSC4PEHx7ZZRwQKptl9NkinLZGJztg175paUu8C34sAv+SQnM20c0pdOXAq9GKKhi\nvt61kpkXoRGxjTlc6h+69aidSg==\n=ls8J\n-----END PGP PUBLIC KEY BLOCK-----\n"
       }
     ],
@@ -385,6 +385,7 @@
                   "sha256:738b7caaefeba5bda35229f5f2a831ea722d5eb7dd1931742ba148410f36df53",
                   "sha256:fbb439cbf63c2dcbdfb464d344114c97b09a91d775b3909a154a79653ba54d73",
                   "sha256:1d46eb0723917c1aaa729485f31e129a242a2ac27983c2438837e7c88668dd7e",
+                  "sha256:4db59f521b69593facbdf4221fa754a64edf8e9f19cc94f924ab4659b9c4188f",
                   "sha256:7282be0cfd44ddcaa930d67ac1100ba0d8f335acf97f635a00e1c67d4374af3b",
                   "sha256:6e034e0a91e8c18ac7b1f6ea04d968411c8baa2d44810ce6c11f7017198054b2",
                   "sha256:68df68695fbab307c10053d264c340f696909ae1d35d5290c03255f718fcb356",
@@ -576,7 +577,10 @@
                   "sha256:210425ecf5b9ec9f60ad4c93f943327f571a95c7dc3bcb6004d00a55e4cd22b2",
                   "sha256:ffc3b586fe2542dbfe877f09b8b70000949ee31422560318953f1ff02ad62aae",
                   "sha256:43152a99489ed4eb095251f4cdca55145ed12a3a4e1dd15555424beacca42980",
+                  "sha256:dc2367cc223ec0bb0d01e9a081adc88ca0de5d8cc73dbc9dc77fc49c6a36c93b",
+                  "sha256:6abe11f6d94cf298376652fc71a7a7814083b57bf00d46cdfc96c611bf7b65e5",
                   "sha256:86445c0378ebb8b2887bd3a7327da62762a165b74ee77d38d083365f63fb1b96",
+                  "sha256:f18f9e1547912e9b490db2499982ec339b3d7fbcef089b6fcd603c1a4b784fe6",
                   "sha256:c3db09db1a5b752d28dc5c5de58b9bbbb6275fbdbb44e58b82ddc51ca4ea3ece",
                   "sha256:bc2135331da61c95c795c0c739044e9d46c34dc5662f5c011b4c99ac21a0737a",
                   "sha256:097c9fa13727862d3c08ca94070bda7d62ba40ebe4925ce1373adcebc8051ea7",
@@ -624,6 +628,7 @@
                   "sha256:59446a6aa39ac776a77552b5a799498c9cb1ed12ac89c8726c9909af67c62f98",
                   "sha256:9050f61182012d047cdb909446efe9e85a3c4ba4d30f49b4cb772da96c85d716",
                   "sha256:7934f3a971336a4bb757fd8d2ada206d276f9ab4c2eb14a716dd230f81ba87d8",
+                  "sha256:90827ff90e161df4b72b3fecd62fdc5bbe9aab633c8141a874569612ac4b5aea",
                   "sha256:2d66819cc8adc7a0cbb7b9d12dc0a73ac86551e3b7c3929cc49dddad6d3a884b",
                   "sha256:1592de4f8501d7994d667e6c07d45c6a42bb0d154cec41cd09ba094e59d20c46",
                   "sha256:1513f0f4efcd0a9fcfd4bff7a560f8c8f6c647badbef9ce00b253da39fea3959",
@@ -872,7 +877,8 @@
                 "cloud-init-local",
                 "cloud-config",
                 "cloud-final",
-                "reboot.target"
+                "reboot.target",
+                "tuned"
               ],
               "default_target": "multi-user.target"
             }
@@ -1573,6 +1579,9 @@
           "sha256:4d6ac94dd861ff41486199d60397d9b16c576400e06627530b14adde19460549": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20210930/Packages/libxmlb-0.3.0-3.el9.aarch64.rpm"
           },
+          "sha256:4db59f521b69593facbdf4221fa754a64edf8e9f19cc94f924ab4659b9c4188f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20210930/Packages/hdparm-9.62-2.el9.aarch64.rpm"
+          },
           "sha256:4ec600e2461e10f8596cb6b7edaaf57b3f242737ce2b6937a225bbc703d61d3d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-appstream-n9.0-20210930/Packages/python3-kickstart-3.32.2-2.el9.noarch.rpm"
           },
@@ -1722,6 +1731,9 @@
           },
           "sha256:6a72668714f29fa89abc646debca7571c3ae55171bc0bfd7953df71a59d59c83": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20210930/Packages/prefixdevname-0.1.0-8.el9.aarch64.rpm"
+          },
+          "sha256:6abe11f6d94cf298376652fc71a7a7814083b57bf00d46cdfc96c611bf7b65e5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20210930/Packages/python3-perf-5.14.0-4.el9.aarch64.rpm"
           },
           "sha256:6acc91f918063e16d55f653782bf516704345d16c894a2515735479048efe856": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20210930/Packages/gmp-6.2.0-10.el9.aarch64.rpm"
@@ -1938,6 +1950,9 @@
           },
           "sha256:9050f61182012d047cdb909446efe9e85a3c4ba4d30f49b4cb772da96c85d716": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20210930/Packages/teamd-1.31-10.el9.aarch64.rpm"
+          },
+          "sha256:90827ff90e161df4b72b3fecd62fdc5bbe9aab633c8141a874569612ac4b5aea": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20210930/Packages/tuned-2.16.0-3.el9.noarch.rpm"
           },
           "sha256:922e603fb9efa2c904fa05749b450aaad0255de5abf5cf8c420acd97cd7e0a2b": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20210930/Packages/e2fsprogs-1.46.2-2.el9.aarch64.rpm"
@@ -2311,6 +2326,9 @@
           "sha256:dc1da9164d28f220631535ddd21096ed4eacc208fea9e9666f55cee419c2661e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20210930/Packages/file-5.39-8.el9.aarch64.rpm"
           },
+          "sha256:dc2367cc223ec0bb0d01e9a081adc88ca0de5d8cc73dbc9dc77fc49c6a36c93b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20210930/Packages/python3-linux-procfs-0.6.3-2.el9.noarch.rpm"
+          },
           "sha256:dc7f764658f115feaf199996018c05f67fc01ce3a9522582373be290402af018": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20210930/Packages/pcre2-syntax-10.37-3.el9.1.noarch.rpm"
           },
@@ -2409,6 +2427,9 @@
           },
           "sha256:f0cc6fe2ca571f9423b3abf6da644f91fe6701759556cc05c9ac8273bf1fc74c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20210930/Packages/libini_config-1.3.1-51.el9.aarch64.rpm"
+          },
+          "sha256:f18f9e1547912e9b490db2499982ec339b3d7fbcef089b6fcd603c1a4b784fe6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20210930/Packages/python3-pyudev-0.22.0-6.el9.noarch.rpm"
           },
           "sha256:f3ffa7637d6c835e77da1f19e251147762b3f8206f8fe495722f9bd2b33c89c1": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20210930/Packages/curl-7.76.1-12.el9.aarch64.rpm"
@@ -6165,6 +6186,15 @@
         "checksum": "sha256:1d46eb0723917c1aaa729485f31e129a242a2ac27983c2438837e7c88668dd7e"
       },
       {
+        "name": "hdparm",
+        "epoch": 0,
+        "version": "9.62",
+        "release": "2.el9",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20210930/Packages/hdparm-9.62-2.el9.aarch64.rpm",
+        "checksum": "sha256:4db59f521b69593facbdf4221fa754a64edf8e9f19cc94f924ab4659b9c4188f"
+      },
+      {
         "name": "hostname",
         "epoch": 0,
         "version": "3.23",
@@ -7884,6 +7914,24 @@
         "checksum": "sha256:43152a99489ed4eb095251f4cdca55145ed12a3a4e1dd15555424beacca42980"
       },
       {
+        "name": "python3-linux-procfs",
+        "epoch": 0,
+        "version": "0.6.3",
+        "release": "2.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20210930/Packages/python3-linux-procfs-0.6.3-2.el9.noarch.rpm",
+        "checksum": "sha256:dc2367cc223ec0bb0d01e9a081adc88ca0de5d8cc73dbc9dc77fc49c6a36c93b"
+      },
+      {
+        "name": "python3-perf",
+        "epoch": 0,
+        "version": "5.14.0",
+        "release": "4.el9",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20210930/Packages/python3-perf-5.14.0-4.el9.aarch64.rpm",
+        "checksum": "sha256:6abe11f6d94cf298376652fc71a7a7814083b57bf00d46cdfc96c611bf7b65e5"
+      },
+      {
         "name": "python3-pysocks",
         "epoch": 0,
         "version": "1.7.1",
@@ -7891,6 +7939,15 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20210930/Packages/python3-pysocks-1.7.1-10.el9.noarch.rpm",
         "checksum": "sha256:86445c0378ebb8b2887bd3a7327da62762a165b74ee77d38d083365f63fb1b96"
+      },
+      {
+        "name": "python3-pyudev",
+        "epoch": 0,
+        "version": "0.22.0",
+        "release": "6.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20210930/Packages/python3-pyudev-0.22.0-6.el9.noarch.rpm",
+        "checksum": "sha256:f18f9e1547912e9b490db2499982ec339b3d7fbcef089b6fcd603c1a4b784fe6"
       },
       {
         "name": "python3-pyyaml",
@@ -8314,6 +8371,15 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20210930/Packages/tpm2-tss-3.0.3-6.el9.aarch64.rpm",
         "checksum": "sha256:7934f3a971336a4bb757fd8d2ada206d276f9ab4c2eb14a716dd230f81ba87d8"
+      },
+      {
+        "name": "tuned",
+        "epoch": 0,
+        "version": "2.16.0",
+        "release": "3.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20210930/Packages/tuned-2.16.0-3.el9.noarch.rpm",
+        "checksum": "sha256:90827ff90e161df4b72b3fecd62fdc5bbe9aab633c8141a874569612ac4b5aea"
       },
       {
         "name": "tzdata",
@@ -9045,9 +9111,9 @@
         "grub_arg": "--unrestricted",
         "grub_class": "kernel",
         "grub_users": "$grub_users",
-        "initrd": "/initramfs-5.14.0-4.el9.aarch64.img",
+        "initrd": "/initramfs-5.14.0-4.el9.aarch64.img $tuned_initrd",
         "linux": "/vmlinuz-5.14.0-4.el9.aarch64",
-        "options": "root=UUID=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75 console=ttyS0,115200n8 console=tty0 net.ifnames=0 rd.blacklist=nouveau nvme_core.io_timeout=4294967295 iommu.strict=0 crashkernel=auto",
+        "options": "root=UUID=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75 console=ttyS0,115200n8 console=tty0 net.ifnames=0 rd.blacklist=nouveau nvme_core.io_timeout=4294967295 iommu.strict=0 crashkernel=auto $tuned_params",
         "title": "Red Hat Enterprise Linux (5.14.0-4.el9.aarch64) 9.0 (Plow)",
         "version": "5.14.0-4.el9.aarch64"
       }
@@ -9455,6 +9521,7 @@
       "grub2-tools-minimal-2.06~rc1-8.el9.aarch64",
       "grubby-8.40-54.el9.aarch64",
       "gzip-1.10-8.el9.aarch64",
+      "hdparm-9.62-2.el9.aarch64",
       "hostname-3.23-6.el9.aarch64",
       "hwdata-0.348-9.1.el9.noarch",
       "ima-evm-utils-1.3.2-7.el9.aarch64",
@@ -9686,13 +9753,16 @@
       "python3-libs-3.9.7-1.el9.aarch64",
       "python3-libselinux-3.2-6.el9.aarch64",
       "python3-libsemanage-3.2-4.el9.aarch64",
+      "python3-linux-procfs-0.6.3-2.el9.noarch",
       "python3-markupsafe-1.1.1-12.el9.aarch64",
       "python3-oauthlib-3.1.1-2.el9.noarch",
+      "python3-perf-5.14.0-4.el9.aarch64",
       "python3-policycoreutils-3.2-7.el9.noarch",
       "python3-prettytable-0.7.2-27.el9.noarch",
       "python3-pyserial-3.4-12.el9.noarch",
       "python3-pysocks-1.7.1-10.el9.noarch",
       "python3-pytz-2021.1-4.el9.noarch",
+      "python3-pyudev-0.22.0-6.el9.noarch",
       "python3-pyyaml-5.4.1-4.el9.aarch64",
       "python3-requests-2.25.1-5.el9.noarch",
       "python3-rpm-4.16.1.3-7.el9.aarch64",
@@ -9744,6 +9814,7 @@
       "tar-1.34-3.el9.aarch64",
       "teamd-1.31-10.el9.aarch64",
       "tpm2-tss-3.0.3-6.el9.aarch64",
+      "tuned-2.16.0-3.el9.noarch",
       "tzdata-2021a-3.el9.noarch",
       "udisks2-2.9.2-6.el9.aarch64",
       "unbound-libs-1.13.1-9.el9.aarch64",
@@ -9983,6 +10054,7 @@
       "sshd.service",
       "sssd-kcm.socket",
       "sssd.service",
+      "tuned.service",
       "udisks2.service",
       "unbound-anchor.timer"
     ],
@@ -10233,6 +10305,9 @@
           "a+      /var/lib/tpm2-tss/system/keystore   -    -    -     -           default:group:tss:rwx",
           "d       /run/tpm2-tss/eventlog                2775 tss  tss   -           -",
           "a+      /run/tpm2-tss/eventlog                -    -    -     -           default:group:tss:rwx"
+        ],
+        "tuned.conf": [
+          "d /run/tuned 0755 root root -"
         ],
         "udisks2.conf": [
           "d /run/media 0755 root root"

--- a/test/data/manifests/rhel_90-aarch64-ec2-boot.json
+++ b/test/data/manifests/rhel_90-aarch64-ec2-boot.json
@@ -385,6 +385,7 @@
                   "sha256:738b7caaefeba5bda35229f5f2a831ea722d5eb7dd1931742ba148410f36df53",
                   "sha256:fbb439cbf63c2dcbdfb464d344114c97b09a91d775b3909a154a79653ba54d73",
                   "sha256:1d46eb0723917c1aaa729485f31e129a242a2ac27983c2438837e7c88668dd7e",
+                  "sha256:4db59f521b69593facbdf4221fa754a64edf8e9f19cc94f924ab4659b9c4188f",
                   "sha256:7282be0cfd44ddcaa930d67ac1100ba0d8f335acf97f635a00e1c67d4374af3b",
                   "sha256:6e034e0a91e8c18ac7b1f6ea04d968411c8baa2d44810ce6c11f7017198054b2",
                   "sha256:68df68695fbab307c10053d264c340f696909ae1d35d5290c03255f718fcb356",
@@ -576,7 +577,10 @@
                   "sha256:210425ecf5b9ec9f60ad4c93f943327f571a95c7dc3bcb6004d00a55e4cd22b2",
                   "sha256:ffc3b586fe2542dbfe877f09b8b70000949ee31422560318953f1ff02ad62aae",
                   "sha256:43152a99489ed4eb095251f4cdca55145ed12a3a4e1dd15555424beacca42980",
+                  "sha256:dc2367cc223ec0bb0d01e9a081adc88ca0de5d8cc73dbc9dc77fc49c6a36c93b",
+                  "sha256:6abe11f6d94cf298376652fc71a7a7814083b57bf00d46cdfc96c611bf7b65e5",
                   "sha256:86445c0378ebb8b2887bd3a7327da62762a165b74ee77d38d083365f63fb1b96",
+                  "sha256:f18f9e1547912e9b490db2499982ec339b3d7fbcef089b6fcd603c1a4b784fe6",
                   "sha256:c3db09db1a5b752d28dc5c5de58b9bbbb6275fbdbb44e58b82ddc51ca4ea3ece",
                   "sha256:bc2135331da61c95c795c0c739044e9d46c34dc5662f5c011b4c99ac21a0737a",
                   "sha256:097c9fa13727862d3c08ca94070bda7d62ba40ebe4925ce1373adcebc8051ea7",
@@ -624,6 +628,7 @@
                   "sha256:59446a6aa39ac776a77552b5a799498c9cb1ed12ac89c8726c9909af67c62f98",
                   "sha256:9050f61182012d047cdb909446efe9e85a3c4ba4d30f49b4cb772da96c85d716",
                   "sha256:7934f3a971336a4bb757fd8d2ada206d276f9ab4c2eb14a716dd230f81ba87d8",
+                  "sha256:90827ff90e161df4b72b3fecd62fdc5bbe9aab633c8141a874569612ac4b5aea",
                   "sha256:2d66819cc8adc7a0cbb7b9d12dc0a73ac86551e3b7c3929cc49dddad6d3a884b",
                   "sha256:1592de4f8501d7994d667e6c07d45c6a42bb0d154cec41cd09ba094e59d20c46",
                   "sha256:1513f0f4efcd0a9fcfd4bff7a560f8c8f6c647badbef9ce00b253da39fea3959",
@@ -873,7 +878,8 @@
                 "cloud-init-local",
                 "cloud-config",
                 "cloud-final",
-                "reboot.target"
+                "reboot.target",
+                "tuned"
               ],
               "default_target": "multi-user.target"
             }
@@ -1600,6 +1606,9 @@
           "sha256:4d6ac94dd861ff41486199d60397d9b16c576400e06627530b14adde19460549": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20210930/Packages/libxmlb-0.3.0-3.el9.aarch64.rpm"
           },
+          "sha256:4db59f521b69593facbdf4221fa754a64edf8e9f19cc94f924ab4659b9c4188f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20210930/Packages/hdparm-9.62-2.el9.aarch64.rpm"
+          },
           "sha256:4ec600e2461e10f8596cb6b7edaaf57b3f242737ce2b6937a225bbc703d61d3d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-appstream-n9.0-20210930/Packages/python3-kickstart-3.32.2-2.el9.noarch.rpm"
           },
@@ -1749,6 +1758,9 @@
           },
           "sha256:6a72668714f29fa89abc646debca7571c3ae55171bc0bfd7953df71a59d59c83": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20210930/Packages/prefixdevname-0.1.0-8.el9.aarch64.rpm"
+          },
+          "sha256:6abe11f6d94cf298376652fc71a7a7814083b57bf00d46cdfc96c611bf7b65e5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20210930/Packages/python3-perf-5.14.0-4.el9.aarch64.rpm"
           },
           "sha256:6acc91f918063e16d55f653782bf516704345d16c894a2515735479048efe856": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20210930/Packages/gmp-6.2.0-10.el9.aarch64.rpm"
@@ -1968,6 +1980,9 @@
           },
           "sha256:9050f61182012d047cdb909446efe9e85a3c4ba4d30f49b4cb772da96c85d716": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20210930/Packages/teamd-1.31-10.el9.aarch64.rpm"
+          },
+          "sha256:90827ff90e161df4b72b3fecd62fdc5bbe9aab633c8141a874569612ac4b5aea": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20210930/Packages/tuned-2.16.0-3.el9.noarch.rpm"
           },
           "sha256:922e603fb9efa2c904fa05749b450aaad0255de5abf5cf8c420acd97cd7e0a2b": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20210930/Packages/e2fsprogs-1.46.2-2.el9.aarch64.rpm"
@@ -2341,6 +2356,9 @@
           "sha256:dc1da9164d28f220631535ddd21096ed4eacc208fea9e9666f55cee419c2661e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20210930/Packages/file-5.39-8.el9.aarch64.rpm"
           },
+          "sha256:dc2367cc223ec0bb0d01e9a081adc88ca0de5d8cc73dbc9dc77fc49c6a36c93b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20210930/Packages/python3-linux-procfs-0.6.3-2.el9.noarch.rpm"
+          },
           "sha256:dc7f764658f115feaf199996018c05f67fc01ce3a9522582373be290402af018": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20210930/Packages/pcre2-syntax-10.37-3.el9.1.noarch.rpm"
           },
@@ -2439,6 +2457,9 @@
           },
           "sha256:f0cc6fe2ca571f9423b3abf6da644f91fe6701759556cc05c9ac8273bf1fc74c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20210930/Packages/libini_config-1.3.1-51.el9.aarch64.rpm"
+          },
+          "sha256:f18f9e1547912e9b490db2499982ec339b3d7fbcef089b6fcd603c1a4b784fe6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20210930/Packages/python3-pyudev-0.22.0-6.el9.noarch.rpm"
           },
           "sha256:f3ffa7637d6c835e77da1f19e251147762b3f8206f8fe495722f9bd2b33c89c1": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20210930/Packages/curl-7.76.1-12.el9.aarch64.rpm"
@@ -6195,6 +6216,15 @@
         "checksum": "sha256:1d46eb0723917c1aaa729485f31e129a242a2ac27983c2438837e7c88668dd7e"
       },
       {
+        "name": "hdparm",
+        "epoch": 0,
+        "version": "9.62",
+        "release": "2.el9",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20210930/Packages/hdparm-9.62-2.el9.aarch64.rpm",
+        "checksum": "sha256:4db59f521b69593facbdf4221fa754a64edf8e9f19cc94f924ab4659b9c4188f"
+      },
+      {
         "name": "hostname",
         "epoch": 0,
         "version": "3.23",
@@ -7914,6 +7944,24 @@
         "checksum": "sha256:43152a99489ed4eb095251f4cdca55145ed12a3a4e1dd15555424beacca42980"
       },
       {
+        "name": "python3-linux-procfs",
+        "epoch": 0,
+        "version": "0.6.3",
+        "release": "2.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20210930/Packages/python3-linux-procfs-0.6.3-2.el9.noarch.rpm",
+        "checksum": "sha256:dc2367cc223ec0bb0d01e9a081adc88ca0de5d8cc73dbc9dc77fc49c6a36c93b"
+      },
+      {
+        "name": "python3-perf",
+        "epoch": 0,
+        "version": "5.14.0",
+        "release": "4.el9",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20210930/Packages/python3-perf-5.14.0-4.el9.aarch64.rpm",
+        "checksum": "sha256:6abe11f6d94cf298376652fc71a7a7814083b57bf00d46cdfc96c611bf7b65e5"
+      },
+      {
         "name": "python3-pysocks",
         "epoch": 0,
         "version": "1.7.1",
@@ -7921,6 +7969,15 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20210930/Packages/python3-pysocks-1.7.1-10.el9.noarch.rpm",
         "checksum": "sha256:86445c0378ebb8b2887bd3a7327da62762a165b74ee77d38d083365f63fb1b96"
+      },
+      {
+        "name": "python3-pyudev",
+        "epoch": 0,
+        "version": "0.22.0",
+        "release": "6.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20210930/Packages/python3-pyudev-0.22.0-6.el9.noarch.rpm",
+        "checksum": "sha256:f18f9e1547912e9b490db2499982ec339b3d7fbcef089b6fcd603c1a4b784fe6"
       },
       {
         "name": "python3-pyyaml",
@@ -8344,6 +8401,15 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20210930/Packages/tpm2-tss-3.0.3-6.el9.aarch64.rpm",
         "checksum": "sha256:7934f3a971336a4bb757fd8d2ada206d276f9ab4c2eb14a716dd230f81ba87d8"
+      },
+      {
+        "name": "tuned",
+        "epoch": 0,
+        "version": "2.16.0",
+        "release": "3.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20210930/Packages/tuned-2.16.0-3.el9.noarch.rpm",
+        "checksum": "sha256:90827ff90e161df4b72b3fecd62fdc5bbe9aab633c8141a874569612ac4b5aea"
       },
       {
         "name": "tzdata",
@@ -9084,9 +9150,9 @@
         "grub_arg": "--unrestricted",
         "grub_class": "kernel",
         "grub_users": "$grub_users",
-        "initrd": "/initramfs-5.14.0-4.el9.aarch64.img",
+        "initrd": "/initramfs-5.14.0-4.el9.aarch64.img $tuned_initrd",
         "linux": "/vmlinuz-5.14.0-4.el9.aarch64",
-        "options": "root=UUID=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75 console=ttyS0,115200n8 console=tty0 net.ifnames=0 rd.blacklist=nouveau nvme_core.io_timeout=4294967295 iommu.strict=0 crashkernel=auto",
+        "options": "root=UUID=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75 console=ttyS0,115200n8 console=tty0 net.ifnames=0 rd.blacklist=nouveau nvme_core.io_timeout=4294967295 iommu.strict=0 crashkernel=auto $tuned_params",
         "title": "Red Hat Enterprise Linux (5.14.0-4.el9.aarch64) 9.0 (Plow)",
         "version": "5.14.0-4.el9.aarch64"
       }
@@ -9494,6 +9560,7 @@
       "grub2-tools-minimal-2.06~rc1-8.el9.aarch64",
       "grubby-8.40-54.el9.aarch64",
       "gzip-1.10-8.el9.aarch64",
+      "hdparm-9.62-2.el9.aarch64",
       "hostname-3.23-6.el9.aarch64",
       "hwdata-0.348-9.1.el9.noarch",
       "ima-evm-utils-1.3.2-7.el9.aarch64",
@@ -9725,13 +9792,16 @@
       "python3-libs-3.9.7-1.el9.aarch64",
       "python3-libselinux-3.2-6.el9.aarch64",
       "python3-libsemanage-3.2-4.el9.aarch64",
+      "python3-linux-procfs-0.6.3-2.el9.noarch",
       "python3-markupsafe-1.1.1-12.el9.aarch64",
       "python3-oauthlib-3.1.1-2.el9.noarch",
+      "python3-perf-5.14.0-4.el9.aarch64",
       "python3-policycoreutils-3.2-7.el9.noarch",
       "python3-prettytable-0.7.2-27.el9.noarch",
       "python3-pyserial-3.4-12.el9.noarch",
       "python3-pysocks-1.7.1-10.el9.noarch",
       "python3-pytz-2021.1-4.el9.noarch",
+      "python3-pyudev-0.22.0-6.el9.noarch",
       "python3-pyyaml-5.4.1-4.el9.aarch64",
       "python3-requests-2.25.1-5.el9.noarch",
       "python3-rpm-4.16.1.3-7.el9.aarch64",
@@ -9784,6 +9854,7 @@
       "tar-1.34-3.el9.aarch64",
       "teamd-1.31-10.el9.aarch64",
       "tpm2-tss-3.0.3-6.el9.aarch64",
+      "tuned-2.16.0-3.el9.noarch",
       "tzdata-2021a-3.el9.noarch",
       "udisks2-2.9.2-6.el9.aarch64",
       "unbound-libs-1.13.1-9.el9.aarch64",
@@ -10027,6 +10098,7 @@
       "sshd.service",
       "sssd-kcm.socket",
       "sssd.service",
+      "tuned.service",
       "udisks2.service",
       "unbound-anchor.timer"
     ],
@@ -10277,6 +10349,9 @@
           "a+      /var/lib/tpm2-tss/system/keystore   -    -    -     -           default:group:tss:rwx",
           "d       /run/tpm2-tss/eventlog                2775 tss  tss   -           -",
           "a+      /run/tpm2-tss/eventlog                -    -    -     -           default:group:tss:rwx"
+        ],
+        "tuned.conf": [
+          "d /run/tuned 0755 root root -"
         ],
         "udisks2.conf": [
           "d /run/media 0755 root root"

--- a/test/data/manifests/rhel_90-x86_64-ami-boot.json
+++ b/test/data/manifests/rhel_90-x86_64-ami-boot.json
@@ -36,7 +36,7 @@
       },
       {
         "name": "rhui",
-        "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-rhui-3-20210930/",
+        "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-rhui-4-20211105/",
         "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBErgSTsBEACh2A4b0O9t+vzC9VrVtL1AKvUWi9OPCjkvR7Xd8DtJxeeMZ5eF\n0HtzIG58qDRybwUe89FZprB1ffuUKzdE+HcL3FbNWSSOXVjZIersdXyH3NvnLLLF\n0DNRB2ix3bXG9Rh/RXpFsNxDp2CEMdUvbYCzE79K1EnUTVh1L0Of023FtPSZXX0c\nu7Pb5DI5lX5YeoXO6RoodrIGYJsVBQWnrWw4xNTconUfNPk0EGZtEnzvH2zyPoJh\nXGF+Ncu9XwbalnYde10OCvSWAZ5zTCpoLMTvQjWpbCdWXJzCm6G+/hx9upke546H\n5IjtYm4dTIVTnc3wvDiODgBKRzOl9rEOCIgOuGtDxRxcQkjrC+xvg5Vkqn7vBUyW\n9pHedOU+PoF3DGOM+dqv+eNKBvh9YF9ugFAQBkcG7viZgvGEMGGUpzNgN7XnS1gj\n/DPo9mZESOYnKceve2tIC87p2hqjrxOHuI7fkZYeNIcAoa83rBltFXaBDYhWAKS1\nPcXS1/7JzP0ky7d0L6Xbu/If5kqWQpKwUInXtySRkuraVfuK3Bpa+X1XecWi24JY\nHVtlNX025xx1ewVzGNCTlWn1skQN2OOoQTV4C8/qFpTW6DTWYurd4+fE0OJFJZQF\nbuhfXYwmRlVOgN5i77NTIJZJQfYFj38c/Iv5vZBPokO6mffrOTv3MHWVgQARAQAB\ntDNSZWQgSGF0LCBJbmMuIChyZWxlYXNlIGtleSAyKSA8c2VjdXJpdHlAcmVkaGF0\nLmNvbT6JAjYEEwECACAFAkrgSTsCGwMGCwkIBwMCBBUCCAMEFgIDAQIeAQIXgAAK\nCRAZni+R/UMdUWzpD/9s5SFR/ZF3yjY5VLUFLMXIKUztNN3oc45fyLdTI3+UClKC\n2tEruzYjqNHhqAEXa2sN1fMrsuKec61Ll2NfvJjkLKDvgVIh7kM7aslNYVOP6BTf\nC/JJ7/ufz3UZmyViH/WDl+AYdgk3JqCIO5w5ryrC9IyBzYv2m0HqYbWfphY3uHw5\nun3ndLJcu8+BGP5F+ONQEGl+DRH58Il9Jp3HwbRa7dvkPgEhfFR+1hI+Btta2C7E\n0/2NKzCxZw7Lx3PBRcU92YKyaEihfy/aQKZCAuyfKiMvsmzs+4poIX7I9NQCJpyE\nIGfINoZ7VxqHwRn/d5mw2MZTJjbzSf+Um9YJyA0iEEyD6qjriWQRbuxpQXmlAJbh\n8okZ4gbVFv1F8MzK+4R8VvWJ0XxgtikSo72fHjwha7MAjqFnOq6eo6fEC/75g3NL\nGht5VdpGuHk0vbdENHMC8wS99e5qXGNDued3hlTavDMlEAHl34q2H9nakTGRF5Ki\nJUfNh3DVRGhg8cMIti21njiRh7gyFI2OccATY7bBSr79JhuNwelHuxLrCFpY7V25\nOFktl15jZJaMxuQBqYdBgSay2G0U6D1+7VsWufpzd/Abx1/c3oi9ZaJvW22kAggq\ndzdA27UUYjWvx42w9menJwh/0jeQcTecIUd0d0rFcw/c1pvgMMl/Q73yzKgKYw==\n=zbHE\n-----END PGP PUBLIC KEY BLOCK-----\n-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBFsy23UBEACUKSphFEIEvNpy68VeW4Dt6qv+mU6am9a2AAl10JANLj1oqWX+\noYk3en1S6cVe2qehSL5DGVa3HMUZkP3dtbD4SgzXzxPodebPcr4+0QNWigkUisri\nXGL5SCEcOP30zDhZvg+4mpO2jMi7Kc1DLPzBBkgppcX91wa0L1pQzBcvYMPyV/Dh\nKbQHR75WdkP6OA2JXdfC94nxYq+2e0iPqC1hCP3Elh+YnSkOkrawDPmoB1g4+ft/\nxsiVGVy/W0ekXmgvYEHt6si6Y8NwXgnTMqxeSXQ9YUgVIbTpsxHQKGy76T5lMlWX\n4LCOmEVomBJg1SqF6yi9Vu8TeNThaDqT4/DddYInd0OO69s0kGIXalVgGYiW2HOD\nx2q5R1VGCoJxXomz+EbOXY+HpKPOHAjU0DB9MxbU3S248LQ69nIB5uxysy0PSco1\nsdZ8sxRNQ9Dw6on0Nowx5m6Thefzs5iK3dnPGBqHTT43DHbnWc2scjQFG+eZhe98\nEll/kb6vpBoY4bG9/wCG9qu7jj9Z+BceCNKeHllbezVLCU/Hswivr7h2dnaEFvPD\nO4GqiWiwOF06XaBMVgxA8p2HRw0KtXqOpZk+o+sUvdPjsBw42BB96A1yFX4jgFNA\nPyZYnEUdP6OOv9HSjnl7k/iEkvHq/jGYMMojixlvXpGXhnt5jNyc4GSUJQARAQAB\ntDNSZWQgSGF0LCBJbmMuIChhdXhpbGlhcnkga2V5KSA8c2VjdXJpdHlAcmVkaGF0\nLmNvbT6JAjkEEwECACMFAlsy23UCGwMHCwkIBwMCAQYVCAIJCgsEFgIDAQIeAQIX\ngAAKCRD3b2bD1AgnknqOD/9fB2ASuG2aJIiap4kK58R+RmOVM4qgclAnaG57+vjI\nnKvyfV3NH/keplGNRxwqHekfPCqvkpABwhdGEXIE8ILqnPewIMr6PZNZWNJynZ9i\neSMzVuCG7jDoGyQ5/6B0f6xeBtTeBDiRl7+Alehet1twuGL1BJUYG0QuLgcEzkaE\n/gkuumeVcazLzz7L12D22nMk66GxmgXfqS5zcbqOAuZwaA6VgSEgFdV2X2JU79zS\nBQJXv7NKc+nDXFG7M7EHjY3Rma3HXkDbkT8bzh9tJV7Z7TlpT829pStWQyoxKCVq\nsEX8WsSapTKA3P9YkYCwLShgZu4HKRFvHMaIasSIZWzLu+RZH/4yyHOhj0QB7XMY\neHQ6fGSbtJ+K6SrpHOOsKQNAJ0hVbSrnA1cr5+2SDfel1RfYt0W9FA6DoH/S5gAR\ndzT1u44QVwwp3U+eFpHphFy//uzxNMtCjjdkpzhYYhOCLNkDrlRPb+bcoL/6ePSr\n016PA7eEnuC305YU1Ml2WcCn7wQV8x90o33klJmEkWtXh3X39vYtI4nCPIvZn1eP\nVy+F+wWt4vN2b8oOdlzc2paOembbCo2B+Wapv5Y9peBvlbsDSgqtJABfK8KQq/jK\nYl3h5elIa1I3uNfczeHOnf1enLOUOlq630yeM/yHizz99G1g+z/guMh5+x/OHraW\niLkCDQRbMtt1ARAA1lNsWklhS9LoBdolTVtg65FfdFJr47pzKRGYIoGLbcJ155ND\nG+P8UrM06E/ah06EEWuvu2YyyYAz1iYGsCwHAXtbEJh+1tF0iOVx2vnZPgtIGE9V\nP95V5ZvWvB3bdke1z8HadDA+/Ve7fbwXXLa/z9QhSQgsJ8NS8KYnDDjI4EvQtv0i\nPVLY8+u8z6VyiV9RJyn8UEZEJdbFDF9AZAT8103w8SEo/cvIoUbVKZLGcXdAIjCa\ny04u6jsrMp9UGHZX7+srT+9YHDzQixei4IdmxUcqtiNR2/bFHpHCu1pzYjXj968D\n8Ng2txBXDgs16BF/9l++GWKz2dOSH0jdS6sFJ/Dmg7oYnJ2xKSJEmcnV8Z0M1n4w\nXR1t/KeKZe3aR+RXCAEVC5dQ3GbRW2+WboJ6ldgFcVcOv6iOSWP9TrLzFPOpCsIr\nnHE+cMBmPHq3dUm7KeYXQ6wWWmtXlw6widf7cBcGFeELpuU9klzqdKze8qo2oMkf\nrfxIq8zdciPxZXb/75dGWs6dLHQmDpo4MdQVskw5vvwHicMpUpGpxkX7X1XAfdQf\nyIHLGT4ZXuMLIMUPdzJE0Vwt/RtJrZ+feLSv/+0CkkpGHORYroGwIBrJ2RikgcV2\nbc98V/27Kz2ngUCEwnmlhIcrY4IGAAZzUAl0GLHSevPbAREu4fDW4Y+ztOsAEQEA\nAYkCHwQYAQIACQUCWzLbdQIbDAAKCRD3b2bD1AgnkusfD/9U4sPtZfMw6cII167A\nXRZOO195G7oiAnBUw5AW6EK0SAHVZcuW0LMMXnGe9f4UsEUgCNwo5mvLWPxzKqFq\n6/G3kEZVFwZ0qrlLoJPeHNbOcfkeZ9NgD/OhzQmdylM0IwGM9DMrm2YS4EVsmm2b\n53qKIfIyysp1yAGcTnBwBbZ85osNBl2KRDIPhMs0bnmGB7IAvwlSb+xm6vWKECkO\nlwQDO5Kg8YZ8+Z3pn/oS688t/fPXvWLZYUqwR63oWfIaPJI7Ahv2jJmgw1ofL81r\n2CE3T/OydtUeGLzqWJAB8sbUgT3ug0cjtxsHuroQBSYBND3XDb/EQh5GeVVnGKKH\ngESLFAoweoNjDSXrlIu1gFjCDHF4CqBRmNYKrNQjLmhCrSfwkytXESJwlLzFKY8P\nK1yZyTpDC9YK0G7qgrk7EHmH9JAZTQ5V65pp0vR9KvqTU5ewkQDIljD2f3FIqo2B\nSKNCQE+N6NjWaTeNlU75m+yZocKObSPg0zS8FAuSJetNtzXA7ouqk34OoIMQj4gq\nUnh/i1FcZAd4U6Dtr9aRZ6PeLlm6MJ/h582L6fJLNEu136UWDtJj5eBYEzX13l+d\nSC4PEHx7ZZRwQKptl9NkinLZGJztg175paUu8C34sAv+SQnM20c0pdOXAq9GKKhi\nvt61kpkXoRGxjTlc6h+69aidSg==\n=ls8J\n-----END PGP PUBLIC KEY BLOCK-----\n"
       }
     ],
@@ -418,6 +418,7 @@
                   "sha256:8c6cb347759c1f84fcbc5d11291e90310d2d79a87e05104206c9599e112b30da",
                   "sha256:f9700192a3d79f11afcadde29204aa6f7b73d766f0b4afb636fcf2b068b23a4c",
                   "sha256:bb49855f3c7bd6e7724eb47964b4d8453f21e5b212c121f58bb2d02645317aa4",
+                  "sha256:becb9051ac92783886265b665471c1b2088df0f1fbb65046170f1179ac7288f5",
                   "sha256:adfbb23da7180b179797c30f45a2c7ba57aa87c7874f8b71068c7ad002463d8f",
                   "sha256:6e034e0a91e8c18ac7b1f6ea04d968411c8baa2d44810ce6c11f7017198054b2",
                   "sha256:38c0490726f755809738a48faaf8fb3c1942be9757de40db70b07470754260bc",
@@ -574,6 +575,9 @@
                   "sha256:9895310924240b44c46a03be44a62745ea770c4e8a0ff173e5160bbf4a4307dd",
                   "sha256:dc7f764658f115feaf199996018c05f67fc01ce3a9522582373be290402af018",
                   "sha256:f599f03413667b040b0ddd4b43e04606597c66eebb5e325f76a08ca242bcb40d",
+                  "sha256:51063b84fd3001b9bec9590d27388d7a1291dbee07a8b09d952a232bf835bfd3",
+                  "sha256:04f285e1135c4a971526bcd9462917f04433b41d7bba005f6bd8a4fbfa986bf5",
+                  "sha256:54f0a33b5c290dfbdb7fcc5634e11129089b24f18f766db522fec7ba7927fd87",
                   "sha256:760a27547fab9b3d667d173e693fcebe5cedeb3719e3f0dd6c4ab072b8665bc2",
                   "sha256:343d7dc3662b29762b8233ddf25f9fdaf05974aae3bb1519ecc7c73b8fe0a46e",
                   "sha256:28de7dc534d0e3231f2217843f9c330fa4d0bab126315a74441d50ac8bcd5fb3",
@@ -602,7 +606,10 @@
                   "sha256:af86d10e99293bc982720b339fe751babe75013c5920b92fc654cac700d2a125",
                   "sha256:00b013eb7ea3b3007b28a7aff2c9f7714f3166dbf7c4788dacaa92794beb4351",
                   "sha256:f6ba5d9dfbaaf1c8e82d52919e72099e2374b81af2338d96c719374e92bf2907",
+                  "sha256:dc2367cc223ec0bb0d01e9a081adc88ca0de5d8cc73dbc9dc77fc49c6a36c93b",
+                  "sha256:d511eb61ae1dbf8d0bedba4a7ebaa6fcab6773d2e5417af8d9eacedd4a2f4941",
                   "sha256:86445c0378ebb8b2887bd3a7327da62762a165b74ee77d38d083365f63fb1b96",
+                  "sha256:f18f9e1547912e9b490db2499982ec339b3d7fbcef089b6fcd603c1a4b784fe6",
                   "sha256:65c3a7db749188b8e10af962d5ba509ed4f43c3e2049940b8b2fa8352ddffadc",
                   "sha256:bc2135331da61c95c795c0c739044e9d46c34dc5662f5c011b4c99ac21a0737a",
                   "sha256:9c3d8d17f2e9454b8b3b2ba5ef5e3b8ce045856c8f7859ab135afd00323c2f24",
@@ -648,6 +655,7 @@
                   "sha256:eb08d43161370a87137908b62a8322f49bb5e3b3d562393f3e6efa2b91d20951",
                   "sha256:82f46270c3ea5c4c286d93ff77f206dcded8c602eab10c9c4885d6284d47d8d2",
                   "sha256:28f81d243f8f40a5d93a42a757b0566ed3bca116e612c716bd4c8ae356140a05",
+                  "sha256:90827ff90e161df4b72b3fecd62fdc5bbe9aab633c8141a874569612ac4b5aea",
                   "sha256:2d66819cc8adc7a0cbb7b9d12dc0a73ac86551e3b7c3929cc49dddad6d3a884b",
                   "sha256:dfa7f95918435249ed4c85c13ad7d2197cffd3fd5b4d8b441c91791363493fc6",
                   "sha256:77d8019978eee228b7999c0170fa08f15c9659043e21c750052a9c948e21b7a6",
@@ -878,7 +886,8 @@
                 "cloud-init-local",
                 "cloud-config",
                 "cloud-final",
-                "reboot.target"
+                "reboot.target",
+                "tuned"
               ],
               "default_target": "multi-user.target"
             }
@@ -1182,6 +1191,9 @@
           },
           "sha256:04bf3e872657858088771dc4c7d3a605bdaacae74cff10c6bd665458bfb7cd82": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20210930/Packages/pciutils-3.7.0-5.el9.x86_64.rpm"
+          },
+          "sha256:04f285e1135c4a971526bcd9462917f04433b41d7bba005f6bd8a4fbfa986bf5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20210930/Packages/polkit-libs-0.117-7.el9.x86_64.rpm"
           },
           "sha256:051a0502d4d493fff84442e84c189abaa70989f0718548d3734655fb59318c74": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20210930/Packages/libmnl-1.0.4-15.el9.x86_64.rpm"
@@ -1513,6 +1525,9 @@
           "sha256:50325a1809731759583e25d445f3b65549c24b0a5342eeda6fb15bdcc2f08982": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20210930/Packages/libdhash-0.5.0-51.el9.x86_64.rpm"
           },
+          "sha256:51063b84fd3001b9bec9590d27388d7a1291dbee07a8b09d952a232bf835bfd3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20210930/Packages/polkit-0.117-7.el9.x86_64.rpm"
+          },
           "sha256:51ac91f318c6ce55bbd121e045244fea33a31d663c01d22b43506737e4189df3": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20210930/Packages/cryptsetup-libs-2.4.0-1.el9.x86_64.rpm"
           },
@@ -1533,6 +1548,9 @@
           },
           "sha256:5459ee79b751912556b2bc4b4cd25581e7f03a1b4b611255aa73e65622a75537": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20210930/Packages/libpipeline-1.5.3-4.el9.x86_64.rpm"
+          },
+          "sha256:54f0a33b5c290dfbdb7fcc5634e11129089b24f18f766db522fec7ba7927fd87": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20210930/Packages/polkit-pkla-compat-0.1-21.el9.x86_64.rpm"
           },
           "sha256:553681e4775eef1fc8ec802977b7a48a94aef69b6eb29ed06569ef23a96747a9": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20210930/Packages/dnf-plugins-core-4.0.21-2.el9.noarch.rpm"
@@ -1795,6 +1813,9 @@
           "sha256:9056f201e0d4576bf66e1b7e14dfa06c6f64321f6ced08b0fb637ba18d76baae": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20210930/Packages/libusbx-1.0.24-4.el9.x86_64.rpm"
           },
+          "sha256:90827ff90e161df4b72b3fecd62fdc5bbe9aab633c8141a874569612ac4b5aea": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20210930/Packages/tuned-2.16.0-3.el9.noarch.rpm"
+          },
           "sha256:9092b0ad7e9d343d446ae0030763c2e526ff922e7680df4c29d507e38c858d7d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20210930/Packages/rsyslog-8.2102.0-9.el9.x86_64.rpm"
           },
@@ -2011,6 +2032,9 @@
           "sha256:be769b9a1fd0346498033ecaf57773c2e45c0c9ea04bdd3332fa794a9396e252": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20210930/Packages/libcbor-0.7.0-5.el9.x86_64.rpm"
           },
+          "sha256:becb9051ac92783886265b665471c1b2088df0f1fbb65046170f1179ac7288f5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20210930/Packages/hdparm-9.62-2.el9.x86_64.rpm"
+          },
           "sha256:bf72c510221056b8f740138fb6ace335aa02dfabf6a75aa221f2257ab9b13014": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20210930/Packages/cronie-anacron-1.5.7-5.el9.x86_64.rpm"
           },
@@ -2131,6 +2155,9 @@
           "sha256:d4f62c76c8fdc59644a71f2567b2501a6a2735043853bd800ec89903ca3e6eb1": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20210930/Packages/libcom_err-1.46.2-2.el9.x86_64.rpm"
           },
+          "sha256:d511eb61ae1dbf8d0bedba4a7ebaa6fcab6773d2e5417af8d9eacedd4a2f4941": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20210930/Packages/python3-perf-5.14.0-4.el9.x86_64.rpm"
+          },
           "sha256:d556570916e8b5315623ffcb014c57fed4a856a8a7b472f59cef67e27c23de46": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20210930/Packages/openssl-libs-3.0.0-2.el9.x86_64.rpm"
           },
@@ -2163,6 +2190,9 @@
           },
           "sha256:dbed6952228c36fc126ce8c4bb9e20199bb878428f0f15de28504311c59eccf7": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20210930/Packages/gnutls-3.7.2-4.el9.x86_64.rpm"
+          },
+          "sha256:dc2367cc223ec0bb0d01e9a081adc88ca0de5d8cc73dbc9dc77fc49c6a36c93b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20210930/Packages/python3-linux-procfs-0.6.3-2.el9.noarch.rpm"
           },
           "sha256:dc2b36e69134189ba5b9a5275ec84d9c545b7700932e0c34559e9c302804c174": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20210930/Packages/libxml2-2.9.12-4.el9.x86_64.rpm"
@@ -2274,6 +2304,9 @@
           },
           "sha256:f147e5cd2d52db40e7841b7f968b0884e33acb092ebded8ac6a0a3709da053dd": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20210930/Packages/libffi-3.4.2-7.el9.x86_64.rpm"
+          },
+          "sha256:f18f9e1547912e9b490db2499982ec339b3d7fbcef089b6fcd603c1a4b784fe6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20210930/Packages/python3-pyudev-0.22.0-6.el9.noarch.rpm"
           },
           "sha256:f19cf4387113bb8584165e4bbbc53ca3c17c752c89f6e08a56a507e39ca3038c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20210930/Packages/npth-1.6-8.el9.x86_64.rpm"
@@ -6111,6 +6144,15 @@
         "checksum": "sha256:bb49855f3c7bd6e7724eb47964b4d8453f21e5b212c121f58bb2d02645317aa4"
       },
       {
+        "name": "hdparm",
+        "epoch": 0,
+        "version": "9.62",
+        "release": "2.el9",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20210930/Packages/hdparm-9.62-2.el9.x86_64.rpm",
+        "checksum": "sha256:becb9051ac92783886265b665471c1b2088df0f1fbb65046170f1179ac7288f5"
+      },
+      {
         "name": "hostname",
         "epoch": 0,
         "version": "3.23",
@@ -7515,6 +7557,33 @@
         "checksum": "sha256:f599f03413667b040b0ddd4b43e04606597c66eebb5e325f76a08ca242bcb40d"
       },
       {
+        "name": "polkit",
+        "epoch": 0,
+        "version": "0.117",
+        "release": "7.el9",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20210930/Packages/polkit-0.117-7.el9.x86_64.rpm",
+        "checksum": "sha256:51063b84fd3001b9bec9590d27388d7a1291dbee07a8b09d952a232bf835bfd3"
+      },
+      {
+        "name": "polkit-libs",
+        "epoch": 0,
+        "version": "0.117",
+        "release": "7.el9",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20210930/Packages/polkit-libs-0.117-7.el9.x86_64.rpm",
+        "checksum": "sha256:04f285e1135c4a971526bcd9462917f04433b41d7bba005f6bd8a4fbfa986bf5"
+      },
+      {
+        "name": "polkit-pkla-compat",
+        "epoch": 0,
+        "version": "0.1",
+        "release": "21.el9",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20210930/Packages/polkit-pkla-compat-0.1-21.el9.x86_64.rpm",
+        "checksum": "sha256:54f0a33b5c290dfbdb7fcc5634e11129089b24f18f766db522fec7ba7927fd87"
+      },
+      {
         "name": "popt",
         "epoch": 0,
         "version": "1.18",
@@ -7767,6 +7836,24 @@
         "checksum": "sha256:f6ba5d9dfbaaf1c8e82d52919e72099e2374b81af2338d96c719374e92bf2907"
       },
       {
+        "name": "python3-linux-procfs",
+        "epoch": 0,
+        "version": "0.6.3",
+        "release": "2.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20210930/Packages/python3-linux-procfs-0.6.3-2.el9.noarch.rpm",
+        "checksum": "sha256:dc2367cc223ec0bb0d01e9a081adc88ca0de5d8cc73dbc9dc77fc49c6a36c93b"
+      },
+      {
+        "name": "python3-perf",
+        "epoch": 0,
+        "version": "5.14.0",
+        "release": "4.el9",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20210930/Packages/python3-perf-5.14.0-4.el9.x86_64.rpm",
+        "checksum": "sha256:d511eb61ae1dbf8d0bedba4a7ebaa6fcab6773d2e5417af8d9eacedd4a2f4941"
+      },
+      {
         "name": "python3-pysocks",
         "epoch": 0,
         "version": "1.7.1",
@@ -7774,6 +7861,15 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20210930/Packages/python3-pysocks-1.7.1-10.el9.noarch.rpm",
         "checksum": "sha256:86445c0378ebb8b2887bd3a7327da62762a165b74ee77d38d083365f63fb1b96"
+      },
+      {
+        "name": "python3-pyudev",
+        "epoch": 0,
+        "version": "0.22.0",
+        "release": "6.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20210930/Packages/python3-pyudev-0.22.0-6.el9.noarch.rpm",
+        "checksum": "sha256:f18f9e1547912e9b490db2499982ec339b3d7fbcef089b6fcd603c1a4b784fe6"
       },
       {
         "name": "python3-pyyaml",
@@ -8179,6 +8275,15 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20210930/Packages/tpm2-tss-3.0.3-6.el9.x86_64.rpm",
         "checksum": "sha256:28f81d243f8f40a5d93a42a757b0566ed3bca116e612c716bd4c8ae356140a05"
+      },
+      {
+        "name": "tuned",
+        "epoch": 0,
+        "version": "2.16.0",
+        "release": "3.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20210930/Packages/tuned-2.16.0-3.el9.noarch.rpm",
+        "checksum": "sha256:90827ff90e161df4b72b3fecd62fdc5bbe9aab633c8141a874569612ac4b5aea"
       },
       {
         "name": "tzdata",
@@ -8730,9 +8835,9 @@
         "grub_arg": "--unrestricted",
         "grub_class": "kernel",
         "grub_users": "$grub_users",
-        "initrd": "/boot/initramfs-5.14.0-4.el9.x86_64.img",
+        "initrd": "/boot/initramfs-5.14.0-4.el9.x86_64.img $tuned_initrd",
         "linux": "/boot/vmlinuz-5.14.0-4.el9.x86_64",
-        "options": "root=UUID=0194fdc2-fa2f-4cc0-81d3-ff12045b73c8 console=ttyS0,115200n8 console=tty0 net.ifnames=0 rd.blacklist=nouveau nvme_core.io_timeout=4294967295 crashkernel=auto",
+        "options": "root=UUID=0194fdc2-fa2f-4cc0-81d3-ff12045b73c8 console=ttyS0,115200n8 console=tty0 net.ifnames=0 rd.blacklist=nouveau nvme_core.io_timeout=4294967295 crashkernel=auto $tuned_params",
         "title": "Red Hat Enterprise Linux (5.14.0-4.el9.x86_64) 9.0 (Plow)",
         "version": "5.14.0-4.el9.x86_64"
       }
@@ -8934,7 +9039,7 @@
       "audio:x:63:",
       "bin:x:1:",
       "cdrom:x:11:",
-      "chrony:x:993:",
+      "chrony:x:992:",
       "daemon:x:2:",
       "dbus:x:81:",
       "dialout:x:18:",
@@ -8951,11 +9056,12 @@
       "man:x:15:",
       "mem:x:8:",
       "nobody:x:65534:",
+      "polkitd:x:994:",
       "render:x:996:",
       "root:x:0:",
       "ssh_keys:x:998:",
       "sshd:x:74:",
-      "sssd:x:994:",
+      "sssd:x:993:",
       "sys:x:3:",
       "systemd-coredump:x:995:",
       "systemd-journal:x:190:",
@@ -9119,6 +9225,7 @@
       "grub2-tools-minimal-2.06~rc1-8.el9.x86_64",
       "grubby-8.40-54.el9.x86_64",
       "gzip-1.10-8.el9.x86_64",
+      "hdparm-9.62-2.el9.x86_64",
       "hostname-3.23-6.el9.x86_64",
       "hwdata-0.348-9.1.el9.noarch",
       "ima-evm-utils-1.3.2-7.el9.x86_64",
@@ -9287,6 +9394,9 @@
       "pcre2-syntax-10.37-3.el9.1.noarch",
       "pigz-2.5-3.el9.x86_64",
       "policycoreutils-3.2-7.el9.x86_64",
+      "polkit-0.117-7.el9.x86_64",
+      "polkit-libs-0.117-7.el9.x86_64",
+      "polkit-pkla-compat-0.1-21.el9.x86_64",
       "popt-1.18-8.el9.x86_64",
       "prefixdevname-0.1.0-8.el9.x86_64",
       "procps-ng-3.3.17-4.el9.x86_64",
@@ -9327,13 +9437,16 @@
       "python3-libselinux-3.2-6.el9.x86_64",
       "python3-libsemanage-3.2-4.el9.x86_64",
       "python3-libxml2-2.9.12-4.el9.x86_64",
+      "python3-linux-procfs-0.6.3-2.el9.noarch",
       "python3-markupsafe-1.1.1-12.el9.x86_64",
       "python3-oauthlib-3.1.1-2.el9.noarch",
+      "python3-perf-5.14.0-4.el9.x86_64",
       "python3-policycoreutils-3.2-7.el9.noarch",
       "python3-prettytable-0.7.2-27.el9.noarch",
       "python3-pyserial-3.4-12.el9.noarch",
       "python3-pysocks-1.7.1-10.el9.noarch",
       "python3-pytz-2021.1-4.el9.noarch",
+      "python3-pyudev-0.22.0-6.el9.noarch",
       "python3-pyyaml-5.4.1-4.el9.x86_64",
       "python3-requests-2.25.1-5.el9.noarch",
       "python3-rpm-4.16.1.3-7.el9.x86_64",
@@ -9383,6 +9496,7 @@
       "tar-1.34-3.el9.x86_64",
       "teamd-1.31-10.el9.x86_64",
       "tpm2-tss-3.0.3-6.el9.x86_64",
+      "tuned-2.16.0-3.el9.noarch",
       "tzdata-2021a-3.el9.noarch",
       "unbound-libs-1.13.1-9.el9.x86_64",
       "usermode-1.114-2.el9.x86_64",
@@ -9426,7 +9540,7 @@
     "passwd": [
       "adm:x:3:4:adm:/var/adm:/sbin/nologin",
       "bin:x:1:1:bin:/bin:/sbin/nologin",
-      "chrony:x:996:993::/var/lib/chrony:/sbin/nologin",
+      "chrony:x:995:992::/var/lib/chrony:/sbin/nologin",
       "daemon:x:2:2:daemon:/sbin:/sbin/nologin",
       "dbus:x:81:81:System message bus:/:/sbin/nologin",
       "ftp:x:14:50:FTP User:/var/ftp:/sbin/nologin",
@@ -9436,10 +9550,11 @@
       "mail:x:8:12:mail:/var/spool/mail:/sbin/nologin",
       "nobody:x:65534:65534:Kernel Overflow User:/:/sbin/nologin",
       "operator:x:11:0:operator:/root:/sbin/nologin",
+      "polkitd:x:997:994:User for polkitd:/:/sbin/nologin",
       "root:x:0:0:root:/root:/bin/bash",
       "shutdown:x:6:0:shutdown:/sbin:/sbin/shutdown",
       "sshd:x:74:74:Privilege-separated SSH:/usr/share/empty.sshd:/sbin/nologin",
-      "sssd:x:997:994:User for sssd:/:/sbin/nologin",
+      "sssd:x:996:993:User for sssd:/:/sbin/nologin",
       "sync:x:5:0:sync:/sbin:/bin/sync",
       "systemd-coredump:x:998:995:systemd Core Dumper:/:/sbin/nologin",
       "tss:x:59:59:Account used for TPM access:/dev/null:/sbin/nologin",
@@ -9602,6 +9717,7 @@
       "sshd.service",
       "sssd-kcm.socket",
       "sssd.service",
+      "tuned.service",
       "unbound-anchor.timer"
     ],
     "sudoers": {
@@ -9848,6 +9964,9 @@
           "a+      /var/lib/tpm2-tss/system/keystore   -    -    -     -           default:group:tss:rwx",
           "d       /run/tpm2-tss/eventlog                2775 tss  tss   -           -",
           "a+      /run/tpm2-tss/eventlog                -    -    -     -           default:group:tss:rwx"
+        ],
+        "tuned.conf": [
+          "d /run/tuned 0755 root root -"
         ],
         "var.conf": [
           "q /var 0755 - - -",

--- a/test/data/manifests/rhel_90-x86_64-ec2-boot.json
+++ b/test/data/manifests/rhel_90-x86_64-ec2-boot.json
@@ -418,6 +418,7 @@
                   "sha256:8c6cb347759c1f84fcbc5d11291e90310d2d79a87e05104206c9599e112b30da",
                   "sha256:f9700192a3d79f11afcadde29204aa6f7b73d766f0b4afb636fcf2b068b23a4c",
                   "sha256:bb49855f3c7bd6e7724eb47964b4d8453f21e5b212c121f58bb2d02645317aa4",
+                  "sha256:becb9051ac92783886265b665471c1b2088df0f1fbb65046170f1179ac7288f5",
                   "sha256:adfbb23da7180b179797c30f45a2c7ba57aa87c7874f8b71068c7ad002463d8f",
                   "sha256:6e034e0a91e8c18ac7b1f6ea04d968411c8baa2d44810ce6c11f7017198054b2",
                   "sha256:38c0490726f755809738a48faaf8fb3c1942be9757de40db70b07470754260bc",
@@ -574,6 +575,9 @@
                   "sha256:9895310924240b44c46a03be44a62745ea770c4e8a0ff173e5160bbf4a4307dd",
                   "sha256:dc7f764658f115feaf199996018c05f67fc01ce3a9522582373be290402af018",
                   "sha256:f599f03413667b040b0ddd4b43e04606597c66eebb5e325f76a08ca242bcb40d",
+                  "sha256:51063b84fd3001b9bec9590d27388d7a1291dbee07a8b09d952a232bf835bfd3",
+                  "sha256:04f285e1135c4a971526bcd9462917f04433b41d7bba005f6bd8a4fbfa986bf5",
+                  "sha256:54f0a33b5c290dfbdb7fcc5634e11129089b24f18f766db522fec7ba7927fd87",
                   "sha256:760a27547fab9b3d667d173e693fcebe5cedeb3719e3f0dd6c4ab072b8665bc2",
                   "sha256:343d7dc3662b29762b8233ddf25f9fdaf05974aae3bb1519ecc7c73b8fe0a46e",
                   "sha256:28de7dc534d0e3231f2217843f9c330fa4d0bab126315a74441d50ac8bcd5fb3",
@@ -602,7 +606,10 @@
                   "sha256:af86d10e99293bc982720b339fe751babe75013c5920b92fc654cac700d2a125",
                   "sha256:00b013eb7ea3b3007b28a7aff2c9f7714f3166dbf7c4788dacaa92794beb4351",
                   "sha256:f6ba5d9dfbaaf1c8e82d52919e72099e2374b81af2338d96c719374e92bf2907",
+                  "sha256:dc2367cc223ec0bb0d01e9a081adc88ca0de5d8cc73dbc9dc77fc49c6a36c93b",
+                  "sha256:d511eb61ae1dbf8d0bedba4a7ebaa6fcab6773d2e5417af8d9eacedd4a2f4941",
                   "sha256:86445c0378ebb8b2887bd3a7327da62762a165b74ee77d38d083365f63fb1b96",
+                  "sha256:f18f9e1547912e9b490db2499982ec339b3d7fbcef089b6fcd603c1a4b784fe6",
                   "sha256:65c3a7db749188b8e10af962d5ba509ed4f43c3e2049940b8b2fa8352ddffadc",
                   "sha256:bc2135331da61c95c795c0c739044e9d46c34dc5662f5c011b4c99ac21a0737a",
                   "sha256:9c3d8d17f2e9454b8b3b2ba5ef5e3b8ce045856c8f7859ab135afd00323c2f24",
@@ -648,6 +655,7 @@
                   "sha256:eb08d43161370a87137908b62a8322f49bb5e3b3d562393f3e6efa2b91d20951",
                   "sha256:82f46270c3ea5c4c286d93ff77f206dcded8c602eab10c9c4885d6284d47d8d2",
                   "sha256:28f81d243f8f40a5d93a42a757b0566ed3bca116e612c716bd4c8ae356140a05",
+                  "sha256:90827ff90e161df4b72b3fecd62fdc5bbe9aab633c8141a874569612ac4b5aea",
                   "sha256:2d66819cc8adc7a0cbb7b9d12dc0a73ac86551e3b7c3929cc49dddad6d3a884b",
                   "sha256:dfa7f95918435249ed4c85c13ad7d2197cffd3fd5b4d8b441c91791363493fc6",
                   "sha256:77d8019978eee228b7999c0170fa08f15c9659043e21c750052a9c948e21b7a6",
@@ -879,7 +887,8 @@
                 "cloud-init-local",
                 "cloud-config",
                 "cloud-final",
-                "reboot.target"
+                "reboot.target",
+                "tuned"
               ],
               "default_target": "multi-user.target"
             }
@@ -1209,6 +1218,9 @@
           },
           "sha256:04bf3e872657858088771dc4c7d3a605bdaacae74cff10c6bd665458bfb7cd82": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20210930/Packages/pciutils-3.7.0-5.el9.x86_64.rpm"
+          },
+          "sha256:04f285e1135c4a971526bcd9462917f04433b41d7bba005f6bd8a4fbfa986bf5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20210930/Packages/polkit-libs-0.117-7.el9.x86_64.rpm"
           },
           "sha256:051a0502d4d493fff84442e84c189abaa70989f0718548d3734655fb59318c74": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20210930/Packages/libmnl-1.0.4-15.el9.x86_64.rpm"
@@ -1540,6 +1552,9 @@
           "sha256:50325a1809731759583e25d445f3b65549c24b0a5342eeda6fb15bdcc2f08982": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20210930/Packages/libdhash-0.5.0-51.el9.x86_64.rpm"
           },
+          "sha256:51063b84fd3001b9bec9590d27388d7a1291dbee07a8b09d952a232bf835bfd3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20210930/Packages/polkit-0.117-7.el9.x86_64.rpm"
+          },
           "sha256:51ac91f318c6ce55bbd121e045244fea33a31d663c01d22b43506737e4189df3": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20210930/Packages/cryptsetup-libs-2.4.0-1.el9.x86_64.rpm"
           },
@@ -1560,6 +1575,9 @@
           },
           "sha256:5459ee79b751912556b2bc4b4cd25581e7f03a1b4b611255aa73e65622a75537": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20210930/Packages/libpipeline-1.5.3-4.el9.x86_64.rpm"
+          },
+          "sha256:54f0a33b5c290dfbdb7fcc5634e11129089b24f18f766db522fec7ba7927fd87": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20210930/Packages/polkit-pkla-compat-0.1-21.el9.x86_64.rpm"
           },
           "sha256:553681e4775eef1fc8ec802977b7a48a94aef69b6eb29ed06569ef23a96747a9": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20210930/Packages/dnf-plugins-core-4.0.21-2.el9.noarch.rpm"
@@ -1825,6 +1843,9 @@
           "sha256:9056f201e0d4576bf66e1b7e14dfa06c6f64321f6ced08b0fb637ba18d76baae": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20210930/Packages/libusbx-1.0.24-4.el9.x86_64.rpm"
           },
+          "sha256:90827ff90e161df4b72b3fecd62fdc5bbe9aab633c8141a874569612ac4b5aea": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20210930/Packages/tuned-2.16.0-3.el9.noarch.rpm"
+          },
           "sha256:9092b0ad7e9d343d446ae0030763c2e526ff922e7680df4c29d507e38c858d7d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20210930/Packages/rsyslog-8.2102.0-9.el9.x86_64.rpm"
           },
@@ -2041,6 +2062,9 @@
           "sha256:be769b9a1fd0346498033ecaf57773c2e45c0c9ea04bdd3332fa794a9396e252": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20210930/Packages/libcbor-0.7.0-5.el9.x86_64.rpm"
           },
+          "sha256:becb9051ac92783886265b665471c1b2088df0f1fbb65046170f1179ac7288f5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20210930/Packages/hdparm-9.62-2.el9.x86_64.rpm"
+          },
           "sha256:bf72c510221056b8f740138fb6ace335aa02dfabf6a75aa221f2257ab9b13014": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20210930/Packages/cronie-anacron-1.5.7-5.el9.x86_64.rpm"
           },
@@ -2161,6 +2185,9 @@
           "sha256:d4f62c76c8fdc59644a71f2567b2501a6a2735043853bd800ec89903ca3e6eb1": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20210930/Packages/libcom_err-1.46.2-2.el9.x86_64.rpm"
           },
+          "sha256:d511eb61ae1dbf8d0bedba4a7ebaa6fcab6773d2e5417af8d9eacedd4a2f4941": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20210930/Packages/python3-perf-5.14.0-4.el9.x86_64.rpm"
+          },
           "sha256:d556570916e8b5315623ffcb014c57fed4a856a8a7b472f59cef67e27c23de46": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20210930/Packages/openssl-libs-3.0.0-2.el9.x86_64.rpm"
           },
@@ -2193,6 +2220,9 @@
           },
           "sha256:dbed6952228c36fc126ce8c4bb9e20199bb878428f0f15de28504311c59eccf7": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20210930/Packages/gnutls-3.7.2-4.el9.x86_64.rpm"
+          },
+          "sha256:dc2367cc223ec0bb0d01e9a081adc88ca0de5d8cc73dbc9dc77fc49c6a36c93b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20210930/Packages/python3-linux-procfs-0.6.3-2.el9.noarch.rpm"
           },
           "sha256:dc2b36e69134189ba5b9a5275ec84d9c545b7700932e0c34559e9c302804c174": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20210930/Packages/libxml2-2.9.12-4.el9.x86_64.rpm"
@@ -2304,6 +2334,9 @@
           },
           "sha256:f147e5cd2d52db40e7841b7f968b0884e33acb092ebded8ac6a0a3709da053dd": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20210930/Packages/libffi-3.4.2-7.el9.x86_64.rpm"
+          },
+          "sha256:f18f9e1547912e9b490db2499982ec339b3d7fbcef089b6fcd603c1a4b784fe6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20210930/Packages/python3-pyudev-0.22.0-6.el9.noarch.rpm"
           },
           "sha256:f19cf4387113bb8584165e4bbbc53ca3c17c752c89f6e08a56a507e39ca3038c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20210930/Packages/npth-1.6-8.el9.x86_64.rpm"
@@ -6141,6 +6174,15 @@
         "checksum": "sha256:bb49855f3c7bd6e7724eb47964b4d8453f21e5b212c121f58bb2d02645317aa4"
       },
       {
+        "name": "hdparm",
+        "epoch": 0,
+        "version": "9.62",
+        "release": "2.el9",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20210930/Packages/hdparm-9.62-2.el9.x86_64.rpm",
+        "checksum": "sha256:becb9051ac92783886265b665471c1b2088df0f1fbb65046170f1179ac7288f5"
+      },
+      {
         "name": "hostname",
         "epoch": 0,
         "version": "3.23",
@@ -7545,6 +7587,33 @@
         "checksum": "sha256:f599f03413667b040b0ddd4b43e04606597c66eebb5e325f76a08ca242bcb40d"
       },
       {
+        "name": "polkit",
+        "epoch": 0,
+        "version": "0.117",
+        "release": "7.el9",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20210930/Packages/polkit-0.117-7.el9.x86_64.rpm",
+        "checksum": "sha256:51063b84fd3001b9bec9590d27388d7a1291dbee07a8b09d952a232bf835bfd3"
+      },
+      {
+        "name": "polkit-libs",
+        "epoch": 0,
+        "version": "0.117",
+        "release": "7.el9",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20210930/Packages/polkit-libs-0.117-7.el9.x86_64.rpm",
+        "checksum": "sha256:04f285e1135c4a971526bcd9462917f04433b41d7bba005f6bd8a4fbfa986bf5"
+      },
+      {
+        "name": "polkit-pkla-compat",
+        "epoch": 0,
+        "version": "0.1",
+        "release": "21.el9",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20210930/Packages/polkit-pkla-compat-0.1-21.el9.x86_64.rpm",
+        "checksum": "sha256:54f0a33b5c290dfbdb7fcc5634e11129089b24f18f766db522fec7ba7927fd87"
+      },
+      {
         "name": "popt",
         "epoch": 0,
         "version": "1.18",
@@ -7797,6 +7866,24 @@
         "checksum": "sha256:f6ba5d9dfbaaf1c8e82d52919e72099e2374b81af2338d96c719374e92bf2907"
       },
       {
+        "name": "python3-linux-procfs",
+        "epoch": 0,
+        "version": "0.6.3",
+        "release": "2.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20210930/Packages/python3-linux-procfs-0.6.3-2.el9.noarch.rpm",
+        "checksum": "sha256:dc2367cc223ec0bb0d01e9a081adc88ca0de5d8cc73dbc9dc77fc49c6a36c93b"
+      },
+      {
+        "name": "python3-perf",
+        "epoch": 0,
+        "version": "5.14.0",
+        "release": "4.el9",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20210930/Packages/python3-perf-5.14.0-4.el9.x86_64.rpm",
+        "checksum": "sha256:d511eb61ae1dbf8d0bedba4a7ebaa6fcab6773d2e5417af8d9eacedd4a2f4941"
+      },
+      {
         "name": "python3-pysocks",
         "epoch": 0,
         "version": "1.7.1",
@@ -7804,6 +7891,15 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20210930/Packages/python3-pysocks-1.7.1-10.el9.noarch.rpm",
         "checksum": "sha256:86445c0378ebb8b2887bd3a7327da62762a165b74ee77d38d083365f63fb1b96"
+      },
+      {
+        "name": "python3-pyudev",
+        "epoch": 0,
+        "version": "0.22.0",
+        "release": "6.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20210930/Packages/python3-pyudev-0.22.0-6.el9.noarch.rpm",
+        "checksum": "sha256:f18f9e1547912e9b490db2499982ec339b3d7fbcef089b6fcd603c1a4b784fe6"
       },
       {
         "name": "python3-pyyaml",
@@ -8209,6 +8305,15 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20210930/Packages/tpm2-tss-3.0.3-6.el9.x86_64.rpm",
         "checksum": "sha256:28f81d243f8f40a5d93a42a757b0566ed3bca116e612c716bd4c8ae356140a05"
+      },
+      {
+        "name": "tuned",
+        "epoch": 0,
+        "version": "2.16.0",
+        "release": "3.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20210930/Packages/tuned-2.16.0-3.el9.noarch.rpm",
+        "checksum": "sha256:90827ff90e161df4b72b3fecd62fdc5bbe9aab633c8141a874569612ac4b5aea"
       },
       {
         "name": "tzdata",
@@ -8769,9 +8874,9 @@
         "grub_arg": "--unrestricted",
         "grub_class": "kernel",
         "grub_users": "$grub_users",
-        "initrd": "/boot/initramfs-5.14.0-4.el9.x86_64.img",
+        "initrd": "/boot/initramfs-5.14.0-4.el9.x86_64.img $tuned_initrd",
         "linux": "/boot/vmlinuz-5.14.0-4.el9.x86_64",
-        "options": "root=UUID=0194fdc2-fa2f-4cc0-81d3-ff12045b73c8 console=ttyS0,115200n8 console=tty0 net.ifnames=0 rd.blacklist=nouveau nvme_core.io_timeout=4294967295 crashkernel=auto",
+        "options": "root=UUID=0194fdc2-fa2f-4cc0-81d3-ff12045b73c8 console=ttyS0,115200n8 console=tty0 net.ifnames=0 rd.blacklist=nouveau nvme_core.io_timeout=4294967295 crashkernel=auto $tuned_params",
         "title": "Red Hat Enterprise Linux (5.14.0-4.el9.x86_64) 9.0 (Plow)",
         "version": "5.14.0-4.el9.x86_64"
       }
@@ -8973,7 +9078,7 @@
       "audio:x:63:",
       "bin:x:1:",
       "cdrom:x:11:",
-      "chrony:x:993:",
+      "chrony:x:992:",
       "daemon:x:2:",
       "dbus:x:81:",
       "dialout:x:18:",
@@ -8990,11 +9095,12 @@
       "man:x:15:",
       "mem:x:8:",
       "nobody:x:65534:",
+      "polkitd:x:994:",
       "render:x:996:",
       "root:x:0:",
       "ssh_keys:x:998:",
       "sshd:x:74:",
-      "sssd:x:994:",
+      "sssd:x:993:",
       "sys:x:3:",
       "systemd-coredump:x:995:",
       "systemd-journal:x:190:",
@@ -9158,6 +9264,7 @@
       "grub2-tools-minimal-2.06~rc1-8.el9.x86_64",
       "grubby-8.40-54.el9.x86_64",
       "gzip-1.10-8.el9.x86_64",
+      "hdparm-9.62-2.el9.x86_64",
       "hostname-3.23-6.el9.x86_64",
       "hwdata-0.348-9.1.el9.noarch",
       "ima-evm-utils-1.3.2-7.el9.x86_64",
@@ -9326,6 +9433,9 @@
       "pcre2-syntax-10.37-3.el9.1.noarch",
       "pigz-2.5-3.el9.x86_64",
       "policycoreutils-3.2-7.el9.x86_64",
+      "polkit-0.117-7.el9.x86_64",
+      "polkit-libs-0.117-7.el9.x86_64",
+      "polkit-pkla-compat-0.1-21.el9.x86_64",
       "popt-1.18-8.el9.x86_64",
       "prefixdevname-0.1.0-8.el9.x86_64",
       "procps-ng-3.3.17-4.el9.x86_64",
@@ -9366,13 +9476,16 @@
       "python3-libselinux-3.2-6.el9.x86_64",
       "python3-libsemanage-3.2-4.el9.x86_64",
       "python3-libxml2-2.9.12-4.el9.x86_64",
+      "python3-linux-procfs-0.6.3-2.el9.noarch",
       "python3-markupsafe-1.1.1-12.el9.x86_64",
       "python3-oauthlib-3.1.1-2.el9.noarch",
+      "python3-perf-5.14.0-4.el9.x86_64",
       "python3-policycoreutils-3.2-7.el9.noarch",
       "python3-prettytable-0.7.2-27.el9.noarch",
       "python3-pyserial-3.4-12.el9.noarch",
       "python3-pysocks-1.7.1-10.el9.noarch",
       "python3-pytz-2021.1-4.el9.noarch",
+      "python3-pyudev-0.22.0-6.el9.noarch",
       "python3-pyyaml-5.4.1-4.el9.x86_64",
       "python3-requests-2.25.1-5.el9.noarch",
       "python3-rpm-4.16.1.3-7.el9.x86_64",
@@ -9423,6 +9536,7 @@
       "tar-1.34-3.el9.x86_64",
       "teamd-1.31-10.el9.x86_64",
       "tpm2-tss-3.0.3-6.el9.x86_64",
+      "tuned-2.16.0-3.el9.noarch",
       "tzdata-2021a-3.el9.noarch",
       "unbound-libs-1.13.1-9.el9.x86_64",
       "usermode-1.114-2.el9.x86_64",
@@ -9466,7 +9580,7 @@
     "passwd": [
       "adm:x:3:4:adm:/var/adm:/sbin/nologin",
       "bin:x:1:1:bin:/bin:/sbin/nologin",
-      "chrony:x:996:993::/var/lib/chrony:/sbin/nologin",
+      "chrony:x:995:992::/var/lib/chrony:/sbin/nologin",
       "daemon:x:2:2:daemon:/sbin:/sbin/nologin",
       "dbus:x:81:81:System message bus:/:/sbin/nologin",
       "ftp:x:14:50:FTP User:/var/ftp:/sbin/nologin",
@@ -9476,10 +9590,11 @@
       "mail:x:8:12:mail:/var/spool/mail:/sbin/nologin",
       "nobody:x:65534:65534:Kernel Overflow User:/:/sbin/nologin",
       "operator:x:11:0:operator:/root:/sbin/nologin",
+      "polkitd:x:997:994:User for polkitd:/:/sbin/nologin",
       "root:x:0:0:root:/root:/bin/bash",
       "shutdown:x:6:0:shutdown:/sbin:/sbin/shutdown",
       "sshd:x:74:74:Privilege-separated SSH:/usr/share/empty.sshd:/sbin/nologin",
-      "sssd:x:997:994:User for sssd:/:/sbin/nologin",
+      "sssd:x:996:993:User for sssd:/:/sbin/nologin",
       "sync:x:5:0:sync:/sbin:/bin/sync",
       "systemd-coredump:x:998:995:systemd Core Dumper:/:/sbin/nologin",
       "tss:x:59:59:Account used for TPM access:/dev/null:/sbin/nologin",
@@ -9646,6 +9761,7 @@
       "sshd.service",
       "sssd-kcm.socket",
       "sssd.service",
+      "tuned.service",
       "unbound-anchor.timer"
     ],
     "sudoers": {
@@ -9892,6 +10008,9 @@
           "a+      /var/lib/tpm2-tss/system/keystore   -    -    -     -           default:group:tss:rwx",
           "d       /run/tpm2-tss/eventlog                2775 tss  tss   -           -",
           "a+      /run/tpm2-tss/eventlog                -    -    -     -           default:group:tss:rwx"
+        ],
+        "tuned.conf": [
+          "d /run/tuned 0755 root root -"
         ],
         "var.conf": [
           "q /var 0755 - - -",

--- a/test/data/manifests/rhel_90-x86_64-ec2_ha-boot.json
+++ b/test/data/manifests/rhel_90-x86_64-ec2_ha-boot.json
@@ -428,6 +428,7 @@
                   "sha256:f9700192a3d79f11afcadde29204aa6f7b73d766f0b4afb636fcf2b068b23a4c",
                   "sha256:6ac810d19f8b6419fa06d84de9f18278481bfba0035f5462fd838b166ac1af64",
                   "sha256:bb49855f3c7bd6e7724eb47964b4d8453f21e5b212c121f58bb2d02645317aa4",
+                  "sha256:becb9051ac92783886265b665471c1b2088df0f1fbb65046170f1179ac7288f5",
                   "sha256:adfbb23da7180b179797c30f45a2c7ba57aa87c7874f8b71068c7ad002463d8f",
                   "sha256:6e034e0a91e8c18ac7b1f6ea04d968411c8baa2d44810ce6c11f7017198054b2",
                   "sha256:38c0490726f755809738a48faaf8fb3c1942be9757de40db70b07470754260bc",
@@ -599,6 +600,9 @@
                   "sha256:9de8c60e56d01de9c036a011028d215a6ec3bb9683e82530336c154689941034",
                   "sha256:de2d1f73d8758e1e20357836dc31916f737093157b2e0b72e618b221a4660e0e",
                   "sha256:f599f03413667b040b0ddd4b43e04606597c66eebb5e325f76a08ca242bcb40d",
+                  "sha256:51063b84fd3001b9bec9590d27388d7a1291dbee07a8b09d952a232bf835bfd3",
+                  "sha256:04f285e1135c4a971526bcd9462917f04433b41d7bba005f6bd8a4fbfa986bf5",
+                  "sha256:54f0a33b5c290dfbdb7fcc5634e11129089b24f18f766db522fec7ba7927fd87",
                   "sha256:760a27547fab9b3d667d173e693fcebe5cedeb3719e3f0dd6c4ab072b8665bc2",
                   "sha256:343d7dc3662b29762b8233ddf25f9fdaf05974aae3bb1519ecc7c73b8fe0a46e",
                   "sha256:28de7dc534d0e3231f2217843f9c330fa4d0bab126315a74441d50ac8bcd5fb3",
@@ -627,8 +631,11 @@
                   "sha256:af86d10e99293bc982720b339fe751babe75013c5920b92fc654cac700d2a125",
                   "sha256:00b013eb7ea3b3007b28a7aff2c9f7714f3166dbf7c4788dacaa92794beb4351",
                   "sha256:f6ba5d9dfbaaf1c8e82d52919e72099e2374b81af2338d96c719374e92bf2907",
+                  "sha256:dc2367cc223ec0bb0d01e9a081adc88ca0de5d8cc73dbc9dc77fc49c6a36c93b",
+                  "sha256:d511eb61ae1dbf8d0bedba4a7ebaa6fcab6773d2e5417af8d9eacedd4a2f4941",
                   "sha256:e65eeed09d690958426474437b9406abd19e49dc83814c2754b96280e8311061",
                   "sha256:86445c0378ebb8b2887bd3a7327da62762a165b74ee77d38d083365f63fb1b96",
+                  "sha256:f18f9e1547912e9b490db2499982ec339b3d7fbcef089b6fcd603c1a4b784fe6",
                   "sha256:65c3a7db749188b8e10af962d5ba509ed4f43c3e2049940b8b2fa8352ddffadc",
                   "sha256:bc2135331da61c95c795c0c739044e9d46c34dc5662f5c011b4c99ac21a0737a",
                   "sha256:9c3d8d17f2e9454b8b3b2ba5ef5e3b8ce045856c8f7859ab135afd00323c2f24",
@@ -680,6 +687,7 @@
                   "sha256:eb08d43161370a87137908b62a8322f49bb5e3b3d562393f3e6efa2b91d20951",
                   "sha256:82f46270c3ea5c4c286d93ff77f206dcded8c602eab10c9c4885d6284d47d8d2",
                   "sha256:28f81d243f8f40a5d93a42a757b0566ed3bca116e612c716bd4c8ae356140a05",
+                  "sha256:90827ff90e161df4b72b3fecd62fdc5bbe9aab633c8141a874569612ac4b5aea",
                   "sha256:2d66819cc8adc7a0cbb7b9d12dc0a73ac86551e3b7c3929cc49dddad6d3a884b",
                   "sha256:dfa7f95918435249ed4c85c13ad7d2197cffd3fd5b4d8b441c91791363493fc6",
                   "sha256:88f0893754780ab3f6b54b5db279dbbb61ae360c332401967a69dd67418dff0f",
@@ -1062,7 +1070,8 @@
                 "cloud-init-local",
                 "cloud-config",
                 "cloud-final",
-                "reboot.target"
+                "reboot.target",
+                "tuned"
               ],
               "default_target": "multi-user.target"
             }
@@ -1395,6 +1404,9 @@
           },
           "sha256:04bf3e872657858088771dc4c7d3a605bdaacae74cff10c6bd665458bfb7cd82": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20210930/Packages/pciutils-3.7.0-5.el9.x86_64.rpm"
+          },
+          "sha256:04f285e1135c4a971526bcd9462917f04433b41d7bba005f6bd8a4fbfa986bf5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20210930/Packages/polkit-libs-0.117-7.el9.x86_64.rpm"
           },
           "sha256:051a0502d4d493fff84442e84c189abaa70989f0718548d3734655fb59318c74": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20210930/Packages/libmnl-1.0.4-15.el9.x86_64.rpm"
@@ -1897,6 +1909,9 @@
           "sha256:50325a1809731759583e25d445f3b65549c24b0a5342eeda6fb15bdcc2f08982": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20210930/Packages/libdhash-0.5.0-51.el9.x86_64.rpm"
           },
+          "sha256:51063b84fd3001b9bec9590d27388d7a1291dbee07a8b09d952a232bf835bfd3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20210930/Packages/polkit-0.117-7.el9.x86_64.rpm"
+          },
           "sha256:51ac91f318c6ce55bbd121e045244fea33a31d663c01d22b43506737e4189df3": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20210930/Packages/cryptsetup-libs-2.4.0-1.el9.x86_64.rpm"
           },
@@ -1923,6 +1938,9 @@
           },
           "sha256:5459ee79b751912556b2bc4b4cd25581e7f03a1b4b611255aa73e65622a75537": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20210930/Packages/libpipeline-1.5.3-4.el9.x86_64.rpm"
+          },
+          "sha256:54f0a33b5c290dfbdb7fcc5634e11129089b24f18f766db522fec7ba7927fd87": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20210930/Packages/polkit-pkla-compat-0.1-21.el9.x86_64.rpm"
           },
           "sha256:553681e4775eef1fc8ec802977b7a48a94aef69b6eb29ed06569ef23a96747a9": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20210930/Packages/dnf-plugins-core-4.0.21-2.el9.noarch.rpm"
@@ -2293,6 +2311,9 @@
           "sha256:9056f201e0d4576bf66e1b7e14dfa06c6f64321f6ced08b0fb637ba18d76baae": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20210930/Packages/libusbx-1.0.24-4.el9.x86_64.rpm"
           },
+          "sha256:90827ff90e161df4b72b3fecd62fdc5bbe9aab633c8141a874569612ac4b5aea": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20210930/Packages/tuned-2.16.0-3.el9.noarch.rpm"
+          },
           "sha256:9092b0ad7e9d343d446ae0030763c2e526ff922e7680df4c29d507e38c858d7d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20210930/Packages/rsyslog-8.2102.0-9.el9.x86_64.rpm"
           },
@@ -2623,6 +2644,9 @@
           "sha256:be769b9a1fd0346498033ecaf57773c2e45c0c9ea04bdd3332fa794a9396e252": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20210930/Packages/libcbor-0.7.0-5.el9.x86_64.rpm"
           },
+          "sha256:becb9051ac92783886265b665471c1b2088df0f1fbb65046170f1179ac7288f5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20210930/Packages/hdparm-9.62-2.el9.x86_64.rpm"
+          },
           "sha256:bf72c510221056b8f740138fb6ace335aa02dfabf6a75aa221f2257ab9b13014": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20210930/Packages/cronie-anacron-1.5.7-5.el9.x86_64.rpm"
           },
@@ -2803,6 +2827,9 @@
           "sha256:d4f62c76c8fdc59644a71f2567b2501a6a2735043853bd800ec89903ca3e6eb1": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20210930/Packages/libcom_err-1.46.2-2.el9.x86_64.rpm"
           },
+          "sha256:d511eb61ae1dbf8d0bedba4a7ebaa6fcab6773d2e5417af8d9eacedd4a2f4941": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20210930/Packages/python3-perf-5.14.0-4.el9.x86_64.rpm"
+          },
           "sha256:d556570916e8b5315623ffcb014c57fed4a856a8a7b472f59cef67e27c23de46": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20210930/Packages/openssl-libs-3.0.0-2.el9.x86_64.rpm"
           },
@@ -2850,6 +2877,9 @@
           },
           "sha256:dbed6952228c36fc126ce8c4bb9e20199bb878428f0f15de28504311c59eccf7": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20210930/Packages/gnutls-3.7.2-4.el9.x86_64.rpm"
+          },
+          "sha256:dc2367cc223ec0bb0d01e9a081adc88ca0de5d8cc73dbc9dc77fc49c6a36c93b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20210930/Packages/python3-linux-procfs-0.6.3-2.el9.noarch.rpm"
           },
           "sha256:dc2b36e69134189ba5b9a5275ec84d9c545b7700932e0c34559e9c302804c174": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20210930/Packages/libxml2-2.9.12-4.el9.x86_64.rpm"
@@ -3015,6 +3045,9 @@
           },
           "sha256:f147e5cd2d52db40e7841b7f968b0884e33acb092ebded8ac6a0a3709da053dd": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20210930/Packages/libffi-3.4.2-7.el9.x86_64.rpm"
+          },
+          "sha256:f18f9e1547912e9b490db2499982ec339b3d7fbcef089b6fcd603c1a4b784fe6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20210930/Packages/python3-pyudev-0.22.0-6.el9.noarch.rpm"
           },
           "sha256:f19cf4387113bb8584165e4bbbc53ca3c17c752c89f6e08a56a507e39ca3038c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20210930/Packages/npth-1.6-8.el9.x86_64.rpm"
@@ -6960,6 +6993,15 @@
         "checksum": "sha256:bb49855f3c7bd6e7724eb47964b4d8453f21e5b212c121f58bb2d02645317aa4"
       },
       {
+        "name": "hdparm",
+        "epoch": 0,
+        "version": "9.62",
+        "release": "2.el9",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20210930/Packages/hdparm-9.62-2.el9.x86_64.rpm",
+        "checksum": "sha256:becb9051ac92783886265b665471c1b2088df0f1fbb65046170f1179ac7288f5"
+      },
+      {
         "name": "hostname",
         "epoch": 0,
         "version": "3.23",
@@ -8499,6 +8541,33 @@
         "checksum": "sha256:f599f03413667b040b0ddd4b43e04606597c66eebb5e325f76a08ca242bcb40d"
       },
       {
+        "name": "polkit",
+        "epoch": 0,
+        "version": "0.117",
+        "release": "7.el9",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20210930/Packages/polkit-0.117-7.el9.x86_64.rpm",
+        "checksum": "sha256:51063b84fd3001b9bec9590d27388d7a1291dbee07a8b09d952a232bf835bfd3"
+      },
+      {
+        "name": "polkit-libs",
+        "epoch": 0,
+        "version": "0.117",
+        "release": "7.el9",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20210930/Packages/polkit-libs-0.117-7.el9.x86_64.rpm",
+        "checksum": "sha256:04f285e1135c4a971526bcd9462917f04433b41d7bba005f6bd8a4fbfa986bf5"
+      },
+      {
+        "name": "polkit-pkla-compat",
+        "epoch": 0,
+        "version": "0.1",
+        "release": "21.el9",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20210930/Packages/polkit-pkla-compat-0.1-21.el9.x86_64.rpm",
+        "checksum": "sha256:54f0a33b5c290dfbdb7fcc5634e11129089b24f18f766db522fec7ba7927fd87"
+      },
+      {
         "name": "popt",
         "epoch": 0,
         "version": "1.18",
@@ -8751,6 +8820,24 @@
         "checksum": "sha256:f6ba5d9dfbaaf1c8e82d52919e72099e2374b81af2338d96c719374e92bf2907"
       },
       {
+        "name": "python3-linux-procfs",
+        "epoch": 0,
+        "version": "0.6.3",
+        "release": "2.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20210930/Packages/python3-linux-procfs-0.6.3-2.el9.noarch.rpm",
+        "checksum": "sha256:dc2367cc223ec0bb0d01e9a081adc88ca0de5d8cc73dbc9dc77fc49c6a36c93b"
+      },
+      {
+        "name": "python3-perf",
+        "epoch": 0,
+        "version": "5.14.0",
+        "release": "4.el9",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20210930/Packages/python3-perf-5.14.0-4.el9.x86_64.rpm",
+        "checksum": "sha256:d511eb61ae1dbf8d0bedba4a7ebaa6fcab6773d2e5417af8d9eacedd4a2f4941"
+      },
+      {
         "name": "python3-pyparsing",
         "epoch": 0,
         "version": "2.4.7",
@@ -8767,6 +8854,15 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20210930/Packages/python3-pysocks-1.7.1-10.el9.noarch.rpm",
         "checksum": "sha256:86445c0378ebb8b2887bd3a7327da62762a165b74ee77d38d083365f63fb1b96"
+      },
+      {
+        "name": "python3-pyudev",
+        "epoch": 0,
+        "version": "0.22.0",
+        "release": "6.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20210930/Packages/python3-pyudev-0.22.0-6.el9.noarch.rpm",
+        "checksum": "sha256:f18f9e1547912e9b490db2499982ec339b3d7fbcef089b6fcd603c1a4b784fe6"
       },
       {
         "name": "python3-pyyaml",
@@ -9226,6 +9322,15 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20210930/Packages/tpm2-tss-3.0.3-6.el9.x86_64.rpm",
         "checksum": "sha256:28f81d243f8f40a5d93a42a757b0566ed3bca116e612c716bd4c8ae356140a05"
+      },
+      {
+        "name": "tuned",
+        "epoch": 0,
+        "version": "2.16.0",
+        "release": "3.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20210930/Packages/tuned-2.16.0-3.el9.noarch.rpm",
+        "checksum": "sha256:90827ff90e161df4b72b3fecd62fdc5bbe9aab633c8141a874569612ac4b5aea"
       },
       {
         "name": "tzdata",
@@ -11145,9 +11250,9 @@
         "grub_arg": "--unrestricted",
         "grub_class": "kernel",
         "grub_users": "$grub_users",
-        "initrd": "/boot/initramfs-5.14.0-4.el9.x86_64.img",
+        "initrd": "/boot/initramfs-5.14.0-4.el9.x86_64.img $tuned_initrd",
         "linux": "/boot/vmlinuz-5.14.0-4.el9.x86_64",
-        "options": "root=UUID=0194fdc2-fa2f-4cc0-81d3-ff12045b73c8 console=ttyS0,115200n8 console=tty0 net.ifnames=0 rd.blacklist=nouveau nvme_core.io_timeout=4294967295 crashkernel=auto",
+        "options": "root=UUID=0194fdc2-fa2f-4cc0-81d3-ff12045b73c8 console=ttyS0,115200n8 console=tty0 net.ifnames=0 rd.blacklist=nouveau nvme_core.io_timeout=4294967295 crashkernel=auto $tuned_params",
         "title": "Red Hat Enterprise Linux (5.14.0-4.el9.x86_64) 9.0 (Plow)",
         "version": "5.14.0-4.el9.x86_64"
       }
@@ -11352,7 +11457,7 @@
       "audio:x:63:",
       "bin:x:1:",
       "cdrom:x:11:",
-      "chrony:x:992:",
+      "chrony:x:991:",
       "daemon:x:2:",
       "dbus:x:81:",
       "dialout:x:18:",
@@ -11370,14 +11475,15 @@
       "man:x:15:",
       "mem:x:8:",
       "nobody:x:65534:",
+      "polkitd:x:994:",
       "printadmin:x:995:",
       "render:x:997:",
       "root:x:0:",
       "rpc:x:32:",
       "rpcuser:x:29:",
-      "ssh_keys:x:994:",
+      "ssh_keys:x:993:",
       "sshd:x:74:",
-      "sssd:x:993:",
+      "sssd:x:992:",
       "sys:x:3:",
       "systemd-coredump:x:996:",
       "systemd-journal:x:190:",
@@ -11591,6 +11697,7 @@
       "grubby-8.40-54.el9.x86_64",
       "gssproxy-0.8.4-4.el9.x86_64",
       "gzip-1.10-8.el9.x86_64",
+      "hdparm-9.62-2.el9.x86_64",
       "hostname-3.23-6.el9.x86_64",
       "hwdata-0.348-9.1.el9.noarch",
       "ima-evm-utils-1.3.2-7.el9.x86_64",
@@ -11864,6 +11971,9 @@
       "pkgconf-m4-1.7.3-9.el9.noarch",
       "pkgconf-pkg-config-1.7.3-9.el9.x86_64",
       "policycoreutils-3.2-7.el9.x86_64",
+      "polkit-0.117-7.el9.x86_64",
+      "polkit-libs-0.117-7.el9.x86_64",
+      "polkit-pkla-compat-0.1-21.el9.x86_64",
       "popt-1.18-8.el9.x86_64",
       "prefixdevname-0.1.0-8.el9.x86_64",
       "procps-ng-3.3.17-4.el9.x86_64",
@@ -11906,9 +12016,11 @@
       "python3-libselinux-3.2-6.el9.x86_64",
       "python3-libsemanage-3.2-4.el9.x86_64",
       "python3-libxml2-2.9.12-4.el9.x86_64",
+      "python3-linux-procfs-0.6.3-2.el9.noarch",
       "python3-lxml-4.6.3-3.el9.x86_64",
       "python3-markupsafe-1.1.1-12.el9.x86_64",
       "python3-oauthlib-3.1.1-2.el9.noarch",
+      "python3-perf-5.14.0-4.el9.x86_64",
       "python3-ply-3.11-13.el9.noarch",
       "python3-policycoreutils-3.2-7.el9.noarch",
       "python3-prettytable-0.7.2-27.el9.noarch",
@@ -11918,6 +12030,7 @@
       "python3-pyserial-3.4-12.el9.noarch",
       "python3-pysocks-1.7.1-10.el9.noarch",
       "python3-pytz-2021.1-4.el9.noarch",
+      "python3-pyudev-0.22.0-6.el9.noarch",
       "python3-pyyaml-5.4.1-4.el9.x86_64",
       "python3-requests-2.25.1-5.el9.noarch",
       "python3-rpm-4.16.1.3-7.el9.x86_64",
@@ -11988,6 +12101,7 @@
       "teamd-1.31-10.el9.x86_64",
       "telnet-0.17-85.el9.x86_64",
       "tpm2-tss-3.0.3-6.el9.x86_64",
+      "tuned-2.16.0-3.el9.noarch",
       "tzdata-2021a-3.el9.noarch",
       "unbound-libs-1.13.1-9.el9.x86_64",
       "usermode-1.114-2.el9.x86_64",
@@ -12032,7 +12146,7 @@
     "passwd": [
       "adm:x:3:4:adm:/var/adm:/sbin/nologin",
       "bin:x:1:1:bin:/bin:/sbin/nologin",
-      "chrony:x:996:992::/var/lib/chrony:/sbin/nologin",
+      "chrony:x:995:991::/var/lib/chrony:/sbin/nologin",
       "daemon:x:2:2:daemon:/sbin:/sbin/nologin",
       "dbus:x:81:81:System message bus:/:/sbin/nologin",
       "ftp:x:14:50:FTP User:/var/ftp:/sbin/nologin",
@@ -12043,12 +12157,13 @@
       "mail:x:8:12:mail:/var/spool/mail:/sbin/nologin",
       "nobody:x:65534:65534:Kernel Overflow User:/:/sbin/nologin",
       "operator:x:11:0:operator:/root:/sbin/nologin",
+      "polkitd:x:997:994:User for polkitd:/:/sbin/nologin",
       "root:x:0:0:root:/root:/bin/bash",
       "rpc:x:32:32:Rpcbind Daemon:/var/lib/rpcbind:/sbin/nologin",
       "rpcuser:x:29:29:RPC Service User:/var/lib/nfs:/sbin/nologin",
       "shutdown:x:6:0:shutdown:/sbin:/sbin/shutdown",
       "sshd:x:74:74:Privilege-separated SSH:/usr/share/empty.sshd:/sbin/nologin",
-      "sssd:x:997:993:User for sssd:/:/sbin/nologin",
+      "sssd:x:996:992:User for sssd:/:/sbin/nologin",
       "sync:x:5:0:sync:/sbin:/bin/sync",
       "systemd-coredump:x:998:996:systemd Core Dumper:/:/sbin/nologin",
       "tss:x:59:59:Account used for TPM access:/dev/null:/sbin/nologin",
@@ -12232,6 +12347,7 @@
       "sshd.service",
       "sssd-kcm.socket",
       "sssd.service",
+      "tuned.service",
       "unbound-anchor.timer"
     ],
     "sudoers": {
@@ -12491,6 +12607,9 @@
           "a+      /var/lib/tpm2-tss/system/keystore   -    -    -     -           default:group:tss:rwx",
           "d       /run/tpm2-tss/eventlog                2775 tss  tss   -           -",
           "a+      /run/tpm2-tss/eventlog                -    -    -     -           default:group:tss:rwx"
+        ],
+        "tuned.conf": [
+          "d /run/tuned 0755 root root -"
         ],
         "var.conf": [
           "q /var 0755 - - -",

--- a/test/data/manifests/rhel_90-x86_64-ec2_sap-boot.json
+++ b/test/data/manifests/rhel_90-x86_64-ec2_sap-boot.json
@@ -1104,7 +1104,8 @@
                 "cloud-init-local",
                 "cloud-config",
                 "cloud-final",
-                "reboot.target"
+                "reboot.target",
+                "tuned"
               ],
               "default_target": "multi-user.target"
             }


### PR DESCRIPTION
Add TuneD package to the base package set for all EC2 image types,
including the `ami` image type. In addition to installing the package,
also enable the service by default. TuneD will by default auto-detect
the environment in which the image is running and set the most
appropriate TuneD profile, with exception of the `ec2-sap` image, which
explicitly sets a specific TuneD profile.

This change affects the `ami`, `ec2`, and `ec2-ha` image types on all
supported architectures.

Regenerate affected image test cases.

Related to RHELPLAN-102615
Fix #1972

Signed-off-by: Tomas Hozza <thozza@redhat.com>


This pull request includes:

- [x] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`
-->
