### PR TITLE
Two minor logging improvements

### DIFF
--- a/cmd/osbuild-worker/main.go
+++ b/cmd/osbuild-worker/main.go
@@ -104,7 +104,7 @@ func RequestAndRunJob(client *worker.Client, acceptedJobTypes []string, jobImpls
 		return err
 	}
 
-	logrus.Infof("Running '%s' job %v\n", job.Type(), job.Id())
+	logrus.Infof("Running job '%s' (%s)\n", job.Id(), job.Type())
 
 	ctx, cancelWatcher := context.WithCancel(context.Background())
 	go WatchJob(ctx, job)
@@ -112,12 +112,12 @@ func RequestAndRunJob(client *worker.Client, acceptedJobTypes []string, jobImpls
 	err = impl.Run(job)
 	cancelWatcher()
 	if err != nil {
-		logrus.Warnf("Job %s failed: %v", job.Id(), err)
+		logrus.Warnf("Job '%s' (%s) failed: %v", job.Id(), job.Type(), err)
 		// Don't return this error so the worker picks up the next job immediately
 		return nil
 	}
 
-	logrus.Infof("Job %s finished", job.Id())
+	logrus.Infof("Job '%s' (%s) finished", job.Id(), job.Type())
 	return nil
 }
 

--- a/internal/jobqueue/dbjobqueue/dbjobqueue.go
+++ b/internal/jobqueue/dbjobqueue/dbjobqueue.go
@@ -174,7 +174,7 @@ func (q *dbJobQueue) Dequeue(ctx context.Context, jobTypes []string) (uuid.UUID,
 	}
 	defer func() {
 		_, err := conn.Exec(ctx, sqlUnlisten)
-		if err != nil {
+		if err != nil && !errors.Is(err, context.DeadlineExceeded) {
 			logrus.Error("Error unlistening for jobs in dequeue: ", err)
 		}
 		conn.Release()


### PR DESCRIPTION
Two logging adjustments:
* worker: normalize job logging

  The format is now always 'JOB_ID' (JOB_TYPE). This means that we also know
  the job type when a job is finished or when it failed.

* dbjobqueue: don't log when context's deadline was exceeded

  This happens rather often as we limit the request job timeout to 20s on the
  service.

This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`
-->
