### PR TITLE
Doc: remove unused doc/news directory

### DIFF
--- a/docs/news/unreleased/centos-8-update.md
+++ b/docs/news/unreleased/centos-8-update.md
@@ -1,7 +1,0 @@
-# Update image definitions for CentOS Stream 8
-
-Image definitions for the CentOS Stream 8 distribution have been
-updated. CentOS Stream 8 (internally `centos-8`) is now an alias to the current
-RHEL 8.6 distribution, with appropriate modifications.
-
-All Edge image types are now supported in CentOS Stream 8.

--- a/docs/news/unreleased/log-options.md
+++ b/docs/news/unreleased/log-options.md
@@ -1,4 +1,0 @@
-# Configurable logging
-
-* Logging is now configurable via the config file, `log_level` can be set to one of `trace`, `debug`, `info`, `warn`, `error` or `fatal`.
-* JSON Logging is supported and configurable via the config file/env, `log_format` can be set to `text` or `json`.


### PR DESCRIPTION
The doc/news directory has been re-added by some recent PRs, but it is
not used any more since [1]. Clean up the repository of the unused
files.

[1] https://github.com/osbuild/osbuild-composer/pull/1933

Signed-off-by: Tomas Hozza <thozza@redhat.com>


This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`
-->
