### PR TITLE
Prepare CI to build -tests RPM for downstream testing from source

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -498,6 +498,8 @@ SCHEDULED_CLOUD_CLEANER:
 SonarQube:
   stage: test
   extends: .terraform
+  rules:
+    - if: '$CI_PIPELINE_SOURCE != "schedule"'
   script:
     - schutzbot/sonarqube.sh
   variables:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -380,8 +380,8 @@ API:
   extends: .terraform
   rules:
     - if: '$CI_PIPELINE_SOURCE != "schedule"'
-    - if: '$CI_PIPELINE_SOURCE == "schedule" && $RUNNER =~ /[\S]+rhel-9.0-[^ga][\S]+/ && $NIGHTLY == "true" && $RHEL_MAJOR == "9"'
-    - if: '$CI_PIPELINE_SOURCE == "schedule" && $RUNNER =~ /[\S]+rhel-8.6-[^ga][\S]+/ && $NIGHTLY == "true" && $RHEL_MAJOR == "8"'
+    # note: cloud API is not supported for on-prem installations so
+    # don't run this test case for nightly trees
   script:
     - schutzbot/deploy.sh
     - /usr/libexec/tests/osbuild-composer/api.sh ${IMAGE_TYPE}

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -38,6 +38,15 @@ init:
   script:
     - schutzbot/update_github_status.sh start
 
+
+.RPM_RUNNERS_RHEL: &RPM_RUNNERS_RHEL
+  RUNNER:
+    - aws/rhel-8.6-nightly-x86_64
+    - aws/rhel-8.6-nightly-aarch64
+    - aws/rhel-9.0-nightly-x86_64
+    - aws/rhel-9.0-nightly-aarch64
+  INTERNAL_NETWORK: ["true"]
+
 RPM:
   stage: rpmbuild
   extends: .terraform
@@ -63,12 +72,26 @@ RPM:
           - aws/rhel-8.5-ga-aarch64
           - aws/centos-stream-8-x86_64
           - aws/centos-stream-8-aarch64
-      - RUNNER:
-          - aws/rhel-8.6-nightly-x86_64
-          - aws/rhel-8.6-nightly-aarch64
-          - aws/rhel-9.0-nightly-x86_64
-          - aws/rhel-9.0-nightly-aarch64
-        INTERNAL_NETWORK: ["true"]
+      - <<: *RPM_RUNNERS_RHEL
+
+Build -tests RPM for RHEL:
+  stage: rpmbuild
+  extends: .terraform
+  rules:
+    - if: '$CI_PIPELINE_SOURCE == "schedule" && $RUNNER =~ /[\S]+rhel-9.0-[^ga][\S]+/ && $NIGHTLY == "true" && $RHEL_MAJOR == "9"'
+    - if: '$CI_PIPELINE_SOURCE == "schedule" && $RUNNER =~ /[\S]+rhel-8.6-[^ga][\S]+/ && $NIGHTLY == "true" && $RHEL_MAJOR == "8"'
+  script:
+    - sh "schutzbot/mockbuild.sh"
+  interruptible: true
+  after_script:
+    - schutzbot/update_github_status.sh update
+    - schutzbot/save_journal.sh
+  artifacts:
+    paths:
+      - journal-log.gpg
+  parallel:
+    matrix:
+      - <<: *RPM_RUNNERS_RHEL
 
 Container:
   stage: rpmbuild

--- a/osbuild-composer.spec
+++ b/osbuild-composer.spec
@@ -408,6 +408,7 @@ Requires:   libvirt-daemon-driver-storage-disk
 Requires:   libvirt-daemon-kvm
 Requires:   qemu-img
 Requires:   qemu-kvm
+Requires:   rpmdevtools
 Requires:   virt-install
 Requires:   expect
 Requires:   python3-lxml

--- a/osbuild-composer.spec
+++ b/osbuild-composer.spec
@@ -2,6 +2,11 @@
 # Pass --with tests to rpmbuild to override
 %bcond_with tests
 
+# When --with relax_requires is specified osbuild-composer-tests
+# will require osbuild-composer only by name, excluding version/release
+# This is used internally during nightly pipeline testing!
+%bcond_with relax_requires
+
 %global goipath         github.com/osbuild/osbuild-composer
 
 Version:        44
@@ -371,7 +376,11 @@ The dnf-json binary used by osbuild-composer and the workers.
 
 %package tests
 Summary:    Integration tests
+%if %{with relax_requires}
+Requires:   %{name}
+%else
 Requires:   %{name} = %{version}-%{release}
+%endif
 Requires:   composer-cli
 Requires:   createrepo_c
 Requires:   xorriso

--- a/schutzbot/deploy.sh
+++ b/schutzbot/deploy.sh
@@ -110,13 +110,6 @@ fi
 if [ -f "rhel${VERSION_ID%.*}internal.repo" ]; then
     greenprint "Preparing repos for internal build testing"
     sudo mv rhel"${VERSION_ID%.*}"internal.repo /etc/yum.repos.d/
-    # Use osbuild from schutzfile if desired for testing custom osbuild-composer packages
-    # specified by $REPO_URL in ENV and used in prepare-rhel-internal.sh
-    if [ "${SCHUTZ_OSBUILD:=false}" == true ]; then
-        sudo rm -f /etc/yum.repos.d/osbuild-composer.repo
-    else
-        sudo rm -f /etc/yum.repos.d/osbuild*.repo
-    fi
 fi
 
 greenprint "Installing test packages for ${PROJECT}"

