### PR TITLE
Add support for new osbuild stages needed for GCE image

### DIFF
--- a/internal/osbuild2/dnf_automatic_config_stage.go
+++ b/internal/osbuild2/dnf_automatic_config_stage.go
@@ -1,0 +1,70 @@
+package osbuild2
+
+import "fmt"
+
+type DNFAutomaticUpgradeTypeValue string
+
+// Valid values of the 'upgrade_type' option
+const (
+	DNFAutomaticUpgradeTypeDefault  DNFAutomaticUpgradeTypeValue = "default"
+	DNFAutomaticUpgradeTypeSecurity DNFAutomaticUpgradeTypeValue = "security"
+)
+
+// DNFAutomaticConfigCommands represents the 'commands' configuration section.
+type DNFAutomaticConfigCommands struct {
+	// Whether packages comprising the available updates should be installed
+	ApplyUpdates *bool `json:"apply_updates,omitempty"`
+	// What kind of upgrades to look at
+	UpgradeType DNFAutomaticUpgradeTypeValue `json:"upgrade_type,omitempty"`
+}
+
+// DNFAutomaticConfig represents DNF Automatic configuration.
+type DNFAutomaticConfig struct {
+	Commands *DNFAutomaticConfigCommands `json:"commands,omitempty"`
+}
+
+type DNFAutomaticConfigStageOptions struct {
+	Config *DNFAutomaticConfig `json:"config,omitempty"`
+}
+
+func (DNFAutomaticConfigStageOptions) isStageOptions() {}
+
+// NewDNFAutomaticConfigStageOptions creates a new DNFAutomaticConfig Stage options object.
+func NewDNFAutomaticConfigStageOptions(config *DNFAutomaticConfig) *DNFAutomaticConfigStageOptions {
+	return &DNFAutomaticConfigStageOptions{
+		Config: config,
+	}
+}
+
+func (o DNFAutomaticConfigStageOptions) validate() error {
+	if o.Config != nil && o.Config.Commands != nil {
+		allowedUpgradeTypeValues := []DNFAutomaticUpgradeTypeValue{
+			DNFAutomaticUpgradeTypeDefault,
+			DNFAutomaticUpgradeTypeSecurity,
+			"", // default empty value when the option is not set
+		}
+		valid := false
+		for _, value := range allowedUpgradeTypeValues {
+			if o.Config.Commands.UpgradeType == value {
+				valid = true
+				break
+			}
+		}
+		if !valid {
+			return fmt.Errorf("'upgrade_type' option does not allow %q as a value", o.Config.Commands.UpgradeType)
+		}
+	}
+
+	return nil
+}
+
+func NewDNFAutomaticConfigStage(options *DNFAutomaticConfigStageOptions) *Stage {
+	if err := options.validate(); err != nil {
+		panic(err)
+	}
+
+	return &Stage{
+		Type:    "org.osbuild.dnf-automatic.config",
+		Options: options,
+	}
+}

--- a/internal/osbuild2/dnf_automatic_config_stage_test.go
+++ b/internal/osbuild2/dnf_automatic_config_stage_test.go
@@ -1,0 +1,79 @@
+package osbuild2
+
+import (
+	"testing"
+
+	"github.com/osbuild/osbuild-composer/internal/common"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewDNFAutomaticConfigStage(t *testing.T) {
+	stageOptions := NewDNFAutomaticConfigStageOptions(&DNFAutomaticConfig{})
+	expectedStage := &Stage{
+		Type:    "org.osbuild.dnf-automatic.config",
+		Options: stageOptions,
+	}
+	actualStage := NewDNFAutomaticConfigStage(stageOptions)
+	assert.Equal(t, expectedStage, actualStage)
+}
+
+func TestDNFAutomaticConfigStageOptionsValidate(t *testing.T) {
+	tests := []struct {
+		name    string
+		options DNFAutomaticConfigStageOptions
+		err     bool
+	}{
+		{
+			name:    "empty-options",
+			options: DNFAutomaticConfigStageOptions{},
+			err:     false,
+		},
+		{
+			name: "invalid-upgrade_type",
+			options: DNFAutomaticConfigStageOptions{
+				Config: &DNFAutomaticConfig{
+					Commands: &DNFAutomaticConfigCommands{
+						ApplyUpdates: common.BoolToPtr(true),
+						UpgradeType:  "invalid",
+					},
+				},
+			},
+			err: true,
+		},
+		{
+			name: "valid-data-1",
+			options: DNFAutomaticConfigStageOptions{
+				Config: &DNFAutomaticConfig{
+					Commands: &DNFAutomaticConfigCommands{
+						ApplyUpdates: common.BoolToPtr(true),
+						UpgradeType:  DNFAutomaticUpgradeTypeDefault,
+					},
+				},
+			},
+			err: false,
+		},
+		{
+			name: "valid-data-2",
+			options: DNFAutomaticConfigStageOptions{
+				Config: &DNFAutomaticConfig{
+					Commands: &DNFAutomaticConfigCommands{
+						ApplyUpdates: common.BoolToPtr(false),
+						UpgradeType:  DNFAutomaticUpgradeTypeSecurity,
+					},
+				},
+			},
+			err: false,
+		},
+	}
+	for idx, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.err {
+				assert.Errorf(t, tt.options.validate(), "%q didn't return an error [idx: %d]", tt.name, idx)
+				assert.Panics(t, func() { NewDNFAutomaticConfigStage(&tt.options) })
+			} else {
+				assert.NoErrorf(t, tt.options.validate(), "%q returned an error [idx: %d]", tt.name, idx)
+				assert.NotPanics(t, func() { NewDNFAutomaticConfigStage(&tt.options) })
+			}
+		})
+	}
+}

