### PR TITLE
Regression test fixes

### DIFF
--- a/test/cases/regression-composer-works-behind-satellite.sh
+++ b/test/cases/regression-composer-works-behind-satellite.sh
@@ -349,6 +349,8 @@ function try_image_build {
 
     done
 
+    sudo composer-cli compose delete "${COMPOSE_ID}" >/dev/null
+
     sudo journalctl -xe --unit osbuild-composer
     sudo journalctl -xe --unit osbuild-worker
 

--- a/test/cases/regression-composer-works-behind-satellite.sh
+++ b/test/cases/regression-composer-works-behind-satellite.sh
@@ -328,7 +328,8 @@ function try_image_build {
     if ! sudo composer-cli --json compose start ${BLUEPRINT_NAME} qcow2 | tee "${COMPOSE_START}";
     then
         sudo journalctl -xe --unit osbuild-composer
-        sudo journalctl -xe --unit osbuild-worker
+        WORKER_UNIT=$(sudo systemctl list-units | grep -o -E "osbuild.*worker.*\.service")
+        sudo journalctl -xe --unit "${WORKER_UNIT}"
         exit 1
     fi
     COMPOSE_ID=$(get_build_info ".build_id" "$COMPOSE_START")
@@ -352,7 +353,8 @@ function try_image_build {
     sudo composer-cli compose delete "${COMPOSE_ID}" >/dev/null
 
     sudo journalctl -xe --unit osbuild-composer
-    sudo journalctl -xe --unit osbuild-worker
+    WORKER_UNIT=$(sudo systemctl list-units | grep -o -E "osbuild.*worker.*\.service")
+    sudo journalctl -xe --unit "${WORKER_UNIT}"
 
     # Did the compose finish with success?
     if [[ $COMPOSE_STATUS != FINISHED ]]; then

--- a/test/cases/regression-composer-works-behind-satellite.sh
+++ b/test/cases/regression-composer-works-behind-satellite.sh
@@ -321,15 +321,15 @@ function try_image_build {
     sudo composer-cli blueprints push "$BLUEPRINT_FILE"
     if ! sudo composer-cli blueprints depsolve ${BLUEPRINT_NAME};
     then
-    sudo cat /var/log/httpd/error_log
-    sudo journalctl -xe --unit osbuild-composer
-    exit 1
+        sudo cat /var/log/httpd/error_log
+        sudo journalctl -xe --unit osbuild-composer
+        exit 1
     fi
     if ! sudo composer-cli --json compose start ${BLUEPRINT_NAME} qcow2 | tee "${COMPOSE_START}";
     then
-    sudo journalctl -xe --unit osbuild-composer
-    sudo journalctl -xe --unit osbuild-worker
-    exit 1
+        sudo journalctl -xe --unit osbuild-composer
+        sudo journalctl -xe --unit osbuild-worker
+        exit 1
     fi
     COMPOSE_ID=$(get_build_info ".build_id" "$COMPOSE_START")
 

--- a/test/cases/regression-excluded-dependency.sh
+++ b/test/cases/regression-excluded-dependency.sh
@@ -75,6 +75,8 @@ while true; do
     sleep 30
 done
 
+sudo composer-cli compose delete "${COMPOSE_ID}" >/dev/null
+
 jq . "${COMPOSE_INFO}"
 
 # Did the compose finish with success?

--- a/test/cases/regression-include-excluded-packages.sh
+++ b/test/cases/regression-include-excluded-packages.sh
@@ -69,6 +69,8 @@ while true; do
     sleep 30
 done
 
+sudo composer-cli compose delete "${COMPOSE_ID}" >/dev/null
+
 jq . "${COMPOSE_INFO}"
 
 # Did the compose finish with success?

--- a/test/cases/regression-old-worker-new-composer.sh
+++ b/test/cases/regression-old-worker-new-composer.sh
@@ -118,6 +118,8 @@ while true; do
     sleep 30
 done
 
+sudo composer-cli -s "$WELDR_SOCK" compose delete "${COMPOSE_ID}" >/dev/null
+
 sudo journalctl -u osbuild-remote-worker@localhost:8700.service
 # Verify that the remote worker finished a job
 sudo journalctl -u osbuild-remote-worker@localhost:8700.service |


### PR DESCRIPTION
The biggest fix is that the tests are now cleaning up after themselves which currently blocks RHEL CI.

This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`
-->
