### PR TITLE
Image Builder Composer - Grafana dashboard Updates

### DIFF
--- a/templates/dashboards/grafana-dashboard-image-builder-composer-general.configmap.yml
+++ b/templates/dashboards/grafana-dashboard-image-builder-composer-general.configmap.yml
@@ -130,7 +130,7 @@ data:
           "targets": [
             {
               "exemplar": true,
-              "expr": "1 - sum(increase(image_builder_composer_total_failed_compose_requests[$__range]))/sum(increase(image_builder_composer_total_compose_requests[$__range]))",
+              "expr": "1 - sum(increase(image_builder_composer_total_failed_compose_requests[$interval]))/sum(increase(image_builder_composer_total_compose_requests[$interval]))",
               "interval": "",
               "legendFormat": "",
               "refId": "A"
@@ -187,7 +187,7 @@ data:
           "targets": [
             {
               "exemplar": true,
-              "expr": "sum(increase(image_builder_composer_total_compose_requests[$__range]))",
+              "expr": "sum(increase(image_builder_composer_total_compose_requests[$interval]))",
               "interval": "",
               "legendFormat": "",
               "refId": "A"
@@ -371,7 +371,7 @@ data:
           "targets": [
             {
               "exemplar": true,
-              "expr": "sum(increase(image_builder_composer_total_failed_compose_requests[$__range]))/sum(increase(image_builder_composer_total_compose_requests[$__range]))",
+              "expr": "sum(increase(image_builder_composer_total_failed_compose_requests[$interval]))/sum(increase(image_builder_composer_total_compose_requests[$interval]))",
               "interval": "",
               "legendFormat": "",
               "refId": "A"
@@ -465,7 +465,7 @@ data:
           "targets": [
             {
               "exemplar": true,
-              "expr": "28 * 24 * (1 - $stability_slo) / ((sum(rate(image_builder_composer_total_failed_compose_requests[$__range]))/ sum(rate(image_builder_composer_total_compose_requests[$__range]))) + 0.001)",
+              "expr": "28 * 24 * (1 - $stability_slo) / ((sum(rate(image_builder_composer_total_failed_compose_requests[$interval]))/ sum(rate(image_builder_composer_total_compose_requests[$interval]))) + 0.001)",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 1,
@@ -564,7 +564,7 @@ data:
           "targets": [
             {
               "exemplar": true,
-              "expr": "1 - ((1 - sum(increase(image_builder_composer_total_failed_compose_requests[$__range]))/sum(increase(image_builder_composer_total_compose_requests[$__range]))) - $stability_slo)/ (1 - $stability_slo)",
+              "expr": "1 - ((1 - sum(increase(image_builder_composer_total_failed_compose_requests[$interval]))/sum(increase(image_builder_composer_total_compose_requests[$interval]))) - $stability_slo)/ (1 - $stability_slo)",
               "instant": false,
               "interval": "",
               "intervalFactor": 10,
@@ -670,7 +670,7 @@ data:
           "targets": [
             {
               "exemplar": true,
-              "expr": "histogram_quantile(0.9, sum(rate(image_builder_composer_http_duration_seconds_bucket[$__range])) by (le)) * 1000",
+              "expr": "histogram_quantile(0.9, sum(rate(image_builder_composer_http_duration_seconds_bucket[$interval])) by (le)) * 1000",
               "interval": "",
               "legendFormat": "",
               "refId": "A"
@@ -864,14 +864,14 @@ data:
           "targets": [
             {
               "exemplar": true,
-              "expr": "histogram_quantile(0.5, sum(rate(image_builder_composer_http_duration_seconds_bucket[$__range])) by (le))",
+              "expr": "histogram_quantile(0.5, sum(rate(image_builder_composer_http_duration_seconds_bucket[$interval])) by (le))",
               "interval": "",
               "legendFormat": "p50",
               "refId": "A"
             },
             {
               "exemplar": true,
-              "expr": "histogram_quantile(0.9, sum(rate(image_builder_composer_http_duration_seconds_bucket[$__range])) by (le))",
+              "expr": "histogram_quantile(0.9, sum(rate(image_builder_composer_http_duration_seconds_bucket[$interval])) by (le))",
               "hide": false,
               "interval": "",
               "legendFormat": "p90",
@@ -879,7 +879,7 @@ data:
             },
             {
               "exemplar": true,
-              "expr": "histogram_quantile(0.99, sum(rate(image_builder_composer_http_duration_seconds_bucket[$__range])) by (le))",
+              "expr": "histogram_quantile(0.99, sum(rate(image_builder_composer_http_duration_seconds_bucket[$interval])) by (le))",
               "hide": false,
               "interval": "",
               "legendFormat": "p99",
@@ -974,7 +974,7 @@ data:
           "targets": [
             {
               "exemplar": true,
-              "expr": "28 * 24 * (1 - $latency_slo) / (1 - sum(rate(image_builder_composer_http_duration_seconds_bucket{le=\"0.2\"}[$__range]))/sum(rate(image_builder_composer_http_duration_seconds_count[$__range])))",
+              "expr": "28 * 24 * (1 - $latency_slo) / (1 - sum(rate(image_builder_composer_http_duration_seconds_bucket{le=\"0.2\"}[$interval]))/sum(rate(image_builder_composer_http_duration_seconds_count[$interval])))",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 1,
@@ -1072,7 +1072,7 @@ data:
           "targets": [
             {
               "exemplar": true,
-              "expr": "1 - ((sum(increase(image_builder_composer_http_duration_seconds_bucket{le=\"0.2\"}[$__range]))/sum(increase(image_builder_composer_http_duration_seconds_count[$__range]))) - $latency_slo)/ (1 - $latency_slo)",
+              "expr": "1 - ((sum(increase(image_builder_composer_http_duration_seconds_bucket{le=\"0.2\"}[$interval]))/sum(increase(image_builder_composer_http_duration_seconds_count[$interval]))) - $latency_slo)/ (1 - $latency_slo)",
               "instant": false,
               "interval": "",
               "intervalFactor": 10,

--- a/templates/dashboards/grafana-dashboard-image-builder-composer-general.configmap.yml
+++ b/templates/dashboards/grafana-dashboard-image-builder-composer-general.configmap.yml
@@ -187,7 +187,7 @@ data:
           "targets": [
             {
               "exemplar": true,
-              "expr": "sum(increase(image_builder_composer_total_compose_requests[$interval]))",
+              "expr": "sum(increase(image_builder_composer_total_compose_requests[$__range]))",
               "interval": "",
               "legendFormat": "",
               "refId": "A"
@@ -233,7 +233,6 @@ data:
                 }
               },
               "mappings": [],
-              "max": 1,
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
@@ -243,7 +242,7 @@ data:
                   }
                 ]
               },
-              "unit": "percentunit"
+              "unit": "none"
             },
             "overrides": [
               {
@@ -372,7 +371,7 @@ data:
           "targets": [
             {
               "exemplar": true,
-              "expr": "sum(increase(image_builder_composer_total_failed_compose_requests[$interval]))/sum(increase(image_builder_composer_total_compose_requests[$interval]))",
+              "expr": "sum(rate(image_builder_composer_total_failed_compose_requests[$interval]))/sum(rate(image_builder_composer_total_compose_requests[$interval]))",
               "interval": "",
               "legendFormat": "",
               "refId": "A"
@@ -1204,7 +1203,7 @@ data:
             "auto_count": 30,
             "auto_min": "10s",
             "current": {
-              "selected": true,
+              "selected": false,
               "text": "5m",
               "value": "5m"
             },
@@ -1294,7 +1293,7 @@ data:
         ]
       },
       "time": {
-        "from": "now-1h",
+        "from": "now-30d",
         "to": "now"
       },
       "timepicker": {

--- a/templates/dashboards/grafana-dashboard-image-builder-composer-general.configmap.yml
+++ b/templates/dashboards/grafana-dashboard-image-builder-composer-general.configmap.yml
@@ -32,8 +32,8 @@ data:
       "fiscalYearStartMonth": 0,
       "gnetId": null,
       "graphTooltip": 0,
-      "id": 207,
-      "iteration": 1635760556540,
+      "id": 32,
+      "iteration": 1638482859191,
       "links": [],
       "liveNow": false,
       "panels": [
@@ -163,7 +163,7 @@ data:
           },
           "gridPos": {
             "h": 8,
-            "w": 5,
+            "w": 3,
             "x": 5,
             "y": 1
           },
@@ -195,6 +195,110 @@ data:
           ],
           "title": "Compose Requests",
           "type": "stat"
+        },
+        {
+          "datasource": "${datasource}",
+          "description": "The throughput rate of Compose errors and non-errors over time for the selected time range",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "custom": {
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 11,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "red",
+                    "value": null
+                  }
+                ]
+              },
+              "unit": "none"
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "success/sec"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "green",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 8,
+            "y": 1
+          },
+          "id": 202,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "single"
+            }
+          },
+          "targets": [
+            {
+              "exemplar": true,
+              "expr": "sum(rate(image_builder_composer_total_compose_requests[$interval])) - sum(rate(image_builder_composer_total_failed_compose_requests[$interval]))",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "success/sec",
+              "refId": "A"
+            },
+            {
+              "exemplar": true,
+              "expr": "sum(rate(image_builder_composer_total_failed_compose_requests[$interval]))",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "errors/sec",
+              "refId": "B"
+            }
+          ],
+          "title": "Compose Throughput Rate",
+          "type": "timeseries"
         },
         {
           "datasource": "${datasource}",
@@ -249,8 +353,8 @@ data:
           },
           "gridPos": {
             "h": 8,
-            "w": 14,
-            "x": 10,
+            "w": 8,
+            "x": 16,
             "y": 1
           },
           "id": 194,
@@ -273,7 +377,7 @@ data:
               "refId": "A"
             }
           ],
-          "title": "Compose Errors",
+          "title": "Compose Error Rate",
           "type": "timeseries"
         },
         {
@@ -630,9 +734,115 @@ data:
                   }
                 ]
               },
-              "unit": "ms"
+              "unit": "s"
             },
-            "overrides": []
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "99p"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "red",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "95p"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "blue",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "90p"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "yellow",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "50p"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "blue",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "p90"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "yellow",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "p99"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "red",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "p50"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "blue",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              }
+            ]
           },
           "gridPos": {
             "h": 8,
@@ -644,7 +854,7 @@ data:
           "options": {
             "legend": {
               "calcs": [],
-              "displayMode": "hidden",
+              "displayMode": "list",
               "placement": "bottom"
             },
             "tooltip": {
@@ -654,10 +864,26 @@ data:
           "targets": [
             {
               "exemplar": true,
-              "expr": "histogram_quantile(0.9, sum(rate(image_builder_composer_http_duration_seconds_bucket[$__range])) by (le)) * 1000",
+              "expr": "histogram_quantile(0.5, sum(rate(image_builder_composer_http_duration_seconds_bucket[$__range])) by (le))",
               "interval": "",
-              "legendFormat": "",
+              "legendFormat": "p50",
               "refId": "A"
+            },
+            {
+              "exemplar": true,
+              "expr": "histogram_quantile(0.9, sum(rate(image_builder_composer_http_duration_seconds_bucket[$__range])) by (le))",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "p90",
+              "refId": "B"
+            },
+            {
+              "exemplar": true,
+              "expr": "histogram_quantile(0.99, sum(rate(image_builder_composer_http_duration_seconds_bucket[$__range])) by (le))",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "p99",
+              "refId": "C"
             }
           ],
           "title": "Compose Request Latency",
@@ -868,7 +1094,7 @@ data:
         "list": [
           {
             "current": {
-              "selected": true,
+              "selected": false,
               "text": "app-sre-prod-04-prometheus",
               "value": "app-sre-prod-04-prometheus"
             },
@@ -892,9 +1118,9 @@ data:
             "auto_count": 30,
             "auto_min": "10s",
             "current": {
-              "selected": false,
-              "text": "28d",
-              "value": "28d"
+              "selected": true,
+              "text": "5m",
+              "value": "5m"
             },
             "description": null,
             "error": null,
@@ -903,7 +1129,7 @@ data:
             "name": "interval",
             "options": [
               {
-                "selected": false,
+                "selected": true,
                 "text": "5m",
                 "value": "5m"
               },
@@ -948,7 +1174,7 @@ data:
                 "value": "14d"
               },
               {
-                "selected": true,
+                "selected": false,
                 "text": "28d",
                 "value": "28d"
               }
@@ -965,7 +1191,7 @@ data:
             "hide": 2,
             "label": null,
             "name": "stability_slo",
-            "query": "0.95",
+            "query": "0.9",
             "skipUrlSync": false,
             "type": "constant"
           },
@@ -982,7 +1208,7 @@ data:
         ]
       },
       "time": {
-        "from": "now-28d",
+        "from": "now-7d",
         "to": "now"
       },
       "timepicker": {
@@ -1013,5 +1239,5 @@ data:
       "timezone": "",
       "title": "Image Builder Composer",
       "uid": "cNGfs4Knz",
-      "version": 2
+      "version": 1
     }

--- a/templates/dashboards/grafana-dashboard-image-builder-composer-general.configmap.yml
+++ b/templates/dashboards/grafana-dashboard-image-builder-composer-general.configmap.yml
@@ -32,8 +32,8 @@ data:
       "fiscalYearStartMonth": 0,
       "gnetId": null,
       "graphTooltip": 0,
-      "id": 32,
-      "iteration": 1638482859201,
+      "id": 219,
+      "iteration": 1638547440887,
       "links": [],
       "liveNow": false,
       "panels": [
@@ -130,7 +130,7 @@ data:
           "targets": [
             {
               "exemplar": true,
-              "expr": "1 - sum(increase(image_builder_composer_total_failed_compose_requests[$interval]))/sum(increase(image_builder_composer_total_compose_requests[$interval]))",
+              "expr": "1 - sum(increase(image_builder_composer_total_failed_compose_requests[$__range]))/sum(increase(image_builder_composer_total_compose_requests[$__range]))",
               "interval": "",
               "legendFormat": "",
               "refId": "A"
@@ -465,7 +465,7 @@ data:
           "targets": [
             {
               "exemplar": true,
-              "expr": "28 * 24 * (1 - $stability_slo) / ((sum(rate(image_builder_composer_total_failed_compose_requests[$interval]))/ sum(rate(image_builder_composer_total_compose_requests[$interval]))) + 0.001)",
+              "expr": "28 * 24 * (1 - $stability_slo) / ((sum(rate(image_builder_composer_total_failed_compose_requests[28d]))/ sum(rate(image_builder_composer_total_compose_requests[28d]))) + 0.001)",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 1,
@@ -564,7 +564,7 @@ data:
           "targets": [
             {
               "exemplar": true,
-              "expr": "1 - ((1 - sum(increase(image_builder_composer_total_failed_compose_requests[$interval]))/sum(increase(image_builder_composer_total_compose_requests[$interval]))) - $stability_slo)/ (1 - $stability_slo)",
+              "expr": "1 - ((1 - sum(increase(image_builder_composer_total_failed_compose_requests[28d]))/sum(increase(image_builder_composer_total_compose_requests[28d]))) - $stability_slo)/ (1 - $stability_slo)",
               "instant": false,
               "interval": "",
               "intervalFactor": 10,
@@ -670,7 +670,7 @@ data:
           "targets": [
             {
               "exemplar": true,
-              "expr": "histogram_quantile(0.9, sum(rate(image_builder_composer_http_duration_seconds_bucket[$interval])) by (le)) * 1000",
+              "expr": "histogram_quantile(0.9, sum(rate(image_builder_composer_http_duration_seconds_bucket[$__range])) by (le)) * 1000",
               "interval": "",
               "legendFormat": "",
               "refId": "A"
@@ -1059,7 +1059,7 @@ data:
           "targets": [
             {
               "exemplar": true,
-              "expr": "28 * 24 * (1 - $latency_slo) / (1 - sum(rate(image_builder_composer_http_duration_seconds_bucket{le=\"0.2\"}[$interval]))/sum(rate(image_builder_composer_http_duration_seconds_count[$interval])))",
+              "expr": "28 * 24 * (1 - $latency_slo) / (1 - sum(rate(image_builder_composer_http_duration_seconds_bucket{le=\"0.2\"}[$__range]))/sum(rate(image_builder_composer_http_duration_seconds_count[$__range])))",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 1,
@@ -1157,7 +1157,7 @@ data:
           "targets": [
             {
               "exemplar": true,
-              "expr": "1 - ((sum(increase(image_builder_composer_http_duration_seconds_bucket{le=\"0.2\"}[$interval]))/sum(increase(image_builder_composer_http_duration_seconds_count[$interval]))) - $latency_slo)/ (1 - $latency_slo)",
+              "expr": "1 - ((sum(increase(image_builder_composer_http_duration_seconds_bucket{le=\"0.2\"}[28d]))/sum(increase(image_builder_composer_http_duration_seconds_count[28d]))) - $latency_slo)/ (1 - $latency_slo)",
               "instant": false,
               "interval": "",
               "intervalFactor": 10,
@@ -1203,9 +1203,9 @@ data:
             "auto_count": 30,
             "auto_min": "10s",
             "current": {
-              "selected": false,
-              "text": "5m",
-              "value": "5m"
+              "selected": true,
+              "text": "14d",
+              "value": "14d"
             },
             "description": null,
             "error": null,
@@ -1214,7 +1214,7 @@ data:
             "name": "interval",
             "options": [
               {
-                "selected": true,
+                "selected": false,
                 "text": "5m",
                 "value": "5m"
               },
@@ -1254,7 +1254,7 @@ data:
                 "value": "7d"
               },
               {
-                "selected": false,
+                "selected": true,
                 "text": "14d",
                 "value": "14d"
               },
@@ -1293,7 +1293,7 @@ data:
         ]
       },
       "time": {
-        "from": "now-30d",
+        "from": "now-7d",
         "to": "now"
       },
       "timepicker": {
@@ -1323,6 +1323,6 @@ data:
       },
       "timezone": "",
       "title": "Image Builder Composer",
-      "uid": "cNGfs4Knz",
-      "version": 1
+      "uid": "cNGfs4Knzasdf",
+      "version": 3
     }

--- a/templates/dashboards/grafana-dashboard-image-builder-composer-general.configmap.yml
+++ b/templates/dashboards/grafana-dashboard-image-builder-composer-general.configmap.yml
@@ -1276,7 +1276,7 @@ data:
             "hide": 2,
             "label": null,
             "name": "stability_slo",
-            "query": "0.9",
+            "query": "0.95",
             "skipUrlSync": false,
             "type": "constant"
           },
@@ -1286,7 +1286,7 @@ data:
             "hide": 2,
             "label": null,
             "name": "latency_slo",
-            "query": "0.9",
+            "query": "0.95",
             "skipUrlSync": false,
             "type": "constant"
           }

--- a/templates/dashboards/grafana-dashboard-image-builder-composer-general.configmap.yml
+++ b/templates/dashboards/grafana-dashboard-image-builder-composer-general.configmap.yml
@@ -1323,6 +1323,6 @@ data:
       },
       "timezone": "",
       "title": "Image Builder Composer",
-      "uid": "cNGfs4Knzasdf",
+      "uid": "cNGfs4Knz",
       "version": 3
     }

--- a/templates/dashboards/grafana-dashboard-image-builder-composer-general.configmap.yml
+++ b/templates/dashboards/grafana-dashboard-image-builder-composer-general.configmap.yml
@@ -33,7 +33,7 @@ data:
       "gnetId": null,
       "graphTooltip": 0,
       "id": 32,
-      "iteration": 1638482859191,
+      "iteration": 1638482859201,
       "links": [],
       "liveNow": false,
       "panels": [
@@ -233,6 +233,7 @@ data:
                 }
               },
               "mappings": [],
+              "max": 1,
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
@@ -242,7 +243,7 @@ data:
                   }
                 ]
               },
-              "unit": "none"
+              "unit": "percentunit"
             },
             "overrides": [
               {
@@ -846,7 +847,7 @@ data:
           },
           "gridPos": {
             "h": 8,
-            "w": 19,
+            "w": 11,
             "x": 5,
             "y": 18
           },
@@ -887,6 +888,91 @@ data:
             }
           ],
           "title": "Compose Request Latency",
+          "type": "timeseries"
+        },
+        {
+          "datasource": "${datasource}",
+          "description": "Percent of requests exceeding latency allowed by SLO",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "max": 1,
+              "min": 0,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "percentunit"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 16,
+            "y": 18
+          },
+          "id": 204,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "hidden",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "single"
+            }
+          },
+          "targets": [
+            {
+              "exemplar": true,
+              "expr": "1 - sum(rate(image_builder_composer_http_duration_seconds_bucket{le=\"0.2\"}[$interval]))/sum(rate(image_builder_composer_http_duration_seconds_count[$interval]))",
+              "interval": "",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "title": "Slow Request Rate",
           "type": "timeseries"
         },
         {
@@ -1208,7 +1294,7 @@ data:
         ]
       },
       "time": {
-        "from": "now-7d",
+        "from": "now-1h",
         "to": "now"
       },
       "timepicker": {


### PR DESCRIPTION
This pull request includes:

- [ N/A ] adequate testing for the new functionality or fixed issue
- [ X ] adequate documentation informing people about the change such as
- [ N/A ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`
-->
<img width="1868" alt="Screen Shot 2021-12-02 at 5 19 37 PM" src="https://user-images.githubusercontent.com/12194139/144518432-57d1472c-3f39-417f-83ed-db415d38f52f.png">

This PR makes several changes to the Image-Builder-Composer Grafana dashboard:
* Changes the Grafana variable “latency_slo” from 0.9 to 0.95. 
* Adds 0.5 and 0.99 percentiles to the latency panel
* Adds a success vs errors 'compose throughput rate' panel
* Adds a 'slow request rate' panel, tracking the rate of requests with excessive response times
* Changes all prometheus queries to use the variable '$interval' instead of '$__range' (except for the single-stat panels)
* error budget related panels now use the hard-coded interval of 28d (this is to avoid confusing people looking at the dashboard; image-builder's actual SLOs are calculated on a 28-day interval)