--- a/internal/osbuild2/pam_limits_conf_stage.go
+++ b/internal/osbuild2/pam_limits_conf_stage.go
@@ -3,7 +3,6 @@ package osbuild2
 import (
 	"encoding/json"
 	"fmt"
-	"reflect"
 )
 
 // PamLimitsConfStageOptions represents a single pam_limits module configuration file.
@@ -134,13 +133,13 @@ func (l *PamLimitsConfigLine) UnmarshalJSON(data []byte) error {
 	}
 
 	var value PamLimitsValue
-	switch valueType := reflect.TypeOf(rawLine.Value); valueType.Kind() {
+	switch valueType := rawLine.Value.(type) {
 	// json.Unmarshal() uses float64 for JSON numbers
 	// https://pkg.go.dev/encoding/json#Unmarshal
 	// However the expected value is only integer.
-	case reflect.Float64:
+	case float64:
 		value = PamLimitsValueInt(rawLine.Value.(float64))
-	case reflect.String:
+	case string:
 		value = PamLimitsValueStr(rawLine.Value.(string))
 	default:
 		return fmt.Errorf("the 'value' item has unsupported type %q", valueType)

--- a/internal/osbuild2/sshd_config_stage.go
+++ b/internal/osbuild2/sshd_config_stage.go
@@ -1,9 +1,78 @@
 package osbuild2
 
+import (
+	"encoding/json"
+	"fmt"
+)
+
 type SshdConfigConfig struct {
-	PasswordAuthentication          *bool `json:"PasswordAuthentication,omitempty"`
-	ChallengeResponseAuthentication *bool `json:"ChallengeResponseAuthentication,omitempty"`
-	ClientAliveInterval             *int  `json:"ClientAliveInterval,omitempty"`
+	PasswordAuthentication          *bool                `json:"PasswordAuthentication,omitempty"`
+	ChallengeResponseAuthentication *bool                `json:"ChallengeResponseAuthentication,omitempty"`
+	ClientAliveInterval             *int                 `json:"ClientAliveInterval,omitempty"`
+	PermitRootLogin                 PermitRootLoginValue `json:"PermitRootLogin,omitempty"`
+}
+
+// PermitRootLoginValue is defined to represent all valid types of the
+// 'PermitRootLogin' item in the SshdConfigConfig structure.
+type PermitRootLoginValue interface {
+	isPermitRootLoginValue()
+}
+
+// PermitRootLoginValueStr represents a string type of the 'PermitRootLogin'
+// item in the SshdConfigConfig structure.
+type PermitRootLoginValueStr string
+
+func (v PermitRootLoginValueStr) isPermitRootLoginValue() {}
+
+// PermitRootLoginValueBool represents a bool type of the 'PermitRootLogin'
+// item in the SshdConfigConfig structure.
+type PermitRootLoginValueBool bool
+
+func (v PermitRootLoginValueBool) isPermitRootLoginValue() {}
+
+// Valid values which can be used for the 'PermitRootLogin' item in
+// the SshdConfigConfig structure.
+const (
+	PermitRootLoginValueYes PermitRootLoginValueBool = true
+	PermitRootLoginValueNo  PermitRootLoginValueBool = false
+
+	PermitRootLoginValueProhibitPassword   PermitRootLoginValueStr = "prohibit-password"
+	PermitRootLoginValueForcedCommandsOnly PermitRootLoginValueStr = "forced-commands-only"
+)
+
+// Unexported struct used for Unmarshalling of SshdConfigConfig due to
+// 'PermitRootLogin' being a boolean or a string.
+type rawSshdConfigConfig struct {
+	PasswordAuthentication          *bool       `json:"PasswordAuthentication,omitempty"`
+	ChallengeResponseAuthentication *bool       `json:"ChallengeResponseAuthentication,omitempty"`
+	ClientAliveInterval             *int        `json:"ClientAliveInterval,omitempty"`
+	PermitRootLogin                 interface{} `json:"PermitRootLogin,omitempty"`
+}
+
+func (c *SshdConfigConfig) UnmarshalJSON(data []byte) error {
+	var rawConfig rawSshdConfigConfig
+	if err := json.Unmarshal(data, &rawConfig); err != nil {
+		return err
+	}
+
+	var permitRootLogin PermitRootLoginValue
+	if rawConfig.PermitRootLogin != nil {
+		switch valueType := rawConfig.PermitRootLogin.(type) {
+		case bool:
+			permitRootLogin = PermitRootLoginValueBool(rawConfig.PermitRootLogin.(bool))
+		case string:
+			permitRootLogin = PermitRootLoginValueStr(rawConfig.PermitRootLogin.(string))
+		default:
+			return fmt.Errorf("the 'PermitRootLogin' item has unsupported type %q", valueType)
+		}
+	}
+
+	c.PasswordAuthentication = rawConfig.PasswordAuthentication
+	c.ChallengeResponseAuthentication = rawConfig.ChallengeResponseAuthentication
+	c.ClientAliveInterval = rawConfig.ClientAliveInterval
+	c.PermitRootLogin = permitRootLogin
+
+	return nil
 }
 
 type SshdConfigStageOptions struct {
@@ -12,7 +81,35 @@ type SshdConfigStageOptions struct {
 
 func (SshdConfigStageOptions) isStageOptions() {}
 
+func (o SshdConfigStageOptions) validate() error {
+	if o.Config.PermitRootLogin != nil {
+		value, ok := o.Config.PermitRootLogin.(PermitRootLoginValueStr)
+		if ok {
+			allowedPermitRootLoginStrValues := []PermitRootLoginValueStr{
+				PermitRootLoginValueForcedCommandsOnly,
+				PermitRootLoginValueProhibitPassword,
+			}
+			valid := false
+			for _, validValue := range allowedPermitRootLoginStrValues {
+				if value == validValue {
+					valid = true
+					break
+				}
+			}
+			if !valid {
+				return fmt.Errorf("%q is not a valid value for 'PermitRootLogin' option", value)
+			}
+		}
+	}
+
+	return nil
+}
+
 func NewSshdConfigStage(options *SshdConfigStageOptions) *Stage {
+	if err := options.validate(); err != nil {
+		panic(err)
+	}
+
 	return &Stage{
 		Type:    "org.osbuild.sshd.config",
 		Options: options,

--- a/internal/osbuild2/stage.go
+++ b/internal/osbuild2/stage.go
@@ -71,6 +71,8 @@ func (stage *Stage) UnmarshalJSON(data []byte) error {
 		options = new(ChronyStageOptions)
 	case "org.osbuild.dnf.config":
 		options = new(DNFConfigStageOptions)
+	case "org.osbuild.dnf-automatic.config":
+		options = new(DNFAutomaticConfigStageOptions)
 	case "org.osbuild.dracut":
 		options = new(DracutStageOptions)
 	case "org.osbuild.dracut.conf":

--- a/internal/osbuild2/stage.go
+++ b/internal/osbuild2/stage.go
@@ -154,6 +154,8 @@ func (stage *Stage) UnmarshalJSON(data []byte) error {
 		options = new(PwqualityConfStageOptions)
 	case "org.osbuild.yum.config":
 		options = new(YumConfigStageOptions)
+	case "org.osbuild.yum.repos":
+		options = new(YumReposStageOptions)
 	default:
 		return fmt.Errorf("unexpected stage type: %s", rawStage.Type)
 	}

--- a/internal/osbuild2/stage_test.go
+++ b/internal/osbuild2/stage_test.go
@@ -728,6 +728,24 @@ func TestStage_UnmarshalJSON(t *testing.T) {
 				data: []byte(`{"type":"org.osbuild.yum.config","options":{}}`),
 			},
 		},
+		{
+			name: "yum.repos",
+			fields: fields{
+				Type: "org.osbuild.yum.repos",
+				Options: &YumReposStageOptions{
+					Filename: "test.repo",
+					Repos: []YumRepository{
+						{
+							Id:      "my-repo",
+							BaseURL: []string{"http://example.org/repo"},
+						},
+					},
+				},
+			},
+			args: args{
+				data: []byte(`{"type":"org.osbuild.yum.repos","options":{"filename":"test.repo","repos":[{"id":"my-repo","baseurl":["http://example.org/repo"]}]}}`),
+			},
+		},
 	}
 	for idx, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/osbuild2/stage_test.go
+++ b/internal/osbuild2/stage_test.go
@@ -147,6 +147,16 @@ func TestStage_UnmarshalJSON(t *testing.T) {
 			},
 		},
 		{
+			name: "dnf-automatic-config",
+			fields: fields{
+				Type:    "org.osbuild.dnf-automatic.config",
+				Options: &DNFAutomaticConfigStageOptions{},
+			},
+			args: args{
+				data: []byte(`{"type":"org.osbuild.dnf-automatic.config","options":{}}`),
+			},
+		},
+		{
 			name: "dracut",
 			fields: fields{
 				Type:    "org.osbuild.dracut",

--- a/internal/osbuild2/stage_test.go
+++ b/internal/osbuild2/stage_test.go
@@ -665,6 +665,40 @@ func TestStage_UnmarshalJSON(t *testing.T) {
 			},
 		},
 		{
+			name: "sshd.config-data1",
+			fields: fields{
+				Type: "org.osbuild.sshd.config",
+				Options: &SshdConfigStageOptions{
+					Config: SshdConfigConfig{
+						PasswordAuthentication:          common.BoolToPtr(false),
+						ChallengeResponseAuthentication: common.BoolToPtr(false),
+						ClientAliveInterval:             common.IntToPtr(42),
+						PermitRootLogin:                 PermitRootLoginValueNo,
+					},
+				},
+			},
+			args: args{
+				data: []byte(`{"type":"org.osbuild.sshd.config","options":{"config":{"PasswordAuthentication":false,"ChallengeResponseAuthentication":false,"ClientAliveInterval":42,"PermitRootLogin":false}}}`),
+			},
+		},
+		{
+			name: "sshd.config-data2",
+			fields: fields{
+				Type: "org.osbuild.sshd.config",
+				Options: &SshdConfigStageOptions{
+					Config: SshdConfigConfig{
+						PasswordAuthentication:          common.BoolToPtr(false),
+						ChallengeResponseAuthentication: common.BoolToPtr(false),
+						ClientAliveInterval:             common.IntToPtr(42),
+						PermitRootLogin:                 PermitRootLoginValueForcedCommandsOnly,
+					},
+				},
+			},
+			args: args{
+				data: []byte(`{"type":"org.osbuild.sshd.config","options":{"config":{"PasswordAuthentication":false,"ChallengeResponseAuthentication":false,"ClientAliveInterval":42,"PermitRootLogin":"forced-commands-only"}}}`),
+			},
+		},
+		{
 			name: "authconfig",
 			fields: fields{
 				Type:    "org.osbuild.authconfig",

--- a/internal/osbuild2/yum_repos_stage.go
+++ b/internal/osbuild2/yum_repos_stage.go
@@ -1,0 +1,106 @@
+package osbuild2
+
+import (
+	"fmt"
+	"regexp"
+)
+
+const repoFilenameRegex = "^[\\w.-]{1,250}\\.repo$"
+const repoIDRegex = "^[\\w.\\-:]+$"
+
+// YumRepository represents a single DNF / YUM repository.
+type YumRepository struct {
+	Id             string   `json:"id"`
+	BaseURL        []string `json:"baseurl,omitempty"`
+	Cost           *int     `json:"cost,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty"`
+	GPGKey         []string `json:"gpgkey,omitempty"`
+	Metalink       string   `json:"metalink,omitempty"`
+	Mirrorlist     string   `json:"mirrorlist,omitempty"`
+	ModuleHotfixes *bool    `json:"module_hotfixes,omitempty"`
+	Name           string   `json:"name,omitempty"`
+	GPGCheck       *bool    `json:"gpgcheck,omitempty"`
+	RepoGPGCheck   *bool    `json:"repo_gpgcheck,omitempty"`
+}
+
+func (r YumRepository) validate() error {
+	// Plain string values which can not be empty strings as mandated by
+	// the stage schema are not validated. The reason is that if they
+	// are empty, they will be omitted from the resulting JSON, therefore
+	// they will be never passed to osbuild in the stage options.
+	// The same logic is applied to slices of strings, which must have
+	// at least one item if defined. These won't appear in the resulting
+	// JSON if the slice it empty.
+
+	idRegex := regexp.MustCompile(repoIDRegex)
+	if !idRegex.MatchString(r.Id) {
+		return fmt.Errorf("repo ID %q doesn't conform to schema (%s)", r.Id, repoIDRegex)
+	}
+
+	// at least one of baseurl, metalink or mirrorlist must be provided
+	if len(r.BaseURL) == 0 && r.Metalink == "" && r.Mirrorlist == "" {
+		return fmt.Errorf("at least one of baseurl, metalink or mirrorlist values must be provided")
+	}
+
+	for idx, url := range r.BaseURL {
+		if url == "" {
+			return fmt.Errorf("baseurl must not be an empty string (idx %d)", idx)
+		}
+	}
+
+	for idx, gpgkey := range r.GPGKey {
+		if gpgkey == "" {
+			return fmt.Errorf("gpgkey must not be an empty string (idx %d)", idx)
+		}
+	}
+
+	return nil
+}
+
+// YumReposStageOptions represents a single DNF / YUM repo configuration file.
+type YumReposStageOptions struct {
+	// Filename of the configuration file to be created. Must end with '.repo'.
+	Filename string `json:"filename"`
+	// List of repositories. The list must contain at least one item.
+	Repos []YumRepository `json:"repos"`
+}
+
+func (YumReposStageOptions) isStageOptions() {}
+
+// NewYumReposStageOptions creates a new YumRepos Stage options object.
+func NewYumReposStageOptions(filename string, repos []YumRepository) *YumReposStageOptions {
+	return &YumReposStageOptions{
+		Filename: filename,
+		Repos:    repos,
+	}
+}
+
+func (o YumReposStageOptions) validate() error {
+	filenameRegex := regexp.MustCompile(repoFilenameRegex)
+	if !filenameRegex.MatchString(o.Filename) {
+		return fmt.Errorf("filename %q doesn't conform to schema (%s)", o.Filename, repoFilenameRegex)
+	}
+
+	if len(o.Repos) == 0 {
+		return fmt.Errorf("at least one repository must be defined")
+	}
+
+	for idx, repo := range o.Repos {
+		if err := repo.validate(); err != nil {
+			return fmt.Errorf("validation of repository #%d failed: %s", idx, err)
+		}
+	}
+
+	return nil
+}
+
+func NewYumReposStage(options *YumReposStageOptions) *Stage {
+	if err := options.validate(); err != nil {
+		panic(err)
+	}
+
+	return &Stage{
+		Type:    "org.osbuild.yum.repos",
+		Options: options,
+	}
+}

--- a/internal/osbuild2/yum_repos_stage_test.go
+++ b/internal/osbuild2/yum_repos_stage_test.go
@@ -1,0 +1,186 @@
+package osbuild2
+
+import (
+	"testing"
+
+	"github.com/osbuild/osbuild-composer/internal/common"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewYumReposStage(t *testing.T) {
+	stageOptions := NewYumReposStageOptions("testing.repo", []YumRepository{
+		{
+			Id:      "cool-id",
+			BaseURL: []string{"http://example.org/repo"},
+		},
+	})
+	expectedStage := &Stage{
+		Type:    "org.osbuild.yum.repos",
+		Options: stageOptions,
+	}
+	actualStage := NewYumReposStage(stageOptions)
+	assert.Equal(t, expectedStage, actualStage)
+}
+
+func TestYumReposStageOptionsValidate(t *testing.T) {
+	tests := []struct {
+		name    string
+		options YumReposStageOptions
+		err     bool
+	}{
+		{
+			name:    "empty-options",
+			options: YumReposStageOptions{},
+			err:     true,
+		},
+		{
+			name: "no-repos",
+			options: YumReposStageOptions{
+				Filename: "test.repo",
+				Repos:    []YumRepository{},
+			},
+			err: true,
+		},
+		{
+			name: "invalid-filename",
+			options: YumReposStageOptions{
+				Filename: "@#$%^&.rap",
+				Repos: []YumRepository{
+					{
+						Id:      "cool-id",
+						BaseURL: []string{"http://example.org/repo"},
+					},
+				},
+			},
+			err: true,
+		},
+		{
+			name: "no-filename",
+			options: YumReposStageOptions{
+				Repos: []YumRepository{
+					{
+						Id:      "cool-id",
+						BaseURL: []string{"http://example.org/repo"},
+					},
+				},
+			},
+			err: true,
+		},
+		{
+			name: "no-baseurl-mirrorlist-metalink",
+			options: YumReposStageOptions{
+				Filename: "test.repo",
+				Repos: []YumRepository{
+					{
+						Id: "cool-id",
+					},
+				},
+			},
+			err: true,
+		},
+		{
+			name: "baseurl-empty-string",
+			options: YumReposStageOptions{
+				Filename: "test.repo",
+				Repos: []YumRepository{
+					{
+						Id:      "cool-id",
+						BaseURL: []string{""},
+					},
+				},
+			},
+			err: true,
+		},
+		{
+			name: "gpgkey-empty-string",
+			options: YumReposStageOptions{
+				Filename: "test.repo",
+				Repos: []YumRepository{
+					{
+						Id:      "cool-id",
+						BaseURL: []string{"http://example.org/repo"},
+						GPGKey:  []string{""},
+					},
+				},
+			},
+			err: true,
+		},
+		{
+			name: "invalid-repo-id",
+			options: YumReposStageOptions{
+				Filename: "test.repo",
+				Repos: []YumRepository{
+					{
+						Id:      "c@@l-id",
+						BaseURL: []string{"http://example.org/repo"},
+					},
+				},
+			},
+			err: true,
+		},
+		{
+			name: "good-options-baseurl",
+			options: YumReposStageOptions{
+				Filename: "test.repo",
+				Repos: []YumRepository{
+					{
+						Id:             "cool-id",
+						Cost:           common.IntToPtr(0),
+						Enabled:        common.BoolToPtr(false),
+						ModuleHotfixes: common.BoolToPtr(false),
+						Name:           "c@@l-name",
+						GPGCheck:       common.BoolToPtr(true),
+						RepoGPGCheck:   common.BoolToPtr(true),
+						BaseURL:        []string{"http://example.org/repo"},
+						GPGKey:         []string{"secretkey"},
+					},
+				},
+			},
+			err: false,
+		},
+		{
+			name: "good-options-mirrorlist",
+			options: YumReposStageOptions{
+				Filename: "test.repo",
+				Repos: []YumRepository{
+					{
+						Id:             "cool-id",
+						Cost:           common.IntToPtr(200),
+						Enabled:        common.BoolToPtr(true),
+						ModuleHotfixes: common.BoolToPtr(true),
+						Name:           "c@@l-name",
+						GPGCheck:       common.BoolToPtr(false),
+						RepoGPGCheck:   common.BoolToPtr(false),
+						Mirrorlist:     "http://example.org/mirrorlist",
+						GPGKey:         []string{"secretkey"},
+					},
+				},
+			},
+			err: false,
+		},
+		{
+			name: "good-options-metalink",
+			options: YumReposStageOptions{
+				Filename: "test.repo",
+				Repos: []YumRepository{
+					{
+						Id:       "cool-id",
+						Metalink: "http://example.org/metalink",
+					},
+				},
+			},
+			err: false,
+		},
+	}
+	for idx, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.err {
+				assert.Errorf(t, tt.options.validate(), "%q didn't return an error [idx: %d]", tt.name, idx)
+				assert.Panics(t, func() { NewYumReposStage(&tt.options) })
+			} else {
+				assert.NoErrorf(t, tt.options.validate(), "%q returned an error [idx: %d]", tt.name, idx)
+				assert.NotPanics(t, func() { NewYumReposStage(&tt.options) })
+			}
+		})
+	}
+}


### PR DESCRIPTION
- osbuild2: support `PermitRootLogin` in sshd.config stage
- osbuild2: support `org.osbuild.yum.repos` stage
- osbuild2: support `org.osbuild.dnf-automatic.config` stage

This pull request includes:

- [x] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`
-->
