### PR TITLE
osbuild-auth-tests: add a build constraint also to certificates.go

### DIFF
--- a/cmd/osbuild-auth-tests/certificates.go
+++ b/cmd/osbuild-auth-tests/certificates.go
@@ -1,3 +1,5 @@
+// +build integration
+
 package main
 
 import (


### PR DESCRIPTION
These tests can be run only in our CI environment, and not as pure unit tests
launched by go test ./... Let's make sure that all files that belong to these
tests are properly marked with build constraints.

This should fix the following error in Coverity Scan runs:

 # github.com/osbuild/osbuild-composer/cmd/osbuild-auth-tests
runtime.main_main·f: function main is undeclared in the main package
Warning:  Build command go build -o bin/ ./... exited with code 2. Please verify that the build completed successfully.

See https://github.com/osbuild/osbuild-composer/runs/4427232580?check_suite_focus=true

Signed-off-by: Ondřej Budai <ondrej@budai.cz>


This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`
-->
