### PR TITLE
Tests-generation: start dnf-json without systemd

### DIFF
--- a/test/cases/generation.sh
+++ b/test/cases/generation.sh
@@ -15,11 +15,26 @@ function greenprint {
 # install requirements
 sudo dnf -y install go
 
+# test the test cases generation when systemd starts dnf-json
 # stop dnf-json socket
 sudo systemctl stop osbuild-dnf-json.socket
 
-# test the test cases generation
 WORKDIR=$(mktemp -d -p /var/tmp)
+
+OSBUILD_LABEL=$(matchpathcon -n "$(which osbuild)")
+chcon "$OSBUILD_LABEL" tools/image-info
+
+# test the test case generation when dnf-json socket is stopped
+sudo ./tools/test-case-generators/generate-test-cases\
+    --output test/data/manifests\
+    --arch x86_64\
+    --distro rhel-8\
+    --image-type qcow2\
+    --store "$WORKDIR"
+
+# test the test cases generation without systemd
+WORKDIR=$(mktemp -d -p /var/tmp)
+sudo dnf remove osbuild*
 
 OSBUILD_LABEL=$(matchpathcon -n "$(which osbuild)")
 chcon "$OSBUILD_LABEL" tools/image-info

--- a/tools/test-case-generators/generate-test-cases
+++ b/tools/test-case-generators/generate-test-cases
@@ -66,13 +66,19 @@ class TestCaseGenerator:
     def get_test_case(self, no_image_info, store):
         compose_request = json.dumps(self.test_case["compose-request"])
 
+        dnf_json_instance = None
         command = ["systemctl", "is-active", "--quiet", "osbuild-dnf-json.socket"]
         if not is_subprocess_succeeding(command):
             print("osbuild-dnf-json.socket is not running, starting it up")
             command = ["systemctl", "start", "osbuild-dnf-json.socket", "--quiet"]
             if not is_subprocess_succeeding(command):
-                print("impossible to start osbuild-dnf-json.socket with systemd")
-                sys.exit(1)
+                print("unable to start osbuild-dnf-json.socket with systemd")
+                dnf_json_command = ["python", "./dnf-json"]
+                dnf_json_instance = subprocess.Popen(dnf_json_command)
+                if dnf_json_instance.poll() != None:
+                    print("unable to start dnf-json as a standalone executable")
+                    sys.exit(1)
+
 
         pipeline_command = ["go", "run", "./cmd/osbuild-pipeline", "-"]
         self.test_case["manifest"] = json.loads(get_subprocess_stdout(pipeline_command, input=compose_request, encoding="utf-8"))
@@ -96,6 +102,8 @@ class TestCaseGenerator:
                 image_info = get_subprocess_stdout(["tools/image-info", image_file], encoding="utf-8")
                 self.test_case["image-info"] = json.loads(image_info)
 
+        if dnf_json_instance != None:
+            dnf_json_instance.kill()
         return self.test_case
 
 


### PR DESCRIPTION
If needed start the dnf-json dameon directly without using systemd. This
can allow to use the test case generation even without the packages
installed on the system.


This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`
-->
