### PR TITLE
osbuild2: ensure that empty sysconfig options members are omitted

### DIFF
--- a/internal/distro/rhel84/distro_v2.go
+++ b/internal/distro/rhel84/distro_v2.go
@@ -336,11 +336,11 @@ func (t *imageTypeS2) ostreeTreePipeline(repos []rpmmd.RepoConfig, packages []rp
 
 	// These are the current defaults for the sysconfig stage. This can be changed to be image type exclusive if different configs are needed.
 	p.AddStage(osbuild.NewSysconfigStage(&osbuild.SysconfigStageOptions{
-		Kernel: osbuild.SysconfigKernelOptions{
+		Kernel: &osbuild.SysconfigKernelOptions{
 			UpdateDefault: true,
 			DefaultKernel: "kernel",
 		},
-		Network: osbuild.SysconfigNetworkOptions{
+		Network: &osbuild.SysconfigNetworkOptions{
 			Networking: true,
 			NoZeroConf: true,
 		},

--- a/internal/distro/rhel85/pipelines.go
+++ b/internal/distro/rhel85/pipelines.go
@@ -270,11 +270,11 @@ func ec2BaseTreePipeline(repos []rpmmd.RepoConfig, packages []rpmmd.PackageSpec,
 	}))
 
 	p.AddStage(osbuild.NewSysconfigStage(&osbuild.SysconfigStageOptions{
-		Kernel: osbuild.SysconfigKernelOptions{
+		Kernel: &osbuild.SysconfigKernelOptions{
 			UpdateDefault: true,
 			DefaultKernel: "kernel",
 		},
-		Network: osbuild.SysconfigNetworkOptions{
+		Network: &osbuild.SysconfigNetworkOptions{
 			Networking: true,
 			NoZeroConf: true,
 		},
@@ -678,11 +678,11 @@ func osPipeline(repos []rpmmd.RepoConfig, packages []rpmmd.PackageSpec, bpPackag
 
 	// These are the current defaults for the sysconfig stage. This can be changed to be image type exclusive if different configs are needed.
 	p.AddStage(osbuild.NewSysconfigStage(&osbuild.SysconfigStageOptions{
-		Kernel: osbuild.SysconfigKernelOptions{
+		Kernel: &osbuild.SysconfigKernelOptions{
 			UpdateDefault: true,
 			DefaultKernel: "kernel",
 		},
-		Network: osbuild.SysconfigNetworkOptions{
+		Network: &osbuild.SysconfigNetworkOptions{
 			Networking: true,
 			NoZeroConf: true,
 		},
@@ -765,11 +765,11 @@ func ostreeTreePipeline(repos []rpmmd.RepoConfig, packages []rpmmd.PackageSpec, 
 
 	// These are the current defaults for the sysconfig stage. This can be changed to be image type exclusive if different configs are needed.
 	p.AddStage(osbuild.NewSysconfigStage(&osbuild.SysconfigStageOptions{
-		Kernel: osbuild.SysconfigKernelOptions{
+		Kernel: &osbuild.SysconfigKernelOptions{
 			UpdateDefault: true,
 			DefaultKernel: "kernel",
 		},
-		Network: osbuild.SysconfigNetworkOptions{
+		Network: &osbuild.SysconfigNetworkOptions{
 			Networking: true,
 			NoZeroConf: true,
 		},

--- a/internal/distro/rhel86/pipelines.go
+++ b/internal/distro/rhel86/pipelines.go
@@ -277,11 +277,11 @@ func ec2BaseTreePipeline(
 	}))
 
 	p.AddStage(osbuild.NewSysconfigStage(&osbuild.SysconfigStageOptions{
-		Kernel: osbuild.SysconfigKernelOptions{
+		Kernel: &osbuild.SysconfigKernelOptions{
 			UpdateDefault: true,
 			DefaultKernel: "kernel",
 		},
-		Network: osbuild.SysconfigNetworkOptions{
+		Network: &osbuild.SysconfigNetworkOptions{
 			Networking: true,
 			NoZeroConf: true,
 		},
@@ -848,11 +848,11 @@ func osPipeline(repos []rpmmd.RepoConfig, packages []rpmmd.PackageSpec, bpPackag
 
 	// These are the current defaults for the sysconfig stage. This can be changed to be image type exclusive if different configs are needed.
 	p.AddStage(osbuild.NewSysconfigStage(&osbuild.SysconfigStageOptions{
-		Kernel: osbuild.SysconfigKernelOptions{
+		Kernel: &osbuild.SysconfigKernelOptions{
 			UpdateDefault: true,
 			DefaultKernel: "kernel",
 		},
-		Network: osbuild.SysconfigNetworkOptions{
+		Network: &osbuild.SysconfigNetworkOptions{
 			Networking: true,
 			NoZeroConf: true,
 		},
@@ -935,11 +935,11 @@ func ostreeTreePipeline(repos []rpmmd.RepoConfig, packages []rpmmd.PackageSpec, 
 
 	// These are the current defaults for the sysconfig stage. This can be changed to be image type exclusive if different configs are needed.
 	p.AddStage(osbuild.NewSysconfigStage(&osbuild.SysconfigStageOptions{
-		Kernel: osbuild.SysconfigKernelOptions{
+		Kernel: &osbuild.SysconfigKernelOptions{
 			UpdateDefault: true,
 			DefaultKernel: "kernel",
 		},
-		Network: osbuild.SysconfigNetworkOptions{
+		Network: &osbuild.SysconfigNetworkOptions{
 			Networking: true,
 			NoZeroConf: true,
 		},

--- a/internal/distro/rhel90/pipelines.go
+++ b/internal/distro/rhel90/pipelines.go
@@ -269,11 +269,11 @@ func ec2BaseTreePipeline(
 	}))
 
 	p.AddStage(osbuild.NewSysconfigStage(&osbuild.SysconfigStageOptions{
-		Kernel: osbuild.SysconfigKernelOptions{
+		Kernel: &osbuild.SysconfigKernelOptions{
 			UpdateDefault: true,
 			DefaultKernel: "kernel",
 		},
-		Network: osbuild.SysconfigNetworkOptions{
+		Network: &osbuild.SysconfigNetworkOptions{
 			Networking: true,
 			NoZeroConf: true,
 		},
@@ -853,11 +853,11 @@ func osPipeline(repos []rpmmd.RepoConfig,
 
 	// These are the current defaults for the sysconfig stage. This can be changed to be image type exclusive if different configs are needed.
 	p.AddStage(osbuild.NewSysconfigStage(&osbuild.SysconfigStageOptions{
-		Kernel: osbuild.SysconfigKernelOptions{
+		Kernel: &osbuild.SysconfigKernelOptions{
 			UpdateDefault: true,
 			DefaultKernel: "kernel",
 		},
-		Network: osbuild.SysconfigNetworkOptions{
+		Network: &osbuild.SysconfigNetworkOptions{
 			Networking: true,
 			NoZeroConf: true,
 		},
@@ -940,11 +940,11 @@ func ostreeTreePipeline(repos []rpmmd.RepoConfig, packages []rpmmd.PackageSpec, 
 
 	// These are the current defaults for the sysconfig stage. This can be changed to be image type exclusive if different configs are needed.
 	p.AddStage(osbuild.NewSysconfigStage(&osbuild.SysconfigStageOptions{
-		Kernel: osbuild.SysconfigKernelOptions{
+		Kernel: &osbuild.SysconfigKernelOptions{
 			UpdateDefault: true,
 			DefaultKernel: "kernel",
 		},
-		Network: osbuild.SysconfigNetworkOptions{
+		Network: &osbuild.SysconfigNetworkOptions{
 			Networking: true,
 			NoZeroConf: true,
 		},

--- a/internal/distro/rhel90beta/pipelines.go
+++ b/internal/distro/rhel90beta/pipelines.go
@@ -255,11 +255,11 @@ func ec2BaseTreePipeline(repos []rpmmd.RepoConfig, packages []rpmmd.PackageSpec,
 	}))
 
 	p.AddStage(osbuild.NewSysconfigStage(&osbuild.SysconfigStageOptions{
-		Kernel: osbuild.SysconfigKernelOptions{
+		Kernel: &osbuild.SysconfigKernelOptions{
 			UpdateDefault: true,
 			DefaultKernel: "kernel",
 		},
-		Network: osbuild.SysconfigNetworkOptions{
+		Network: &osbuild.SysconfigNetworkOptions{
 			Networking: true,
 			NoZeroConf: true,
 		},
@@ -764,11 +764,11 @@ func osPipeline(repos []rpmmd.RepoConfig, packages []rpmmd.PackageSpec, bpPackag
 
 	// These are the current defaults for the sysconfig stage. This can be changed to be image type exclusive if different configs are needed.
 	p.AddStage(osbuild.NewSysconfigStage(&osbuild.SysconfigStageOptions{
-		Kernel: osbuild.SysconfigKernelOptions{
+		Kernel: &osbuild.SysconfigKernelOptions{
 			UpdateDefault: true,
 			DefaultKernel: "kernel",
 		},
-		Network: osbuild.SysconfigNetworkOptions{
+		Network: &osbuild.SysconfigNetworkOptions{
 			Networking: true,
 			NoZeroConf: true,
 		},
@@ -846,11 +846,11 @@ func ostreeTreePipeline(repos []rpmmd.RepoConfig, packages []rpmmd.PackageSpec, 
 
 	// These are the current defaults for the sysconfig stage. This can be changed to be image type exclusive if different configs are needed.
 	p.AddStage(osbuild.NewSysconfigStage(&osbuild.SysconfigStageOptions{
-		Kernel: osbuild.SysconfigKernelOptions{
+		Kernel: &osbuild.SysconfigKernelOptions{
 			UpdateDefault: true,
 			DefaultKernel: "kernel",
 		},
-		Network: osbuild.SysconfigNetworkOptions{
+		Network: &osbuild.SysconfigNetworkOptions{
 			Networking: true,
 			NoZeroConf: true,
 		},

--- a/internal/osbuild2/stage_test.go
+++ b/internal/osbuild2/stage_test.go
@@ -494,7 +494,7 @@ func TestStage_UnmarshalJSON(t *testing.T) {
 				Options: &SysconfigStageOptions{},
 			},
 			args: args{
-				data: []byte(`{"type":"org.osbuild.sysconfig","options":{"kernel":{},"network":{}}}`),
+				data: []byte(`{"type":"org.osbuild.sysconfig","options":{}}`),
 			},
 		},
 		{
@@ -502,11 +502,11 @@ func TestStage_UnmarshalJSON(t *testing.T) {
 			fields: fields{
 				Type: "org.osbuild.sysconfig",
 				Options: &SysconfigStageOptions{
-					Kernel: SysconfigKernelOptions{
+					Kernel: &SysconfigKernelOptions{
 						UpdateDefault: true,
 						DefaultKernel: "kernel",
 					},
-					Network: SysconfigNetworkOptions{
+					Network: &SysconfigNetworkOptions{
 						Networking: true,
 						NoZeroConf: true,
 					},

--- a/internal/osbuild2/sysconfig_stage.go
+++ b/internal/osbuild2/sysconfig_stage.go
@@ -1,9 +1,9 @@
 package osbuild2
 
 type SysconfigStageOptions struct {
-	Kernel         SysconfigKernelOptions  `json:"kernel,omitempty"`
-	Network        SysconfigNetworkOptions `json:"network,omitempty"`
-	NetworkScripts *NetworkScriptsOptions  `json:"network-scripts,omitempty"`
+	Kernel         *SysconfigKernelOptions  `json:"kernel,omitempty"`
+	Network        *SysconfigNetworkOptions `json:"network,omitempty"`
+	NetworkScripts *NetworkScriptsOptions   `json:"network-scripts,omitempty"`
 }
 
 func (SysconfigStageOptions) isStageOptions() {}


### PR DESCRIPTION
The `Kernel` and `Network` members of the sysconfig stage options
structure were previously not declared as pointers. As a result, they
always appeared in the resulting JSON object, even though they were
empty. Use pointers to ensure that the members are omitted from the
resulting JSON object, if they were not defined.

Signed-off-by: Tomas Hozza <thozza@redhat.com>


This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`
-->
