### PR TITLE
composer: Only set queue and artifact dir for fsqueue

### DIFF
--- a/cmd/osbuild-composer/composer.go
+++ b/cmd/osbuild-composer/composer.go
@@ -53,14 +53,13 @@ func NewComposer(config *ComposerConfigFile, stateDir, cacheDir string) (*Compos
 		cacheDir: cacheDir,
 	}
 
-	queueDir, err := c.ensureStateDirectory("jobs", 0700)
-	if err != nil {
-		return nil, err
-	}
-
-	artifactsDir, err := c.ensureStateDirectory("artifacts", 0755)
-	if err != nil {
-		return nil, err
+	var err error
+	artifactsDir := ""
+	if config.Worker.EnableArtifacts {
+		artifactsDir, err = c.ensureStateDirectory("artifacts", 0755)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	c.distros = distroregistry.NewDefault()
@@ -88,6 +87,10 @@ func NewComposer(config *ComposerConfigFile, stateDir, cacheDir string) (*Compos
 			return nil, fmt.Errorf("cannot create jobqueue: %v", err)
 		}
 	} else {
+		queueDir, err := c.ensureStateDirectory("jobs", 0700)
+		if err != nil {
+			return nil, err
+		}
 		jobs, err = fsjobqueue.New(queueDir)
 		if err != nil {
 			return nil, fmt.Errorf("cannot create jobqueue: %v", err)

--- a/cmd/osbuild-composer/config.go
+++ b/cmd/osbuild-composer/config.go
@@ -39,6 +39,7 @@ type WorkerAPIConfig struct {
 	CA                string   `toml:"ca"`
 	RequestJobTimeout string   `toml:"request_job_timeout"`
 	BasePath          string   `toml:"base_path"`
+	EnableArtifacts   bool     `toml:"enable_artifacts"`
 	PGHost            string   `toml:"pg_host" env:"PGHOST"`
 	PGPort            string   `toml:"pg_port" env:"PGPORT"`
 	PGDatabase        string   `toml:"pg_database" env:"PGDATABASE"`
@@ -92,6 +93,7 @@ func GetDefaultConfig() *ComposerConfigFile {
 		Worker: WorkerAPIConfig{
 			RequestJobTimeout: "0",
 			BasePath:          "/api/worker/v1",
+			EnableArtifacts:   true,
 			EnableTLS:         true,
 			EnableMTLS:        true,
 			EnableJWT:         false,

--- a/cmd/osbuild-composer/config_test.go
+++ b/cmd/osbuild-composer/config_test.go
@@ -41,6 +41,7 @@ func TestDefaultConfig(t *testing.T) {
 	require.Equal(t, WorkerAPIConfig{
 		RequestJobTimeout: "0",
 		BasePath:          "/api/worker/v1",
+		EnableArtifacts:   true,
 		EnableTLS:         true,
 		EnableMTLS:        true,
 		EnableJWT:         false,

--- a/templates/composer.yml
+++ b/templates/composer.yml
@@ -214,6 +214,7 @@ objects:
       [worker]
       request_job_timeout = "20s"
       base_path = "/api/image-builder-worker/v1"
+      enable_artifacts = false
       enable_tls = false
       enable_mtls = false
       enable_jwt = true

--- a/test/cases/api.sh
+++ b/test/cases/api.sh
@@ -1197,6 +1197,7 @@ jwt_acl_file = ""
 [worker]
 pg_host = "localhost"
 pg_port = "5432"
+enable_artifacts = false
 pg_database = "osbuildcomposer"
 pg_user = "postgres"
 pg_password = "foobar"


### PR DESCRIPTION
 When backed by a DB, composer has no need of a queue or artifact directory.
    
This also addresses "Error moving artifacts for job" logging noise when using a dbqueue.
