### PR TITLE
generate-all-test-cases: use `make scratch` for building RPMs

### DIFF
--- a/tools/test-case-generators/generate-all-test-cases
+++ b/tools/test-case-generators/generate-all-test-cases
@@ -932,7 +932,11 @@ class BaseTestCaseMatrixGenerator(contextlib.AbstractContextManager):
 
         runner.dnf_install(["'@RPM Development Tools'"])
         runner.run_command_check_call(f"{enter_src_dir} sudo dnf -y builddep *.spec")
-        runner.run_command_check_call(f"{enter_src_dir} make rpm")
+        # Build RPMs without tests to prevent failing the unit test that checks
+        # image manifests. Since we are regenerating image test cases, it is
+        # assumed that the unit test would not pass until the respective tests
+        # are regenerated.
+        runner.run_command_check_call(f"{enter_src_dir} make scratch")
         # do not install debuginfo and debugsource RPMs
         runner.run_command_check_call(f"{enter_src_dir} sudo dnf install -y $(ls rpmbuild/RPMS/*/*.rpm | grep -Ev 'debugsource|debuginfo')")
 


### PR DESCRIPTION
Use `make scratch` for building RPMs without tests. This fixes the case,
when the RPM build with test fails to build due to changes in image
manifests. The whole reason of running the script is to regenerate image
test cases when the manifest changed, so this was a chicken and egg
problem.

Signed-off-by: Tomas Hozza <thozza@redhat.com>

No CI testing is needed, as this is a development tool.

This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`
-->
