### PR TITLE
ci: make some jobs interruptible

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -36,6 +36,7 @@ init:
     - shell
   script:
     - schutzbot/update_github_status.sh start
+  interruptible: true
 
 RPM:
   stage: rpmbuild
@@ -44,6 +45,7 @@ RPM:
     - if: '$CI_PIPELINE_SOURCE != "schedule"'
   script:
     - sh "schutzbot/mockbuild.sh"
+  interruptible: true
   after_script:
     - schutzbot/update_github_status.sh update
     - schutzbot/save_journal.sh
@@ -75,6 +77,7 @@ Container:
     - if: '$CI_PIPELINE_SOURCE != "schedule"'
   script:
     - sh "schutzbot/containerbuild.sh"
+  interruptible: true
   parallel:
     matrix:
       - RUNNER:
@@ -88,6 +91,7 @@ Prepare-rhel-internal:
     - if: '$CI_PIPELINE_SOURCE == "schedule" && $RUNNER =~ /[\S]+rhel-8.6-[^ga][\S]+/ && $NIGHTLY == "true" && $RHEL_MAJOR == "8"'
   script:
     - schutzbot/prepare-rhel-internal.sh
+  interruptible: true
   artifacts:
     paths:
       - rhel-${RHEL_MAJOR}.json
@@ -113,6 +117,7 @@ Base:
   script:
     - schutzbot/deploy.sh
     - /usr/libexec/tests/osbuild-composer/base_tests.sh
+  interruptible: true
   parallel:
     matrix:
       - RUNNER:
@@ -168,6 +173,7 @@ Regression:
   script:
     - schutzbot/deploy.sh
     - /usr/libexec/tests/osbuild-composer/regression.sh
+  interruptible: true
   parallel:
     matrix:
       - RUNNER:
@@ -200,6 +206,7 @@ OSTree:
   script:
     - schutzbot/deploy.sh
     - /usr/libexec/tests/osbuild-composer/ostree.sh
+  interruptible: true
   parallel:
     matrix:
       - RUNNER:
@@ -345,6 +352,7 @@ libvirt:
   script:
     - schutzbot/deploy.sh
     - /usr/libexec/tests/osbuild-composer/libvirt.sh
+  interruptible: true
   parallel:
     matrix:
       - RUNNER:
@@ -364,6 +372,7 @@ RHEL 9 on 8:
   script:
     - schutzbot/deploy.sh
     - /usr/libexec/tests/osbuild-composer/koji.sh
+  interruptible: true
   variables:
     RUNNER: aws/rhel-8.4-ga-x86_64
     INTERNAL_NETWORK: "true"
@@ -398,6 +407,7 @@ Installer:
   script:
     - schutzbot/deploy.sh
     - /usr/libexec/tests/osbuild-composer/installers.sh
+  interruptible: true
   parallel:
     matrix:
       - RUNNER:


### PR DESCRIPTION
Jobs that don't interact with clouds can be canceled at any time without
the risk of leaving unused resources in the cloud. This enables the use
of "automatic cancellation of redundant pipelines" which means that if
and update is pushed to an open PR the current running pipeline is
canceled. This is done by adding an "interruptible" flag to the jobs.
Default value is false so only jobs that have it explicitly set to true
will be canceled.

It should help reduce stress on the CI in some cases.

This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`
-->