--- a/schutzbot/deploy.sh
+++ b/schutzbot/deploy.sh
@@ -39,11 +39,17 @@ function setup_repo {
   local project=$1
   local commit=$2
   local priority=${3:-10}
+
+  local REPO_PATH=${project}/${DISTRO_VERSION}/${ARCH}/${commit}
+  if [[ "${NIGHTLY:=false}" == "true" && "${project}" == "osbuild-composer" ]]; then
+    REPO_PATH=nightly/${REPO_PATH}
+  fi
+
   greenprint "Setting up dnf repository for ${project} ${commit}"
   sudo tee "/etc/yum.repos.d/${project}.repo" << EOF
 [${project}]
 name=${project} ${commit}
-baseurl=http://osbuild-composer-repos.s3-website.us-east-2.amazonaws.com/${project}/${DISTRO_VERSION}/${ARCH}/${commit}
+baseurl=http://osbuild-composer-repos.s3-website.us-east-2.amazonaws.com/${REPO_PATH}
 enabled=1
 gpgcheck=0
 priority=${priority}

--- a/schutzbot/mockbuild.sh
+++ b/schutzbot/mockbuild.sh
@@ -99,10 +99,15 @@ sudo mock -r "$MOCK_CONFIG" --buildsrpm \
   --sources "./osbuild-composer-${COMMIT}.tar.gz" \
   --resultdir ./srpm
 
+if [ "${NIGHTLY:=false}" == "true" ]; then
+    RELAX_REQUIRES="--with=relax_requires"
+fi
+
 greenprint "🎁 Building RPMs"
 sudo mock -r "$MOCK_CONFIG" \
     --define "commit ${COMMIT}" \
     --with=tests \
+    ${RELAX_REQUIRES:+"$RELAX_REQUIRES"} \
     --resultdir "$REPO_DIR" \
     srpm/*.src.rpm
 
@@ -111,6 +116,12 @@ sudo chown -R "$USER" "${REPO_DIR%%/*}"
 
 greenprint "🧹 Remove logs from mock build"
 rm "${REPO_DIR}"/*.log
+
+# leave only -tests RPM to minimize interference when installing
+# osbuild-composer.rpm from distro repositories
+if [ "${NIGHTLY:=false}" == "true" ]; then
+    find "${REPO_DIR}" -type f -not -name "osbuild-composer-tests*.rpm" -exec rm -f "{}" \;
+fi
 
 # Create a repo of the built RPMs.
 greenprint "⛓️ Creating dnf repository"

--- a/schutzbot/mockbuild.sh
+++ b/schutzbot/mockbuild.sh
@@ -38,6 +38,9 @@ fi
 # Relative path of the repository – used for constructing both the local and
 # remote paths below, so that they're consistent.
 REPO_PATH=osbuild-composer/${DISTRO_VERSION}/${ARCH}/${COMMIT}
+if [ "${NIGHTLY:=false}" == "true" ]; then
+    REPO_PATH=nightly/${REPO_PATH}
+fi
 
 # Directory to hold the RPMs temporarily before we upload them.
 REPO_DIR=repo/${REPO_PATH}

--- a/test/cases/api.sh
+++ b/test/cases/api.sh
@@ -238,6 +238,7 @@ function cleanupAzure() {
   # since this function can be called at any time, ensure that we don't expand unbound variables
   AZURE_CMD="${AZURE_CMD:-}"
   AZURE_IMAGE_NAME="${AZURE_IMAGE_NAME:-}"
+  AZURE_INSTANCE_NAME="${AZURE_INSTANCE_NAME:-}"
 
   # do not run clean-up if the image name is not yet defined
   if [[ -n "$AZURE_CMD" && -n "$AZURE_IMAGE_NAME" ]]; then

--- a/test/cases/base_tests.sh
+++ b/test/cases/base_tests.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -euo pipefail
 
+source /usr/libexec/tests/osbuild-composer/shared_lib.sh
+
 WORKING_DIRECTORY=/usr/libexec/osbuild-composer
 TESTS_PATH=/usr/libexec/osbuild-composer-test
 mkdir --parents /tmp/logs
@@ -11,11 +13,18 @@ FAILED_TESTS=()
 
 TEST_CASES=(
   "osbuild-weldr-tests"
-  "osbuild-dnf-json-tests"
   "osbuild-composer-cli-tests"
   "osbuild-auth-tests"
   "osbuild-composer-dbjobqueue-tests"
 )
+
+if nvrGreaterOrEqual "osbuild-composer" "41"; then
+    # 0 - osbuild-composer == v41
+    # 11 - osbuild-composer > v41
+    # 12 - osbuild-composer < v41
+    echo "INFO: enabling osbuild-dnf-json-tests"
+    TEST_CASES+=("osbuild-dnf-json-tests")
+fi
 
 # Print out a nice test divider so we know when tests stop and start.
 test_divider () {

--- a/test/cases/shared_lib.sh
+++ b/test/cases/shared_lib.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/bash
+
+function nvrGreaterOrEqual {
+    local rpm_name=$1
+    local min_version=$2
+
+    set +e
+
+    rpm_version=$(rpm -q --qf "%{version}" "${rpm_name}")
+    rpmdev-vercmp "${rpm_version}" "${min_version}"
+    if [ "$?" != "12" ]; then
+        # 0 - rpm_version == min_version
+        # 11 - rpm_version > min_version
+        # 12 - rpm_version < min_version
+        echo "DEBUG: ${rpm_version} >= ${min_version}"
+        set -e
+        return
+    fi
+
+    set -e
+    false
+}


### PR DESCRIPTION
I had just realized that building osbuild-composer-tests rpm from main is sometimes going to result in a different NVR than we have downstream (this will be more prominent toward the end of a minor release cycle).  Because we've got 

```
Requires:   %{name} = %{version}-%{release}
```

installing this RPM inside our test systems will fail with broken dependencies. Another possibility is that this will result in silently pulling a newer osbuild-composer RPM from the S3 repos instead of pulling the RPM from the nightly tree. 