### PR TITLE
test: make test more resilient

### DIFF
--- a/test/cases/azure.sh
+++ b/test/cases/azure.sh
@@ -178,6 +178,17 @@ name = "cloud-init"
 enabled = ["sshd", "cloud-init", "cloud-init-local", "cloud-config", "cloud-final"]
 EOF
 
+# Make sure the specified storage account exists
+if [ "$(az resource list --name "$AZURE_STORAGE_ACCOUNT")" == "[]" ]; then
+	echo "The storage account ${AZURE_STORAGE_ACCOUNT} was removed!"
+	az storage account create \
+		--name "${AZURE_STORAGE_ACCOUNT}" \
+		--resource-group "${AZURE_RESOURCE_GROUP}" \
+		--location  "${AZURE_LOCATION}" \
+		--sku Standard_RAGRS \
+		--kind StorageV2
+fi
+
 # Prepare the blueprint for the compose.
 greenprint "📋 Preparing blueprint"
 sudo composer-cli blueprints push "$BLUEPRINT_FILE"


### PR DESCRIPTION
During manual cleanup of unused resources, the storage account can get
removed. The current storage account is not possible to remove
manually, but adding this check to make it more resilient in future
scenarios.

This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/