### PR TITLE
RHEL-86/90: refactoring of `osPipeline` and its variants

### DIFF
--- a/internal/distro/image_config.go
+++ b/internal/distro/image_config.go
@@ -1,0 +1,48 @@
+package distro
+
+import "github.com/osbuild/osbuild-composer/internal/osbuild2"
+
+// ImageConfig represents a (default) configuration applied to the image
+type ImageConfig struct {
+	Timezone            string
+	TimeSynchronization *osbuild2.ChronyStageOptions
+	Locale              string
+	Keyboard            *osbuild2.KeymapStageOptions
+	EnabledServices     []string
+	DisabledServices    []string
+	DefaultTarget       string
+	Sysconfig           []*osbuild2.SysconfigStageOptions
+}
+
+// InheritFrom inherits unset values from the provided parent configuration and
+// returns a new structure instance, which is a result of the inheritance.
+func (c *ImageConfig) InheritFrom(parentConfig *ImageConfig) *ImageConfig {
+	finalConfig := ImageConfig(*c)
+	if parentConfig != nil {
+		if finalConfig.Timezone == "" {
+			finalConfig.Timezone = parentConfig.Timezone
+		}
+		if finalConfig.TimeSynchronization == nil {
+			finalConfig.TimeSynchronization = parentConfig.TimeSynchronization
+		}
+		if finalConfig.Locale == "" {
+			finalConfig.Locale = parentConfig.Locale
+		}
+		if finalConfig.Keyboard == nil {
+			finalConfig.Keyboard = parentConfig.Keyboard
+		}
+		if finalConfig.EnabledServices == nil {
+			finalConfig.EnabledServices = parentConfig.EnabledServices
+		}
+		if finalConfig.DisabledServices == nil {
+			finalConfig.DisabledServices = parentConfig.DisabledServices
+		}
+		if finalConfig.DefaultTarget == "" {
+			finalConfig.DefaultTarget = parentConfig.DefaultTarget
+		}
+		if finalConfig.Sysconfig == nil {
+			finalConfig.Sysconfig = parentConfig.Sysconfig
+		}
+	}
+	return &finalConfig
+}

--- a/internal/distro/image_config.go
+++ b/internal/distro/image_config.go
@@ -2,6 +2,13 @@ package distro
 
 import "github.com/osbuild/osbuild-composer/internal/osbuild2"
 
+type RHSMSubscriptionStatus string
+
+const (
+	RHSMConfigWithSubscription RHSMSubscriptionStatus = "with-subscription"
+	RHSMConfigNoSubscription   RHSMSubscriptionStatus = "no-subscription"
+)
+
 // ImageConfig represents a (default) configuration applied to the image
 type ImageConfig struct {
 	Timezone            string
@@ -12,6 +19,10 @@ type ImageConfig struct {
 	DisabledServices    []string
 	DefaultTarget       string
 	Sysconfig           []*osbuild2.SysconfigStageOptions
+
+	// for RHSM configuration, we need to potentially distinguish the case
+	// when the user want the image to be subscribed on first boot and when not
+	RHSMConfig map[RHSMSubscriptionStatus]*osbuild2.RHSMStageOptions
 }
 
 // InheritFrom inherits unset values from the provided parent configuration and
@@ -42,6 +53,9 @@ func (c *ImageConfig) InheritFrom(parentConfig *ImageConfig) *ImageConfig {
 		}
 		if finalConfig.Sysconfig == nil {
 			finalConfig.Sysconfig = parentConfig.Sysconfig
+		}
+		if finalConfig.RHSMConfig == nil {
+			finalConfig.RHSMConfig = parentConfig.RHSMConfig
 		}
 	}
 	return &finalConfig

--- a/internal/distro/image_config.go
+++ b/internal/distro/image_config.go
@@ -30,6 +30,12 @@ type ImageConfig struct {
 	DracutConf    []*osbuild2.DracutConfStageOptions
 	SystemdUnit   []*osbuild2.SystemdUnitStageOptions
 	Authselect    *osbuild2.AuthselectStageOptions
+	SELinuxConfig *osbuild2.SELinuxConfigStageOptions
+	Tuned         *osbuild2.TunedStageOptions
+	Tmpfilesd     []*osbuild2.TmpfilesdStageOptions
+	PamLimitsConf []*osbuild2.PamLimitsConfStageOptions
+	Sysctld       []*osbuild2.SysctldStageOptions
+	DNFConfig     []*osbuild2.DNFConfigStageOptions
 }
 
 // InheritFrom inherits unset values from the provided parent configuration and
@@ -81,6 +87,24 @@ func (c *ImageConfig) InheritFrom(parentConfig *ImageConfig) *ImageConfig {
 		}
 		if finalConfig.Authselect == nil {
 			finalConfig.Authselect = parentConfig.Authselect
+		}
+		if finalConfig.SELinuxConfig == nil {
+			finalConfig.SELinuxConfig = parentConfig.SELinuxConfig
+		}
+		if finalConfig.Tuned == nil {
+			finalConfig.Tuned = parentConfig.Tuned
+		}
+		if finalConfig.Tmpfilesd == nil {
+			finalConfig.Tmpfilesd = parentConfig.Tmpfilesd
+		}
+		if finalConfig.PamLimitsConf == nil {
+			finalConfig.PamLimitsConf = parentConfig.PamLimitsConf
+		}
+		if finalConfig.Sysctld == nil {
+			finalConfig.Sysctld = parentConfig.Sysctld
+		}
+		if finalConfig.DNFConfig == nil {
+			finalConfig.DNFConfig = parentConfig.DNFConfig
 		}
 	}
 	return &finalConfig

--- a/internal/distro/image_config.go
+++ b/internal/distro/image_config.go
@@ -23,6 +23,13 @@ type ImageConfig struct {
 	// for RHSM configuration, we need to potentially distinguish the case
 	// when the user want the image to be subscribed on first boot and when not
 	RHSMConfig map[RHSMSubscriptionStatus]*osbuild2.RHSMStageOptions
+
+	SystemdLogind []*osbuild2.SystemdLogindStageOptions
+	CloudInit     []*osbuild2.CloudInitStageOptions
+	Modprobe      []*osbuild2.ModprobeStageOptions
+	DracutConf    []*osbuild2.DracutConfStageOptions
+	SystemdUnit   []*osbuild2.SystemdUnitStageOptions
+	Authselect    *osbuild2.AuthselectStageOptions
 }
 
 // InheritFrom inherits unset values from the provided parent configuration and
@@ -56,6 +63,24 @@ func (c *ImageConfig) InheritFrom(parentConfig *ImageConfig) *ImageConfig {
 		}
 		if finalConfig.RHSMConfig == nil {
 			finalConfig.RHSMConfig = parentConfig.RHSMConfig
+		}
+		if finalConfig.SystemdLogind == nil {
+			finalConfig.SystemdLogind = parentConfig.SystemdLogind
+		}
+		if finalConfig.CloudInit == nil {
+			finalConfig.CloudInit = parentConfig.CloudInit
+		}
+		if finalConfig.Modprobe == nil {
+			finalConfig.Modprobe = parentConfig.Modprobe
+		}
+		if finalConfig.DracutConf == nil {
+			finalConfig.DracutConf = parentConfig.DracutConf
+		}
+		if finalConfig.SystemdUnit == nil {
+			finalConfig.SystemdUnit = parentConfig.SystemdUnit
+		}
+		if finalConfig.Authselect == nil {
+			finalConfig.Authselect = parentConfig.Authselect
 		}
 	}
 	return &finalConfig

--- a/internal/distro/image_config_test.go
+++ b/internal/distro/image_config_test.go
@@ -29,6 +29,31 @@ func TestImageConfigInheritFrom(t *testing.T) {
 				EnabledServices:  []string{"sshd"},
 				DisabledServices: []string{"named"},
 				DefaultTarget:    "multi-user.target",
+				Sysconfig: []*osbuild2.SysconfigStageOptions{
+					{
+						Kernel: &osbuild2.SysconfigKernelOptions{
+							UpdateDefault: true,
+							DefaultKernel: "kernel",
+						},
+						Network: &osbuild2.SysconfigNetworkOptions{
+							Networking: true,
+							NoZeroConf: true,
+						},
+						NetworkScripts: &osbuild2.NetworkScriptsOptions{
+							IfcfgFiles: map[string]osbuild2.IfcfgFile{
+								"eth0": {
+									Device:    "eth0",
+									Bootproto: osbuild2.IfcfgBootprotoDHCP,
+									OnBoot:    common.BoolToPtr(true),
+									Type:      osbuild2.IfcfgTypeEthernet,
+									UserCtl:   common.BoolToPtr(true),
+									PeerDNS:   common.BoolToPtr(true),
+									IPv6Init:  common.BoolToPtr(false),
+								},
+							},
+						},
+					},
+				},
 			},
 			imageConfig: &ImageConfig{
 				Timezone: "UTC",
@@ -66,6 +91,31 @@ func TestImageConfigInheritFrom(t *testing.T) {
 				EnabledServices:  []string{"sshd"},
 				DisabledServices: []string{"named"},
 				DefaultTarget:    "multi-user.target",
+				Sysconfig: []*osbuild2.SysconfigStageOptions{
+					{
+						Kernel: &osbuild2.SysconfigKernelOptions{
+							UpdateDefault: true,
+							DefaultKernel: "kernel",
+						},
+						Network: &osbuild2.SysconfigNetworkOptions{
+							Networking: true,
+							NoZeroConf: true,
+						},
+						NetworkScripts: &osbuild2.NetworkScriptsOptions{
+							IfcfgFiles: map[string]osbuild2.IfcfgFile{
+								"eth0": {
+									Device:    "eth0",
+									Bootproto: osbuild2.IfcfgBootprotoDHCP,
+									OnBoot:    common.BoolToPtr(true),
+									Type:      osbuild2.IfcfgTypeEthernet,
+									UserCtl:   common.BoolToPtr(true),
+									PeerDNS:   common.BoolToPtr(true),
+									IPv6Init:  common.BoolToPtr(false),
+								},
+							},
+						},
+					},
+				},
 			},
 		},
 		{

--- a/internal/distro/image_config_test.go
+++ b/internal/distro/image_config_test.go
@@ -1,0 +1,167 @@
+package distro
+
+import (
+	"testing"
+
+	"github.com/osbuild/osbuild-composer/internal/common"
+	"github.com/osbuild/osbuild-composer/internal/osbuild2"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestImageConfigInheritFrom(t *testing.T) {
+	tests := []struct {
+		name           string
+		distroConfig   *ImageConfig
+		imageConfig    *ImageConfig
+		expectedConfig *ImageConfig
+	}{
+		{
+			name: "inheritance with overridden values",
+			distroConfig: &ImageConfig{
+				Timezone: "America/New_York",
+				TimeSynchronization: &osbuild2.ChronyStageOptions{
+					Timeservers: []string{"127.0.0.1"},
+				},
+				Locale: "en_US.UTF-8",
+				Keyboard: &osbuild2.KeymapStageOptions{
+					Keymap: "us",
+				},
+				EnabledServices:  []string{"sshd"},
+				DisabledServices: []string{"named"},
+				DefaultTarget:    "multi-user.target",
+			},
+			imageConfig: &ImageConfig{
+				Timezone: "UTC",
+				TimeSynchronization: &osbuild2.ChronyStageOptions{
+					Servers: []osbuild2.ChronyConfigServer{
+						{
+							Hostname: "169.254.169.123",
+							Prefer:   common.BoolToPtr(true),
+							Iburst:   common.BoolToPtr(true),
+							Minpoll:  common.IntToPtr(4),
+							Maxpoll:  common.IntToPtr(4),
+						},
+					},
+					LeapsecTz: common.StringToPtr(""),
+				},
+			},
+			expectedConfig: &ImageConfig{
+				Timezone: "UTC",
+				TimeSynchronization: &osbuild2.ChronyStageOptions{
+					Servers: []osbuild2.ChronyConfigServer{
+						{
+							Hostname: "169.254.169.123",
+							Prefer:   common.BoolToPtr(true),
+							Iburst:   common.BoolToPtr(true),
+							Minpoll:  common.IntToPtr(4),
+							Maxpoll:  common.IntToPtr(4),
+						},
+					},
+					LeapsecTz: common.StringToPtr(""),
+				},
+				Locale: "en_US.UTF-8",
+				Keyboard: &osbuild2.KeymapStageOptions{
+					Keymap: "us",
+				},
+				EnabledServices:  []string{"sshd"},
+				DisabledServices: []string{"named"},
+				DefaultTarget:    "multi-user.target",
+			},
+		},
+		{
+			name: "empty image type configuration",
+			distroConfig: &ImageConfig{
+				Timezone: "America/New_York",
+				TimeSynchronization: &osbuild2.ChronyStageOptions{
+					Timeservers: []string{"127.0.0.1"},
+				},
+				Locale: "en_US.UTF-8",
+				Keyboard: &osbuild2.KeymapStageOptions{
+					Keymap: "us",
+				},
+				EnabledServices:  []string{"sshd"},
+				DisabledServices: []string{"named"},
+				DefaultTarget:    "multi-user.target",
+			},
+			imageConfig: &ImageConfig{},
+			expectedConfig: &ImageConfig{
+				Timezone: "America/New_York",
+				TimeSynchronization: &osbuild2.ChronyStageOptions{
+					Timeservers: []string{"127.0.0.1"},
+				},
+				Locale: "en_US.UTF-8",
+				Keyboard: &osbuild2.KeymapStageOptions{
+					Keymap: "us",
+				},
+				EnabledServices:  []string{"sshd"},
+				DisabledServices: []string{"named"},
+				DefaultTarget:    "multi-user.target",
+			},
+		},
+		{
+			name:         "empty distro configuration",
+			distroConfig: &ImageConfig{},
+			imageConfig: &ImageConfig{
+				Timezone: "America/New_York",
+				TimeSynchronization: &osbuild2.ChronyStageOptions{
+					Timeservers: []string{"127.0.0.1"},
+				},
+				Locale: "en_US.UTF-8",
+				Keyboard: &osbuild2.KeymapStageOptions{
+					Keymap: "us",
+				},
+				EnabledServices:  []string{"sshd"},
+				DisabledServices: []string{"named"},
+				DefaultTarget:    "multi-user.target",
+			},
+			expectedConfig: &ImageConfig{
+				Timezone: "America/New_York",
+				TimeSynchronization: &osbuild2.ChronyStageOptions{
+					Timeservers: []string{"127.0.0.1"},
+				},
+				Locale: "en_US.UTF-8",
+				Keyboard: &osbuild2.KeymapStageOptions{
+					Keymap: "us",
+				},
+				EnabledServices:  []string{"sshd"},
+				DisabledServices: []string{"named"},
+				DefaultTarget:    "multi-user.target",
+			},
+		},
+		{
+			name:         "empty distro configuration",
+			distroConfig: nil,
+			imageConfig: &ImageConfig{
+				Timezone: "America/New_York",
+				TimeSynchronization: &osbuild2.ChronyStageOptions{
+					Timeservers: []string{"127.0.0.1"},
+				},
+				Locale: "en_US.UTF-8",
+				Keyboard: &osbuild2.KeymapStageOptions{
+					Keymap: "us",
+				},
+				EnabledServices:  []string{"sshd"},
+				DisabledServices: []string{"named"},
+				DefaultTarget:    "multi-user.target",
+			},
+			expectedConfig: &ImageConfig{
+				Timezone: "America/New_York",
+				TimeSynchronization: &osbuild2.ChronyStageOptions{
+					Timeservers: []string{"127.0.0.1"},
+				},
+				Locale: "en_US.UTF-8",
+				Keyboard: &osbuild2.KeymapStageOptions{
+					Keymap: "us",
+				},
+				EnabledServices:  []string{"sshd"},
+				DisabledServices: []string{"named"},
+				DefaultTarget:    "multi-user.target",
+			},
+		},
+	}
+	for idx, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equalf(t, tt.expectedConfig, tt.imageConfig.InheritFrom(tt.distroConfig), "test case %q failed (idx %d)", tt.name, idx)
+		})
+	}
+}

--- a/internal/distro/rhel86/package_sets.go
+++ b/internal/distro/rhel86/package_sets.go
@@ -253,7 +253,7 @@ func s390xLegacyBootPackageSet(t *imageType) rpmmd.PackageSet {
 // OS package sets
 
 func qcow2CommonPackageSet(t *imageType) rpmmd.PackageSet {
-	return rpmmd.PackageSet{
+	ps := rpmmd.PackageSet{
 		Include: []string{
 			"@core", "authselect-compat", "chrony", "cloud-init",
 			"cloud-utils-growpart", "cockpit-system", "cockpit-ws",
@@ -261,7 +261,7 @@ func qcow2CommonPackageSet(t *imageType) rpmmd.PackageSet {
 			"NetworkManager", "net-tools", "nfs-utils", "oddjob",
 			"oddjob-mkhomedir", "psmisc", "python3-jsonschema",
 			"qemu-guest-agent", "redhat-release", "redhat-release-eula",
-			"rsync", "subscription-manager-cockpit", "tar", "tcpdump", "yum",
+			"rsync", "tar", "tcpdump", "yum",
 		},
 		Exclude: []string{
 			"aic94xx-firmware", "alsa-firmware", "alsa-lib",
@@ -279,6 +279,17 @@ func qcow2CommonPackageSet(t *imageType) rpmmd.PackageSet {
 			"udisks2",
 		},
 	}.Append(bootPackageSet(t)).Append(distroSpecificPackageSet(t))
+
+	// Ensure to not pull in subscription-manager on non-RHEL distro
+	if t.arch.distro.isRHEL() {
+		ps = ps.Append(rpmmd.PackageSet{
+			Include: []string{
+				"subscription-manager-cockpit",
+			},
+		})
+	}
+
+	return ps
 }
 
 func vhdCommonPackageSet(t *imageType) rpmmd.PackageSet {
@@ -481,7 +492,7 @@ func aarch64EdgeCommitPackageSet(t *imageType) rpmmd.PackageSet {
 }
 
 func bareMetalPackageSet(t *imageType) rpmmd.PackageSet {
-	return rpmmd.PackageSet{
+	ps := rpmmd.PackageSet{
 		Include: []string{
 			"authselect-compat", "chrony", "cockpit-system", "cockpit-ws",
 			"@core", "dhcp-client", "dnf", "dnf-utils", "dosfstools",
@@ -495,10 +506,21 @@ func bareMetalPackageSet(t *imageType) rpmmd.PackageSet {
 			"oddjob-mkhomedir", "policycoreutils", "psmisc",
 			"python3-jsonschema", "qemu-guest-agent", "redhat-release",
 			"redhat-release-eula", "rsync", "selinux-policy-targeted",
-			"subscription-manager-cockpit", "tar", "tcpdump", "yum",
+			"tar", "tcpdump", "yum",
 		},
 		Exclude: nil,
 	}.Append(bootPackageSet(t)).Append(distroSpecificPackageSet(t))
+
+	// Ensure to not pull in subscription-manager on non-RHEL distro
+	if t.arch.distro.isRHEL() {
+		ps = ps.Append(rpmmd.PackageSet{
+			Include: []string{
+				"subscription-manager-cockpit",
+			},
+		})
+	}
+
+	return ps
 }
 
 // packages that are only in some (sub)-distributions

--- a/internal/distro/rhel90/distro.go
+++ b/internal/distro/rhel90/distro.go
@@ -891,6 +891,60 @@ func newDistro(distroName string) distro.Distro {
 				},
 			},
 		},
+		SystemdLogind: []*osbuild.SystemdLogindStageOptions{
+			{
+				Filename: "00-getty-fixes.conf",
+				Config: osbuild.SystemdLogindConfigDropin{
+
+					Login: osbuild.SystemdLogindConfigLoginSection{
+						NAutoVTs: common.IntToPtr(0),
+					},
+				},
+			},
+		},
+		CloudInit: []*osbuild.CloudInitStageOptions{
+			{
+				Filename: "00-rhel-default-user.cfg",
+				Config: osbuild.CloudInitConfigFile{
+					SystemInfo: &osbuild.CloudInitConfigSystemInfo{
+						DefaultUser: &osbuild.CloudInitConfigDefaultUser{
+							Name: "ec2-user",
+						},
+					},
+				},
+			},
+		},
+		Modprobe: []*osbuild.ModprobeStageOptions{
+			{
+				Filename: "blacklist-nouveau.conf",
+				Commands: osbuild.ModprobeConfigCmdList{
+					osbuild.NewModprobeConfigCmdBlacklist("nouveau"),
+				},
+			},
+		},
+		DracutConf: []*osbuild.DracutConfStageOptions{
+			{
+				Filename: "sgdisk.conf",
+				Config: osbuild.DracutConfigFile{
+					Install: []string{"sgdisk"},
+				},
+			},
+		},
+		SystemdUnit: []*osbuild.SystemdUnitStageOptions{
+			// RHBZ#1822863
+			{
+				Unit:   "nm-cloud-setup.service",
+				Dropin: "10-rh-enable-for-ec2.conf",
+				Config: osbuild.SystemdServiceUnitDropin{
+					Service: &osbuild.SystemdUnitServiceSection{
+						Environment: "NM_CLOUD_SETUP_EC2=yes",
+					},
+				},
+			},
+		},
+		Authselect: &osbuild.AuthselectStageOptions{
+			Profile: "sssd",
+		},
 	}
 
 	defaultAMIImageConfig := &distro.ImageConfig{

--- a/internal/distro/rhel90/distro.go
+++ b/internal/distro/rhel90/distro.go
@@ -808,7 +808,7 @@ func newDistro(distroName string) distro.Distro {
 		basePartitionTables: defaultBasePartitionTables,
 	}
 
-	// default EC2 images config
+	// default EC2 images config (common for all architectures)
 	defaultEc2ImageConfig := &distro.ImageConfig{
 		Timezone: "UTC",
 		TimeSynchronization: &osbuild.ChronyStageOptions{
@@ -947,6 +947,22 @@ func newDistro(distroName string) distro.Distro {
 		},
 	}
 
+	// default EC2 images config (x86_64)
+	defaultEc2ImageConfigX86_64 := &distro.ImageConfig{
+		DracutConf: append(defaultEc2ImageConfig.DracutConf,
+			&osbuild.DracutConfStageOptions{
+				Filename: "ec2.conf",
+				Config: osbuild.DracutConfigFile{
+					AddDrivers: []string{
+						"nvme",
+						"xen-blkfront",
+					},
+				},
+			}),
+	}
+	defaultEc2ImageConfigX86_64 = defaultEc2ImageConfigX86_64.InheritFrom(defaultEc2ImageConfig)
+
+	// default AMI (EC2 BYOS) images config
 	defaultAMIImageConfig := &distro.ImageConfig{
 		RHSMConfig: map[distro.RHSMSubscriptionStatus]*osbuild.RHSMStageOptions{
 			distro.RHSMConfigNoSubscription: {
@@ -976,6 +992,7 @@ func newDistro(distroName string) distro.Distro {
 			},
 		},
 	}
+	defaultAMIImageConfigX86_64 := defaultAMIImageConfig.InheritFrom(defaultEc2ImageConfigX86_64)
 	defaultAMIImageConfig = defaultAMIImageConfig.InheritFrom(defaultEc2ImageConfig)
 
 	amiImgTypeX86_64 := imageType{
@@ -986,7 +1003,7 @@ func newDistro(distroName string) distro.Distro {
 			buildPkgsKey: ec2BuildPackageSet,
 			osPkgsKey:    ec2CommonPackageSet,
 		},
-		defaultImageConfig:  defaultAMIImageConfig,
+		defaultImageConfig:  defaultAMIImageConfigX86_64,
 		kernelOptions:       "console=ttyS0,115200n8 console=tty0 net.ifnames=0 rd.blacklist=nouveau nvme_core.io_timeout=4294967295 crashkernel=auto",
 		bootable:            true,
 		bootType:            distro.LegacyBootType,
@@ -1025,7 +1042,7 @@ func newDistro(distroName string) distro.Distro {
 			buildPkgsKey: ec2BuildPackageSet,
 			osPkgsKey:    rhelEc2PackageSet,
 		},
-		defaultImageConfig:  defaultEc2ImageConfig,
+		defaultImageConfig:  defaultEc2ImageConfigX86_64,
 		kernelOptions:       "console=ttyS0,115200n8 console=tty0 net.ifnames=0 rd.blacklist=nouveau nvme_core.io_timeout=4294967295 crashkernel=auto",
 		bootable:            true,
 		bootType:            distro.LegacyBootType,
@@ -1064,7 +1081,7 @@ func newDistro(distroName string) distro.Distro {
 			buildPkgsKey: ec2BuildPackageSet,
 			osPkgsKey:    rhelEc2HaPackageSet,
 		},
-		defaultImageConfig:  defaultEc2ImageConfig,
+		defaultImageConfig:  defaultEc2ImageConfigX86_64,
 		kernelOptions:       "console=ttyS0,115200n8 console=tty0 net.ifnames=0 rd.blacklist=nouveau nvme_core.io_timeout=4294967295 crashkernel=auto",
 		bootable:            true,
 		bootType:            distro.LegacyBootType,
@@ -1084,7 +1101,7 @@ func newDistro(distroName string) distro.Distro {
 			buildPkgsKey: ec2BuildPackageSet,
 			osPkgsKey:    rhelEc2SapPackageSet,
 		},
-		defaultImageConfig:  defaultEc2ImageConfig,
+		defaultImageConfig:  defaultEc2ImageConfigX86_64,
 		kernelOptions:       "console=ttyS0,115200n8 console=tty0 net.ifnames=0 rd.blacklist=nouveau nvme_core.io_timeout=4294967295 crashkernel=auto processor.max_cstate=1 intel_idle.max_cstate=1",
 		bootable:            true,
 		bootType:            distro.LegacyBootType,

--- a/internal/distro/rhel90/package_sets.go
+++ b/internal/distro/rhel90/package_sets.go
@@ -323,7 +323,6 @@ func coreOsCommonPackageSet(t *imageType) rpmmd.PackageSet {
 			"selinux-policy-targeted",
 			"setup",
 			"shadow-utils",
-			"subscription-manager", // should be included only if 'redhat-release' is in the package set, which it always is
 			"sssd-common",
 			"sssd-kcm",
 			"sudo",
@@ -347,6 +346,17 @@ func coreOsCommonPackageSet(t *imageType) rpmmd.PackageSet {
 			"sg3_utils-libs",
 			"python3-libselinux",
 		},
+	}
+
+	// Do not include this in the distroSpecificPackageSet for now,
+	// because it includes 'insights-client' which is not installed
+	// by default on all RHEL images (although it would probably make sense).
+	if t.arch.distro.isRHEL() {
+		ps = ps.Append(rpmmd.PackageSet{
+			Include: []string{
+				"subscription-manager",
+			},
+		})
 	}
 
 	switch t.arch.Name() {
@@ -388,7 +398,7 @@ func coreOsCommonPackageSet(t *imageType) rpmmd.PackageSet {
 }
 
 func qcow2CommonPackageSet(t *imageType) rpmmd.PackageSet {
-	return rpmmd.PackageSet{
+	ps := rpmmd.PackageSet{
 		Include: []string{
 			"authselect-compat",
 			"chrony",
@@ -407,7 +417,6 @@ func qcow2CommonPackageSet(t *imageType) rpmmd.PackageSet {
 			"redhat-release",
 			"redhat-release-eula",
 			"rsync",
-			"subscription-manager-cockpit",
 			"tar",
 			"tcpdump",
 		},
@@ -431,6 +440,17 @@ func qcow2CommonPackageSet(t *imageType) rpmmd.PackageSet {
 			"udisks2",
 		},
 	}.Append(bootPackageSet(t)).Append(coreOsCommonPackageSet(t)).Append(distroSpecificPackageSet(t))
+
+	// Ensure to not pull in subscription-manager on non-RHEL distro
+	if t.arch.distro.isRHEL() {
+		ps = ps.Append(rpmmd.PackageSet{
+			Include: []string{
+				"subscription-manager-cockpit",
+			},
+		})
+	}
+
+	return ps
 }
 
 func vhdCommonPackageSet(t *imageType) rpmmd.PackageSet {
@@ -802,7 +822,7 @@ func aarch64EdgeCommitPackageSet(t *imageType) rpmmd.PackageSet {
 }
 
 func bareMetalPackageSet(t *imageType) rpmmd.PackageSet {
-	return rpmmd.PackageSet{
+	ps := rpmmd.PackageSet{
 		Include: []string{
 			"authselect-compat",
 			"chrony",
@@ -837,11 +857,21 @@ func bareMetalPackageSet(t *imageType) rpmmd.PackageSet {
 			"redhat-release",
 			"redhat-release-eula",
 			"rsync",
-			"subscription-manager-cockpit",
 			"tar",
 			"tcpdump",
 		},
 	}.Append(bootPackageSet(t)).Append(coreOsCommonPackageSet(t)).Append(distroBuildPackageSet(t))
+
+	// Ensure to not pull in subscription-manager on non-RHEL distro
+	if t.arch.distro.isRHEL() {
+		ps = ps.Append(rpmmd.PackageSet{
+			Include: []string{
+				"subscription-manager-cockpit",
+			},
+		})
+	}
+
+	return ps
 }
 
 // packages that are only in some (sub)-distributions

--- a/internal/distro/rhel90/pipelines.go
+++ b/internal/distro/rhel90/pipelines.go
@@ -28,16 +28,10 @@ func qcow2Pipelines(t *imageType, customizations *blueprint.Customizations, opti
 	if err != nil {
 		return nil, err
 	}
-
-	treePipeline = prependKernelCmdlineStage(treePipeline, t, &partitionTable)
-
-	treePipeline.AddStage(osbuild.NewFSTabStage(partitionTable.FSTabStageOptionsV2()))
-	kernelVer := kernelVerStr(packageSetSpecs[blueprintPkgsKey], customizations.GetKernel().Name, t.Arch().Name())
-	treePipeline.AddStage(bootloaderConfigStage(t, partitionTable, customizations.GetKernel(), kernelVer, false, false))
-	treePipeline.AddStage(osbuild.NewSELinuxStage(selinuxStageOptions(false)))
 	pipelines = append(pipelines, *treePipeline)
 
 	diskfile := "disk.img"
+	kernelVer := kernelVerStr(packageSetSpecs[blueprintPkgsKey], customizations.GetKernel().Name, t.Arch().Name())
 	imagePipeline := liveImagePipeline(treePipeline.Name, diskfile, &partitionTable, t.arch, kernelVer)
 	pipelines = append(pipelines, *imagePipeline)
 
@@ -67,15 +61,10 @@ func vhdPipelines(t *imageType, customizations *blueprint.Customizations, option
 	if err != nil {
 		return nil, err
 	}
-
-	treePipeline = prependKernelCmdlineStage(treePipeline, t, &partitionTable)
-	treePipeline.AddStage(osbuild.NewFSTabStage(partitionTable.FSTabStageOptionsV2()))
-	kernelVer := kernelVerStr(packageSetSpecs[blueprintPkgsKey], customizations.GetKernel().Name, t.Arch().Name())
-	treePipeline.AddStage(bootloaderConfigStage(t, partitionTable, customizations.GetKernel(), kernelVer, false, false))
-	treePipeline.AddStage(osbuild.NewSELinuxStage(selinuxStageOptions(false)))
 	pipelines = append(pipelines, *treePipeline)
 
 	diskfile := "disk.img"
+	kernelVer := kernelVerStr(packageSetSpecs[blueprintPkgsKey], customizations.GetKernel().Name, t.Arch().Name())
 	imagePipeline := liveImagePipeline(treePipeline.Name, diskfile, &partitionTable, t.arch, kernelVer)
 	pipelines = append(pipelines, *imagePipeline)
 
@@ -97,15 +86,10 @@ func vmdkPipelines(t *imageType, customizations *blueprint.Customizations, optio
 	if err != nil {
 		return nil, err
 	}
-
-	treePipeline = prependKernelCmdlineStage(treePipeline, t, &partitionTable)
-	treePipeline.AddStage(osbuild.NewFSTabStage(partitionTable.FSTabStageOptionsV2()))
-	kernelVer := kernelVerStr(packageSetSpecs[blueprintPkgsKey], customizations.GetKernel().Name, t.Arch().Name())
-	treePipeline.AddStage(bootloaderConfigStage(t, partitionTable, customizations.GetKernel(), kernelVer, false, false))
-	treePipeline.AddStage(osbuild.NewSELinuxStage(selinuxStageOptions(false)))
 	pipelines = append(pipelines, *treePipeline)
 
 	diskfile := "disk.img"
+	kernelVer := kernelVerStr(packageSetSpecs[blueprintPkgsKey], customizations.GetKernel().Name, t.Arch().Name())
 	imagePipeline := liveImagePipeline(treePipeline.Name, diskfile, &partitionTable, t.arch, kernelVer)
 	pipelines = append(pipelines, *imagePipeline)
 
@@ -127,15 +111,10 @@ func openstackPipelines(t *imageType, customizations *blueprint.Customizations, 
 	if err != nil {
 		return nil, err
 	}
-
-	treePipeline = prependKernelCmdlineStage(treePipeline, t, &partitionTable)
-	treePipeline.AddStage(osbuild.NewFSTabStage(partitionTable.FSTabStageOptionsV2()))
-	kernelVer := kernelVerStr(packageSetSpecs[blueprintPkgsKey], customizations.GetKernel().Name, t.Arch().Name())
-	treePipeline.AddStage(bootloaderConfigStage(t, partitionTable, customizations.GetKernel(), kernelVer, false, false))
-	treePipeline.AddStage(osbuild.NewSELinuxStage(selinuxStageOptions(false)))
 	pipelines = append(pipelines, *treePipeline)
 
 	diskfile := "disk.img"
+	kernelVer := kernelVerStr(packageSetSpecs[blueprintPkgsKey], customizations.GetKernel().Name, t.Arch().Name())
 	imagePipeline := liveImagePipeline(treePipeline.Name, diskfile, &partitionTable, t.arch, kernelVer)
 	pipelines = append(pipelines, *imagePipeline)
 
@@ -159,15 +138,9 @@ func ec2CommonPipelines(t *imageType, customizations *blueprint.Customizations, 
 	if err != nil {
 		return nil, err
 	}
-
-	treePipeline = prependKernelCmdlineStage(treePipeline, t, &partitionTable)
-	treePipeline.AddStage(osbuild.NewFSTabStage(partitionTable.FSTabStageOptionsV2()))
-	kernelVer := kernelVerStr(packageSetSpecs[blueprintPkgsKey], customizations.GetKernel().Name, t.Arch().Name())
-	treePipeline.AddStage(bootloaderConfigStage(t, partitionTable, customizations.GetKernel(), kernelVer, false, false))
-	// The last stage must be the SELinux stage
-	treePipeline.AddStage(osbuild.NewSELinuxStage(selinuxStageOptions(false)))
 	pipelines = append(pipelines, *treePipeline)
 
+	kernelVer := kernelVerStr(packageSetSpecs[blueprintPkgsKey], customizations.GetKernel().Name, t.Arch().Name())
 	imagePipeline := liveImagePipeline(treePipeline.Name, diskfile, &partitionTable, t.arch, kernelVer)
 	pipelines = append(pipelines, *imagePipeline)
 	return pipelines, nil
@@ -201,7 +174,6 @@ func tarPipelines(t *imageType, customizations *blueprint.Customizations, option
 	if err != nil {
 		return nil, err
 	}
-	treePipeline.AddStage(osbuild.NewSELinuxStage(selinuxStageOptions(false)))
 	pipelines = append(pipelines, *treePipeline)
 	tarPipeline := osbuild.Pipeline{
 		Name:  "root-tar",
@@ -244,7 +216,6 @@ func tarInstallerPipelines(t *imageType, customizations *blueprint.Customization
 	if err != nil {
 		return nil, err
 	}
-	treePipeline.AddStage(osbuild.NewSELinuxStage(selinuxStageOptions(false)))
 	pipelines = append(pipelines, *treePipeline)
 
 	kernelPkg := new(rpmmd.PackageSpec)
@@ -517,6 +488,15 @@ func osPipeline(t *imageType,
 	for _, dnfConfig := range imageConfig.DNFConfig {
 		p.AddStage(osbuild.NewDNFConfigStage(dnfConfig))
 	}
+
+	if pt != nil {
+		p = prependKernelCmdlineStage(p, t, pt)
+		p.AddStage(osbuild.NewFSTabStage(pt.FSTabStageOptionsV2()))
+		kernelVer := kernelVerStr(bpPackages, c.GetKernel().Name, t.Arch().Name())
+		p.AddStage(bootloaderConfigStage(t, *pt, c.GetKernel(), kernelVer, false, false))
+	}
+
+	p.AddStage(osbuild.NewSELinuxStage(selinuxStageOptions(false)))
 
 	return p, nil
 }

--- a/test/data/manifests/centos_8-aarch64-ami-boot.json
+++ b/test/data/manifests/centos_8-aarch64-ami-boot.json
@@ -941,17 +941,6 @@
             }
           },
           {
-            "type": "org.osbuild.systemd-logind",
-            "options": {
-              "filename": "00-getty-fixes.conf",
-              "config": {
-                "Login": {
-                  "NAutoVTs": 0
-                }
-              }
-            }
-          },
-          {
             "type": "org.osbuild.sysconfig",
             "options": {
               "kernel": {
@@ -973,6 +962,17 @@
                     "type": "Ethernet",
                     "userctl": true
                   }
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.systemd-logind",
+            "options": {
+              "filename": "00-getty-fixes.conf",
+              "config": {
+                "Login": {
+                  "NAutoVTs": 0
                 }
               }
             }

--- a/test/data/manifests/centos_8-aarch64-qcow2-boot.json
+++ b/test/data/manifests/centos_8-aarch64-qcow2-boot.json
@@ -372,7 +372,6 @@
                   "sha256:066d47b6d9a955ba52ab53525db1c7f92cb09c9a8db40cf0f28e050e119a344d",
                   "sha256:42464424b9fa731f8122fe748aad0005519fc87b770dbbdb71f29f514ea0e889",
                   "sha256:45c48d32120739734ae97479cc0f3ca19796ea47e360ba39d52b77ce3ada61d7",
-                  "sha256:1cde7ec8148e826642d9c3572b36f97fb4bb1af0ea58c62ad3e7855c37aad50c",
                   "sha256:47b61754a278c4ca378871c874ccf6a0a07bffaef38505315cfa94f262887845",
                   "sha256:e57a218c73df587fb441a22bd4e5f97afb8cbe8812707b26b6dd658910e52dcc",
                   "sha256:cddd0c28a1549f6563cba12771886a1cb990b69b086ebeeced035d962b0eac6f",
@@ -606,7 +605,6 @@
                   "sha256:122fe05bd35778f2887e7f5cad32e8e93247fbbd71bd3da5ed78f788d529d028",
                   "sha256:7cf94e71d42aecccf095c8225aabe5085f8cf7fb4f956fabbe04d23ba7688029",
                   "sha256:176ffcb2cf0fdcbdd2d8119cbd98eef60a30fdb0fb065a9382d2c95e90c79652",
-                  "sha256:c77ac1a164a6e5d042b86bcdcffe7876bc6c60eb3be78c1cb5e09ad239b73299",
                   "sha256:1bd969e0521820374122f5132e5998d9bd2ab185be66565a7266096297419c8e",
                   "sha256:60f68176eddcf15cdcf8c772c2d52d670e2d324f6412131bdd7d604d74b928cd",
                   "sha256:c5b5967a094ced90899052a82e2c245529b75ba3f46e0ce1a89cfc95edb935ea",
@@ -614,17 +612,13 @@
                   "sha256:0e9a8a0f823bf0ef948862f0ccb62353460bd07931e756c98f23908c1c526578",
                   "sha256:ccfa1810aa19fae08aefd29cffe28b65d5123cd17bd7d2d4207f03cf9795594c",
                   "sha256:28c0f457d67213319f0313d993a3b2f8a778a077b202cd75bf45eb2792949d32",
-                  "sha256:caa73f06b13aaef91c4115e0af1689821cdf5130f9f75b416e2f0d2b0c3a6cf8",
                   "sha256:ddc064aa8fb904fbcb1c0da0946f61581a30f6dea8fde9343c29491b0bcd7009",
                   "sha256:777ed4abb0360d2b0e34021bdee6e6b0357629c84e34a8f47adfe1059ecc6cfa",
                   "sha256:db8b1968ff715eb7fbbe326efd5ee3dd2d7aef0d29645de12f36ae474514f909",
                   "sha256:78c43d8a15ca018de1803e4baac5819e1baab1963fd31f1e44e54e8a573acbfc",
-                  "sha256:5c0957decce3babef9864904be13190b0072aef720e9f4ca820bab6c02a20178",
-                  "sha256:109d6db30e5515601b00954b2fd8750c421730a18afc12e1fa7781e24e5b0863",
                   "sha256:ebeb05a4a9cdd5d060859eabac1349029c0120615c98fc939e26664c030655c1",
                   "sha256:72beca700b827714b57f9c61c7647df6eee90820e53af67fc3bee7f08ef631c3",
                   "sha256:62d08a0e508fe8bebd28e2a3fd65ea6c6fe26920d631872e676a100d8e35e806",
-                  "sha256:2ec8ee9578cb0eee9c45186118e0c1e999585e177f1e9de6423a4d79d896d6de",
                   "sha256:c4b1088492cb05631edda4cd62ea537911b79eb36e847270755bf083afafc6d9",
                   "sha256:1a39d5db45d7e97f0a9b564b263ae22d20433bd2f40a6298b8e3ca6a80875da3",
                   "sha256:bc96ccd4671ee6a42d4ad5bbfbbd67ad397d276e29b4353ca6d67ae9705924a7",
@@ -646,14 +640,12 @@
                   "sha256:a04cb3117395b962edc32bf45d8411f240632476b0706b2df7f4a1a87b2ce34b",
                   "sha256:233e5f78027b684e5aaac1395cc574aea3039059bf86eb4494422bc74216a396",
                   "sha256:563b3741d26b6af963fdb7b0634e0791445a707d0b6093ac71c3224299241639",
-                  "sha256:f24d03d0022841fc574d8b7f621b93001bd4ba40785f1db5b35bc2960332a693",
                   "sha256:6c308aa7a826674e1bc1e7ac99d8a1b6b0f2bc4d501086f1985af27e50baa4ff",
                   "sha256:aa1835fd302a37b84ac256db5dd0de09bd9883a5a07775aedb491faf46b18ee0",
                   "sha256:210ad2df4ce04d6792c43d16a7c3b40bfbd13103db7ba7326039852a7ea84322",
                   "sha256:bc7fc2028a29ac7a406719ed4f6740f6bf12c20961223c1e839a2a39069af38d",
                   "sha256:b170c69f99c0bacc01a003c70098e04132629589bf3b0737a73e229da75d0571",
                   "sha256:ef74f2c65ed0e38dd021177d6e59fcdf7fb8de8929b7544b7a6f0709eff6562c",
-                  "sha256:76acb678a5c1d93353d4f506e703ac9ce4925295d61c876f6a420e244102aaba",
                   "sha256:d967d6bbb33bf7a295a64807f81875c84e82a8ecc59b6c72fe955141b1660d39",
                   "sha256:19de7245f0ce7a0fed90263e2b63d98edb549ba1f40ce17916842ef3eb937c44",
                   "sha256:58cad77e10210a5c9183ce5518d452c6a234c5553b93b94af0de3f470c0d944b",
@@ -680,9 +672,6 @@
                   "sha256:4ce2a957083b7cac9ef04a17d2fd6d57039f1c9875d82fe00fe08a62e9fadaef",
                   "sha256:779241d34b7afcd80ef482421c8be90c53872e20254dab27a84f4fc263f0641b",
                   "sha256:08e0218eb17401cd38b3536d2502dfe0676ff05de764b6d4011ba9bf5a6da253",
-                  "sha256:a35e2d0f795f3fa58eaa5f27bd821df24f06a770d736b83a72c38562de6a4183",
-                  "sha256:3386ebe6e649b2cb6a4b3eef260d68f3c165d9ccf54b4e6767ee064aa32d3334",
-                  "sha256:4ac569d8ac68bc904a0a27398e49e3dff6d18cef65c5079c89bde9c953ca0eec",
                   "sha256:633737dc830de1084efc2637d6f4246f4a5b93eba3106184e4541f698c4f99e9",
                   "sha256:454ec267900a2b43ac86d9730b65e8b78bb0ef823c3b8777b531021029c5ce86",
                   "sha256:feb22f3d5529fce8a1d60fe9ddc9fba7dadf4d0864b6ae8bb8245985aef709ec",
@@ -696,7 +685,6 @@
                   "sha256:f006928e944be95bb8d6cb757d759ad25d76d2c36d05e7eab1c4308ed6134c90",
                   "sha256:654d9074dc8ebb93230fe258188a17ba3f7dbac2f360f9f79cc4fb1516953018",
                   "sha256:44999c555a6e4bb6cf5e6f6a79819e76912d036732cb50efaeefc20a180dd839",
-                  "sha256:1865d83df30869bb74fde21b6c31b5440c34b36323a0001fcf140698a9746c40",
                   "sha256:1600cd7372ca2682c9bd58de6e783092d6bdb6412c9888e3dd767db92c9b5239",
                   "sha256:2b743f157f47b27a0528d53fd9ae3e4eb0553f4b8357d01d362dd1b0e4e87c06",
                   "sha256:b9138ff38b834e05b9a34173709bc9b72ed55c7d8ddee4da3e5a4a68648fab5e",
@@ -972,19 +960,6 @@
               "network": {
                 "networking": true,
                 "no_zero_conf": true
-              }
-            }
-          },
-          {
-            "type": "org.osbuild.rhsm",
-            "options": {
-              "dnf-plugins": {
-                "product-id": {
-                  "enabled": false
-                },
-                "subscription-manager": {
-                  "enabled": false
-                }
               }
             }
           },
@@ -1275,9 +1250,6 @@
           "sha256:107a781be497f1a51ffd370aba59dbc4de3d7f89802830c66051dc51a5ec185b": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20210827/Packages/dbus-1.12.8-14.el8.aarch64.rpm"
           },
-          "sha256:109d6db30e5515601b00954b2fd8750c421730a18afc12e1fa7781e24e5b0863": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20210827/Packages/python3-inotify-0.9.6-13.el8.noarch.rpm"
-          },
           "sha256:116c1d18b0bda6388cde56e4c93f28b2449dc496ea6a9c5e2d4b581065e2e6c4": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20210827/Packages/python3-dbus-1.2.4-15.el8.aarch64.rpm"
           },
@@ -1326,9 +1298,6 @@
           "sha256:185f60a22dc698b4a48fc8c032787a999e56731f0e582f311bb682a8a975a439": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-appstream-20210827/Packages/lorax-templates-generic-28.14.61-2.el8.aarch64.rpm"
           },
-          "sha256:1865d83df30869bb74fde21b6c31b5440c34b36323a0001fcf140698a9746c40": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20210827/Packages/usermode-1.113-1.el8.aarch64.rpm"
-          },
           "sha256:187a1fbb7e2992dfa777c7ca5c2f7369ecb85e4be4a483e6c0c6036e02bacf95": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20210827/Packages/info-6.5-6.el8.aarch64.rpm"
           },
@@ -1346,9 +1315,6 @@
           },
           "sha256:1bd969e0521820374122f5132e5998d9bd2ab185be66565a7266096297419c8e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20210827/Packages/python3-configobj-5.0.6-11.el8.noarch.rpm"
-          },
-          "sha256:1cde7ec8148e826642d9c3572b36f97fb4bb1af0ea58c62ad3e7855c37aad50c": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20210827/Packages/dnf-plugin-subscription-manager-1.28.20-1.el8.aarch64.rpm"
           },
           "sha256:1db2307d955fa6a794b6f691e64d0d7f0ab7eabadd30f679cd7a780a45565571": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20210827/Packages/dracut-network-049-188.git20210802.el8.aarch64.rpm"
@@ -1466,9 +1432,6 @@
           },
           "sha256:3187b5a82f1e6906539903c42b3bbd0b9979f00ae41d73c52e69e239f1090bf7": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-appstream-20210827/Packages/cairo-1.15.12-3.el8.aarch64.rpm"
-          },
-          "sha256:3386ebe6e649b2cb6a4b3eef260d68f3c165d9ccf54b4e6767ee064aa32d3334": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20210827/Packages/subscription-manager-cockpit-1.28.20-1.el8.noarch.rpm"
           },
           "sha256:3401ccfb7fd08c12578b6257b4dac7e94ba5f4cd70fc6a234fd90bb99d1bb108": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20210827/Packages/libtasn1-4.13-3.el8.aarch64.rpm"
@@ -1604,9 +1567,6 @@
           },
           "sha256:4a08d5264e865548e65d31886c91b659b33a2c2ba39fd115b00af3ea0bc91a83": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20210827/Packages/grub2-common-2.02-99.el8.noarch.rpm"
-          },
-          "sha256:4ac569d8ac68bc904a0a27398e49e3dff6d18cef65c5079c89bde9c953ca0eec": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20210827/Packages/subscription-manager-rhsm-certificates-1.28.20-1.el8.aarch64.rpm"
           },
           "sha256:4ae071ebcf06cec6e4e7e49a50d83464cb1f1f1c72449a02ba1dfc820dbf67c5": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20210827/Packages/c-ares-1.13.0-5.el8.aarch64.rpm"
@@ -1818,9 +1778,6 @@
           "sha256:75dc9e6f813392de179031656e2ff5a3cc92771e545bf029a8bdeb42909e98e8": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20210827/Packages/bash-4.4.20-2.el8.aarch64.rpm"
           },
-          "sha256:76acb678a5c1d93353d4f506e703ac9ce4925295d61c876f6a420e244102aaba": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20210827/Packages/rhsm-icons-1.28.20-1.el8.noarch.rpm"
-          },
           "sha256:76df9e0fc779fcd7d3ee836ae254ead30b5f9492022b55901d1f8bd914d38ef6": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20210827/Packages/selinux-policy-targeted-3.14.3-76.el8.noarch.rpm"
           },
@@ -2024,9 +1981,6 @@
           },
           "sha256:a33349c435ef9b8348864e5b8f09ed050d0b7a79fb2db5a88b2f7a5d869231d7": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20210827/Packages/pam-1.3.1-15.el8.aarch64.rpm"
-          },
-          "sha256:a35e2d0f795f3fa58eaa5f27bd821df24f06a770d736b83a72c38562de6a4183": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20210827/Packages/subscription-manager-1.28.20-1.el8.aarch64.rpm"
           },
           "sha256:a3ef96219165bfc64d4f5d50f51fbd43e803c500619240ffe4db1f9f8e337f83": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20210827/Packages/kbd-legacy-2.0.4-10.el8.noarch.rpm"
@@ -2247,9 +2201,6 @@
           "sha256:c76813885102c12a962a8adf3cd864fa5965e4005050a1bbbd350c3f0040d6b5": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20210827/Packages/librepo-1.14.0-2.el8.aarch64.rpm"
           },
-          "sha256:c77ac1a164a6e5d042b86bcdcffe7876bc6c60eb3be78c1cb5e09ad239b73299": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20210827/Packages/python3-cloud-what-1.28.20-1.el8.aarch64.rpm"
-          },
           "sha256:c92efb4ac2ef027b0a3ab39d520362c9199f3945d0237a897b3c8d7ea2b42a8b": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20210827/Packages/kernel-4.18.0-331.el8.aarch64.rpm"
           },
@@ -2258,9 +2209,6 @@
           },
           "sha256:c98e748866b96eab0e8ea4170fe312cb48fd46db98e23c6125b1262c4b8b495d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-appstream-20210827/Packages/cairo-gobject-1.15.12-3.el8.aarch64.rpm"
-          },
-          "sha256:caa73f06b13aaef91c4115e0af1689821cdf5130f9f75b416e2f0d2b0c3a6cf8": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20210827/Packages/python3-ethtool-0.14-3.el8.aarch64.rpm"
           },
           "sha256:cab4f9caf4d9e51a7bcaa4d69e7550d5b9372ce817d956d2e5fa4e374c76a8ab": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20210827/Packages/libdb-5.3.28-40.el8.aarch64.rpm"
@@ -2486,9 +2434,6 @@
           },
           "sha256:f1f10022c95ef2ff496b3a358f6fa7f7474fecd4840ac0fac689075356a09689": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20210827/Packages/libgcc-8.5.0-3.el8.aarch64.rpm"
-          },
-          "sha256:f24d03d0022841fc574d8b7f621b93001bd4ba40785f1db5b35bc2960332a693": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20210827/Packages/python3-subscription-manager-rhsm-1.28.20-1.el8.aarch64.rpm"
           },
           "sha256:f2628a19999f78a3ec1a796d66c8cd45f58cfb670850ecb7790528279f410677": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20210827/Packages/libmodman-2.0.1-17.el8.aarch64.rpm"
@@ -7114,16 +7059,6 @@
         "check_gpg": true
       },
       {
-        "name": "dnf-plugin-subscription-manager",
-        "epoch": 0,
-        "version": "1.28.20",
-        "release": "1.el8",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20210827/Packages/dnf-plugin-subscription-manager-1.28.20-1.el8.aarch64.rpm",
-        "checksum": "sha256:1cde7ec8148e826642d9c3572b36f97fb4bb1af0ea58c62ad3e7855c37aad50c",
-        "check_gpg": true
-      },
-      {
         "name": "dnf-plugins-core",
         "epoch": 0,
         "version": "4.0.21",
@@ -9454,16 +9389,6 @@
         "check_gpg": true
       },
       {
-        "name": "python3-cloud-what",
-        "epoch": 0,
-        "version": "1.28.20",
-        "release": "1.el8",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20210827/Packages/python3-cloud-what-1.28.20-1.el8.aarch64.rpm",
-        "checksum": "sha256:c77ac1a164a6e5d042b86bcdcffe7876bc6c60eb3be78c1cb5e09ad239b73299",
-        "check_gpg": true
-      },
-      {
         "name": "python3-configobj",
         "epoch": 0,
         "version": "5.0.6",
@@ -9534,16 +9459,6 @@
         "check_gpg": true
       },
       {
-        "name": "python3-ethtool",
-        "epoch": 0,
-        "version": "0.14",
-        "release": "3.el8",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20210827/Packages/python3-ethtool-0.14-3.el8.aarch64.rpm",
-        "checksum": "sha256:caa73f06b13aaef91c4115e0af1689821cdf5130f9f75b416e2f0d2b0c3a6cf8",
-        "check_gpg": true
-      },
-      {
         "name": "python3-gobject-base",
         "epoch": 0,
         "version": "3.28.3",
@@ -9584,26 +9499,6 @@
         "check_gpg": true
       },
       {
-        "name": "python3-iniparse",
-        "epoch": 0,
-        "version": "0.4",
-        "release": "31.el8",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20210827/Packages/python3-iniparse-0.4-31.el8.noarch.rpm",
-        "checksum": "sha256:5c0957decce3babef9864904be13190b0072aef720e9f4ca820bab6c02a20178",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-inotify",
-        "epoch": 0,
-        "version": "0.9.6",
-        "release": "13.el8",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20210827/Packages/python3-inotify-0.9.6-13.el8.noarch.rpm",
-        "checksum": "sha256:109d6db30e5515601b00954b2fd8750c421730a18afc12e1fa7781e24e5b0863",
-        "check_gpg": true
-      },
-      {
         "name": "python3-jwt",
         "epoch": 0,
         "version": "1.6.1",
@@ -9631,16 +9526,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20210827/Packages/python3-libdnf-0.63.0-2.el8.aarch64.rpm",
         "checksum": "sha256:62d08a0e508fe8bebd28e2a3fd65ea6c6fe26920d631872e676a100d8e35e806",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-librepo",
-        "epoch": 0,
-        "version": "1.14.0",
-        "release": "2.el8",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20210827/Packages/python3-librepo-1.14.0-2.el8.aarch64.rpm",
-        "checksum": "sha256:2ec8ee9578cb0eee9c45186118e0c1e999585e177f1e9de6423a4d79d896d6de",
         "check_gpg": true
       },
       {
@@ -9854,16 +9739,6 @@
         "check_gpg": true
       },
       {
-        "name": "python3-subscription-manager-rhsm",
-        "epoch": 0,
-        "version": "1.28.20",
-        "release": "1.el8",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20210827/Packages/python3-subscription-manager-rhsm-1.28.20-1.el8.aarch64.rpm",
-        "checksum": "sha256:f24d03d0022841fc574d8b7f621b93001bd4ba40785f1db5b35bc2960332a693",
-        "check_gpg": true
-      },
-      {
         "name": "python3-syspurpose",
         "epoch": 0,
         "version": "1.28.20",
@@ -9921,16 +9796,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20210827/Packages/readline-7.0-10.el8.aarch64.rpm",
         "checksum": "sha256:ef74f2c65ed0e38dd021177d6e59fcdf7fb8de8929b7544b7a6f0709eff6562c",
-        "check_gpg": true
-      },
-      {
-        "name": "rhsm-icons",
-        "epoch": 0,
-        "version": "1.28.20",
-        "release": "1.el8",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20210827/Packages/rhsm-icons-1.28.20-1.el8.noarch.rpm",
-        "checksum": "sha256:76acb678a5c1d93353d4f506e703ac9ce4925295d61c876f6a420e244102aaba",
         "check_gpg": true
       },
       {
@@ -10194,36 +10059,6 @@
         "check_gpg": true
       },
       {
-        "name": "subscription-manager",
-        "epoch": 0,
-        "version": "1.28.20",
-        "release": "1.el8",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20210827/Packages/subscription-manager-1.28.20-1.el8.aarch64.rpm",
-        "checksum": "sha256:a35e2d0f795f3fa58eaa5f27bd821df24f06a770d736b83a72c38562de6a4183",
-        "check_gpg": true
-      },
-      {
-        "name": "subscription-manager-cockpit",
-        "epoch": 0,
-        "version": "1.28.20",
-        "release": "1.el8",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20210827/Packages/subscription-manager-cockpit-1.28.20-1.el8.noarch.rpm",
-        "checksum": "sha256:3386ebe6e649b2cb6a4b3eef260d68f3c165d9ccf54b4e6767ee064aa32d3334",
-        "check_gpg": true
-      },
-      {
-        "name": "subscription-manager-rhsm-certificates",
-        "epoch": 0,
-        "version": "1.28.20",
-        "release": "1.el8",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20210827/Packages/subscription-manager-rhsm-certificates-1.28.20-1.el8.aarch64.rpm",
-        "checksum": "sha256:4ac569d8ac68bc904a0a27398e49e3dff6d18cef65c5079c89bde9c953ca0eec",
-        "check_gpg": true
-      },
-      {
         "name": "sudo",
         "epoch": 0,
         "version": "1.8.29",
@@ -10351,16 +10186,6 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20210827/Packages/tzdata-2021a-1.el8.noarch.rpm",
         "checksum": "sha256:44999c555a6e4bb6cf5e6f6a79819e76912d036732cb50efaeefc20a180dd839",
-        "check_gpg": true
-      },
-      {
-        "name": "usermode",
-        "epoch": 0,
-        "version": "1.113",
-        "release": "1.el8",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20210827/Packages/usermode-1.113-1.el8.aarch64.rpm",
-        "checksum": "sha256:1865d83df30869bb74fde21b6c31b5440c34b36323a0001fcf140698a9746c40",
         "check_gpg": true
       },
       {
@@ -11296,7 +11121,6 @@
       "dmidecode-3.2-10.el8.aarch64",
       "dnf-4.7.0-2.el8.noarch",
       "dnf-data-4.7.0-2.el8.noarch",
-      "dnf-plugin-subscription-manager-1.28.20-1.el8.aarch64",
       "dnf-plugins-core-4.0.21-2.el8.noarch",
       "dosfstools-4.1-6.el8.aarch64",
       "dracut-049-188.git20210802.el8.aarch64",
@@ -11549,7 +11373,6 @@
       "python3-cairo-1.16.3-6.el8.aarch64",
       "python3-cffi-1.11.5-5.el8.aarch64",
       "python3-chardet-3.0.4-7.el8.noarch",
-      "python3-cloud-what-1.28.20-1.el8.aarch64",
       "python3-configobj-5.0.6-11.el8.noarch",
       "python3-cryptography-3.2.1-5.el8.aarch64",
       "python3-dateutil-2.6.1-6.el8.noarch",
@@ -11557,14 +11380,11 @@
       "python3-decorator-4.2.1-2.el8.noarch",
       "python3-dnf-4.7.0-2.el8.noarch",
       "python3-dnf-plugins-core-4.0.21-2.el8.noarch",
-      "python3-ethtool-0.14-3.el8.aarch64",
       "python3-gobject-3.28.3-2.el8.aarch64",
       "python3-gobject-base-3.28.3-2.el8.aarch64",
       "python3-gpg-1.13.1-9.el8.aarch64",
       "python3-hawkey-0.63.0-2.el8.aarch64",
       "python3-idna-2.5-5.el8.noarch",
-      "python3-iniparse-0.4-31.el8.noarch",
-      "python3-inotify-0.9.6-13.el8.noarch",
       "python3-jinja2-2.10.1-3.el8.noarch",
       "python3-jsonpatch-1.21-2.el8.noarch",
       "python3-jsonpointer-1.10-11.el8.noarch",
@@ -11572,7 +11392,6 @@
       "python3-jwt-1.6.1-2.el8.noarch",
       "python3-libcomps-0.1.16-2.el8.aarch64",
       "python3-libdnf-0.63.0-2.el8.aarch64",
-      "python3-librepo-1.14.0-2.el8.aarch64",
       "python3-libs-3.6.8-39.el8.aarch64",
       "python3-libselinux-2.9-5.el8.aarch64",
       "python3-libsemanage-2.9-6.el8.aarch64",
@@ -11601,7 +11420,6 @@
       "python3-six-1.11.0-8.el8.noarch",
       "python3-slip-0.6.4-11.el8.noarch",
       "python3-slip-dbus-0.6.4-11.el8.noarch",
-      "python3-subscription-manager-rhsm-1.28.20-1.el8.aarch64",
       "python3-syspurpose-1.28.20-1.el8.aarch64",
       "python3-systemd-234-8.el8.aarch64",
       "python3-unbound-1.7.3-17.el8.aarch64",
@@ -11611,7 +11429,6 @@
       "quota-nls-4.04-14.el8.noarch",
       "rdma-core-35.0-1.el8.aarch64",
       "readline-7.0-10.el8.aarch64",
-      "rhsm-icons-1.28.20-1.el8.noarch",
       "rootfiles-8.1-22.el8.noarch",
       "rpcbind-1.2.5-8.el8.aarch64",
       "rpm-4.14.3-15.el8.aarch64",
@@ -11642,9 +11459,6 @@
       "sssd-common-2.5.2-2.el8.aarch64",
       "sssd-kcm-2.5.2-2.el8.aarch64",
       "sssd-nfs-idmap-2.5.2-2.el8.aarch64",
-      "subscription-manager-1.28.20-1.el8.aarch64",
-      "subscription-manager-cockpit-1.28.20-1.el8.noarch",
-      "subscription-manager-rhsm-certificates-1.28.20-1.el8.aarch64",
       "sudo-1.8.29-7.el8.aarch64",
       "systemd-239-49.el8.aarch64",
       "systemd-libs-239-49.el8.aarch64",
@@ -11660,7 +11474,6 @@
       "tuned-2.16.0-1.el8.noarch",
       "tzdata-2021a-1.el8.noarch",
       "unbound-libs-1.7.3-17.el8.aarch64",
-      "usermode-1.113-1.el8.aarch64",
       "util-linux-2.32.1-28.el8.aarch64",
       "vim-minimal-8.0.1763-15.el8.aarch64",
       "virt-what-1.18-12.el8.aarch64",
@@ -11728,59 +11541,6 @@
       "tss:x:59:59:Account used for TPM access:/dev/null:/sbin/nologin",
       "unbound:x:997:994:Unbound DNS resolver:/etc/unbound:/sbin/nologin"
     ],
-    "rhsm": {
-      "dnf-plugins": {
-        "product-id": {
-          "enabled": false
-        },
-        "subscription-manager": {
-          "enabled": false
-        }
-      },
-      "rhsm.conf": {
-        "logging": {
-          "default_log_level": "INFO"
-        },
-        "rhsm": {
-          "auto_enable_yum_plugins": "1",
-          "baseurl": "https://cdn.redhat.com",
-          "ca_cert_dir": "/etc/rhsm/ca/",
-          "consumercertdir": "/etc/pki/consumer",
-          "entitlementcertdir": "/etc/pki/entitlement",
-          "full_refresh_on_yum": "0",
-          "inotify": "1",
-          "manage_repos": "1",
-          "package_profile_on_trans": "0",
-          "pluginconfdir": "/etc/rhsm/pluginconf.d",
-          "plugindir": "/usr/share/rhsm-plugins",
-          "productcertdir": "/etc/pki/product",
-          "repo_ca_cert": "/etc/rhsm/ca/redhat-uep.pem",
-          "repomd_gpg_url": "",
-          "report_package_profile": "1"
-        },
-        "rhsmcertd": {
-          "auto_registration": "0",
-          "auto_registration_interval": "60",
-          "autoattachinterval": "1440",
-          "certcheckinterval": "240",
-          "disable": "0",
-          "splay": "1"
-        },
-        "server": {
-          "hostname": "subscription.rhsm.redhat.com",
-          "insecure": "0",
-          "no_proxy": "",
-          "port": "443",
-          "prefix": "/subscription",
-          "proxy_hostname": "",
-          "proxy_password": "",
-          "proxy_port": "",
-          "proxy_scheme": "http",
-          "proxy_user": "",
-          "ssl_verify_depth": "3"
-        }
-      }
-    },
     "rpm-verify": {
       "changed": {
         "/boot/efi/EFI/BOOT/BOOTAA64.EFI": ".......T.",
@@ -11790,8 +11550,6 @@
         "/boot/efi/EFI/centos/shim.efi": ".......T.",
         "/boot/efi/EFI/centos/shimaa64-centos.efi": ".......T.",
         "/boot/efi/EFI/centos/shimaa64.efi": ".......T.",
-        "/etc/dnf/plugins/product-id.conf": "..5....T.",
-        "/etc/dnf/plugins/subscription-manager.conf": ".......T.",
         "/etc/machine-id": ".M.......",
         "/proc": ".M.......",
         "/sys": ".M.......",
@@ -11831,8 +11589,6 @@
       "poweroff.target",
       "rdisc.service",
       "remote-cryptsetup.target",
-      "rhsm-facts.service",
-      "rhsm.service",
       "runlevel0.target",
       "serial-getty@.service",
       "sshd-keygen@.service",
@@ -11874,7 +11630,6 @@
       "qemu-guest-agent.service",
       "reboot.target",
       "remote-fs.target",
-      "rhsmcertd.service",
       "rpcbind.service",
       "rpcbind.socket",
       "rsyslog.service",
@@ -12032,9 +11787,6 @@
         ],
         "setroubleshoot.conf": [
           "d /run/setroubleshoot 711 setroubleshoot setroubleshoot -"
-        ],
-        "subscription-manager.conf": [
-          "d /run/rhsm 0755 root root -"
         ],
         "sudo.conf": [
           "d /run/sudo 0711 root root",

--- a/test/data/manifests/centos_8-aarch64-qcow2_customize-boot.json
+++ b/test/data/manifests/centos_8-aarch64-qcow2_customize-boot.json
@@ -430,7 +430,6 @@
                   "sha256:066d47b6d9a955ba52ab53525db1c7f92cb09c9a8db40cf0f28e050e119a344d",
                   "sha256:42464424b9fa731f8122fe748aad0005519fc87b770dbbdb71f29f514ea0e889",
                   "sha256:45c48d32120739734ae97479cc0f3ca19796ea47e360ba39d52b77ce3ada61d7",
-                  "sha256:1cde7ec8148e826642d9c3572b36f97fb4bb1af0ea58c62ad3e7855c37aad50c",
                   "sha256:47b61754a278c4ca378871c874ccf6a0a07bffaef38505315cfa94f262887845",
                   "sha256:e57a218c73df587fb441a22bd4e5f97afb8cbe8812707b26b6dd658910e52dcc",
                   "sha256:cddd0c28a1549f6563cba12771886a1cb990b69b086ebeeced035d962b0eac6f",
@@ -664,7 +663,6 @@
                   "sha256:122fe05bd35778f2887e7f5cad32e8e93247fbbd71bd3da5ed78f788d529d028",
                   "sha256:7cf94e71d42aecccf095c8225aabe5085f8cf7fb4f956fabbe04d23ba7688029",
                   "sha256:176ffcb2cf0fdcbdd2d8119cbd98eef60a30fdb0fb065a9382d2c95e90c79652",
-                  "sha256:c77ac1a164a6e5d042b86bcdcffe7876bc6c60eb3be78c1cb5e09ad239b73299",
                   "sha256:1bd969e0521820374122f5132e5998d9bd2ab185be66565a7266096297419c8e",
                   "sha256:60f68176eddcf15cdcf8c772c2d52d670e2d324f6412131bdd7d604d74b928cd",
                   "sha256:c5b5967a094ced90899052a82e2c245529b75ba3f46e0ce1a89cfc95edb935ea",
@@ -672,17 +670,13 @@
                   "sha256:0e9a8a0f823bf0ef948862f0ccb62353460bd07931e756c98f23908c1c526578",
                   "sha256:ccfa1810aa19fae08aefd29cffe28b65d5123cd17bd7d2d4207f03cf9795594c",
                   "sha256:28c0f457d67213319f0313d993a3b2f8a778a077b202cd75bf45eb2792949d32",
-                  "sha256:caa73f06b13aaef91c4115e0af1689821cdf5130f9f75b416e2f0d2b0c3a6cf8",
                   "sha256:ddc064aa8fb904fbcb1c0da0946f61581a30f6dea8fde9343c29491b0bcd7009",
                   "sha256:777ed4abb0360d2b0e34021bdee6e6b0357629c84e34a8f47adfe1059ecc6cfa",
                   "sha256:db8b1968ff715eb7fbbe326efd5ee3dd2d7aef0d29645de12f36ae474514f909",
                   "sha256:78c43d8a15ca018de1803e4baac5819e1baab1963fd31f1e44e54e8a573acbfc",
-                  "sha256:5c0957decce3babef9864904be13190b0072aef720e9f4ca820bab6c02a20178",
-                  "sha256:109d6db30e5515601b00954b2fd8750c421730a18afc12e1fa7781e24e5b0863",
                   "sha256:ebeb05a4a9cdd5d060859eabac1349029c0120615c98fc939e26664c030655c1",
                   "sha256:72beca700b827714b57f9c61c7647df6eee90820e53af67fc3bee7f08ef631c3",
                   "sha256:62d08a0e508fe8bebd28e2a3fd65ea6c6fe26920d631872e676a100d8e35e806",
-                  "sha256:2ec8ee9578cb0eee9c45186118e0c1e999585e177f1e9de6423a4d79d896d6de",
                   "sha256:c4b1088492cb05631edda4cd62ea537911b79eb36e847270755bf083afafc6d9",
                   "sha256:1a39d5db45d7e97f0a9b564b263ae22d20433bd2f40a6298b8e3ca6a80875da3",
                   "sha256:bc96ccd4671ee6a42d4ad5bbfbbd67ad397d276e29b4353ca6d67ae9705924a7",
@@ -704,14 +698,12 @@
                   "sha256:a04cb3117395b962edc32bf45d8411f240632476b0706b2df7f4a1a87b2ce34b",
                   "sha256:233e5f78027b684e5aaac1395cc574aea3039059bf86eb4494422bc74216a396",
                   "sha256:563b3741d26b6af963fdb7b0634e0791445a707d0b6093ac71c3224299241639",
-                  "sha256:f24d03d0022841fc574d8b7f621b93001bd4ba40785f1db5b35bc2960332a693",
                   "sha256:6c308aa7a826674e1bc1e7ac99d8a1b6b0f2bc4d501086f1985af27e50baa4ff",
                   "sha256:aa1835fd302a37b84ac256db5dd0de09bd9883a5a07775aedb491faf46b18ee0",
                   "sha256:210ad2df4ce04d6792c43d16a7c3b40bfbd13103db7ba7326039852a7ea84322",
                   "sha256:bc7fc2028a29ac7a406719ed4f6740f6bf12c20961223c1e839a2a39069af38d",
                   "sha256:b170c69f99c0bacc01a003c70098e04132629589bf3b0737a73e229da75d0571",
                   "sha256:ef74f2c65ed0e38dd021177d6e59fcdf7fb8de8929b7544b7a6f0709eff6562c",
-                  "sha256:76acb678a5c1d93353d4f506e703ac9ce4925295d61c876f6a420e244102aaba",
                   "sha256:d967d6bbb33bf7a295a64807f81875c84e82a8ecc59b6c72fe955141b1660d39",
                   "sha256:19de7245f0ce7a0fed90263e2b63d98edb549ba1f40ce17916842ef3eb937c44",
                   "sha256:58cad77e10210a5c9183ce5518d452c6a234c5553b93b94af0de3f470c0d944b",
@@ -738,9 +730,6 @@
                   "sha256:4ce2a957083b7cac9ef04a17d2fd6d57039f1c9875d82fe00fe08a62e9fadaef",
                   "sha256:779241d34b7afcd80ef482421c8be90c53872e20254dab27a84f4fc263f0641b",
                   "sha256:08e0218eb17401cd38b3536d2502dfe0676ff05de764b6d4011ba9bf5a6da253",
-                  "sha256:a35e2d0f795f3fa58eaa5f27bd821df24f06a770d736b83a72c38562de6a4183",
-                  "sha256:3386ebe6e649b2cb6a4b3eef260d68f3c165d9ccf54b4e6767ee064aa32d3334",
-                  "sha256:4ac569d8ac68bc904a0a27398e49e3dff6d18cef65c5079c89bde9c953ca0eec",
                   "sha256:633737dc830de1084efc2637d6f4246f4a5b93eba3106184e4541f698c4f99e9",
                   "sha256:454ec267900a2b43ac86d9730b65e8b78bb0ef823c3b8777b531021029c5ce86",
                   "sha256:feb22f3d5529fce8a1d60fe9ddc9fba7dadf4d0864b6ae8bb8245985aef709ec",
@@ -754,7 +743,6 @@
                   "sha256:f006928e944be95bb8d6cb757d759ad25d76d2c36d05e7eab1c4308ed6134c90",
                   "sha256:654d9074dc8ebb93230fe258188a17ba3f7dbac2f360f9f79cc4fb1516953018",
                   "sha256:44999c555a6e4bb6cf5e6f6a79819e76912d036732cb50efaeefc20a180dd839",
-                  "sha256:1865d83df30869bb74fde21b6c31b5440c34b36323a0001fcf140698a9746c40",
                   "sha256:1600cd7372ca2682c9bd58de6e783092d6bdb6412c9888e3dd767db92c9b5239",
                   "sha256:2b743f157f47b27a0528d53fd9ae3e4eb0553f4b8357d01d362dd1b0e4e87c06",
                   "sha256:b9138ff38b834e05b9a34173709bc9b72ed55c7d8ddee4da3e5a4a68648fab5e",
@@ -1275,19 +1263,6 @@
             }
           },
           {
-            "type": "org.osbuild.rhsm",
-            "options": {
-              "dnf-plugins": {
-                "product-id": {
-                  "enabled": false
-                },
-                "subscription-manager": {
-                  "enabled": false
-                }
-              }
-            }
-          },
-          {
             "type": "org.osbuild.fstab",
             "options": {
               "filesystems": [
@@ -1586,9 +1561,6 @@
           "sha256:10814d88ff647e12aeceae4c3815f9eeb66ce7327099c642f934a391fd915f2c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20210827/Packages/iwl3160-firmware-25.30.13.0-103.el8.1.noarch.rpm"
           },
-          "sha256:109d6db30e5515601b00954b2fd8750c421730a18afc12e1fa7781e24e5b0863": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20210827/Packages/python3-inotify-0.9.6-13.el8.noarch.rpm"
-          },
           "sha256:116c1d18b0bda6388cde56e4c93f28b2449dc496ea6a9c5e2d4b581065e2e6c4": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20210827/Packages/python3-dbus-1.2.4-15.el8.aarch64.rpm"
           },
@@ -1637,9 +1609,6 @@
           "sha256:185f60a22dc698b4a48fc8c032787a999e56731f0e582f311bb682a8a975a439": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-appstream-20210827/Packages/lorax-templates-generic-28.14.61-2.el8.aarch64.rpm"
           },
-          "sha256:1865d83df30869bb74fde21b6c31b5440c34b36323a0001fcf140698a9746c40": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20210827/Packages/usermode-1.113-1.el8.aarch64.rpm"
-          },
           "sha256:187a1fbb7e2992dfa777c7ca5c2f7369ecb85e4be4a483e6c0c6036e02bacf95": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20210827/Packages/info-6.5-6.el8.aarch64.rpm"
           },
@@ -1657,9 +1626,6 @@
           },
           "sha256:1bd969e0521820374122f5132e5998d9bd2ab185be66565a7266096297419c8e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20210827/Packages/python3-configobj-5.0.6-11.el8.noarch.rpm"
-          },
-          "sha256:1cde7ec8148e826642d9c3572b36f97fb4bb1af0ea58c62ad3e7855c37aad50c": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20210827/Packages/dnf-plugin-subscription-manager-1.28.20-1.el8.aarch64.rpm"
           },
           "sha256:1db2307d955fa6a794b6f691e64d0d7f0ab7eabadd30f679cd7a780a45565571": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20210827/Packages/dracut-network-049-188.git20210802.el8.aarch64.rpm"
@@ -1783,9 +1749,6 @@
           },
           "sha256:3187b5a82f1e6906539903c42b3bbd0b9979f00ae41d73c52e69e239f1090bf7": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-appstream-20210827/Packages/cairo-1.15.12-3.el8.aarch64.rpm"
-          },
-          "sha256:3386ebe6e649b2cb6a4b3eef260d68f3c165d9ccf54b4e6767ee064aa32d3334": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20210827/Packages/subscription-manager-cockpit-1.28.20-1.el8.noarch.rpm"
           },
           "sha256:3401ccfb7fd08c12578b6257b4dac7e94ba5f4cd70fc6a234fd90bb99d1bb108": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20210827/Packages/libtasn1-4.13-3.el8.aarch64.rpm"
@@ -1927,9 +1890,6 @@
           },
           "sha256:4a08d5264e865548e65d31886c91b659b33a2c2ba39fd115b00af3ea0bc91a83": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20210827/Packages/grub2-common-2.02-99.el8.noarch.rpm"
-          },
-          "sha256:4ac569d8ac68bc904a0a27398e49e3dff6d18cef65c5079c89bde9c953ca0eec": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20210827/Packages/subscription-manager-rhsm-certificates-1.28.20-1.el8.aarch64.rpm"
           },
           "sha256:4ae071ebcf06cec6e4e7e49a50d83464cb1f1f1c72449a02ba1dfc820dbf67c5": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20210827/Packages/c-ares-1.13.0-5.el8.aarch64.rpm"
@@ -2168,9 +2128,6 @@
           "sha256:75dc9e6f813392de179031656e2ff5a3cc92771e545bf029a8bdeb42909e98e8": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20210827/Packages/bash-4.4.20-2.el8.aarch64.rpm"
           },
-          "sha256:76acb678a5c1d93353d4f506e703ac9ce4925295d61c876f6a420e244102aaba": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20210827/Packages/rhsm-icons-1.28.20-1.el8.noarch.rpm"
-          },
           "sha256:76df9e0fc779fcd7d3ee836ae254ead30b5f9492022b55901d1f8bd914d38ef6": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20210827/Packages/selinux-policy-targeted-3.14.3-76.el8.noarch.rpm"
           },
@@ -2395,9 +2352,6 @@
           },
           "sha256:a33349c435ef9b8348864e5b8f09ed050d0b7a79fb2db5a88b2f7a5d869231d7": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20210827/Packages/pam-1.3.1-15.el8.aarch64.rpm"
-          },
-          "sha256:a35e2d0f795f3fa58eaa5f27bd821df24f06a770d736b83a72c38562de6a4183": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20210827/Packages/subscription-manager-1.28.20-1.el8.aarch64.rpm"
           },
           "sha256:a3ef96219165bfc64d4f5d50f51fbd43e803c500619240ffe4db1f9f8e337f83": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20210827/Packages/kbd-legacy-2.0.4-10.el8.noarch.rpm"
@@ -2627,9 +2581,6 @@
           "sha256:c76813885102c12a962a8adf3cd864fa5965e4005050a1bbbd350c3f0040d6b5": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20210827/Packages/librepo-1.14.0-2.el8.aarch64.rpm"
           },
-          "sha256:c77ac1a164a6e5d042b86bcdcffe7876bc6c60eb3be78c1cb5e09ad239b73299": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20210827/Packages/python3-cloud-what-1.28.20-1.el8.aarch64.rpm"
-          },
           "sha256:c85fbf0045e810a8a7df257799a82e32fee141db8119e9f1eb7abdb96553127f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20210827/Packages/libnftnl-1.1.5-4.el8.aarch64.rpm"
           },
@@ -2641,9 +2592,6 @@
           },
           "sha256:c98e748866b96eab0e8ea4170fe312cb48fd46db98e23c6125b1262c4b8b495d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-appstream-20210827/Packages/cairo-gobject-1.15.12-3.el8.aarch64.rpm"
-          },
-          "sha256:caa73f06b13aaef91c4115e0af1689821cdf5130f9f75b416e2f0d2b0c3a6cf8": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20210827/Packages/python3-ethtool-0.14-3.el8.aarch64.rpm"
           },
           "sha256:cab4f9caf4d9e51a7bcaa4d69e7550d5b9372ce817d956d2e5fa4e374c76a8ab": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20210827/Packages/libdb-5.3.28-40.el8.aarch64.rpm"
@@ -2875,9 +2823,6 @@
           },
           "sha256:f1f10022c95ef2ff496b3a358f6fa7f7474fecd4840ac0fac689075356a09689": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20210827/Packages/libgcc-8.5.0-3.el8.aarch64.rpm"
-          },
-          "sha256:f24d03d0022841fc574d8b7f621b93001bd4ba40785f1db5b35bc2960332a693": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20210827/Packages/python3-subscription-manager-rhsm-1.28.20-1.el8.aarch64.rpm"
           },
           "sha256:f2628a19999f78a3ec1a796d66c8cd45f58cfb670850ecb7790528279f410677": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20210827/Packages/libmodman-2.0.1-17.el8.aarch64.rpm"
@@ -9386,16 +9331,6 @@
         "check_gpg": true
       },
       {
-        "name": "dnf-plugin-subscription-manager",
-        "epoch": 0,
-        "version": "1.28.20",
-        "release": "1.el8",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20210827/Packages/dnf-plugin-subscription-manager-1.28.20-1.el8.aarch64.rpm",
-        "checksum": "sha256:1cde7ec8148e826642d9c3572b36f97fb4bb1af0ea58c62ad3e7855c37aad50c",
-        "check_gpg": true
-      },
-      {
         "name": "dnf-plugins-core",
         "epoch": 0,
         "version": "4.0.21",
@@ -11726,16 +11661,6 @@
         "check_gpg": true
       },
       {
-        "name": "python3-cloud-what",
-        "epoch": 0,
-        "version": "1.28.20",
-        "release": "1.el8",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20210827/Packages/python3-cloud-what-1.28.20-1.el8.aarch64.rpm",
-        "checksum": "sha256:c77ac1a164a6e5d042b86bcdcffe7876bc6c60eb3be78c1cb5e09ad239b73299",
-        "check_gpg": true
-      },
-      {
         "name": "python3-configobj",
         "epoch": 0,
         "version": "5.0.6",
@@ -11806,16 +11731,6 @@
         "check_gpg": true
       },
       {
-        "name": "python3-ethtool",
-        "epoch": 0,
-        "version": "0.14",
-        "release": "3.el8",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20210827/Packages/python3-ethtool-0.14-3.el8.aarch64.rpm",
-        "checksum": "sha256:caa73f06b13aaef91c4115e0af1689821cdf5130f9f75b416e2f0d2b0c3a6cf8",
-        "check_gpg": true
-      },
-      {
         "name": "python3-gobject-base",
         "epoch": 0,
         "version": "3.28.3",
@@ -11856,26 +11771,6 @@
         "check_gpg": true
       },
       {
-        "name": "python3-iniparse",
-        "epoch": 0,
-        "version": "0.4",
-        "release": "31.el8",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20210827/Packages/python3-iniparse-0.4-31.el8.noarch.rpm",
-        "checksum": "sha256:5c0957decce3babef9864904be13190b0072aef720e9f4ca820bab6c02a20178",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-inotify",
-        "epoch": 0,
-        "version": "0.9.6",
-        "release": "13.el8",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20210827/Packages/python3-inotify-0.9.6-13.el8.noarch.rpm",
-        "checksum": "sha256:109d6db30e5515601b00954b2fd8750c421730a18afc12e1fa7781e24e5b0863",
-        "check_gpg": true
-      },
-      {
         "name": "python3-jwt",
         "epoch": 0,
         "version": "1.6.1",
@@ -11903,16 +11798,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20210827/Packages/python3-libdnf-0.63.0-2.el8.aarch64.rpm",
         "checksum": "sha256:62d08a0e508fe8bebd28e2a3fd65ea6c6fe26920d631872e676a100d8e35e806",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-librepo",
-        "epoch": 0,
-        "version": "1.14.0",
-        "release": "2.el8",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20210827/Packages/python3-librepo-1.14.0-2.el8.aarch64.rpm",
-        "checksum": "sha256:2ec8ee9578cb0eee9c45186118e0c1e999585e177f1e9de6423a4d79d896d6de",
         "check_gpg": true
       },
       {
@@ -12126,16 +12011,6 @@
         "check_gpg": true
       },
       {
-        "name": "python3-subscription-manager-rhsm",
-        "epoch": 0,
-        "version": "1.28.20",
-        "release": "1.el8",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20210827/Packages/python3-subscription-manager-rhsm-1.28.20-1.el8.aarch64.rpm",
-        "checksum": "sha256:f24d03d0022841fc574d8b7f621b93001bd4ba40785f1db5b35bc2960332a693",
-        "check_gpg": true
-      },
-      {
         "name": "python3-syspurpose",
         "epoch": 0,
         "version": "1.28.20",
@@ -12193,16 +12068,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20210827/Packages/readline-7.0-10.el8.aarch64.rpm",
         "checksum": "sha256:ef74f2c65ed0e38dd021177d6e59fcdf7fb8de8929b7544b7a6f0709eff6562c",
-        "check_gpg": true
-      },
-      {
-        "name": "rhsm-icons",
-        "epoch": 0,
-        "version": "1.28.20",
-        "release": "1.el8",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20210827/Packages/rhsm-icons-1.28.20-1.el8.noarch.rpm",
-        "checksum": "sha256:76acb678a5c1d93353d4f506e703ac9ce4925295d61c876f6a420e244102aaba",
         "check_gpg": true
       },
       {
@@ -12466,36 +12331,6 @@
         "check_gpg": true
       },
       {
-        "name": "subscription-manager",
-        "epoch": 0,
-        "version": "1.28.20",
-        "release": "1.el8",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20210827/Packages/subscription-manager-1.28.20-1.el8.aarch64.rpm",
-        "checksum": "sha256:a35e2d0f795f3fa58eaa5f27bd821df24f06a770d736b83a72c38562de6a4183",
-        "check_gpg": true
-      },
-      {
-        "name": "subscription-manager-cockpit",
-        "epoch": 0,
-        "version": "1.28.20",
-        "release": "1.el8",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20210827/Packages/subscription-manager-cockpit-1.28.20-1.el8.noarch.rpm",
-        "checksum": "sha256:3386ebe6e649b2cb6a4b3eef260d68f3c165d9ccf54b4e6767ee064aa32d3334",
-        "check_gpg": true
-      },
-      {
-        "name": "subscription-manager-rhsm-certificates",
-        "epoch": 0,
-        "version": "1.28.20",
-        "release": "1.el8",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20210827/Packages/subscription-manager-rhsm-certificates-1.28.20-1.el8.aarch64.rpm",
-        "checksum": "sha256:4ac569d8ac68bc904a0a27398e49e3dff6d18cef65c5079c89bde9c953ca0eec",
-        "check_gpg": true
-      },
-      {
         "name": "sudo",
         "epoch": 0,
         "version": "1.8.29",
@@ -12623,16 +12458,6 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20210827/Packages/tzdata-2021a-1.el8.noarch.rpm",
         "checksum": "sha256:44999c555a6e4bb6cf5e6f6a79819e76912d036732cb50efaeefc20a180dd839",
-        "check_gpg": true
-      },
-      {
-        "name": "usermode",
-        "epoch": 0,
-        "version": "1.113",
-        "release": "1.el8",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20210827/Packages/usermode-1.113-1.el8.aarch64.rpm",
-        "checksum": "sha256:1865d83df30869bb74fde21b6c31b5440c34b36323a0001fcf140698a9746c40",
         "check_gpg": true
       },
       {
@@ -13595,7 +13420,6 @@
       "dmidecode-3.2-10.el8.aarch64",
       "dnf-4.7.0-2.el8.noarch",
       "dnf-data-4.7.0-2.el8.noarch",
-      "dnf-plugin-subscription-manager-1.28.20-1.el8.aarch64",
       "dnf-plugins-core-4.0.21-2.el8.noarch",
       "dosfstools-4.1-6.el8.aarch64",
       "dracut-049-188.git20210802.el8.aarch64",
@@ -13877,7 +13701,6 @@
       "python3-cairo-1.16.3-6.el8.aarch64",
       "python3-cffi-1.11.5-5.el8.aarch64",
       "python3-chardet-3.0.4-7.el8.noarch",
-      "python3-cloud-what-1.28.20-1.el8.aarch64",
       "python3-configobj-5.0.6-11.el8.noarch",
       "python3-cryptography-3.2.1-5.el8.aarch64",
       "python3-dateutil-2.6.1-6.el8.noarch",
@@ -13885,15 +13708,12 @@
       "python3-decorator-4.2.1-2.el8.noarch",
       "python3-dnf-4.7.0-2.el8.noarch",
       "python3-dnf-plugins-core-4.0.21-2.el8.noarch",
-      "python3-ethtool-0.14-3.el8.aarch64",
       "python3-firewall-0.9.3-7.el8.noarch",
       "python3-gobject-3.28.3-2.el8.aarch64",
       "python3-gobject-base-3.28.3-2.el8.aarch64",
       "python3-gpg-1.13.1-9.el8.aarch64",
       "python3-hawkey-0.63.0-2.el8.aarch64",
       "python3-idna-2.5-5.el8.noarch",
-      "python3-iniparse-0.4-31.el8.noarch",
-      "python3-inotify-0.9.6-13.el8.noarch",
       "python3-jinja2-2.10.1-3.el8.noarch",
       "python3-jsonpatch-1.21-2.el8.noarch",
       "python3-jsonpointer-1.10-11.el8.noarch",
@@ -13901,7 +13721,6 @@
       "python3-jwt-1.6.1-2.el8.noarch",
       "python3-libcomps-0.1.16-2.el8.aarch64",
       "python3-libdnf-0.63.0-2.el8.aarch64",
-      "python3-librepo-1.14.0-2.el8.aarch64",
       "python3-libs-3.6.8-39.el8.aarch64",
       "python3-libselinux-2.9-5.el8.aarch64",
       "python3-libsemanage-2.9-6.el8.aarch64",
@@ -13931,7 +13750,6 @@
       "python3-six-1.11.0-8.el8.noarch",
       "python3-slip-0.6.4-11.el8.noarch",
       "python3-slip-dbus-0.6.4-11.el8.noarch",
-      "python3-subscription-manager-rhsm-1.28.20-1.el8.aarch64",
       "python3-syspurpose-1.28.20-1.el8.aarch64",
       "python3-systemd-234-8.el8.aarch64",
       "python3-unbound-1.7.3-17.el8.aarch64",
@@ -13941,7 +13759,6 @@
       "quota-nls-4.04-14.el8.noarch",
       "rdma-core-35.0-1.el8.aarch64",
       "readline-7.0-10.el8.aarch64",
-      "rhsm-icons-1.28.20-1.el8.noarch",
       "rootfiles-8.1-22.el8.noarch",
       "rpcbind-1.2.5-8.el8.aarch64",
       "rpm-4.14.3-15.el8.aarch64",
@@ -13972,9 +13789,6 @@
       "sssd-common-2.5.2-2.el8.aarch64",
       "sssd-kcm-2.5.2-2.el8.aarch64",
       "sssd-nfs-idmap-2.5.2-2.el8.aarch64",
-      "subscription-manager-1.28.20-1.el8.aarch64",
-      "subscription-manager-cockpit-1.28.20-1.el8.noarch",
-      "subscription-manager-rhsm-certificates-1.28.20-1.el8.aarch64",
       "sudo-1.8.29-7.el8.aarch64",
       "systemd-239-49.el8.aarch64",
       "systemd-libs-239-49.el8.aarch64",
@@ -13990,7 +13804,6 @@
       "tuned-2.16.0-1.el8.noarch",
       "tzdata-2021a-1.el8.noarch",
       "unbound-libs-1.7.3-17.el8.aarch64",
-      "usermode-1.113-1.el8.aarch64",
       "util-linux-2.32.1-28.el8.aarch64",
       "vim-minimal-8.0.1763-15.el8.aarch64",
       "virt-what-1.18-12.el8.aarch64",
@@ -14059,59 +13872,6 @@
       "user1:x:1000:1000::/home/user1:/bin/bash",
       "user2:x:1020:1050:description 2:/home/home2:/bin/sh"
     ],
-    "rhsm": {
-      "dnf-plugins": {
-        "product-id": {
-          "enabled": false
-        },
-        "subscription-manager": {
-          "enabled": false
-        }
-      },
-      "rhsm.conf": {
-        "logging": {
-          "default_log_level": "INFO"
-        },
-        "rhsm": {
-          "auto_enable_yum_plugins": "1",
-          "baseurl": "https://cdn.redhat.com",
-          "ca_cert_dir": "/etc/rhsm/ca/",
-          "consumercertdir": "/etc/pki/consumer",
-          "entitlementcertdir": "/etc/pki/entitlement",
-          "full_refresh_on_yum": "0",
-          "inotify": "1",
-          "manage_repos": "1",
-          "package_profile_on_trans": "0",
-          "pluginconfdir": "/etc/rhsm/pluginconf.d",
-          "plugindir": "/usr/share/rhsm-plugins",
-          "productcertdir": "/etc/pki/product",
-          "repo_ca_cert": "/etc/rhsm/ca/redhat-uep.pem",
-          "repomd_gpg_url": "",
-          "report_package_profile": "1"
-        },
-        "rhsmcertd": {
-          "auto_registration": "0",
-          "auto_registration_interval": "60",
-          "autoattachinterval": "1440",
-          "certcheckinterval": "240",
-          "disable": "0",
-          "splay": "1"
-        },
-        "server": {
-          "hostname": "subscription.rhsm.redhat.com",
-          "insecure": "0",
-          "no_proxy": "",
-          "port": "443",
-          "prefix": "/subscription",
-          "proxy_hostname": "",
-          "proxy_password": "",
-          "proxy_port": "",
-          "proxy_scheme": "http",
-          "proxy_user": "",
-          "ssl_verify_depth": "3"
-        }
-      }
-    },
     "rpm-verify": {
       "changed": {
         "/boot/efi/EFI/BOOT/BOOTAA64.EFI": ".......T.",
@@ -14122,8 +13882,6 @@
         "/boot/efi/EFI/centos/shimaa64-centos.efi": ".......T.",
         "/boot/efi/EFI/centos/shimaa64.efi": ".......T.",
         "/etc/chrony.conf": "S.5....T.",
-        "/etc/dnf/plugins/product-id.conf": "..5....T.",
-        "/etc/dnf/plugins/subscription-manager.conf": ".......T.",
         "/etc/machine-id": ".M.......",
         "/proc": ".M.......",
         "/sys": ".M.......",
@@ -14169,8 +13927,6 @@
       "poweroff.target",
       "rdisc.service",
       "remote-cryptsetup.target",
-      "rhsm-facts.service",
-      "rhsm.service",
       "runlevel0.target",
       "serial-getty@.service",
       "sshd-keygen@.service",
@@ -14213,7 +13969,6 @@
       "qemu-guest-agent.service",
       "reboot.target",
       "remote-fs.target",
-      "rhsmcertd.service",
       "rpcbind.service",
       "rpcbind.socket",
       "rsyslog.service",
@@ -14372,9 +14127,6 @@
         ],
         "setroubleshoot.conf": [
           "d /run/setroubleshoot 711 setroubleshoot setroubleshoot -"
-        ],
-        "subscription-manager.conf": [
-          "d /run/rhsm 0755 root root -"
         ],
         "sudo.conf": [
           "d /run/sudo 0711 root root",

--- a/test/data/manifests/centos_8-ppc64le-qcow2-boot.json
+++ b/test/data/manifests/centos_8-ppc64le-qcow2-boot.json
@@ -1,0 +1,12607 @@
+{
+  "compose-request": {
+    "distro": "centos-8",
+    "arch": "ppc64le",
+    "image-type": "qcow2",
+    "repositories": [
+      {
+        "name": "baseos",
+        "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/",
+        "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\nVersion: GnuPG v2.0.22 (GNU/Linux)\n\nmQINBFzMWxkBEADHrskpBgN9OphmhRkc7P/YrsAGSvvl7kfu+e9KAaU6f5MeAVyn\nrIoM43syyGkgFyWgjZM8/rur7EMPY2yt+2q/1ZfLVCRn9856JqTIq0XRpDUe4nKQ\n8BlA7wDVZoSDxUZkSuTIyExbDf0cpw89Tcf62Mxmi8jh74vRlPy1PgjWL5494b3X\n5fxDidH4bqPZyxTBqPrUFuo+EfUVEqiGF94Ppq6ZUvrBGOVo1V1+Ifm9CGEK597c\naevcGc1RFlgxIgN84UpuDjPR9/zSndwJ7XsXYvZ6HXcKGagRKsfYDWGPkA5cOL/e\nf+yObOnC43yPUvpggQ4KaNJ6+SMTZOKikM8yciyBwLqwrjo8FlJgkv8Vfag/2UR7\nJINbyqHHoLUhQ2m6HXSwK4YjtwidF9EUkaBZWrrskYR3IRZLXlWqeOi/+ezYOW0m\nvufrkcvsh+TKlVVnuwmEPjJ8mwUSpsLdfPJo1DHsd8FS03SCKPaXFdD7ePfEjiYk\nnHpQaKE01aWVSLUiygn7F7rYemGqV9Vt7tBw5pz0vqSC72a5E3zFzIIuHx6aANry\nGat3aqU3qtBXOrA/dPkX9cWE+UR5wo/A2UdKJZLlGhM2WRJ3ltmGT48V9CeS6N9Y\nm4CKdzvg7EWjlTlFrd/8WJ2KoqOE9leDPeXRPncubJfJ6LLIHyG09h9kKQARAQAB\ntDpDZW50T1MgKENlbnRPUyBPZmZpY2lhbCBTaWduaW5nIEtleSkgPHNlY3VyaXR5\nQGNlbnRvcy5vcmc+iQI3BBMBAgAhBQJczFsZAhsDBgsJCAcDAgYVCAIJCgsDFgIB\nAh4BAheAAAoJEAW1VbOEg8ZdjOsP/2ygSxH9jqffOU9SKyJDlraL2gIutqZ3B8pl\nGy/Qnb9QD1EJVb4ZxOEhcY2W9VJfIpnf3yBuAto7zvKe/G1nxH4Bt6WTJQCkUjcs\nN3qPWsx1VslsAEz7bXGiHym6Ay4xF28bQ9XYIokIQXd0T2rD3/lNGxNtORZ2bKjD\nvOzYzvh2idUIY1DgGWJ11gtHFIA9CvHcW+SMPEhkcKZJAO51ayFBqTSSpiorVwTq\na0cB+cgmCQOI4/MY+kIvzoexfG7xhkUqe0wxmph9RQQxlTbNQDCdaxSgwbF2T+gw\nbyaDvkS4xtR6Soj7BKjKAmcnf5fn4C5Or0KLUqMzBtDMbfQQihn62iZJN6ZZ/4dg\nq4HTqyVpyuzMXsFpJ9L/FqH2DJ4exGGpBv00ba/Zauy7GsqOc5PnNBsYaHCply0X\n407DRx51t9YwYI/ttValuehq9+gRJpOTTKp6AjZn/a5Yt3h6jDgpNfM/EyLFIY9z\nV6CXqQQ/8JRvaik/JsGCf+eeLZOw4koIjZGEAg04iuyNTjhx0e/QHEVcYAqNLhXG\nrCTTbCn3NSUO9qxEXC+K/1m1kaXoCGA0UWlVGZ1JSifbbMx0yxq/brpEZPUYm+32\no8XfbocBWljFUJ+6aljTvZ3LQLKTSPW7TFO+GXycAOmCGhlXh2tlc6iTc41PACqy\nyy+mHmSv\n=kkH7\n-----END PGP PUBLIC KEY BLOCK-----\n",
+        "check_gpg": true
+      },
+      {
+        "name": "appstream",
+        "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/",
+        "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\nVersion: GnuPG v2.0.22 (GNU/Linux)\n\nmQINBFzMWxkBEADHrskpBgN9OphmhRkc7P/YrsAGSvvl7kfu+e9KAaU6f5MeAVyn\nrIoM43syyGkgFyWgjZM8/rur7EMPY2yt+2q/1ZfLVCRn9856JqTIq0XRpDUe4nKQ\n8BlA7wDVZoSDxUZkSuTIyExbDf0cpw89Tcf62Mxmi8jh74vRlPy1PgjWL5494b3X\n5fxDidH4bqPZyxTBqPrUFuo+EfUVEqiGF94Ppq6ZUvrBGOVo1V1+Ifm9CGEK597c\naevcGc1RFlgxIgN84UpuDjPR9/zSndwJ7XsXYvZ6HXcKGagRKsfYDWGPkA5cOL/e\nf+yObOnC43yPUvpggQ4KaNJ6+SMTZOKikM8yciyBwLqwrjo8FlJgkv8Vfag/2UR7\nJINbyqHHoLUhQ2m6HXSwK4YjtwidF9EUkaBZWrrskYR3IRZLXlWqeOi/+ezYOW0m\nvufrkcvsh+TKlVVnuwmEPjJ8mwUSpsLdfPJo1DHsd8FS03SCKPaXFdD7ePfEjiYk\nnHpQaKE01aWVSLUiygn7F7rYemGqV9Vt7tBw5pz0vqSC72a5E3zFzIIuHx6aANry\nGat3aqU3qtBXOrA/dPkX9cWE+UR5wo/A2UdKJZLlGhM2WRJ3ltmGT48V9CeS6N9Y\nm4CKdzvg7EWjlTlFrd/8WJ2KoqOE9leDPeXRPncubJfJ6LLIHyG09h9kKQARAQAB\ntDpDZW50T1MgKENlbnRPUyBPZmZpY2lhbCBTaWduaW5nIEtleSkgPHNlY3VyaXR5\nQGNlbnRvcy5vcmc+iQI3BBMBAgAhBQJczFsZAhsDBgsJCAcDAgYVCAIJCgsDFgIB\nAh4BAheAAAoJEAW1VbOEg8ZdjOsP/2ygSxH9jqffOU9SKyJDlraL2gIutqZ3B8pl\nGy/Qnb9QD1EJVb4ZxOEhcY2W9VJfIpnf3yBuAto7zvKe/G1nxH4Bt6WTJQCkUjcs\nN3qPWsx1VslsAEz7bXGiHym6Ay4xF28bQ9XYIokIQXd0T2rD3/lNGxNtORZ2bKjD\nvOzYzvh2idUIY1DgGWJ11gtHFIA9CvHcW+SMPEhkcKZJAO51ayFBqTSSpiorVwTq\na0cB+cgmCQOI4/MY+kIvzoexfG7xhkUqe0wxmph9RQQxlTbNQDCdaxSgwbF2T+gw\nbyaDvkS4xtR6Soj7BKjKAmcnf5fn4C5Or0KLUqMzBtDMbfQQihn62iZJN6ZZ/4dg\nq4HTqyVpyuzMXsFpJ9L/FqH2DJ4exGGpBv00ba/Zauy7GsqOc5PnNBsYaHCply0X\n407DRx51t9YwYI/ttValuehq9+gRJpOTTKp6AjZn/a5Yt3h6jDgpNfM/EyLFIY9z\nV6CXqQQ/8JRvaik/JsGCf+eeLZOw4koIjZGEAg04iuyNTjhx0e/QHEVcYAqNLhXG\nrCTTbCn3NSUO9qxEXC+K/1m1kaXoCGA0UWlVGZ1JSifbbMx0yxq/brpEZPUYm+32\no8XfbocBWljFUJ+6aljTvZ3LQLKTSPW7TFO+GXycAOmCGhlXh2tlc6iTc41PACqy\nyy+mHmSv\n=kkH7\n-----END PGP PUBLIC KEY BLOCK-----\n",
+        "check_gpg": true
+      }
+    ],
+    "filename": "disk.qcow2",
+    "blueprint": {
+      "name": "qcow2-boot-test",
+      "description": "Image for boot test",
+      "packages": [],
+      "modules": [],
+      "groups": [],
+      "customizations": {
+        "user": [
+          {
+            "name": "redhat",
+            "key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC61wMCjOSHwbVb4VfVyl5sn497qW4PsdQ7Ty7aD6wDNZ/QjjULkDV/yW5WjDlDQ7UqFH0Sr7vywjqDizUAqK7zM5FsUKsUXWHWwg/ehKg8j9xKcMv11AkFoUoujtfAujnKODkk58XSA9whPr7qcw3vPrmog680pnMSzf9LC7J6kXfs6lkoKfBh9VnlxusCrw2yg0qI1fHAZBLPx7mW6+me71QZsS6sVz8v8KXyrXsKTdnF50FjzHcK9HXDBtSJS5wA3fkcRYymJe0o6WMWNdgSRVpoSiWaHHmFgdMUJaYoCfhXzyl7LtNb3Q+Sveg+tJK7JaRXBLMUllOlJ6ll5Hod root@localhost"
+          }
+        ]
+      }
+    }
+  },
+  "manifest": {
+    "version": "2",
+    "pipelines": [
+      {
+        "name": "build",
+        "runner": "org.osbuild.centos8",
+        "stages": [
+          {
+            "type": "org.osbuild.rpm",
+            "inputs": {
+              "packages": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  "sha256:2c1baefd0f802507d9741da8da54f6eae42b04967f9d433d7f9e0f124434c70d",
+                  "sha256:be49b69bc5de947ee2151f397993a691a57bc53952058c32cde0fca674da7d8c",
+                  "sha256:48226934763e4c412c1eb65df314e6879720b4b1ebcb3d07c126c9526639cb68",
+                  "sha256:3a438b53e8377eccf90cac0fd42ed2b513fc869bfb7b96e3d2a4f6984a287f90",
+                  "sha256:8729b157f0925feccdaef8aacd91c6aebe0109e621675bcc15e1830673b0e19d",
+                  "sha256:56c3d429ea949467dc0bca882646cf40a58fb6f27750f5664ff2919f5d38ada5",
+                  "sha256:1fad1d1f8b56e6967863aeb60f5fa3615e6a35b0f6532d8a23066e6823b50860",
+                  "sha256:842ff55b80ac9a5c3357bf52646a5761a4c4786bb3e64b56d8fa5d8fe34ef8bb",
+                  "sha256:15b17b95cf9cb9fb64e0c8e56110836bdcaf70de81b8cbdb60e181fc90456e06",
+                  "sha256:a82958266d292f4725fc1981ea57a861b7fc7feeb7a9551d0b61b98ca51a5662",
+                  "sha256:eee92733e8989029929d5cb1f673b15fdb814dac32e148d5bc02378b44c8699a",
+                  "sha256:ff8b51c6a8bacc5ef6b5da0f049d170ab1c1ecebad50ded3c04ed384eca9a2c0",
+                  "sha256:383a5e6bb9e94de53baaf5c7493cd50a68c893c6a30acfbe28407d33bb133efc",
+                  "sha256:19061d12407c0c4bca6abcaef01695b70dcd3967ff102dd07178a2193a280e29",
+                  "sha256:4e3e93a3d2039c2a8305030b7960bd1100d7d20705a1afb1325a4ee79478a74a",
+                  "sha256:084d79ed3d7127e6d46e9ac6e654d8ef181a156435808dc8eb32968b6c1b4946",
+                  "sha256:2a8f9e5119a034801904185dcbf1bc29db67e9e9b0cf5893615722d7bb33099c",
+                  "sha256:67f37cee02ba744dfc7957725f5ef9df229778f6a2f7afc659625b458da6167e",
+                  "sha256:b10d8521963a2494fdb2b5f8fb0de837dc86d4016c3b10019fb8970a09582451",
+                  "sha256:47ad43730c8bc72c90f2fb3dbd3526d716ada2fad94e62cb443658e94c6503c5",
+                  "sha256:5c1940e1f173e22b053f3a89022903cea34a6af20dff81c65548c4e2ba3a8293",
+                  "sha256:1a4e44583a767289bb0d354db93c6a9132420e13376d4fcae866d69620bb11bb",
+                  "sha256:7baac88adafdc5958fb818c7685d3c6548f6e2e585e4435ceee4a168edc3597e",
+                  "sha256:090563f18409c228274bb61dcf1001f63a55c1246fb2838a998cb3c5fd8c3874",
+                  "sha256:c58b0b900a7ffc778980461d74dc236bf2c790d2e5e8c04e28876e221b48a1c8",
+                  "sha256:cc5f8dd4e061da3a73aa67112e24f2cc5c0ad0cd4334dc798b8834cf6259a779",
+                  "sha256:698e8ecaf71719dafacae79de05080d567b69fad3511e8b8d42b9af96a7c41db",
+                  "sha256:441b3862f5a0fd504bbbba18d96d1b2b920fb95a79dc45a753a6a664ad285b07",
+                  "sha256:a42de8ce71380b1f4e8ac5b4ce720bf565c99a0b09ef983c0550a91a467bc155",
+                  "sha256:4f92835a6e4ee4276df49019e068d1871b75821f52b405c699bd9f199df58b80",
+                  "sha256:42464424b9fa731f8122fe748aad0005519fc87b770dbbdb71f29f514ea0e889",
+                  "sha256:45c48d32120739734ae97479cc0f3ca19796ea47e360ba39d52b77ce3ada61d7",
+                  "sha256:04eee0a9c079186aa58b5536ac8bcbd2a360700b83fa7b9f6eb127c1386b7ef4",
+                  "sha256:881b28a3a37d114bc3f046605b24663560009b13a507217e007643f5682efdd5",
+                  "sha256:9e67ac5948125dd165c9a74ec848d48b313ef4264bbbb89630a782dbd972d72c",
+                  "sha256:9fb07c2324cccbbc19e3ffade50ee7da41909b2f6c24f49ffd9978ba375de193",
+                  "sha256:f4eca686b314edb06d3fe1c526f573c7248c811af70cba76132cdc9c541cadc1",
+                  "sha256:30ceeb5a6cadaeccdbde088bfb52ba88190fa530c11f4a2aafd62b4b4ad6b404",
+                  "sha256:e87acf226a9511b3a5f83e7fed9c5c20addbbdae47ab67c614404a9392b77e50",
+                  "sha256:d150e53fa73c3786da9e4f6e23d374100b0dd2923485d4a08e9a56ac2786cf83",
+                  "sha256:88be5116908aa5013f540c767f6811774342780bb72d3ec197b3429bfb2f9862",
+                  "sha256:e156e6fa9ef6a483f8505ce0eeadbcab12b887c4996233ce5d6258076f6bce50",
+                  "sha256:e65f7d7c8def6b168e013914bc0d1137aed65c3010e9796df3b823854472f3e1",
+                  "sha256:a49b922f117b9bfb0b07e9848151f8a2948345328ebc534cd28ac187d7ed3f94",
+                  "sha256:caa0bd6617a8d5e535faedec5f6f3ea7c5e6da1898751f6c9c34a89a95c286ff",
+                  "sha256:d1cf2d973db2f1af46f124776b9ab4bd782e7065c8c8428a4ddef60989e4225d",
+                  "sha256:4992eb036c0797daf9b984af1a34fe27a30287ee5d2bd5e2f5a0df3a09bdbb59",
+                  "sha256:d807e7fb8bf24be50642a6dced954c6ea208199daab2d27c9f73d789ba82fa37",
+                  "sha256:8cd6ef9902851f07cfd9682e2d6873648690f0c2ec65345276b557ede042d8b9",
+                  "sha256:d1d362fd4f8022ad05171efe40e84d15ec6c5e5f419d6099ebc8e46e7da632c1",
+                  "sha256:78fd472a1c7f49b8a432788ea2dfc1119f155a394f41585b4e715d2585fc92ab",
+                  "sha256:e392a6b41381ffad04626d092fd2af9477c72e197a74efddf987832c3bfa521f",
+                  "sha256:ad338b7a3f3bed96300d9ce7f0307e09d758962b8496c10fb3554bf62405d153",
+                  "sha256:bfb45644212cfbbe48b05149f8d53e77d7bd02ca9fc9045cc37115101175a3a0",
+                  "sha256:fa7bef727ba8657208bb3df95916f0bc912332cb8534c695facef32ffbd72f20",
+                  "sha256:257e086bb52086254fa8cc95a5c4998668b4fcb5203ad3c2275c1150816acc9b",
+                  "sha256:af0a4287e302baa7c85655ddfe5a7049b8eaf31aff03886f4fc57c920d26d491",
+                  "sha256:11ff811a72c82084c7c14700b23d29643e153442a34b3b486e270e5b40e38d0a",
+                  "sha256:a2d96efed83ab31d21481af044835a940673ee4ade2763af78c06d2df87b94f7",
+                  "sha256:51760acfb6ca87db5be7a9296d6a3d1220767956c576a26c6d46784e25db85bb",
+                  "sha256:24f5cd46a7395cd046b10d6ddc4de435ec6595d0dcdb2d179c94cc9082a12f14",
+                  "sha256:2451a475f248a4c66e64d149fefa8bfc195fcd7b3f369bae221a94f8ce4c2d67",
+                  "sha256:4a08d5264e865548e65d31886c91b659b33a2c2ba39fd115b00af3ea0bc91a83",
+                  "sha256:7cccedcc359f2a2542858088704bf3d0ec3e46cb7b72f602408fbab937a522d3",
+                  "sha256:d8dad22276baffe9496d5e05ef35d21dd6f9d8f910339daced2c3ff42d7a28c5",
+                  "sha256:78b2b9cbf041d4461daf7ac11a24d1e79a9c57f47aa265dba4d09067efe3d96b",
+                  "sha256:ac3b306c193bd20658950da402ae0cbdd8337110117de5e5d7eba970822671fd",
+                  "sha256:fb276cc0ebc6bd27d344f7e0811f26cb3f0e59da09182489095724bdf2a075f8",
+                  "sha256:5a0927d231fbafa8b865591922fc07d39d9b4b263a1e9c0bbef691282f706cd0",
+                  "sha256:e1e28504928648404a3b652440091eba010cd99221183ef78601cbd152261d91",
+                  "sha256:42bb566be1936bdb40937f9c0a96c4acc93057379385f1807cba18f60443d3e4",
+                  "sha256:8119d276749b35cd9c283c1a8d970b3528bea58427eb37eafc22b6093a978f08",
+                  "sha256:6d1ac29b3a38408f6d238d6718384e05be7346789c6200b354335b0e0c9c77df",
+                  "sha256:331b91a0928c05618c7fed3e12bbe9ecb9e4619d08c7e85d3de344a08d2f0f1a",
+                  "sha256:49c7c718cb4e2b6f0effd0dec4f4cb4e109d260c192b2b329a58a1da9a24ad1d",
+                  "sha256:a3ef96219165bfc64d4f5d50f51fbd43e803c500619240ffe4db1f9f8e337f83",
+                  "sha256:ef86061338fa321c959cadc75ecbdfd405eebaa1042eec9d9c737d4d9d92568f",
+                  "sha256:6fe1188081e441595ce29ebed4d1985e5890815158244f69f092ee930656f755",
+                  "sha256:a80c1d6d32db7ce8fdd58bb4f3f488b74e94261a38512dc8a15179ae33697e63",
+                  "sha256:b437a08d4670ef440ba6dbaae4ccb39f989f0c2a3d280ea66d6fd9532a313286",
+                  "sha256:230731b577f8d29e7e8e8fd6d1ea02702fb4364fcc7034d838ccddc4d66da8c3",
+                  "sha256:54f59ddb56e89a5330373e07ea05934fc58360eb7480615ede2a3ed6982e1eef",
+                  "sha256:ff1580bd4ec5841d4937b383917fa30f318b4f419b8067a77468eb4a9630ba10",
+                  "sha256:3303f41952491bad2b31ee507eaabaf13dabe5ec9624c4b58a4a8301c4cd89dd",
+                  "sha256:df40cada982b04336fe8b250b4fdd576ddd03a014bb519a69b34640369bef661",
+                  "sha256:9c4cd61b98253904436180f58c564bda61be1fa1b5523e4ecbbdc174d0c2a9aa",
+                  "sha256:43bfc890caf7855f2fb55c24474b58cd5c8c7b51e4db4f40d1f302fffd31985b",
+                  "sha256:30ae4489980021a727f247d48b4d74d4c6c7667d00bd1a670f045ea24a885541",
+                  "sha256:77e4cfbc823e3764308822ccf03b257861f9360f3b948829f1d73148b321b00e",
+                  "sha256:9b69a221cf9395a110849bb428bb1cfe9fb489322df0fa6017f5978a827ee0e9",
+                  "sha256:e0a7b9f3b56b4737f5711dc6b03f256fbf2488656b8874acabb494b58ba0c1c1",
+                  "sha256:5c74a0e3005ea3cb90dff80cfa1e7d64c97f5c01612d253cf4e65aca962b7be4",
+                  "sha256:194dbe332ccdb33d58f040da07667257e176975f6b2f17343bbf33fb99deb097",
+                  "sha256:e21a84107568047432e474e08da24aea2340409d57ea8cf170182927dc76de12",
+                  "sha256:b83a0199c3d471151f07f6de626a1a4a362dd6aa29d84cf1c0ada2c966ce29c9",
+                  "sha256:709ea71f36495ac2ac89d72d2eb603b6aa55b2c1a70633f23514dd897936f02b",
+                  "sha256:aea253461d1a34a239b445ee07cb34398a9cbb6ed40e252182a91cddcf59004b",
+                  "sha256:a0b8a6b2c8dad75290228086dd0af342979604bbf4b9500029e25d766835c0f4",
+                  "sha256:0afac6f4f9ed1c59510675d87da45c7966c0f7aae6e8dd056961aceed8c4fe0a",
+                  "sha256:12696f5638ad2068c5c8940495d15c3bb1c57990000dbda7428b008e9e63ab5b",
+                  "sha256:f3d9ccb762146dc97f2d201d979fbb0e9171d1203fb985f3ef48b5c2a176c2a9",
+                  "sha256:c5a60ffb80cd1f9b90c797f1d1ac80e5536eb32a5b276871445e7279ac701c5f",
+                  "sha256:0515afdac097ad54cf4b24e0644f0789cab5535a54107aa44940ffd991a6cef3",
+                  "sha256:020abac486839c7be29fae37a686dc7749398c333cb8ba94b3390b386ffcbff7",
+                  "sha256:31d924d1540dd4e927a4c3aa936cec4bfb54ed302d3e8acc1be8b52dd5deb10c",
+                  "sha256:fd6e1803ff367036da5b52b2183e1408691b379cc1320971bb664737507f89a4",
+                  "sha256:6b312faed4a0508da2f15d3f31a6daccfc0ec6621e5fb7b20956027dce5fa395",
+                  "sha256:a5f9f2c4f39f393971f268aebb1b55d18d0d96693d08a9ed70403e8565807bb6",
+                  "sha256:d6eb27d158b6397e52ab6a952fec4e3c414638a08750a6c011d32eb117accd82",
+                  "sha256:4e497225fe36781735cc92c0886f6858b19d4557ed9ecafe1247b8233c206075",
+                  "sha256:d3a4f367a9c5ba936b1bb5480db390889a303e5ec8ff34bb4274c1d840a1784d",
+                  "sha256:8d7777da3f54f965cf3058cabf987c01b93a1dd041e8359eb7822eba57d8c8df",
+                  "sha256:b58be8f7685340b35e61945b1ab499bc1030b0b021b2ac5576897cf079ff7812",
+                  "sha256:9b8a8a843fe9a972f6433e11b95b5a8d1d2971ed40fe1acda6807e34f0773c62",
+                  "sha256:1aa321c66a3661e78d938b805e5c311d519f04bf3496545ffdacc7c152bc9b21",
+                  "sha256:3dfffdadfb10def9a3671a255e4fa71d8b22231ccf2c929e96689101dda8ce2c",
+                  "sha256:c5c61536e768553067cee488830c64866d109cade24917dbe23f82c861af07c5",
+                  "sha256:98c28a91d41f634edb8c1f001dbc45c0de534332d059a2e8feff448fb7235c49",
+                  "sha256:b4a1ac1ff5cd22a5dab6c96dfc2dbd7cd6ba750691ad5c53a97a1f088fc42abc",
+                  "sha256:01b0562b890a80c202fff9175dc845500660c7f1655292d4ee13ca667acab081",
+                  "sha256:56c866bcff69fd60b630841ff990296b26c2f45d8c6054311b5c476bc67466ac",
+                  "sha256:4fe264ed1cfd0c074f4601354b0128a9e5068f0fcde7382fd5429585f0d4cd2c",
+                  "sha256:95103f7c339aec4b485b7f569aa8a5e1a54286b3d2acde427328c49e4d8d80d1",
+                  "sha256:adc56041458e556df5663e7da264e151c24aaf1c2a94e49df9790ba191ea1b37",
+                  "sha256:0f57b051654b6d75789b437dafd7040b6c90daee17827be24352c0f11a74bba7",
+                  "sha256:1b5136570cefb8273dd5affc73c1456cf239cc8b18be72d6c4d09794af7f3352",
+                  "sha256:679724b45157b4d4c9ebe2eb32e188b9a65d47c23be886498d7a178caaf113bb",
+                  "sha256:767dd64d91c23adda537c7759ae3b4f720d3c76e03b52bc9231e52e0113db3ab",
+                  "sha256:2dbfe3cb37c18b39393870baa77f3bbd42be53517abffdd990b13ed70ee3dd3e",
+                  "sha256:f5bcb82a732c02d6f31bbf156887049883c76cedc9c6a11b049358a74f4d45d0",
+                  "sha256:32ebba6472cdc331bd3366ca996ad3039b3a1b41c61a849b88074e1b722cad2c",
+                  "sha256:75e9ed16ace51ba04a62505aaed215bf9c722d6f4b1c33cc3e3962076c300ee8",
+                  "sha256:d539404dafd8ad5d785ab3da6f8bd5a2bf5dff9e01be0ff1bc1d251786dda25c",
+                  "sha256:bff39fef1fc01564156123fcade75b4bc50402a2971a031d9a426c7014b1e681",
+                  "sha256:6b9875495111bcd2d3c5e9e380b3be17fb0a730891468fb45bdba3b3692b00ea",
+                  "sha256:e217c2687212d931ad9a6a02afb20cc34f6d051786d136e337f91079c9f73d22",
+                  "sha256:c1291b69a65a860069195a33cf6640df8667e960f9f030ceeea4497c47858b94",
+                  "sha256:d8c00baf46e33f9e5f1b9e139bbea9fe0f27badb432c992b9cf8c4f7017094bf",
+                  "sha256:1a968f65db066243cbd0a6e12d193ef674637f044299a15b5d6b910e91411812",
+                  "sha256:4a167fa4a7238bd94b3134173f6267b19cdebc2fde98b583344749e1f4c9bf09",
+                  "sha256:8904fdb492f34e5242ba483fb6b7b158342662575b3d5ac9abbc380568840d4a",
+                  "sha256:6bfc201a12dc7bba21069a663aa692a96c5e8920b0d94a4e355c332d7ead15ba",
+                  "sha256:393e7bb9f93ffb3cbba620fbfeb229f2b8345454bc60ac0508f76735544ed289",
+                  "sha256:f24bce642ec88622490b2f09a45fa3985da7f6511a1aae131853c4ea4c309e6b",
+                  "sha256:4c5aabda0cd9edb40e141066d400d2e4b232bc22ab60e806a6399691c391cabc",
+                  "sha256:9936485ac7111967d6962bc539de7b08807e310117adb78b11c21a5db0f0f890",
+                  "sha256:0230acdbc9da4b36da812f0e585a7602eda4982c899b3b3a4c2bc9b4546d8e74",
+                  "sha256:7abf49cabbaf996afc0c2604f10ea18f8f22a903fc4ba3728a18f5892353c5c9",
+                  "sha256:41716536ea16798238ac89fbc3041b3f9dc80f9a64ea4b19d6e67ad2c909269a",
+                  "sha256:17ffe1d683dbff48f9b2ef903401e471e5e51a992bf0890632bceb94561893de",
+                  "sha256:8403cfc97e0e72e37639b8c54d92f1ee427e48a70d52d5260a37fa104f2df20d",
+                  "sha256:7a66928044c3478964aeaf6f9e981fdbcfa6b2ff7fad9f2ad57a8c09387cbbf2",
+                  "sha256:c24b21415b737f18fad7aeb192e60f7d323f7ba69434ecc1e78b3af0003be8dc",
+                  "sha256:c2479eb811f4d9b8624ef20119e1abdc109f639c2cf576eb945b340362d87b05",
+                  "sha256:46606c1ed76a4da2a9d18016aeb50f4dddf58e1b45d665c983c58f8e605bf73e",
+                  "sha256:d87f7fa5e637442eb638bcaafdc44ca3895d91a153015ff9af6a87219f0dc372",
+                  "sha256:71c88f04921ae61a7009f9443f95c70ec3424a798429fc01e6c1432c1077aacb",
+                  "sha256:bf994cb2e5c367d78483662c7de6e69950aaf04bc6cfdbbef4d1ef7ce153717c",
+                  "sha256:b7330d40f75b8ec786e41c45a202e44f0e49ec29ddf8944120fbdb373a6c6617",
+                  "sha256:bb82b10a91493d745dc533b5de5335db650adb0c8a90548fdf5dad13569a16f4",
+                  "sha256:9e2ef90cb484b37232e829ec400dcddd3f9f0d189eb6f0074b3b5874d4553d1c",
+                  "sha256:3ed319e31a9c38e5f4e336195b5cbd253b3f8b17f93f185829f078c5ef420305",
+                  "sha256:5c46bef8c0e95e05716e9a53b77970c1378d93bcb9a800018a24f7e1763b45b9",
+                  "sha256:3edfdbc82f97ec12e59c80c67897fc1eeb44c3d16820f761a8f15272965ea3a1",
+                  "sha256:cdd6594a3bca71d32a5061b85457cc8148611e7f042ba6e812a1c0a2faebac92",
+                  "sha256:56650f8b8f2b01c1090d184d7d6d396f0109f8a02f915c97b081be73ea12df08",
+                  "sha256:946ba273a3a3b6fdf140f3c03112918c0a556a5871c477f5dbbb98600e6ca557",
+                  "sha256:c64632c85c3a49dc82222cdb3d0ee87eafa64f3096ffeba5bcc16c49ee2d260e",
+                  "sha256:15554476d03595246aec194e63ec9db7469d5b3ed81a27a8a2720e82df1f8bf4",
+                  "sha256:3b00ac82c31b447e306fcb47b4469fdc4e6d87385b42358c2e76badb51b074a3",
+                  "sha256:1cfa672c25cb5849bb2aa652e045e4a4a272c025befb1fe5e58cb32823faa30d",
+                  "sha256:2394d6a1ce4de90590e65111d870b172cb9d4e30e1e6f58a334b29e717fdd031",
+                  "sha256:65ecf1e479dc2b2f7f09c2e86d7457043b3470b3eab3c4ee8909b50b0a669fc2",
+                  "sha256:176ffcb2cf0fdcbdd2d8119cbd98eef60a30fdb0fb065a9382d2c95e90c79652",
+                  "sha256:ccfa1810aa19fae08aefd29cffe28b65d5123cd17bd7d2d4207f03cf9795594c",
+                  "sha256:111d88db3a52121f04f2741cc72ce8dda6d6f6ef2cc36452c042e0141b316334",
+                  "sha256:4715730da2b4a5bf6cc2ab85208071f00c7b279e4b2f75df0bd954446185e14c",
+                  "sha256:78c43d8a15ca018de1803e4baac5819e1baab1963fd31f1e44e54e8a573acbfc",
+                  "sha256:5c0957decce3babef9864904be13190b0072aef720e9f4ca820bab6c02a20178",
+                  "sha256:594d8b368013caa4eaba4eade896fc1cec8ef569052bd491f493c193e07c6d80",
+                  "sha256:abc36bf7797a427b64c3c99b4f74714bfa66b906b62358be6fdafe493a66415e",
+                  "sha256:35eb77080d99941b137da8c6cb25305ad4ff64cf2a7ba1f8adbf8d0998b5fe45",
+                  "sha256:405bda98fe97c1a5cf70511ae2d167256b25dd8721b88899465e9847525e2068",
+                  "sha256:3b5d31b89683be71c72b77cfceb59238f4c76a796de6ae85525b3d5cfe2a8f23",
+                  "sha256:6c9dfb73e199975275633f05d31388cd61c5a77dec5678db958b4e6624eb21ba",
+                  "sha256:7f506879c64e0bb4d98782d025f46fb9a07517487ae4cbebbb3985a98f4e2154",
+                  "sha256:003ee19ec5b88de212c3246bdfdb3e97a9910a25a219fd7cf5030b7bc666fea9",
+                  "sha256:ccf848b42acc0f691b4cb6e2830dc4263c7ce4df89b3f4002c3d6b9cd99b362b",
+                  "sha256:c6f27b6e01d80e756408e3c1451e4af00e7d02da0aa24402644c0785118753fe",
+                  "sha256:b19bd4f106ce301ee21c860183cc1c2ef9c09bdf495059bdf16e8d8ccc71bbe8",
+                  "sha256:a04cb3117395b962edc32bf45d8411f240632476b0706b2df7f4a1a87b2ce34b",
+                  "sha256:aa1835fd302a37b84ac256db5dd0de09bd9883a5a07775aedb491faf46b18ee0",
+                  "sha256:0320663709136d07690fe299903700cc1dcc526d574fe8b952a01e1d24024ae4",
+                  "sha256:4fae16ca54207cb952e3904b8eb8cc424f3f056f400e5e802ab1a9ef3e575834",
+                  "sha256:03ba1e86a04d912fd2878b457b06a6a7abad0ce96cd9a6932bf58cb4641b8fb7",
+                  "sha256:4e22015880d16cb7148d70895a2361f4fa05804f0391386e0e50554e6fd868b0",
+                  "sha256:9b1018a43b1a9245cdc71a342b962aa32fb799bd0ce66ee59b496cdd75200de9",
+                  "sha256:8cb953ea9ea1bd262bef00112e2c433583929cd7aec86ae60f1a725c6dcf7c09",
+                  "sha256:dbde46224833f804d8b92212fa3618ea53d0e0cb84ff07132a5ba36c1bc0b9df",
+                  "sha256:561a61d2d81bccb14d22a53b32301e0b6b9e9b9d80ad75991ee6ff796cae0ef7",
+                  "sha256:76df9e0fc779fcd7d3ee836ae254ead30b5f9492022b55901d1f8bd914d38ef6",
+                  "sha256:9e540fe1fcf866ba1e738e012eef5459d34cca30385df73973e6fc7c6eadb55f",
+                  "sha256:e1153055b6ea57ee81e6fb41b03023279059513d0fec728517ae0805186a5118",
+                  "sha256:f97b5915b3f75d2878104c198f205841813712103f1b3657d71d2c8d079cc947",
+                  "sha256:31277c01ac529cc1c6a55fd87d6ce4dbb20290575d4e1e89cd40600eac9f3405",
+                  "sha256:4b00562fa291e956d910bb056c6120f0079f30093ea107757758683a6d418206",
+                  "sha256:8a501b9d8016eee68ce62a93a65842b15c8a57192b9f8189ebc85a11f2f47f9e",
+                  "sha256:3d175382237a94330d72af67ad2c41535dee7eade3e42178b86d2dc87478d030",
+                  "sha256:e95bb05fa5defeb16dd0e0957de676374b22b9daaf405273e636d1ce91001574",
+                  "sha256:3898e2ac4e04e80373bc7fe4092b26d502d4705177719117e25c083d44a9a150",
+                  "sha256:8c26cce4231f781db7b37d51ded377f9cfa01a5e6833d967082795f1220e2860",
+                  "sha256:d46ef49f8ddba1ee8cce6c9764014851cce2dbfb5dcb2457a31495393e6566c1",
+                  "sha256:4164089bf1754c0ef18ae051e047f11299907204839ad4b7978f146a543a2e91",
+                  "sha256:09096bc32e37443417cd625364df32674f9d5ff4ddbeb175e6d60637ed3d573f",
+                  "sha256:44999c555a6e4bb6cf5e6f6a79819e76912d036732cb50efaeefc20a180dd839",
+                  "sha256:ce954d3900cb547aea14df6ad5f310ea96bb5e83a155b93e2e64b2c13b686193",
+                  "sha256:15cd74b4ad9d82417072fe867f086d68667afd4291b710b6c7feef985c492990",
+                  "sha256:480e0f1a9dcce6ed0728e9aba709e33f5522273da1e4b0859cf9d3bbe2216532",
+                  "sha256:cd8b0adfc4d2467a61ab2aa2b3e617bbd2a2592176da249365eef014faef827c",
+                  "sha256:a4577841148e7e2bf481447ae141eff319007e70a24295a22787bbfaecf4c4fe",
+                  "sha256:33a92d88496e8aa410976f073e324f761b2ae02a94c20c0f291072df84f648be",
+                  "sha256:a388c955ace01f09f522c0ccf3afd47e682b22a87756e185f9134bdff72fb2ff",
+                  "sha256:5374ef6981f9a29d08c3400488b010f477fe7722367fcd6d29244ba8bd29b89c",
+                  "sha256:864f5bf99bf805c3e1143f78a78012d2f910f0d5627519b1f263a4d5cc6fa45e",
+                  "sha256:e14ef6f934d9a20645b9eb781902d6a03b7c8123985c88536e06205b240ba509",
+                  "sha256:b5bd11b47b5b690dc667dc486941331d7cd3aaa4f0e5c4d638ec7b294bcc5012",
+                  "sha256:0bad67cd4773d94db37a39c77f44b6eb380febc0de33fa51cacc2140c9c699b9",
+                  "sha256:94e73ee7b1a5e6791a7cdce615f8a7e23fe1e6359b22ee366b71f45a5ef13483",
+                  "sha256:41512b492c3020571b4d8c671160758ec0e4b78212d75808291a5c56224b644b",
+                  "sha256:12fda64dea45a7b085a35a816a7d8035be6600cae38f7df04a3bc22ced4d4502",
+                  "sha256:3c9de6673cb840c3c6925bd1df87da0ef3b118d35dbe8f30bbafd0dfc67a939c",
+                  "sha256:9dc5c484c7821cc737f872973764203376106d643b9adc4ef66bece1b0cc8fdc",
+                  "sha256:0f54422e17766a9e7385a553d941d1849c9e7ca4caea085305ba9fb1e15ae607",
+                  "sha256:b01c567dbd2b9bf82301b254a8962a8fb8f30d12a8f566145eee0f3936f47b5d",
+                  "sha256:b615599db3ac6249e7b18e0c66474e080dc71ee72612bfa0268ea36b1a74e8da",
+                  "sha256:8571a2aa115d42f8b5e87ef58d10e9c24e6fbe5470fc2612df96f8740f3d960f",
+                  "sha256:3973aa7ac4416f1d33ffa8f4e9a5b126e7e2f77ed1ec63a70312b509b4934a9d",
+                  "sha256:9ea4e52636b010504bfff1662c57988feb81cdfe97ba7c092f6efe3abdbe2dd7",
+                  "sha256:ebd64ac5cc7b9f58a40072fe9afefa2fd835e0eb18cdeaf085395c7e84affac3",
+                  "sha256:a2aeabb3962859069a78acc288bc3bffb35485428e162caafec8134f5ce6ca67"
+                ]
+              }
+            },
+            "options": {
+              "gpgkeys": [
+                "-----BEGIN PGP PUBLIC KEY BLOCK-----\nVersion: GnuPG v2.0.22 (GNU/Linux)\n\nmQINBFzMWxkBEADHrskpBgN9OphmhRkc7P/YrsAGSvvl7kfu+e9KAaU6f5MeAVyn\nrIoM43syyGkgFyWgjZM8/rur7EMPY2yt+2q/1ZfLVCRn9856JqTIq0XRpDUe4nKQ\n8BlA7wDVZoSDxUZkSuTIyExbDf0cpw89Tcf62Mxmi8jh74vRlPy1PgjWL5494b3X\n5fxDidH4bqPZyxTBqPrUFuo+EfUVEqiGF94Ppq6ZUvrBGOVo1V1+Ifm9CGEK597c\naevcGc1RFlgxIgN84UpuDjPR9/zSndwJ7XsXYvZ6HXcKGagRKsfYDWGPkA5cOL/e\nf+yObOnC43yPUvpggQ4KaNJ6+SMTZOKikM8yciyBwLqwrjo8FlJgkv8Vfag/2UR7\nJINbyqHHoLUhQ2m6HXSwK4YjtwidF9EUkaBZWrrskYR3IRZLXlWqeOi/+ezYOW0m\nvufrkcvsh+TKlVVnuwmEPjJ8mwUSpsLdfPJo1DHsd8FS03SCKPaXFdD7ePfEjiYk\nnHpQaKE01aWVSLUiygn7F7rYemGqV9Vt7tBw5pz0vqSC72a5E3zFzIIuHx6aANry\nGat3aqU3qtBXOrA/dPkX9cWE+UR5wo/A2UdKJZLlGhM2WRJ3ltmGT48V9CeS6N9Y\nm4CKdzvg7EWjlTlFrd/8WJ2KoqOE9leDPeXRPncubJfJ6LLIHyG09h9kKQARAQAB\ntDpDZW50T1MgKENlbnRPUyBPZmZpY2lhbCBTaWduaW5nIEtleSkgPHNlY3VyaXR5\nQGNlbnRvcy5vcmc+iQI3BBMBAgAhBQJczFsZAhsDBgsJCAcDAgYVCAIJCgsDFgIB\nAh4BAheAAAoJEAW1VbOEg8ZdjOsP/2ygSxH9jqffOU9SKyJDlraL2gIutqZ3B8pl\nGy/Qnb9QD1EJVb4ZxOEhcY2W9VJfIpnf3yBuAto7zvKe/G1nxH4Bt6WTJQCkUjcs\nN3qPWsx1VslsAEz7bXGiHym6Ay4xF28bQ9XYIokIQXd0T2rD3/lNGxNtORZ2bKjD\nvOzYzvh2idUIY1DgGWJ11gtHFIA9CvHcW+SMPEhkcKZJAO51ayFBqTSSpiorVwTq\na0cB+cgmCQOI4/MY+kIvzoexfG7xhkUqe0wxmph9RQQxlTbNQDCdaxSgwbF2T+gw\nbyaDvkS4xtR6Soj7BKjKAmcnf5fn4C5Or0KLUqMzBtDMbfQQihn62iZJN6ZZ/4dg\nq4HTqyVpyuzMXsFpJ9L/FqH2DJ4exGGpBv00ba/Zauy7GsqOc5PnNBsYaHCply0X\n407DRx51t9YwYI/ttValuehq9+gRJpOTTKp6AjZn/a5Yt3h6jDgpNfM/EyLFIY9z\nV6CXqQQ/8JRvaik/JsGCf+eeLZOw4koIjZGEAg04iuyNTjhx0e/QHEVcYAqNLhXG\nrCTTbCn3NSUO9qxEXC+K/1m1kaXoCGA0UWlVGZ1JSifbbMx0yxq/brpEZPUYm+32\no8XfbocBWljFUJ+6aljTvZ3LQLKTSPW7TFO+GXycAOmCGhlXh2tlc6iTc41PACqy\nyy+mHmSv\n=kkH7\n-----END PGP PUBLIC KEY BLOCK-----\n",
+                "-----BEGIN PGP PUBLIC KEY BLOCK-----\nVersion: GnuPG v2.0.22 (GNU/Linux)\n\nmQINBFzMWxkBEADHrskpBgN9OphmhRkc7P/YrsAGSvvl7kfu+e9KAaU6f5MeAVyn\nrIoM43syyGkgFyWgjZM8/rur7EMPY2yt+2q/1ZfLVCRn9856JqTIq0XRpDUe4nKQ\n8BlA7wDVZoSDxUZkSuTIyExbDf0cpw89Tcf62Mxmi8jh74vRlPy1PgjWL5494b3X\n5fxDidH4bqPZyxTBqPrUFuo+EfUVEqiGF94Ppq6ZUvrBGOVo1V1+Ifm9CGEK597c\naevcGc1RFlgxIgN84UpuDjPR9/zSndwJ7XsXYvZ6HXcKGagRKsfYDWGPkA5cOL/e\nf+yObOnC43yPUvpggQ4KaNJ6+SMTZOKikM8yciyBwLqwrjo8FlJgkv8Vfag/2UR7\nJINbyqHHoLUhQ2m6HXSwK4YjtwidF9EUkaBZWrrskYR3IRZLXlWqeOi/+ezYOW0m\nvufrkcvsh+TKlVVnuwmEPjJ8mwUSpsLdfPJo1DHsd8FS03SCKPaXFdD7ePfEjiYk\nnHpQaKE01aWVSLUiygn7F7rYemGqV9Vt7tBw5pz0vqSC72a5E3zFzIIuHx6aANry\nGat3aqU3qtBXOrA/dPkX9cWE+UR5wo/A2UdKJZLlGhM2WRJ3ltmGT48V9CeS6N9Y\nm4CKdzvg7EWjlTlFrd/8WJ2KoqOE9leDPeXRPncubJfJ6LLIHyG09h9kKQARAQAB\ntDpDZW50T1MgKENlbnRPUyBPZmZpY2lhbCBTaWduaW5nIEtleSkgPHNlY3VyaXR5\nQGNlbnRvcy5vcmc+iQI3BBMBAgAhBQJczFsZAhsDBgsJCAcDAgYVCAIJCgsDFgIB\nAh4BAheAAAoJEAW1VbOEg8ZdjOsP/2ygSxH9jqffOU9SKyJDlraL2gIutqZ3B8pl\nGy/Qnb9QD1EJVb4ZxOEhcY2W9VJfIpnf3yBuAto7zvKe/G1nxH4Bt6WTJQCkUjcs\nN3qPWsx1VslsAEz7bXGiHym6Ay4xF28bQ9XYIokIQXd0T2rD3/lNGxNtORZ2bKjD\nvOzYzvh2idUIY1DgGWJ11gtHFIA9CvHcW+SMPEhkcKZJAO51ayFBqTSSpiorVwTq\na0cB+cgmCQOI4/MY+kIvzoexfG7xhkUqe0wxmph9RQQxlTbNQDCdaxSgwbF2T+gw\nbyaDvkS4xtR6Soj7BKjKAmcnf5fn4C5Or0KLUqMzBtDMbfQQihn62iZJN6ZZ/4dg\nq4HTqyVpyuzMXsFpJ9L/FqH2DJ4exGGpBv00ba/Zauy7GsqOc5PnNBsYaHCply0X\n407DRx51t9YwYI/ttValuehq9+gRJpOTTKp6AjZn/a5Yt3h6jDgpNfM/EyLFIY9z\nV6CXqQQ/8JRvaik/JsGCf+eeLZOw4koIjZGEAg04iuyNTjhx0e/QHEVcYAqNLhXG\nrCTTbCn3NSUO9qxEXC+K/1m1kaXoCGA0UWlVGZ1JSifbbMx0yxq/brpEZPUYm+32\no8XfbocBWljFUJ+6aljTvZ3LQLKTSPW7TFO+GXycAOmCGhlXh2tlc6iTc41PACqy\nyy+mHmSv\n=kkH7\n-----END PGP PUBLIC KEY BLOCK-----\n"
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.selinux",
+            "options": {
+              "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts",
+              "labels": {
+                "/usr/bin/cp": "system_u:object_r:install_exec_t:s0",
+                "/usr/bin/tar": "system_u:object_r:install_exec_t:s0"
+              }
+            }
+          }
+        ]
+      },
+      {
+        "name": "os",
+        "build": "name:build",
+        "stages": [
+          {
+            "type": "org.osbuild.rpm",
+            "inputs": {
+              "packages": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  "sha256:a6ef8e56d53c29e92b46a7ad62c22380056153b2d5810c39c0cc1658a4250d5b",
+                  "sha256:d3ad718b08b44e1fca355abd46a6c315a9d73ab38f9f3c3d551642b55866e182",
+                  "sha256:3ed20aba45a8c175e818de998d906fb2759387c607bd9b15dbbefee8c73097ba",
+                  "sha256:5f068787bd9a0190b03e64cd770e44ace593c5aa09e3f4c470c44d8d484b4674",
+                  "sha256:2c1baefd0f802507d9741da8da54f6eae42b04967f9d433d7f9e0f124434c70d",
+                  "sha256:42829311fe40b7487530ee432aeb8e1df86e5168373f038cccb60d0db94601d3",
+                  "sha256:be49b69bc5de947ee2151f397993a691a57bc53952058c32cde0fca674da7d8c",
+                  "sha256:f14cc62cf70a187384adff6bedf8b09858b8f441a9be87ebf3ae975c4e6b0d73",
+                  "sha256:4966b1832e9eccd8f83ecc20143fb6f18215107bdecd7267b4605cdae4a6562a",
+                  "sha256:48226934763e4c412c1eb65df314e6879720b4b1ebcb3d07c126c9526639cb68",
+                  "sha256:3a438b53e8377eccf90cac0fd42ed2b513fc869bfb7b96e3d2a4f6984a287f90",
+                  "sha256:c12c7dc6676c6ccc5ca08ceddfb1b4e46c9f1ed49cbc241292ae6d1fdb0d9d62",
+                  "sha256:297b8a7b336dfc298d86d76d400459d2fa63af8628f5e19e35314a33a6478234",
+                  "sha256:8729b157f0925feccdaef8aacd91c6aebe0109e621675bcc15e1830673b0e19d",
+                  "sha256:06c8c530fb914e07375c183f13b8431456377cec33376423f6589d1047277587",
+                  "sha256:56c3d429ea949467dc0bca882646cf40a58fb6f27750f5664ff2919f5d38ada5",
+                  "sha256:1f2a096d6a75662a86a06ff2859e6ba916bbc8c6d8cb7b73810ffbb9fef4b089",
+                  "sha256:1fad1d1f8b56e6967863aeb60f5fa3615e6a35b0f6532d8a23066e6823b50860",
+                  "sha256:842ff55b80ac9a5c3357bf52646a5761a4c4786bb3e64b56d8fa5d8fe34ef8bb",
+                  "sha256:15b17b95cf9cb9fb64e0c8e56110836bdcaf70de81b8cbdb60e181fc90456e06",
+                  "sha256:a82958266d292f4725fc1981ea57a861b7fc7feeb7a9551d0b61b98ca51a5662",
+                  "sha256:38fe7db64baf2d4804a14466a6244f3c1de3bd5deca0ad4044e96d0d3f3751c7",
+                  "sha256:eee92733e8989029929d5cb1f673b15fdb814dac32e148d5bc02378b44c8699a",
+                  "sha256:24fcc5bc49b059b221075989f25875fb821079088dca694aec262446cde50cb7",
+                  "sha256:dbc730cf810cc886667a7a9b17883ba15bc40e933a38dd820f2f026cf8007805",
+                  "sha256:3818fe6ec4996402b718827ba40ca01cc3c8276646d80030b652a26153aea2b7",
+                  "sha256:ec85355744a8b37aa7fbe48d6f8afd8d0538129b70e82d238c3b57ae08559430",
+                  "sha256:ff8b51c6a8bacc5ef6b5da0f049d170ab1c1ecebad50ded3c04ed384eca9a2c0",
+                  "sha256:383a5e6bb9e94de53baaf5c7493cd50a68c893c6a30acfbe28407d33bb133efc",
+                  "sha256:19061d12407c0c4bca6abcaef01695b70dcd3967ff102dd07178a2193a280e29",
+                  "sha256:4e3e93a3d2039c2a8305030b7960bd1100d7d20705a1afb1325a4ee79478a74a",
+                  "sha256:084d79ed3d7127e6d46e9ac6e654d8ef181a156435808dc8eb32968b6c1b4946",
+                  "sha256:edf00207b603cbfe86b07f8be5c4ee14ff1dd85ec4b7d82d760483ffcea43891",
+                  "sha256:6faee589c5a7454502e5ec07586a4856e7f1376bd551741af2acf03afb9716e6",
+                  "sha256:bcf25aae89f7368b16346bc1ec92850175bcc2312bf7a5e74bc3c512bcd345b0",
+                  "sha256:2a8f9e5119a034801904185dcbf1bc29db67e9e9b0cf5893615722d7bb33099c",
+                  "sha256:67f37cee02ba744dfc7957725f5ef9df229778f6a2f7afc659625b458da6167e",
+                  "sha256:b10d8521963a2494fdb2b5f8fb0de837dc86d4016c3b10019fb8970a09582451",
+                  "sha256:47ad43730c8bc72c90f2fb3dbd3526d716ada2fad94e62cb443658e94c6503c5",
+                  "sha256:5c1940e1f173e22b053f3a89022903cea34a6af20dff81c65548c4e2ba3a8293",
+                  "sha256:1a4e44583a767289bb0d354db93c6a9132420e13376d4fcae866d69620bb11bb",
+                  "sha256:7baac88adafdc5958fb818c7685d3c6548f6e2e585e4435ceee4a168edc3597e",
+                  "sha256:090563f18409c228274bb61dcf1001f63a55c1246fb2838a998cb3c5fd8c3874",
+                  "sha256:c58b0b900a7ffc778980461d74dc236bf2c790d2e5e8c04e28876e221b48a1c8",
+                  "sha256:cc5f8dd4e061da3a73aa67112e24f2cc5c0ad0cd4334dc798b8834cf6259a779",
+                  "sha256:698e8ecaf71719dafacae79de05080d567b69fad3511e8b8d42b9af96a7c41db",
+                  "sha256:dd80a8169e27959a27651616e998be8b49ffdca141744177cb42126ff0ae12b5",
+                  "sha256:a8a27e1ffbb92356d6376334687b9eaa0cb5f2eece2670128f3a01e391e9f3bb",
+                  "sha256:441b3862f5a0fd504bbbba18d96d1b2b920fb95a79dc45a753a6a664ad285b07",
+                  "sha256:a42de8ce71380b1f4e8ac5b4ce720bf565c99a0b09ef983c0550a91a467bc155",
+                  "sha256:ca5d70414653e1b769124582699bc2400f05b5382a9a8dc6bb4ab4f28dac9c20",
+                  "sha256:d64da85b0e013679fb06eeadad74465d9556d7ad21e97beb1b5f61fb0658cd10",
+                  "sha256:ed40678aa26d63b71a122bd394b46b362df083c8f4ae3267f205a7d77ff69fdf",
+                  "sha256:4f92835a6e4ee4276df49019e068d1871b75821f52b405c699bd9f199df58b80",
+                  "sha256:42464424b9fa731f8122fe748aad0005519fc87b770dbbdb71f29f514ea0e889",
+                  "sha256:45c48d32120739734ae97479cc0f3ca19796ea47e360ba39d52b77ce3ada61d7",
+                  "sha256:47b61754a278c4ca378871c874ccf6a0a07bffaef38505315cfa94f262887845",
+                  "sha256:04eee0a9c079186aa58b5536ac8bcbd2a360700b83fa7b9f6eb127c1386b7ef4",
+                  "sha256:881b28a3a37d114bc3f046605b24663560009b13a507217e007643f5682efdd5",
+                  "sha256:71d45853b0a8673e6354892df7a420ad77200a018ee5334b30b893862d030fa9",
+                  "sha256:2588ff56ab340c06ce8b5be22cbe23de89d4f336b38ae930daf11db1c6a24391",
+                  "sha256:412f3eaa5f7e226fdc4678a3266edab76d8998f7d76763075f690a01362ef89c",
+                  "sha256:9e67ac5948125dd165c9a74ec848d48b313ef4264bbbb89630a782dbd972d72c",
+                  "sha256:9fb07c2324cccbbc19e3ffade50ee7da41909b2f6c24f49ffd9978ba375de193",
+                  "sha256:f4eca686b314edb06d3fe1c526f573c7248c811af70cba76132cdc9c541cadc1",
+                  "sha256:30ceeb5a6cadaeccdbde088bfb52ba88190fa530c11f4a2aafd62b4b4ad6b404",
+                  "sha256:e87acf226a9511b3a5f83e7fed9c5c20addbbdae47ab67c614404a9392b77e50",
+                  "sha256:d150e53fa73c3786da9e4f6e23d374100b0dd2923485d4a08e9a56ac2786cf83",
+                  "sha256:e8b7968fe6613c4cd6324436089cc9c1558cd63fb7da87fd46cc7c15c4ab7f66",
+                  "sha256:88be5116908aa5013f540c767f6811774342780bb72d3ec197b3429bfb2f9862",
+                  "sha256:e156e6fa9ef6a483f8505ce0eeadbcab12b887c4996233ce5d6258076f6bce50",
+                  "sha256:e65f7d7c8def6b168e013914bc0d1137aed65c3010e9796df3b823854472f3e1",
+                  "sha256:a49b922f117b9bfb0b07e9848151f8a2948345328ebc534cd28ac187d7ed3f94",
+                  "sha256:caa0bd6617a8d5e535faedec5f6f3ea7c5e6da1898751f6c9c34a89a95c286ff",
+                  "sha256:e403c9839742c4b13e715541237f79ffe52870d59867bebd39e19e7080948db1",
+                  "sha256:700b9050aa490b5eca6d1f8630cbebceb122fce11c370689b5ccb37f5a43ee2f",
+                  "sha256:d1cf2d973db2f1af46f124776b9ab4bd782e7065c8c8428a4ddef60989e4225d",
+                  "sha256:4992eb036c0797daf9b984af1a34fe27a30287ee5d2bd5e2f5a0df3a09bdbb59",
+                  "sha256:d807e7fb8bf24be50642a6dced954c6ea208199daab2d27c9f73d789ba82fa37",
+                  "sha256:8cd6ef9902851f07cfd9682e2d6873648690f0c2ec65345276b557ede042d8b9",
+                  "sha256:d1d362fd4f8022ad05171efe40e84d15ec6c5e5f419d6099ebc8e46e7da632c1",
+                  "sha256:4fc1c84b4434df8a5ccd960d906896e4094236f43ad4aea083a12fb5b8a824f9",
+                  "sha256:78fd472a1c7f49b8a432788ea2dfc1119f155a394f41585b4e715d2585fc92ab",
+                  "sha256:e392a6b41381ffad04626d092fd2af9477c72e197a74efddf987832c3bfa521f",
+                  "sha256:4942002f6e3a471b8d51801047ea2584d5cd1dad5d4c4e44bce7af50c5b7cb14",
+                  "sha256:ad338b7a3f3bed96300d9ce7f0307e09d758962b8496c10fb3554bf62405d153",
+                  "sha256:bfb45644212cfbbe48b05149f8d53e77d7bd02ca9fc9045cc37115101175a3a0",
+                  "sha256:fa7bef727ba8657208bb3df95916f0bc912332cb8534c695facef32ffbd72f20",
+                  "sha256:257e086bb52086254fa8cc95a5c4998668b4fcb5203ad3c2275c1150816acc9b",
+                  "sha256:af0a4287e302baa7c85655ddfe5a7049b8eaf31aff03886f4fc57c920d26d491",
+                  "sha256:11ff811a72c82084c7c14700b23d29643e153442a34b3b486e270e5b40e38d0a",
+                  "sha256:a2d96efed83ab31d21481af044835a940673ee4ade2763af78c06d2df87b94f7",
+                  "sha256:51760acfb6ca87db5be7a9296d6a3d1220767956c576a26c6d46784e25db85bb",
+                  "sha256:754bf53a39cea727d9d89d59df32e020842dc71f6a0561ea36f8203aff2d5d69",
+                  "sha256:24f5cd46a7395cd046b10d6ddc4de435ec6595d0dcdb2d179c94cc9082a12f14",
+                  "sha256:2451a475f248a4c66e64d149fefa8bfc195fcd7b3f369bae221a94f8ce4c2d67",
+                  "sha256:cff4b4ac50fed2ceab6add52a66513ed9ca04b024f07a25c53df49f762eea2d2",
+                  "sha256:4a08d5264e865548e65d31886c91b659b33a2c2ba39fd115b00af3ea0bc91a83",
+                  "sha256:7cccedcc359f2a2542858088704bf3d0ec3e46cb7b72f602408fbab937a522d3",
+                  "sha256:d8dad22276baffe9496d5e05ef35d21dd6f9d8f910339daced2c3ff42d7a28c5",
+                  "sha256:78b2b9cbf041d4461daf7ac11a24d1e79a9c57f47aa265dba4d09067efe3d96b",
+                  "sha256:ac3b306c193bd20658950da402ae0cbdd8337110117de5e5d7eba970822671fd",
+                  "sha256:fb276cc0ebc6bd27d344f7e0811f26cb3f0e59da09182489095724bdf2a075f8",
+                  "sha256:5a0927d231fbafa8b865591922fc07d39d9b4b263a1e9c0bbef691282f706cd0",
+                  "sha256:7cced5f47c4035e01fffce0989b62113a75016e5220e7b207c4b96be7ed90403",
+                  "sha256:ffb6d471f5c82b0407cc41a25aea25bf83d6779b3ef20f0557c4fd0da6111bb7",
+                  "sha256:e1e28504928648404a3b652440091eba010cd99221183ef78601cbd152261d91",
+                  "sha256:42bb566be1936bdb40937f9c0a96c4acc93057379385f1807cba18f60443d3e4",
+                  "sha256:8c05fe038c7792203afa47f4534318f6c674672999b444909706ce0826bf1b8f",
+                  "sha256:a571c94456b9a1743e94f4f72159de52bb13fe93437b81da675351553a881a17",
+                  "sha256:dfecfa1299d11d6a77503e626a2e9a14e1a75666bc8ea2abaf7ff515d2c86332",
+                  "sha256:8119d276749b35cd9c283c1a8d970b3528bea58427eb37eafc22b6093a978f08",
+                  "sha256:6d1ac29b3a38408f6d238d6718384e05be7346789c6200b354335b0e0c9c77df",
+                  "sha256:d751a4fdecc0dc3c5ff897e3ff4c25e7addc698d590e2bfc4c893e693be7d558",
+                  "sha256:5418cf17fad308fe9a8d3acdf4ae10f433da50c32f10ae4089be2f8423dea4cf",
+                  "sha256:12b0565d080311c7804d8fb1d697ecdef8807563ebeee4443e2fa6d35b1d958f",
+                  "sha256:6d02615212a88eb204b8f6d2a7cfbf6183a12f29d72ca5dbfbe5c45c63068ef8",
+                  "sha256:cbe98d6dcf93449d9c2fbf95de75f065f8da67a23f13401c672d78b28c6b7f6a",
+                  "sha256:965ec1b760513e1ae539747624bd241d6575675e8a04c5caa572faadb54007c7",
+                  "sha256:331b91a0928c05618c7fed3e12bbe9ecb9e4619d08c7e85d3de344a08d2f0f1a",
+                  "sha256:36c05d62567b455f2722c6e5cf431071174adf4c1d3b7450f0c1aaa903210bc3",
+                  "sha256:49c7c718cb4e2b6f0effd0dec4f4cb4e109d260c192b2b329a58a1da9a24ad1d",
+                  "sha256:a3ef96219165bfc64d4f5d50f51fbd43e803c500619240ffe4db1f9f8e337f83",
+                  "sha256:ef86061338fa321c959cadc75ecbdfd405eebaa1042eec9d9c737d4d9d92568f",
+                  "sha256:7bb5051dee5f6633a02cf5a3285dd86890cc6521e497526a8149dc5c5ebad062",
+                  "sha256:4aca3cee9de1a4cd7ac56a12550f286894a215cac593c18857278f7b0e48f328",
+                  "sha256:1d6551bce8f8a1e53682fafe4f67fa830c333f0b37db7acbeaca0095b5ce870b",
+                  "sha256:e45848a3fbfa1d46709448593fa7929fee4c5a83d2168c0d41d498251e4b5dae",
+                  "sha256:83cb349e65d5b783518b735d8fb477264f0a6bd7cdd6f4096f8493dbd45f2ff7",
+                  "sha256:30dd1d58b7b963d052341f4583a7417823cf4dbbe7ac4b536f3a5250c4d34582",
+                  "sha256:588874c2fc18a927a479aac7affef52f52d09e5b20102dfab70836d420ae553e",
+                  "sha256:6fe1188081e441595ce29ebed4d1985e5890815158244f69f092ee930656f755",
+                  "sha256:a80c1d6d32db7ce8fdd58bb4f3f488b74e94261a38512dc8a15179ae33697e63",
+                  "sha256:b437a08d4670ef440ba6dbaae4ccb39f989f0c2a3d280ea66d6fd9532a313286",
+                  "sha256:230731b577f8d29e7e8e8fd6d1ea02702fb4364fcc7034d838ccddc4d66da8c3",
+                  "sha256:54f59ddb56e89a5330373e07ea05934fc58360eb7480615ede2a3ed6982e1eef",
+                  "sha256:427eba707b42761a0ef57107ba5a22f80fc6379d1537c757fe1929d6d066b05c",
+                  "sha256:ff1580bd4ec5841d4937b383917fa30f318b4f419b8067a77468eb4a9630ba10",
+                  "sha256:e778fc7e5d62fe488e250a1916cdb7f692e98e23d0c2b4264672b2574ff416e5",
+                  "sha256:df40cada982b04336fe8b250b4fdd576ddd03a014bb519a69b34640369bef661",
+                  "sha256:9c4cd61b98253904436180f58c564bda61be1fa1b5523e4ecbbdc174d0c2a9aa",
+                  "sha256:43bfc890caf7855f2fb55c24474b58cd5c8c7b51e4db4f40d1f302fffd31985b",
+                  "sha256:2f6c73fdcd5c5e5b6d8b58663e498a0099db8029386869a4aca670471f6c298e",
+                  "sha256:30ae4489980021a727f247d48b4d74d4c6c7667d00bd1a670f045ea24a885541",
+                  "sha256:4a8899d3b91a0f847ce793480700b26dc8336c5ee20d9b66067c76fe0dab2f17",
+                  "sha256:77e4cfbc823e3764308822ccf03b257861f9360f3b948829f1d73148b321b00e",
+                  "sha256:9b69a221cf9395a110849bb428bb1cfe9fb489322df0fa6017f5978a827ee0e9",
+                  "sha256:360be5b93e106d77a8f4e84b318ee8dc14349f223540e0e200e0dfce2676ec04",
+                  "sha256:e0a7b9f3b56b4737f5711dc6b03f256fbf2488656b8874acabb494b58ba0c1c1",
+                  "sha256:5c74a0e3005ea3cb90dff80cfa1e7d64c97f5c01612d253cf4e65aca962b7be4",
+                  "sha256:194dbe332ccdb33d58f040da07667257e176975f6b2f17343bbf33fb99deb097",
+                  "sha256:e21a84107568047432e474e08da24aea2340409d57ea8cf170182927dc76de12",
+                  "sha256:f7a2eddcda47cb75108add34c0ce919ceb847605830ad33aeb4bd64d6bed24f3",
+                  "sha256:b83a0199c3d471151f07f6de626a1a4a362dd6aa29d84cf1c0ada2c966ce29c9",
+                  "sha256:709ea71f36495ac2ac89d72d2eb603b6aa55b2c1a70633f23514dd897936f02b",
+                  "sha256:6ac918d2bc175b3f356926ca96a998c29bffe256f7d802e8ef654b1226da3ef6",
+                  "sha256:aea253461d1a34a239b445ee07cb34398a9cbb6ed40e252182a91cddcf59004b",
+                  "sha256:cc662127a17d4e08e90f75703f376067eed48f5d6b5b8d106fa3824397f1978e",
+                  "sha256:a0b8a6b2c8dad75290228086dd0af342979604bbf4b9500029e25d766835c0f4",
+                  "sha256:0afac6f4f9ed1c59510675d87da45c7966c0f7aae6e8dd056961aceed8c4fe0a",
+                  "sha256:12696f5638ad2068c5c8940495d15c3bb1c57990000dbda7428b008e9e63ab5b",
+                  "sha256:f3d9ccb762146dc97f2d201d979fbb0e9171d1203fb985f3ef48b5c2a176c2a9",
+                  "sha256:c5a60ffb80cd1f9b90c797f1d1ac80e5536eb32a5b276871445e7279ac701c5f",
+                  "sha256:0515afdac097ad54cf4b24e0644f0789cab5535a54107aa44940ffd991a6cef3",
+                  "sha256:020abac486839c7be29fae37a686dc7749398c333cb8ba94b3390b386ffcbff7",
+                  "sha256:8ab06f608f45445bdef489cedb40d419aa7282e127ee26dbfcf417350a3f1630",
+                  "sha256:31d924d1540dd4e927a4c3aa936cec4bfb54ed302d3e8acc1be8b52dd5deb10c",
+                  "sha256:1b95698d64dd299827f62cbe43d373e985da2d8900c4489a49475f53fa04f414",
+                  "sha256:fd6e1803ff367036da5b52b2183e1408691b379cc1320971bb664737507f89a4",
+                  "sha256:6b312faed4a0508da2f15d3f31a6daccfc0ec6621e5fb7b20956027dce5fa395",
+                  "sha256:a5f9f2c4f39f393971f268aebb1b55d18d0d96693d08a9ed70403e8565807bb6",
+                  "sha256:a0a8e31422da7d695a3788a7cae3f929d42cb4982889422588904ecc6879182e",
+                  "sha256:59008e3619cae0f40e183b7003e722cb312b00bdba775ec9f06cdd833b53c26a",
+                  "sha256:d7bacff8f9be89871c6ec98c3356de11008ae574da852bdc15cee7ebb9ac39be",
+                  "sha256:d6eb27d158b6397e52ab6a952fec4e3c414638a08750a6c011d32eb117accd82",
+                  "sha256:4e497225fe36781735cc92c0886f6858b19d4557ed9ecafe1247b8233c206075",
+                  "sha256:2812ae39c665069f4b27e9bd26dde9141d4f4e7802befb1b14ac4e27a8225b4b",
+                  "sha256:07fb48b313f6d4c1c8b1ffd9c5226c68f99616e46bbd04b325527d817b500577",
+                  "sha256:d3a4f367a9c5ba936b1bb5480db390889a303e5ec8ff34bb4274c1d840a1784d",
+                  "sha256:caabc61e9aa83275f9d2fefcfda56fddf19e7031bcf9f9b84f858bb1f040e24c",
+                  "sha256:35bd989d63522f9699b1a90dd453f866818cc3d247096a910a27fd7e49b09ac2",
+                  "sha256:8d7777da3f54f965cf3058cabf987c01b93a1dd041e8359eb7822eba57d8c8df",
+                  "sha256:fb6e437a24450106c03f25dc1c3f6b78549b82c2d0bd4387dce1350ca3c5f1f5",
+                  "sha256:61ba252d7ee5d955b929f6d7d39d65d25c62e3d3cfc65ee6cf55c764b1c64a90",
+                  "sha256:7adc584a7d43968d22706da5ffa127020536375f82beea5ef677cab39c5f64c5",
+                  "sha256:b58be8f7685340b35e61945b1ab499bc1030b0b021b2ac5576897cf079ff7812",
+                  "sha256:6051967b12b097d0027dc1a1aac68448c1bea901fd76c6ea0d43450f24605252",
+                  "sha256:9b8a8a843fe9a972f6433e11b95b5a8d1d2971ed40fe1acda6807e34f0773c62",
+                  "sha256:1aa321c66a3661e78d938b805e5c311d519f04bf3496545ffdacc7c152bc9b21",
+                  "sha256:419f9c08de110eee9b2ff0a61e9aa1bbb56939f9239739c17a753a0d9210d10f",
+                  "sha256:3dfffdadfb10def9a3671a255e4fa71d8b22231ccf2c929e96689101dda8ce2c",
+                  "sha256:c5c61536e768553067cee488830c64866d109cade24917dbe23f82c861af07c5",
+                  "sha256:98c28a91d41f634edb8c1f001dbc45c0de534332d059a2e8feff448fb7235c49",
+                  "sha256:b4a1ac1ff5cd22a5dab6c96dfc2dbd7cd6ba750691ad5c53a97a1f088fc42abc",
+                  "sha256:01b0562b890a80c202fff9175dc845500660c7f1655292d4ee13ca667acab081",
+                  "sha256:56c866bcff69fd60b630841ff990296b26c2f45d8c6054311b5c476bc67466ac",
+                  "sha256:4fe264ed1cfd0c074f4601354b0128a9e5068f0fcde7382fd5429585f0d4cd2c",
+                  "sha256:95103f7c339aec4b485b7f569aa8a5e1a54286b3d2acde427328c49e4d8d80d1",
+                  "sha256:adc56041458e556df5663e7da264e151c24aaf1c2a94e49df9790ba191ea1b37",
+                  "sha256:2669ab8439093418c6c437c1f2e931d4152f5ac371e5a0f2d20b18455483c3a1",
+                  "sha256:0f57b051654b6d75789b437dafd7040b6c90daee17827be24352c0f11a74bba7",
+                  "sha256:1b5136570cefb8273dd5affc73c1456cf239cc8b18be72d6c4d09794af7f3352",
+                  "sha256:679724b45157b4d4c9ebe2eb32e188b9a65d47c23be886498d7a178caaf113bb",
+                  "sha256:1649f9d356cda961dd08dafa92475557ac398da9a657ee019de0c1f2c0593c8a",
+                  "sha256:767dd64d91c23adda537c7759ae3b4f720d3c76e03b52bc9231e52e0113db3ab",
+                  "sha256:2dbfe3cb37c18b39393870baa77f3bbd42be53517abffdd990b13ed70ee3dd3e",
+                  "sha256:f5bcb82a732c02d6f31bbf156887049883c76cedc9c6a11b049358a74f4d45d0",
+                  "sha256:2d1655f040141384ec8760e4a47e0455ce518989f7bb1a830ab9534bfb38a78a",
+                  "sha256:d3e95ed161acd1ba957b1864e7ca2102d9c39380bbdd56eddebf11d5219b3a04",
+                  "sha256:572bec3deb2f8ae7a6ad46976738c2630023eec1d9bd13ab1ccca7b54256daee",
+                  "sha256:466601cf2b7bebf49a6a8e936b32dffc844c9ed4cd82961d008d17cfccc596e8",
+                  "sha256:70fe40ffb2fb3eb2c3626afbfdb200a2429e000c2fbb172886c23b1908000501",
+                  "sha256:32ebba6472cdc331bd3366ca996ad3039b3a1b41c61a849b88074e1b722cad2c",
+                  "sha256:cd603035aa26b9d12e6b23680e3f1a908341fd9f2086eb540834aee45b4c8604",
+                  "sha256:4fb1b85fe3712a292f8dd8f1d65805607485dbf97307cf146bbc6e0293a7c725",
+                  "sha256:5f76a72e58cd374ec83e26f42778adb3b90aacd091527a34c8a347089034d398",
+                  "sha256:75e9ed16ace51ba04a62505aaed215bf9c722d6f4b1c33cc3e3962076c300ee8",
+                  "sha256:c3c1c42a41ab18dc09214bcd3a567bb7ba9b9c2191a6e1079b9770dfe2d3a338",
+                  "sha256:60eb345663d2f6ec4b5c304cd21685dc7148d34739477136d96ab6bc131d9c4d",
+                  "sha256:7962bed04e961194d64769b4b7d5c85836808361c606e943b013098fe53df782",
+                  "sha256:d539404dafd8ad5d785ab3da6f8bd5a2bf5dff9e01be0ff1bc1d251786dda25c",
+                  "sha256:bff39fef1fc01564156123fcade75b4bc50402a2971a031d9a426c7014b1e681",
+                  "sha256:6b9875495111bcd2d3c5e9e380b3be17fb0a730891468fb45bdba3b3692b00ea",
+                  "sha256:b29c8cb61ef138fdf00a458f0646cf9390e0f39783f02f6b81a956585dc6b302",
+                  "sha256:e217c2687212d931ad9a6a02afb20cc34f6d051786d136e337f91079c9f73d22",
+                  "sha256:c1291b69a65a860069195a33cf6640df8667e960f9f030ceeea4497c47858b94",
+                  "sha256:d8c00baf46e33f9e5f1b9e139bbea9fe0f27badb432c992b9cf8c4f7017094bf",
+                  "sha256:d909f0e1b6ddb29ad2d3da21208077e3c976212e07471114745859f70be9738d",
+                  "sha256:62ac185c4d6d242b187022c8376469073c211e8deca2a7b2badf1d775e2fd5a3",
+                  "sha256:1a968f65db066243cbd0a6e12d193ef674637f044299a15b5d6b910e91411812",
+                  "sha256:4a167fa4a7238bd94b3134173f6267b19cdebc2fde98b583344749e1f4c9bf09",
+                  "sha256:8904fdb492f34e5242ba483fb6b7b158342662575b3d5ac9abbc380568840d4a",
+                  "sha256:6bfc201a12dc7bba21069a663aa692a96c5e8920b0d94a4e355c332d7ead15ba",
+                  "sha256:7aeb44195a1c984aff87cf8429d2aa40f6947b0a47d3603e1ca5c3cf8d284459",
+                  "sha256:f6cd5ed6305952c1cd842fbca0e5d9613f736646cfac2082a2db37f5d065468c",
+                  "sha256:791acd72bc40be9ba5fa6b77d78def5da623544408b72baa4c81181c03a205cb",
+                  "sha256:906bffa419bdb1a6d3094d7a6f2308527f5ece250bfcb962df79e9867f28236d",
+                  "sha256:deeeab9fcf6b9cb47235974158561967e299344e040c408e6b5d7464af2f3882",
+                  "sha256:0eb36aba0f471119ccb001ea4f1819002ae535882df63e871be80e01f4f776bb",
+                  "sha256:393e7bb9f93ffb3cbba620fbfeb229f2b8345454bc60ac0508f76735544ed289",
+                  "sha256:f24bce642ec88622490b2f09a45fa3985da7f6511a1aae131853c4ea4c309e6b",
+                  "sha256:4c5aabda0cd9edb40e141066d400d2e4b232bc22ab60e806a6399691c391cabc",
+                  "sha256:4079a1edf72a60c97ee48f0a98820b3b014575b402ea05a64cbc5f2b8af674de",
+                  "sha256:9936485ac7111967d6962bc539de7b08807e310117adb78b11c21a5db0f0f890",
+                  "sha256:c62991989974533b86a29586b799623a908add501287f2c890be4fc8a6af2c7d",
+                  "sha256:0230acdbc9da4b36da812f0e585a7602eda4982c899b3b3a4c2bc9b4546d8e74",
+                  "sha256:7abf49cabbaf996afc0c2604f10ea18f8f22a903fc4ba3728a18f5892353c5c9",
+                  "sha256:41716536ea16798238ac89fbc3041b3f9dc80f9a64ea4b19d6e67ad2c909269a",
+                  "sha256:17ffe1d683dbff48f9b2ef903401e471e5e51a992bf0890632bceb94561893de",
+                  "sha256:d2e9ef1d33330a14155d5bd6a8cf122f9390cceb8a7a12c0364ae8e44410fb8d",
+                  "sha256:8403cfc97e0e72e37639b8c54d92f1ee427e48a70d52d5260a37fa104f2df20d",
+                  "sha256:b64219f2278bf3f032b71593da63f563920778230946b66f1037bef2f2a7358b",
+                  "sha256:bd9a6c7fe7405aaeeeb7d351ca1def52737b8ec2344021263aed64c6dc363d56",
+                  "sha256:7a66928044c3478964aeaf6f9e981fdbcfa6b2ff7fad9f2ad57a8c09387cbbf2",
+                  "sha256:5bcb506bd5559870631aa838711e683a5a2a07c6c0171be6bbeda9ba92dcdf5e",
+                  "sha256:6495f3b729a1ceecd7cfdf318cfaa8ecf776ffa16293aad9f97cc542b6901ef7",
+                  "sha256:c24b21415b737f18fad7aeb192e60f7d323f7ba69434ecc1e78b3af0003be8dc",
+                  "sha256:965dca9dc74ed26f4204debe15b8e4dd1b8e41a80b8608287a9ef22f0b6f507e",
+                  "sha256:bb4b6716669e27c7619f63751770cb87e7cfecd4e302e2ce6588035509168352",
+                  "sha256:f8130aecd446f997d0e2011481275db0552bf57bd7af0d7a655eded5f52ca94e",
+                  "sha256:c2479eb811f4d9b8624ef20119e1abdc109f639c2cf576eb945b340362d87b05",
+                  "sha256:46606c1ed76a4da2a9d18016aeb50f4dddf58e1b45d665c983c58f8e605bf73e",
+                  "sha256:d87f7fa5e637442eb638bcaafdc44ca3895d91a153015ff9af6a87219f0dc372",
+                  "sha256:71c88f04921ae61a7009f9443f95c70ec3424a798429fc01e6c1432c1077aacb",
+                  "sha256:bf994cb2e5c367d78483662c7de6e69950aaf04bc6cfdbbef4d1ef7ce153717c",
+                  "sha256:b7330d40f75b8ec786e41c45a202e44f0e49ec29ddf8944120fbdb373a6c6617",
+                  "sha256:bb82b10a91493d745dc533b5de5335db650adb0c8a90548fdf5dad13569a16f4",
+                  "sha256:9e2ef90cb484b37232e829ec400dcddd3f9f0d189eb6f0074b3b5874d4553d1c",
+                  "sha256:dfb7add4926f9a350755294af3c20f114ac59f32e00cadc9ec625b2a51703ad0",
+                  "sha256:7b334d84bf03876c5738efa3857faaa35ede5c8eab30a5621ecfd4efa7ce39a5",
+                  "sha256:dd96950b4282e64ce3e37f0bd1a51834beb286037184f3796f9889bfa1ed0d72",
+                  "sha256:3ed319e31a9c38e5f4e336195b5cbd253b3f8b17f93f185829f078c5ef420305",
+                  "sha256:5c46bef8c0e95e05716e9a53b77970c1378d93bcb9a800018a24f7e1763b45b9",
+                  "sha256:d03b9f4b9848e3a88d62bcf6e536d659c325b2dc03b2136be7342b5fe5e2b6a9",
+                  "sha256:a34e0c5859e5e8757afafba47d83396226b646f32954ef7ecda4ad3be464bed6",
+                  "sha256:fc9d3ee3946b87efcd9531f876d23a9e8d5769aab3e0ad6007ac2cdb4068499c",
+                  "sha256:cffc31e10891c58edc89cebd211bc0be69d99f54f67682c91f97dc53e6381f0f",
+                  "sha256:7edc503f5a919c489b651757095d8031982d530cc88088fdaeb743188364e9b0",
+                  "sha256:e83928bd4552ecdf8e71d283e2358c7eccd006d284ba31fbc9c89e407989fd60",
+                  "sha256:e269f7d33abbb790311ffa95fa7df9766cac8bf31ace24fce6ed732ba0db19ae",
+                  "sha256:da4c6daa0d5406bc967cc89b02a69689491f42c543aceea1a31136f0f1a8d991",
+                  "sha256:a1af93a1b62e8ca05b7597d5749a2b3d28735a86928f0432064fec61db1ff844",
+                  "sha256:74e11b9013f81bd30ec7934ea695d267d164967fec27a02652aa48602b94bc51",
+                  "sha256:dc1d4f59ba0728e65433bc7f903b3799d61545ed3eed7427ad0fe36dcd0f831b",
+                  "sha256:6b588ff47d46d33b02bc296e6e5cc263d6c8ff51ee97b59ca8b34d5c45d57912",
+                  "sha256:545cd23ad8e4f71a5109551093668fd4b5e1a50d6a60364ce0f04f64eecd99d1",
+                  "sha256:0225dc3999e3d7b1bb57186a2fc93c98bd1e4e08e062fb51c966e1f2a2c91bb4",
+                  "sha256:51c3ee5d824bdde0a8faa10c99841c2590c0c26edfb17125aa97945a688c83ed",
+                  "sha256:794f970f498af07b37f914c19ad5dedc6b6c2f89d343af9dd1768d17232555de",
+                  "sha256:61ee52dfdcbcd98acc765b45781ea5de94831f55675c0faaf615872f92268757",
+                  "sha256:8d19cdf57ba61fecd9e07f24fe88768f58196543f7c032adada8a0cc48eee6b3",
+                  "sha256:c238e0a5472c59c54093ffa23af6a963b4ae437eedfb6b9ebbcb482752c6d16b",
+                  "sha256:f4e3607f242bbca7ec2379822ca961860e6d9c276da51c6e2dfd17a29469ec78",
+                  "sha256:6bbb721dd2c411c85c75f7477b14c54c776d78ee9b93557615e919ef47577440",
+                  "sha256:2975de6545b4ca7907ae368a1716c531764e4afccbf27fb0a694d90e983c38e2",
+                  "sha256:7e50a5d0f2fbd8c95375f72f5772c7731186e999a447121b8247f448b065a4ef",
+                  "sha256:1edcf2b441ddf21417ef2b33e1ab2a30900758819335d7fabafe3b16bb3eab62",
+                  "sha256:04ee771fad226ade609b0e879d15c32898379360db27ef1bc6d9f5a77127d5a8",
+                  "sha256:7559c097998db5e5d14dab1a7a1637a5749e9dab234ca68d17c9c21f8cfbf8d6",
+                  "sha256:d5ee453757bd1b479881f0a57b968427404b81d9fed07d04afebcbcfcbf536ab",
+                  "sha256:4b40402374fc4a9202a67d3ede77dedbe5ed1bab57479a5b5cb5cd6c45283bf4",
+                  "sha256:926ce547a03e1bd2aac94b1792d7ccea16d1e6bd91903458e63a095268e1b02f",
+                  "sha256:f5e73bbd776a2426a796971d8d38664f2e94898479fb76947dccdd28cf9fe1d0",
+                  "sha256:78d17ed089151e7fa3d1a3cdbbac8ca3b1b5c484fae5ba025642cc9107991037",
+                  "sha256:47f414f515a2c3103d0e7dae67c47a3b2bc76ea2413d666052012b11dbdd0feb",
+                  "sha256:b566154cc9b2b1996716def297d58101f3015a1b868187f1f9e4cd3074ae9988",
+                  "sha256:3edfdbc82f97ec12e59c80c67897fc1eeb44c3d16820f761a8f15272965ea3a1",
+                  "sha256:cdd6594a3bca71d32a5061b85457cc8148611e7f042ba6e812a1c0a2faebac92",
+                  "sha256:56650f8b8f2b01c1090d184d7d6d396f0109f8a02f915c97b081be73ea12df08",
+                  "sha256:946ba273a3a3b6fdf140f3c03112918c0a556a5871c477f5dbbb98600e6ca557",
+                  "sha256:c64632c85c3a49dc82222cdb3d0ee87eafa64f3096ffeba5bcc16c49ee2d260e",
+                  "sha256:a9d4dd71786b3147d53da1aa44f134e61b1e5527b6c7ece6c2b19474b6ca9270",
+                  "sha256:e716fd0130980916f4b1aeac8f98dbcd8ced81e2c119b7877204cc6b1a058418",
+                  "sha256:15554476d03595246aec194e63ec9db7469d5b3ed81a27a8a2720e82df1f8bf4",
+                  "sha256:0727078eff2abaf1e5770b331ed8162d8e95cf2cf1de06de7540d034999d72ef",
+                  "sha256:3b00ac82c31b447e306fcb47b4469fdc4e6d87385b42358c2e76badb51b074a3",
+                  "sha256:401a2690658194fdd92994c29aa57c18cc5e3100fe7bbdba33d0fa26f2213eb3",
+                  "sha256:720088f184124166386634a523f3566a7fc56f802dbd6e6f816e959236542770",
+                  "sha256:2d77f4a2166122e3f7c5ace1bbfe5319ec6c2d24fff1c6f3e22ccb3e8b2327e0",
+                  "sha256:0ad85fe7a6b42dae9248268706940b12c01e83141858df79e43223e173fe9840",
+                  "sha256:35983fb2e9104b81caaa9e6d40352ea8b2b987fb811f935602d04cc90fdee76a",
+                  "sha256:1cfa672c25cb5849bb2aa652e045e4a4a272c025befb1fe5e58cb32823faa30d",
+                  "sha256:2394d6a1ce4de90590e65111d870b172cb9d4e30e1e6f58a334b29e717fdd031",
+                  "sha256:65ecf1e479dc2b2f7f09c2e86d7457043b3470b3eab3c4ee8909b50b0a669fc2",
+                  "sha256:d816e850877d0fdbc5ee0951dbd78ca79613602aa5cccd1b324c10d700968d3b",
+                  "sha256:4c124ec5a10a5c32e390d848942a04baa8761f190a4a95d3ed7b5c626ca17fc8",
+                  "sha256:176ffcb2cf0fdcbdd2d8119cbd98eef60a30fdb0fb065a9382d2c95e90c79652",
+                  "sha256:1bd969e0521820374122f5132e5998d9bd2ab185be66565a7266096297419c8e",
+                  "sha256:49e68a65bf87ae9ba812ffce76589c09f6766a0eaa5001d7e4a1c782e91d71c0",
+                  "sha256:c5b5967a094ced90899052a82e2c245529b75ba3f46e0ce1a89cfc95edb935ea",
+                  "sha256:c59538d646715fdb1f94c6be3fa0949871b8c860d5c54db4640a1197663a130b",
+                  "sha256:0e9a8a0f823bf0ef948862f0ccb62353460bd07931e756c98f23908c1c526578",
+                  "sha256:ccfa1810aa19fae08aefd29cffe28b65d5123cd17bd7d2d4207f03cf9795594c",
+                  "sha256:28c0f457d67213319f0313d993a3b2f8a778a077b202cd75bf45eb2792949d32",
+                  "sha256:8781993942f622945aefe59e449a5ff4608f969db79fbe893040890ff08fc1f9",
+                  "sha256:111d88db3a52121f04f2741cc72ce8dda6d6f6ef2cc36452c042e0141b316334",
+                  "sha256:4715730da2b4a5bf6cc2ab85208071f00c7b279e4b2f75df0bd954446185e14c",
+                  "sha256:78c43d8a15ca018de1803e4baac5819e1baab1963fd31f1e44e54e8a573acbfc",
+                  "sha256:ebeb05a4a9cdd5d060859eabac1349029c0120615c98fc939e26664c030655c1",
+                  "sha256:594d8b368013caa4eaba4eade896fc1cec8ef569052bd491f493c193e07c6d80",
+                  "sha256:abc36bf7797a427b64c3c99b4f74714bfa66b906b62358be6fdafe493a66415e",
+                  "sha256:405bda98fe97c1a5cf70511ae2d167256b25dd8721b88899465e9847525e2068",
+                  "sha256:3b5d31b89683be71c72b77cfceb59238f4c76a796de6ae85525b3d5cfe2a8f23",
+                  "sha256:882a327cb5e2d809bfe695e9622caced76e7d89c96dcb40203ad8b7d281630fa",
+                  "sha256:d77a7b1602a9ab7543171091dcb37100552f4738d40389028cbf2992c3152f52",
+                  "sha256:dc835194ecfa6ebda81e0a764c953eff3422a61863e9a3e0dc74ea4cae7a4d94",
+                  "sha256:20874a9d40b12125c9e5b97fe4ccda3f94acbc03da1dec7299123901f5b56631",
+                  "sha256:cb21226326a5a695c993daba749f5d758658d58612b05280a04cca98cba3f83a",
+                  "sha256:6c9dfb73e199975275633f05d31388cd61c5a77dec5678db958b4e6624eb21ba",
+                  "sha256:d1e8c7a00924d1a6dee44ade189025853a501d4f77c73f3bfc006aa907d97daf",
+                  "sha256:3eca41ba67f8121586709b6fa2c57b20b4fab73bbb8a4c133269d0cc964f362c",
+                  "sha256:8891a9a4707611c13a5693b195201dd940254ffdb03cf5742952329282bb8cb7",
+                  "sha256:7f506879c64e0bb4d98782d025f46fb9a07517487ae4cbebbb3985a98f4e2154",
+                  "sha256:aa0007192287faeaecc72d9fa48efdb3108c764d450dc8fea65474476da32c45",
+                  "sha256:5b0f2f11c7d635630ced3cc6431b60d27a2c80f878420654df18a714b3df6c0e",
+                  "sha256:003ee19ec5b88de212c3246bdfdb3e97a9910a25a219fd7cf5030b7bc666fea9",
+                  "sha256:ccf848b42acc0f691b4cb6e2830dc4263c7ce4df89b3f4002c3d6b9cd99b362b",
+                  "sha256:c2776b30c82ad5566fdbcce83fcf9c699ad83dae57c6499eb64f8b8a7bc00b60",
+                  "sha256:b19bd4f106ce301ee21c860183cc1c2ef9c09bdf495059bdf16e8d8ccc71bbe8",
+                  "sha256:a04cb3117395b962edc32bf45d8411f240632476b0706b2df7f4a1a87b2ce34b",
+                  "sha256:233e5f78027b684e5aaac1395cc574aea3039059bf86eb4494422bc74216a396",
+                  "sha256:563b3741d26b6af963fdb7b0634e0791445a707d0b6093ac71c3224299241639",
+                  "sha256:07c65a3efc2bb32027206df4f117b893268d028cbb3741208d73615a63525158",
+                  "sha256:aa1835fd302a37b84ac256db5dd0de09bd9883a5a07775aedb491faf46b18ee0",
+                  "sha256:612c21ec8de299b7244b931b492f17e811ecde1450e359f112bc88d20b115d73",
+                  "sha256:bc7fc2028a29ac7a406719ed4f6740f6bf12c20961223c1e839a2a39069af38d",
+                  "sha256:4cc53ff12e7b8fcfafdd32eaac7b13266876766f22b3262b653eaa7b06fbbaaf",
+                  "sha256:0320663709136d07690fe299903700cc1dcc526d574fe8b952a01e1d24024ae4",
+                  "sha256:d967d6bbb33bf7a295a64807f81875c84e82a8ecc59b6c72fe955141b1660d39",
+                  "sha256:a81afd94bec26037880bccdb97937c7662ecb6c1006a8bbf657d8ffafc7c4614",
+                  "sha256:4fae16ca54207cb952e3904b8eb8cc424f3f056f400e5e802ab1a9ef3e575834",
+                  "sha256:03ba1e86a04d912fd2878b457b06a6a7abad0ce96cd9a6932bf58cb4641b8fb7",
+                  "sha256:4e22015880d16cb7148d70895a2361f4fa05804f0391386e0e50554e6fd868b0",
+                  "sha256:9b1018a43b1a9245cdc71a342b962aa32fb799bd0ce66ee59b496cdd75200de9",
+                  "sha256:8cb953ea9ea1bd262bef00112e2c433583929cd7aec86ae60f1a725c6dcf7c09",
+                  "sha256:88ff01f3d3812bc3fb3d18970ecefde7ac8f1a6a29409946ed85173cf8645a3a",
+                  "sha256:dbde46224833f804d8b92212fa3618ea53d0e0cb84ff07132a5ba36c1bc0b9df",
+                  "sha256:561a61d2d81bccb14d22a53b32301e0b6b9e9b9d80ad75991ee6ff796cae0ef7",
+                  "sha256:76df9e0fc779fcd7d3ee836ae254ead30b5f9492022b55901d1f8bd914d38ef6",
+                  "sha256:605033c50f750dad4c344495a0d6b18dcfb2a091bba072441a38cbf9001c0363",
+                  "sha256:9e540fe1fcf866ba1e738e012eef5459d34cca30385df73973e6fc7c6eadb55f",
+                  "sha256:7d4c363f4a746f3a0946d19f303fe9c60c5fe178892528ec4f34d8ddd2c4c359",
+                  "sha256:8540be85295735194e0053eb2ab6b2bda2e27119b9b030877eff43f9272a20cf",
+                  "sha256:e1153055b6ea57ee81e6fb41b03023279059513d0fec728517ae0805186a5118",
+                  "sha256:f97b5915b3f75d2878104c198f205841813712103f1b3657d71d2c8d079cc947",
+                  "sha256:dd8998fa42db6769700a41203f5ef0efe523ed24734636ef0dc0d2a4d4a94747",
+                  "sha256:17c615aa31cf2afa434d1d1d42e0db85b564fe416d346721bd38c0db75f73119",
+                  "sha256:48f31b2798e2ebbf1a7b83f43c6aa2d2eb438a1e053906623c3a7391065c00d9",
+                  "sha256:31277c01ac529cc1c6a55fd87d6ce4dbb20290575d4e1e89cd40600eac9f3405",
+                  "sha256:4b00562fa291e956d910bb056c6120f0079f30093ea107757758683a6d418206",
+                  "sha256:5796882ac3059835583bc399e8522c19646b717713ef553a71b20ca0535a1718",
+                  "sha256:697f5bf30fbe44dd4dcba8392b85680952b7a1be9a0221349f4fde011a8cdd3c",
+                  "sha256:c477e45fe5f8f5bab1ec1711210dd357392ad19eab48cda18d89b60df5067970",
+                  "sha256:61b1d3440b078f35a3fe2b35c51d6d38498fb3dc8d8f5fedf52c7f0f8f6d8ecf",
+                  "sha256:bba1cd75958b43df5e3ceb820449008c19ed5fa562d54c2d46c5c57e79aa6b2a",
+                  "sha256:8a501b9d8016eee68ce62a93a65842b15c8a57192b9f8189ebc85a11f2f47f9e",
+                  "sha256:3d175382237a94330d72af67ad2c41535dee7eade3e42178b86d2dc87478d030",
+                  "sha256:e95bb05fa5defeb16dd0e0957de676374b22b9daaf405273e636d1ce91001574",
+                  "sha256:3898e2ac4e04e80373bc7fe4092b26d502d4705177719117e25c083d44a9a150",
+                  "sha256:8c26cce4231f781db7b37d51ded377f9cfa01a5e6833d967082795f1220e2860",
+                  "sha256:de9a24cdb3260850b49086745ba6f724aecff0bf7993729ae063c116da6915a4",
+                  "sha256:9dc236a8124d1fcbb41b970b5a4c45d6f7f97430c933c775121cae27f5f352a7",
+                  "sha256:d46ef49f8ddba1ee8cce6c9764014851cce2dbfb5dcb2457a31495393e6566c1",
+                  "sha256:4164089bf1754c0ef18ae051e047f11299907204839ad4b7978f146a543a2e91",
+                  "sha256:09096bc32e37443417cd625364df32674f9d5ff4ddbeb175e6d60637ed3d573f",
+                  "sha256:654d9074dc8ebb93230fe258188a17ba3f7dbac2f360f9f79cc4fb1516953018",
+                  "sha256:44999c555a6e4bb6cf5e6f6a79819e76912d036732cb50efaeefc20a180dd839",
+                  "sha256:ce954d3900cb547aea14df6ad5f310ea96bb5e83a155b93e2e64b2c13b686193",
+                  "sha256:368779f00f427680d954899dd73ad3b6a59c42baafb91cb100ea177f51185198",
+                  "sha256:f0c20dff5211f9c133ad5703daedcbe148528c634b0a1eea7887b420da4dc00c",
+                  "sha256:15cd74b4ad9d82417072fe867f086d68667afd4291b710b6c7feef985c492990",
+                  "sha256:480e0f1a9dcce6ed0728e9aba709e33f5522273da1e4b0859cf9d3bbe2216532",
+                  "sha256:cd8b0adfc4d2467a61ab2aa2b3e617bbd2a2592176da249365eef014faef827c",
+                  "sha256:a4577841148e7e2bf481447ae141eff319007e70a24295a22787bbfaecf4c4fe",
+                  "sha256:bc3e4dd9194760500ce9731d792f46afa049667185487bae88c23a38fdb10c37",
+                  "sha256:3c89b334988c0d1399d25baebe298d9e8cc768f28aefd581aae893aa1e69de84",
+                  "sha256:33a92d88496e8aa410976f073e324f761b2ae02a94c20c0f291072df84f648be",
+                  "sha256:8b73e398f5a3cdc8a7ded303586ca7a50b26cc76213a3cebe36fdfdca769b316",
+                  "sha256:ff02d15997cec2391c7d49203e49f88068993252ac1f496a11e182c92d9d0e88",
+                  "sha256:11838afbfab4da7d5fa6e01046f76cce0b0a0c174a87c522eba440fce16e316f",
+                  "sha256:e526de1fefb832b3e6a025642c77ac2527595925933412a7921606eb072e5ca9",
+                  "sha256:3d4e54f6bb2f6ee5417613d5d9bef407343adc768a0841ea58f831ffa868cbd0",
+                  "sha256:8623975eac20e039a7ba14323490db10169cf205ec98f5df2f55f7d410202663",
+                  "sha256:2b76d31dc0fdff399a5b1d396caff67b9eb2f5b8f6cfa8d7a430eeaf6a09104d",
+                  "sha256:43d4db89cf7aa96d57be2847577cf1dba8cba99d5d43118ee54d0b97a4ef8b7e",
+                  "sha256:80f3973c07c06dd095203553abbb95d6ce1c24ccc92f24f46659bf05416f4778",
+                  "sha256:cad86777bcb265db0da766952ff63e8d33f0fd4f3b90b22d0a1da587a785db44",
+                  "sha256:67419432fe7d373f8e5ddaa7b0dd1c25389608bf2f4ee76dbabcc2d96eb8c9d0",
+                  "sha256:4b81b6f8279b75714cbac2f77b2e006f65cd799c2ec3d1c9c40840b1ab60c885",
+                  "sha256:5f445b2b2a4bdeabd555e25dfa10119d9f4e4e500d1c4492219dd8647f119ce2",
+                  "sha256:8c893a8300f812ca179e1f8863eff109e1b8f1c70044bc5f08eb38a592ffdecd",
+                  "sha256:fc8e4e96da6ee6201a5126473666831314938e98bf699677be296e7811f6b7dd",
+                  "sha256:32ecf5a37bacbeec9451c4ad39672ac2816f9241d5a92f038b45059da2f3ebae",
+                  "sha256:e525544166da577edcd03c6596f1e8787a257caaa19eef98c3a481681d2d978a",
+                  "sha256:b55df489f643b495984915a0671e74262192813e07cff5812d778c8cf4c0b9d1",
+                  "sha256:29214e4bf64efb65d82bd3f318d0ac3b7a6b03f6f6abfd469148bc2f894c6846",
+                  "sha256:16b390c34ddb56c075fb6f4b77bf9a0fffab219fcb3f3588b9151215ab2b0ad4",
+                  "sha256:b5bd11b47b5b690dc667dc486941331d7cd3aaa4f0e5c4d638ec7b294bcc5012",
+                  "sha256:20c3abcc5556f09e557a398886684d1efe8ef59687bedbb78c130a7d1d55868a",
+                  "sha256:1cdd6c2abf0132da0d956398eb1dc736c0b93fd8e8465e7f1111ad05b2c322d8",
+                  "sha256:7e67dba2509f90064325e62e49412d5284a55f09b7b6878b9c8222692c500dde",
+                  "sha256:9f1a745b208091d4b009ec321a6fdc72c8a5e89167effed81c50571a13f1c87d",
+                  "sha256:c7dfa7d5a4917eed3b44af87ffb9c6e18242ecd847a8edd140bcdd178cc8946a",
+                  "sha256:46e371b6245113ebca446adcbd2db39f2887b67dc5a640f62f6d346ec9f6980f",
+                  "sha256:cea5d052286c0a120f6cdd0f3e559f13b0eedf9f83d2538e4369b6e05526d43d",
+                  "sha256:62da6a936871ab7b8c3efc0332fe41b4ac10ff96b357fb2bd67deecb312f9277",
+                  "sha256:9feaf80c733951790bc3578db42ea2abef65643ebb36779e46dccdaf4c76b525",
+                  "sha256:627d792d7cca1e97c121be5f0808c9da96f54d6c986622af246c60354b9c316e",
+                  "sha256:12fda64dea45a7b085a35a816a7d8035be6600cae38f7df04a3bc22ced4d4502",
+                  "sha256:685d8ca4ac9c909ac2daa8bf454d8ce1de993c8ae29a8c78417dfd5d1c3aa65e",
+                  "sha256:d2748115958b57c9c5125e23bad9462edbabb33c81197424a33d8060745ff646",
+                  "sha256:5cf4db298bbda87532af2b2468a0692ec93d28393285ae157c1b4a18efbd1ba5",
+                  "sha256:7632176e2d324ee98701f5d79024361379d510590e477f560a264aa6e8db233d",
+                  "sha256:95cb9c201ee3b54fe6331bd7e74f43485632e95448d31fd340ffaa84a32b41ab",
+                  "sha256:85eb614fc608f3b3f4bbd08d4a3b0ff6af188677ea4e009be021680c521cedae",
+                  "sha256:60b0cbc5e435be346bb06f45f3336f8936d7362022d8bceda80ff16bc3fb7dd2",
+                  "sha256:0feac495306bbe6e3149a352025bea8d23cda512859a230cbd3f510cf48caaf7",
+                  "sha256:0f54422e17766a9e7385a553d941d1849c9e7ca4caea085305ba9fb1e15ae607",
+                  "sha256:0bc637f0d028043e8388b083cdd8d0a0acea7fdbc79c0bc9401dfb02c20fb817",
+                  "sha256:1b53c868277dec628058b31b1a8a8a2ccd8efe832ce9694805b5f82564136eb3",
+                  "sha256:499e48b35f3b5f5da45031fa78fba559fee6a480ecb106e6c300eb8344510958",
+                  "sha256:bfa39369bd3c36833126b6f46b747de0736a66835d97196195c0810161c24549",
+                  "sha256:82ce159a9e4e4b6b4fdce9ad954aa507f67108430bd261a4dcd826e44d0152a4",
+                  "sha256:0edde19e0c027c8cff31b82e1f4b0b198c00bf924047fcf4dd610a7d4965ab52",
+                  "sha256:6b096b1da49230942e736576396091530cecb3f9bd8cc70b8b8a9f72a5148a0d",
+                  "sha256:8571a2aa115d42f8b5e87ef58d10e9c24e6fbe5470fc2612df96f8740f3d960f",
+                  "sha256:2fcacd153d4aa4ddddee3357b717e8d3f411382b180add28328c9faa94dd2ae4",
+                  "sha256:8945279d57ad510e018f92571ba8e5d811cf8a3165adf930b0d4015c5a077a35",
+                  "sha256:30f37ca1fe1592e29d3e97c1dec0646015000d19bffc40f13dcfe73e15be66fc",
+                  "sha256:27f43a7a8d1b18f5ede27728ecded75e510195a78abd9f3d0c1965d341e5e45a",
+                  "sha256:ab2988acbe3a2580703de6070646324e95efe982598a386e69ed9857ab123855",
+                  "sha256:71f54759238edb9ae63dfc6ed893183a809e88321d8117dc40e0d403fc533585",
+                  "sha256:ebd64ac5cc7b9f58a40072fe9afefa2fd835e0eb18cdeaf085395c7e84affac3",
+                  "sha256:a2aeabb3962859069a78acc288bc3bffb35485428e162caafec8134f5ce6ca67",
+                  "sha256:2c1baefd0f802507d9741da8da54f6eae42b04967f9d433d7f9e0f124434c70d",
+                  "sha256:be49b69bc5de947ee2151f397993a691a57bc53952058c32cde0fca674da7d8c",
+                  "sha256:48226934763e4c412c1eb65df314e6879720b4b1ebcb3d07c126c9526639cb68",
+                  "sha256:3a438b53e8377eccf90cac0fd42ed2b513fc869bfb7b96e3d2a4f6984a287f90",
+                  "sha256:8729b157f0925feccdaef8aacd91c6aebe0109e621675bcc15e1830673b0e19d",
+                  "sha256:56c3d429ea949467dc0bca882646cf40a58fb6f27750f5664ff2919f5d38ada5",
+                  "sha256:1fad1d1f8b56e6967863aeb60f5fa3615e6a35b0f6532d8a23066e6823b50860",
+                  "sha256:842ff55b80ac9a5c3357bf52646a5761a4c4786bb3e64b56d8fa5d8fe34ef8bb",
+                  "sha256:15b17b95cf9cb9fb64e0c8e56110836bdcaf70de81b8cbdb60e181fc90456e06",
+                  "sha256:a82958266d292f4725fc1981ea57a861b7fc7feeb7a9551d0b61b98ca51a5662",
+                  "sha256:eee92733e8989029929d5cb1f673b15fdb814dac32e148d5bc02378b44c8699a",
+                  "sha256:ff8b51c6a8bacc5ef6b5da0f049d170ab1c1ecebad50ded3c04ed384eca9a2c0",
+                  "sha256:383a5e6bb9e94de53baaf5c7493cd50a68c893c6a30acfbe28407d33bb133efc",
+                  "sha256:19061d12407c0c4bca6abcaef01695b70dcd3967ff102dd07178a2193a280e29",
+                  "sha256:4e3e93a3d2039c2a8305030b7960bd1100d7d20705a1afb1325a4ee79478a74a",
+                  "sha256:084d79ed3d7127e6d46e9ac6e654d8ef181a156435808dc8eb32968b6c1b4946",
+                  "sha256:2a8f9e5119a034801904185dcbf1bc29db67e9e9b0cf5893615722d7bb33099c",
+                  "sha256:67f37cee02ba744dfc7957725f5ef9df229778f6a2f7afc659625b458da6167e",
+                  "sha256:b10d8521963a2494fdb2b5f8fb0de837dc86d4016c3b10019fb8970a09582451",
+                  "sha256:47ad43730c8bc72c90f2fb3dbd3526d716ada2fad94e62cb443658e94c6503c5",
+                  "sha256:5c1940e1f173e22b053f3a89022903cea34a6af20dff81c65548c4e2ba3a8293",
+                  "sha256:1a4e44583a767289bb0d354db93c6a9132420e13376d4fcae866d69620bb11bb",
+                  "sha256:7baac88adafdc5958fb818c7685d3c6548f6e2e585e4435ceee4a168edc3597e",
+                  "sha256:090563f18409c228274bb61dcf1001f63a55c1246fb2838a998cb3c5fd8c3874",
+                  "sha256:cc5f8dd4e061da3a73aa67112e24f2cc5c0ad0cd4334dc798b8834cf6259a779",
+                  "sha256:698e8ecaf71719dafacae79de05080d567b69fad3511e8b8d42b9af96a7c41db",
+                  "sha256:441b3862f5a0fd504bbbba18d96d1b2b920fb95a79dc45a753a6a664ad285b07",
+                  "sha256:a42de8ce71380b1f4e8ac5b4ce720bf565c99a0b09ef983c0550a91a467bc155",
+                  "sha256:4f92835a6e4ee4276df49019e068d1871b75821f52b405c699bd9f199df58b80",
+                  "sha256:881b28a3a37d114bc3f046605b24663560009b13a507217e007643f5682efdd5",
+                  "sha256:f4eca686b314edb06d3fe1c526f573c7248c811af70cba76132cdc9c541cadc1",
+                  "sha256:30ceeb5a6cadaeccdbde088bfb52ba88190fa530c11f4a2aafd62b4b4ad6b404",
+                  "sha256:e87acf226a9511b3a5f83e7fed9c5c20addbbdae47ab67c614404a9392b77e50",
+                  "sha256:d150e53fa73c3786da9e4f6e23d374100b0dd2923485d4a08e9a56ac2786cf83",
+                  "sha256:88be5116908aa5013f540c767f6811774342780bb72d3ec197b3429bfb2f9862",
+                  "sha256:e156e6fa9ef6a483f8505ce0eeadbcab12b887c4996233ce5d6258076f6bce50",
+                  "sha256:e65f7d7c8def6b168e013914bc0d1137aed65c3010e9796df3b823854472f3e1",
+                  "sha256:a49b922f117b9bfb0b07e9848151f8a2948345328ebc534cd28ac187d7ed3f94",
+                  "sha256:caa0bd6617a8d5e535faedec5f6f3ea7c5e6da1898751f6c9c34a89a95c286ff",
+                  "sha256:d807e7fb8bf24be50642a6dced954c6ea208199daab2d27c9f73d789ba82fa37",
+                  "sha256:8cd6ef9902851f07cfd9682e2d6873648690f0c2ec65345276b557ede042d8b9",
+                  "sha256:d1d362fd4f8022ad05171efe40e84d15ec6c5e5f419d6099ebc8e46e7da632c1",
+                  "sha256:78fd472a1c7f49b8a432788ea2dfc1119f155a394f41585b4e715d2585fc92ab",
+                  "sha256:e392a6b41381ffad04626d092fd2af9477c72e197a74efddf987832c3bfa521f",
+                  "sha256:ad338b7a3f3bed96300d9ce7f0307e09d758962b8496c10fb3554bf62405d153",
+                  "sha256:bfb45644212cfbbe48b05149f8d53e77d7bd02ca9fc9045cc37115101175a3a0",
+                  "sha256:fa7bef727ba8657208bb3df95916f0bc912332cb8534c695facef32ffbd72f20",
+                  "sha256:257e086bb52086254fa8cc95a5c4998668b4fcb5203ad3c2275c1150816acc9b",
+                  "sha256:af0a4287e302baa7c85655ddfe5a7049b8eaf31aff03886f4fc57c920d26d491",
+                  "sha256:51760acfb6ca87db5be7a9296d6a3d1220767956c576a26c6d46784e25db85bb",
+                  "sha256:2451a475f248a4c66e64d149fefa8bfc195fcd7b3f369bae221a94f8ce4c2d67",
+                  "sha256:4a08d5264e865548e65d31886c91b659b33a2c2ba39fd115b00af3ea0bc91a83",
+                  "sha256:78b2b9cbf041d4461daf7ac11a24d1e79a9c57f47aa265dba4d09067efe3d96b",
+                  "sha256:fb276cc0ebc6bd27d344f7e0811f26cb3f0e59da09182489095724bdf2a075f8",
+                  "sha256:5a0927d231fbafa8b865591922fc07d39d9b4b263a1e9c0bbef691282f706cd0",
+                  "sha256:e1e28504928648404a3b652440091eba010cd99221183ef78601cbd152261d91",
+                  "sha256:42bb566be1936bdb40937f9c0a96c4acc93057379385f1807cba18f60443d3e4",
+                  "sha256:6d1ac29b3a38408f6d238d6718384e05be7346789c6200b354335b0e0c9c77df",
+                  "sha256:331b91a0928c05618c7fed3e12bbe9ecb9e4619d08c7e85d3de344a08d2f0f1a",
+                  "sha256:49c7c718cb4e2b6f0effd0dec4f4cb4e109d260c192b2b329a58a1da9a24ad1d",
+                  "sha256:a3ef96219165bfc64d4f5d50f51fbd43e803c500619240ffe4db1f9f8e337f83",
+                  "sha256:ef86061338fa321c959cadc75ecbdfd405eebaa1042eec9d9c737d4d9d92568f",
+                  "sha256:7bb5051dee5f6633a02cf5a3285dd86890cc6521e497526a8149dc5c5ebad062",
+                  "sha256:4aca3cee9de1a4cd7ac56a12550f286894a215cac593c18857278f7b0e48f328",
+                  "sha256:1d6551bce8f8a1e53682fafe4f67fa830c333f0b37db7acbeaca0095b5ce870b",
+                  "sha256:6fe1188081e441595ce29ebed4d1985e5890815158244f69f092ee930656f755",
+                  "sha256:a80c1d6d32db7ce8fdd58bb4f3f488b74e94261a38512dc8a15179ae33697e63",
+                  "sha256:b437a08d4670ef440ba6dbaae4ccb39f989f0c2a3d280ea66d6fd9532a313286",
+                  "sha256:230731b577f8d29e7e8e8fd6d1ea02702fb4364fcc7034d838ccddc4d66da8c3",
+                  "sha256:54f59ddb56e89a5330373e07ea05934fc58360eb7480615ede2a3ed6982e1eef",
+                  "sha256:ff1580bd4ec5841d4937b383917fa30f318b4f419b8067a77468eb4a9630ba10",
+                  "sha256:df40cada982b04336fe8b250b4fdd576ddd03a014bb519a69b34640369bef661",
+                  "sha256:43bfc890caf7855f2fb55c24474b58cd5c8c7b51e4db4f40d1f302fffd31985b",
+                  "sha256:30ae4489980021a727f247d48b4d74d4c6c7667d00bd1a670f045ea24a885541",
+                  "sha256:77e4cfbc823e3764308822ccf03b257861f9360f3b948829f1d73148b321b00e",
+                  "sha256:9b69a221cf9395a110849bb428bb1cfe9fb489322df0fa6017f5978a827ee0e9",
+                  "sha256:e0a7b9f3b56b4737f5711dc6b03f256fbf2488656b8874acabb494b58ba0c1c1",
+                  "sha256:194dbe332ccdb33d58f040da07667257e176975f6b2f17343bbf33fb99deb097",
+                  "sha256:e21a84107568047432e474e08da24aea2340409d57ea8cf170182927dc76de12",
+                  "sha256:b83a0199c3d471151f07f6de626a1a4a362dd6aa29d84cf1c0ada2c966ce29c9",
+                  "sha256:709ea71f36495ac2ac89d72d2eb603b6aa55b2c1a70633f23514dd897936f02b",
+                  "sha256:0afac6f4f9ed1c59510675d87da45c7966c0f7aae6e8dd056961aceed8c4fe0a",
+                  "sha256:12696f5638ad2068c5c8940495d15c3bb1c57990000dbda7428b008e9e63ab5b",
+                  "sha256:f3d9ccb762146dc97f2d201d979fbb0e9171d1203fb985f3ef48b5c2a176c2a9",
+                  "sha256:c5a60ffb80cd1f9b90c797f1d1ac80e5536eb32a5b276871445e7279ac701c5f",
+                  "sha256:0515afdac097ad54cf4b24e0644f0789cab5535a54107aa44940ffd991a6cef3",
+                  "sha256:020abac486839c7be29fae37a686dc7749398c333cb8ba94b3390b386ffcbff7",
+                  "sha256:31d924d1540dd4e927a4c3aa936cec4bfb54ed302d3e8acc1be8b52dd5deb10c",
+                  "sha256:fd6e1803ff367036da5b52b2183e1408691b379cc1320971bb664737507f89a4",
+                  "sha256:6b312faed4a0508da2f15d3f31a6daccfc0ec6621e5fb7b20956027dce5fa395",
+                  "sha256:4e497225fe36781735cc92c0886f6858b19d4557ed9ecafe1247b8233c206075",
+                  "sha256:d3a4f367a9c5ba936b1bb5480db390889a303e5ec8ff34bb4274c1d840a1784d",
+                  "sha256:8d7777da3f54f965cf3058cabf987c01b93a1dd041e8359eb7822eba57d8c8df",
+                  "sha256:9b8a8a843fe9a972f6433e11b95b5a8d1d2971ed40fe1acda6807e34f0773c62",
+                  "sha256:1aa321c66a3661e78d938b805e5c311d519f04bf3496545ffdacc7c152bc9b21",
+                  "sha256:98c28a91d41f634edb8c1f001dbc45c0de534332d059a2e8feff448fb7235c49",
+                  "sha256:b4a1ac1ff5cd22a5dab6c96dfc2dbd7cd6ba750691ad5c53a97a1f088fc42abc",
+                  "sha256:56c866bcff69fd60b630841ff990296b26c2f45d8c6054311b5c476bc67466ac",
+                  "sha256:95103f7c339aec4b485b7f569aa8a5e1a54286b3d2acde427328c49e4d8d80d1",
+                  "sha256:adc56041458e556df5663e7da264e151c24aaf1c2a94e49df9790ba191ea1b37",
+                  "sha256:0f57b051654b6d75789b437dafd7040b6c90daee17827be24352c0f11a74bba7",
+                  "sha256:1b5136570cefb8273dd5affc73c1456cf239cc8b18be72d6c4d09794af7f3352",
+                  "sha256:2dbfe3cb37c18b39393870baa77f3bbd42be53517abffdd990b13ed70ee3dd3e",
+                  "sha256:f5bcb82a732c02d6f31bbf156887049883c76cedc9c6a11b049358a74f4d45d0",
+                  "sha256:32ebba6472cdc331bd3366ca996ad3039b3a1b41c61a849b88074e1b722cad2c",
+                  "sha256:75e9ed16ace51ba04a62505aaed215bf9c722d6f4b1c33cc3e3962076c300ee8",
+                  "sha256:d539404dafd8ad5d785ab3da6f8bd5a2bf5dff9e01be0ff1bc1d251786dda25c",
+                  "sha256:bff39fef1fc01564156123fcade75b4bc50402a2971a031d9a426c7014b1e681",
+                  "sha256:e217c2687212d931ad9a6a02afb20cc34f6d051786d136e337f91079c9f73d22",
+                  "sha256:c1291b69a65a860069195a33cf6640df8667e960f9f030ceeea4497c47858b94",
+                  "sha256:d8c00baf46e33f9e5f1b9e139bbea9fe0f27badb432c992b9cf8c4f7017094bf",
+                  "sha256:1a968f65db066243cbd0a6e12d193ef674637f044299a15b5d6b910e91411812",
+                  "sha256:4a167fa4a7238bd94b3134173f6267b19cdebc2fde98b583344749e1f4c9bf09",
+                  "sha256:6bfc201a12dc7bba21069a663aa692a96c5e8920b0d94a4e355c332d7ead15ba",
+                  "sha256:7aeb44195a1c984aff87cf8429d2aa40f6947b0a47d3603e1ca5c3cf8d284459",
+                  "sha256:393e7bb9f93ffb3cbba620fbfeb229f2b8345454bc60ac0508f76735544ed289",
+                  "sha256:f24bce642ec88622490b2f09a45fa3985da7f6511a1aae131853c4ea4c309e6b",
+                  "sha256:9936485ac7111967d6962bc539de7b08807e310117adb78b11c21a5db0f0f890",
+                  "sha256:0230acdbc9da4b36da812f0e585a7602eda4982c899b3b3a4c2bc9b4546d8e74",
+                  "sha256:7abf49cabbaf996afc0c2604f10ea18f8f22a903fc4ba3728a18f5892353c5c9",
+                  "sha256:41716536ea16798238ac89fbc3041b3f9dc80f9a64ea4b19d6e67ad2c909269a",
+                  "sha256:17ffe1d683dbff48f9b2ef903401e471e5e51a992bf0890632bceb94561893de",
+                  "sha256:8403cfc97e0e72e37639b8c54d92f1ee427e48a70d52d5260a37fa104f2df20d",
+                  "sha256:c24b21415b737f18fad7aeb192e60f7d323f7ba69434ecc1e78b3af0003be8dc",
+                  "sha256:c2479eb811f4d9b8624ef20119e1abdc109f639c2cf576eb945b340362d87b05",
+                  "sha256:46606c1ed76a4da2a9d18016aeb50f4dddf58e1b45d665c983c58f8e605bf73e",
+                  "sha256:d87f7fa5e637442eb638bcaafdc44ca3895d91a153015ff9af6a87219f0dc372",
+                  "sha256:71c88f04921ae61a7009f9443f95c70ec3424a798429fc01e6c1432c1077aacb",
+                  "sha256:bf994cb2e5c367d78483662c7de6e69950aaf04bc6cfdbbef4d1ef7ce153717c",
+                  "sha256:b7330d40f75b8ec786e41c45a202e44f0e49ec29ddf8944120fbdb373a6c6617",
+                  "sha256:bb82b10a91493d745dc533b5de5335db650adb0c8a90548fdf5dad13569a16f4",
+                  "sha256:3ed319e31a9c38e5f4e336195b5cbd253b3f8b17f93f185829f078c5ef420305",
+                  "sha256:5c46bef8c0e95e05716e9a53b77970c1378d93bcb9a800018a24f7e1763b45b9",
+                  "sha256:3edfdbc82f97ec12e59c80c67897fc1eeb44c3d16820f761a8f15272965ea3a1",
+                  "sha256:cdd6594a3bca71d32a5061b85457cc8148611e7f042ba6e812a1c0a2faebac92",
+                  "sha256:56650f8b8f2b01c1090d184d7d6d396f0109f8a02f915c97b081be73ea12df08",
+                  "sha256:946ba273a3a3b6fdf140f3c03112918c0a556a5871c477f5dbbb98600e6ca557",
+                  "sha256:3b00ac82c31b447e306fcb47b4469fdc4e6d87385b42358c2e76badb51b074a3",
+                  "sha256:1cfa672c25cb5849bb2aa652e045e4a4a272c025befb1fe5e58cb32823faa30d",
+                  "sha256:65ecf1e479dc2b2f7f09c2e86d7457043b3470b3eab3c4ee8909b50b0a669fc2",
+                  "sha256:405bda98fe97c1a5cf70511ae2d167256b25dd8721b88899465e9847525e2068",
+                  "sha256:6c9dfb73e199975275633f05d31388cd61c5a77dec5678db958b4e6624eb21ba",
+                  "sha256:b19bd4f106ce301ee21c860183cc1c2ef9c09bdf495059bdf16e8d8ccc71bbe8",
+                  "sha256:0320663709136d07690fe299903700cc1dcc526d574fe8b952a01e1d24024ae4",
+                  "sha256:4fae16ca54207cb952e3904b8eb8cc424f3f056f400e5e802ab1a9ef3e575834",
+                  "sha256:4e22015880d16cb7148d70895a2361f4fa05804f0391386e0e50554e6fd868b0",
+                  "sha256:dbde46224833f804d8b92212fa3618ea53d0e0cb84ff07132a5ba36c1bc0b9df",
+                  "sha256:9e540fe1fcf866ba1e738e012eef5459d34cca30385df73973e6fc7c6eadb55f",
+                  "sha256:e1153055b6ea57ee81e6fb41b03023279059513d0fec728517ae0805186a5118",
+                  "sha256:f97b5915b3f75d2878104c198f205841813712103f1b3657d71d2c8d079cc947",
+                  "sha256:31277c01ac529cc1c6a55fd87d6ce4dbb20290575d4e1e89cd40600eac9f3405",
+                  "sha256:8a501b9d8016eee68ce62a93a65842b15c8a57192b9f8189ebc85a11f2f47f9e",
+                  "sha256:3d175382237a94330d72af67ad2c41535dee7eade3e42178b86d2dc87478d030",
+                  "sha256:e95bb05fa5defeb16dd0e0957de676374b22b9daaf405273e636d1ce91001574",
+                  "sha256:3898e2ac4e04e80373bc7fe4092b26d502d4705177719117e25c083d44a9a150",
+                  "sha256:4164089bf1754c0ef18ae051e047f11299907204839ad4b7978f146a543a2e91",
+                  "sha256:09096bc32e37443417cd625364df32674f9d5ff4ddbeb175e6d60637ed3d573f",
+                  "sha256:44999c555a6e4bb6cf5e6f6a79819e76912d036732cb50efaeefc20a180dd839",
+                  "sha256:ce954d3900cb547aea14df6ad5f310ea96bb5e83a155b93e2e64b2c13b686193",
+                  "sha256:15cd74b4ad9d82417072fe867f086d68667afd4291b710b6c7feef985c492990",
+                  "sha256:cd8b0adfc4d2467a61ab2aa2b3e617bbd2a2592176da249365eef014faef827c",
+                  "sha256:a4577841148e7e2bf481447ae141eff319007e70a24295a22787bbfaecf4c4fe",
+                  "sha256:33a92d88496e8aa410976f073e324f761b2ae02a94c20c0f291072df84f648be",
+                  "sha256:b5bd11b47b5b690dc667dc486941331d7cd3aaa4f0e5c4d638ec7b294bcc5012",
+                  "sha256:a2aeabb3962859069a78acc288bc3bffb35485428e162caafec8134f5ce6ca67"
+                ]
+              }
+            },
+            "options": {
+              "gpgkeys": [
+                "-----BEGIN PGP PUBLIC KEY BLOCK-----\nVersion: GnuPG v2.0.22 (GNU/Linux)\n\nmQINBFzMWxkBEADHrskpBgN9OphmhRkc7P/YrsAGSvvl7kfu+e9KAaU6f5MeAVyn\nrIoM43syyGkgFyWgjZM8/rur7EMPY2yt+2q/1ZfLVCRn9856JqTIq0XRpDUe4nKQ\n8BlA7wDVZoSDxUZkSuTIyExbDf0cpw89Tcf62Mxmi8jh74vRlPy1PgjWL5494b3X\n5fxDidH4bqPZyxTBqPrUFuo+EfUVEqiGF94Ppq6ZUvrBGOVo1V1+Ifm9CGEK597c\naevcGc1RFlgxIgN84UpuDjPR9/zSndwJ7XsXYvZ6HXcKGagRKsfYDWGPkA5cOL/e\nf+yObOnC43yPUvpggQ4KaNJ6+SMTZOKikM8yciyBwLqwrjo8FlJgkv8Vfag/2UR7\nJINbyqHHoLUhQ2m6HXSwK4YjtwidF9EUkaBZWrrskYR3IRZLXlWqeOi/+ezYOW0m\nvufrkcvsh+TKlVVnuwmEPjJ8mwUSpsLdfPJo1DHsd8FS03SCKPaXFdD7ePfEjiYk\nnHpQaKE01aWVSLUiygn7F7rYemGqV9Vt7tBw5pz0vqSC72a5E3zFzIIuHx6aANry\nGat3aqU3qtBXOrA/dPkX9cWE+UR5wo/A2UdKJZLlGhM2WRJ3ltmGT48V9CeS6N9Y\nm4CKdzvg7EWjlTlFrd/8WJ2KoqOE9leDPeXRPncubJfJ6LLIHyG09h9kKQARAQAB\ntDpDZW50T1MgKENlbnRPUyBPZmZpY2lhbCBTaWduaW5nIEtleSkgPHNlY3VyaXR5\nQGNlbnRvcy5vcmc+iQI3BBMBAgAhBQJczFsZAhsDBgsJCAcDAgYVCAIJCgsDFgIB\nAh4BAheAAAoJEAW1VbOEg8ZdjOsP/2ygSxH9jqffOU9SKyJDlraL2gIutqZ3B8pl\nGy/Qnb9QD1EJVb4ZxOEhcY2W9VJfIpnf3yBuAto7zvKe/G1nxH4Bt6WTJQCkUjcs\nN3qPWsx1VslsAEz7bXGiHym6Ay4xF28bQ9XYIokIQXd0T2rD3/lNGxNtORZ2bKjD\nvOzYzvh2idUIY1DgGWJ11gtHFIA9CvHcW+SMPEhkcKZJAO51ayFBqTSSpiorVwTq\na0cB+cgmCQOI4/MY+kIvzoexfG7xhkUqe0wxmph9RQQxlTbNQDCdaxSgwbF2T+gw\nbyaDvkS4xtR6Soj7BKjKAmcnf5fn4C5Or0KLUqMzBtDMbfQQihn62iZJN6ZZ/4dg\nq4HTqyVpyuzMXsFpJ9L/FqH2DJ4exGGpBv00ba/Zauy7GsqOc5PnNBsYaHCply0X\n407DRx51t9YwYI/ttValuehq9+gRJpOTTKp6AjZn/a5Yt3h6jDgpNfM/EyLFIY9z\nV6CXqQQ/8JRvaik/JsGCf+eeLZOw4koIjZGEAg04iuyNTjhx0e/QHEVcYAqNLhXG\nrCTTbCn3NSUO9qxEXC+K/1m1kaXoCGA0UWlVGZ1JSifbbMx0yxq/brpEZPUYm+32\no8XfbocBWljFUJ+6aljTvZ3LQLKTSPW7TFO+GXycAOmCGhlXh2tlc6iTc41PACqy\nyy+mHmSv\n=kkH7\n-----END PGP PUBLIC KEY BLOCK-----\n",
+                "-----BEGIN PGP PUBLIC KEY BLOCK-----\nVersion: GnuPG v2.0.22 (GNU/Linux)\n\nmQINBFzMWxkBEADHrskpBgN9OphmhRkc7P/YrsAGSvvl7kfu+e9KAaU6f5MeAVyn\nrIoM43syyGkgFyWgjZM8/rur7EMPY2yt+2q/1ZfLVCRn9856JqTIq0XRpDUe4nKQ\n8BlA7wDVZoSDxUZkSuTIyExbDf0cpw89Tcf62Mxmi8jh74vRlPy1PgjWL5494b3X\n5fxDidH4bqPZyxTBqPrUFuo+EfUVEqiGF94Ppq6ZUvrBGOVo1V1+Ifm9CGEK597c\naevcGc1RFlgxIgN84UpuDjPR9/zSndwJ7XsXYvZ6HXcKGagRKsfYDWGPkA5cOL/e\nf+yObOnC43yPUvpggQ4KaNJ6+SMTZOKikM8yciyBwLqwrjo8FlJgkv8Vfag/2UR7\nJINbyqHHoLUhQ2m6HXSwK4YjtwidF9EUkaBZWrrskYR3IRZLXlWqeOi/+ezYOW0m\nvufrkcvsh+TKlVVnuwmEPjJ8mwUSpsLdfPJo1DHsd8FS03SCKPaXFdD7ePfEjiYk\nnHpQaKE01aWVSLUiygn7F7rYemGqV9Vt7tBw5pz0vqSC72a5E3zFzIIuHx6aANry\nGat3aqU3qtBXOrA/dPkX9cWE+UR5wo/A2UdKJZLlGhM2WRJ3ltmGT48V9CeS6N9Y\nm4CKdzvg7EWjlTlFrd/8WJ2KoqOE9leDPeXRPncubJfJ6LLIHyG09h9kKQARAQAB\ntDpDZW50T1MgKENlbnRPUyBPZmZpY2lhbCBTaWduaW5nIEtleSkgPHNlY3VyaXR5\nQGNlbnRvcy5vcmc+iQI3BBMBAgAhBQJczFsZAhsDBgsJCAcDAgYVCAIJCgsDFgIB\nAh4BAheAAAoJEAW1VbOEg8ZdjOsP/2ygSxH9jqffOU9SKyJDlraL2gIutqZ3B8pl\nGy/Qnb9QD1EJVb4ZxOEhcY2W9VJfIpnf3yBuAto7zvKe/G1nxH4Bt6WTJQCkUjcs\nN3qPWsx1VslsAEz7bXGiHym6Ay4xF28bQ9XYIokIQXd0T2rD3/lNGxNtORZ2bKjD\nvOzYzvh2idUIY1DgGWJ11gtHFIA9CvHcW+SMPEhkcKZJAO51ayFBqTSSpiorVwTq\na0cB+cgmCQOI4/MY+kIvzoexfG7xhkUqe0wxmph9RQQxlTbNQDCdaxSgwbF2T+gw\nbyaDvkS4xtR6Soj7BKjKAmcnf5fn4C5Or0KLUqMzBtDMbfQQihn62iZJN6ZZ/4dg\nq4HTqyVpyuzMXsFpJ9L/FqH2DJ4exGGpBv00ba/Zauy7GsqOc5PnNBsYaHCply0X\n407DRx51t9YwYI/ttValuehq9+gRJpOTTKp6AjZn/a5Yt3h6jDgpNfM/EyLFIY9z\nV6CXqQQ/8JRvaik/JsGCf+eeLZOw4koIjZGEAg04iuyNTjhx0e/QHEVcYAqNLhXG\nrCTTbCn3NSUO9qxEXC+K/1m1kaXoCGA0UWlVGZ1JSifbbMx0yxq/brpEZPUYm+32\no8XfbocBWljFUJ+6aljTvZ3LQLKTSPW7TFO+GXycAOmCGhlXh2tlc6iTc41PACqy\nyy+mHmSv\n=kkH7\n-----END PGP PUBLIC KEY BLOCK-----\n"
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.fix-bls",
+            "options": {}
+          },
+          {
+            "type": "org.osbuild.locale",
+            "options": {
+              "language": "en_US.UTF-8"
+            }
+          },
+          {
+            "type": "org.osbuild.timezone",
+            "options": {
+              "zone": "America/New_York"
+            }
+          },
+          {
+            "type": "org.osbuild.users",
+            "options": {
+              "users": {
+                "redhat": {
+                  "key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC61wMCjOSHwbVb4VfVyl5sn497qW4PsdQ7Ty7aD6wDNZ/QjjULkDV/yW5WjDlDQ7UqFH0Sr7vywjqDizUAqK7zM5FsUKsUXWHWwg/ehKg8j9xKcMv11AkFoUoujtfAujnKODkk58XSA9whPr7qcw3vPrmog680pnMSzf9LC7J6kXfs6lkoKfBh9VnlxusCrw2yg0qI1fHAZBLPx7mW6+me71QZsS6sVz8v8KXyrXsKTdnF50FjzHcK9HXDBtSJS5wA3fkcRYymJe0o6WMWNdgSRVpoSiWaHHmFgdMUJaYoCfhXzyl7LtNb3Q+Sveg+tJK7JaRXBLMUllOlJ6ll5Hod root@localhost"
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.systemd",
+            "options": {
+              "default_target": "multi-user.target"
+            }
+          },
+          {
+            "type": "org.osbuild.sysconfig",
+            "options": {
+              "kernel": {
+                "update_default": true,
+                "default_kernel": "kernel"
+              },
+              "network": {
+                "networking": true,
+                "no_zero_conf": true
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.fstab",
+            "options": {
+              "filesystems": [
+                {
+                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+                  "vfs_type": "xfs",
+                  "path": "/",
+                  "options": "defaults"
+                }
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.grub2",
+            "options": {
+              "root_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "kernel_opts": "console=tty0 console=ttyS0,115200n8 no_timer_check net.ifnames=0 crashkernel=auto",
+              "legacy": "powerpc-ieee1275",
+              "saved_entry": "ffffffffffffffffffffffffffffffff-4.18.0-331.el8.ppc64le"
+            }
+          },
+          {
+            "type": "org.osbuild.selinux",
+            "options": {
+              "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
+            }
+          }
+        ]
+      },
+      {
+        "name": "image",
+        "build": "name:build",
+        "stages": [
+          {
+            "type": "org.osbuild.truncate",
+            "options": {
+              "filename": "disk.img",
+              "size": "10737418240"
+            }
+          },
+          {
+            "type": "org.osbuild.sfdisk",
+            "options": {
+              "label": "dos",
+              "uuid": "0x14fc63d2",
+              "partitions": [
+                {
+                  "bootable": true,
+                  "size": 8192,
+                  "start": 2048,
+                  "type": "41"
+                },
+                {
+                  "size": 20961180,
+                  "start": 10240
+                }
+              ]
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "disk.img"
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.mkfs.xfs",
+            "options": {
+              "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8"
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "disk.img",
+                  "start": 10240,
+                  "size": 20961180
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.copy",
+            "inputs": {
+              "root-tree": {
+                "type": "org.osbuild.tree",
+                "origin": "org.osbuild.pipeline",
+                "references": [
+                  "name:os"
+                ]
+              }
+            },
+            "options": {
+              "paths": [
+                {
+                  "from": "input://root-tree/",
+                  "to": "mount://root/"
+                }
+              ]
+            },
+            "devices": {
+              "root": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "disk.img",
+                  "start": 10240,
+                  "size": 20961180
+                }
+              }
+            },
+            "mounts": [
+              {
+                "name": "root",
+                "type": "org.osbuild.xfs",
+                "source": "root",
+                "target": "/"
+              }
+            ]
+          },
+          {
+            "type": "org.osbuild.grub2.inst",
+            "options": {
+              "filename": "disk.img",
+              "platform": "powerpc-ieee1275",
+              "location": 2048,
+              "core": {
+                "type": "mkimage",
+                "partlabel": "dos",
+                "filesystem": "xfs"
+              },
+              "prefix": {
+                "type": "partition",
+                "partlabel": "dos",
+                "number": 1,
+                "path": "/boot/grub2"
+              }
+            }
+          }
+        ]
+      },
+      {
+        "name": "qcow2",
+        "build": "name:build",
+        "stages": [
+          {
+            "type": "org.osbuild.qemu",
+            "inputs": {
+              "image": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.pipeline",
+                "references": {
+                  "name:image": {
+                    "file": "disk.img"
+                  }
+                }
+              }
+            },
+            "options": {
+              "filename": "disk.qcow2",
+              "format": {
+                "type": "qcow2",
+                "compat": "0.10"
+              }
+            }
+          }
+        ]
+      }
+    ],
+    "sources": {
+      "org.osbuild.curl": {
+        "items": {
+          "sha256:003ee19ec5b88de212c3246bdfdb3e97a9910a25a219fd7cf5030b7bc666fea9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-requests-2.20.0-2.1.el8_1.noarch.rpm"
+          },
+          "sha256:01b0562b890a80c202fff9175dc845500660c7f1655292d4ee13ca667acab081": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libsecret-0.18.6-1.el8.ppc64le.rpm"
+          },
+          "sha256:020abac486839c7be29fae37a686dc7749398c333cb8ba94b3390b386ffcbff7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libgpg-error-1.31-1.el8.ppc64le.rpm"
+          },
+          "sha256:0225dc3999e3d7b1bb57186a2fc93c98bd1e4e08e062fb51c966e1f2a2c91bb4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/perl-Pod-Perldoc-3.28-396.el8.noarch.rpm"
+          },
+          "sha256:0230acdbc9da4b36da812f0e585a7602eda4982c899b3b3a4c2bc9b4546d8e74": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/mpfr-3.1.6-1.el8.ppc64le.rpm"
+          },
+          "sha256:0320663709136d07690fe299903700cc1dcc526d574fe8b952a01e1d24024ae4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/readline-7.0-10.el8.ppc64le.rpm"
+          },
+          "sha256:03ba1e86a04d912fd2878b457b06a6a7abad0ce96cd9a6932bf58cb4641b8fb7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/rpm-build-libs-4.14.3-15.el8.ppc64le.rpm"
+          },
+          "sha256:04ee771fad226ade609b0e879d15c32898379360db27ef1bc6d9f5a77127d5a8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/perl-Unicode-Normalize-1.25-396.el8.ppc64le.rpm"
+          },
+          "sha256:04eee0a9c079186aa58b5536ac8bcbd2a360700b83fa7b9f6eb127c1386b7ef4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/dosfstools-4.1-6.el8.ppc64le.rpm"
+          },
+          "sha256:0515afdac097ad54cf4b24e0644f0789cab5535a54107aa44940ffd991a6cef3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libgomp-8.5.0-3.el8.ppc64le.rpm"
+          },
+          "sha256:06c8c530fb914e07375c183f13b8431456377cec33376423f6589d1047277587": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/bzip2-1.0.6-26.el8.ppc64le.rpm"
+          },
+          "sha256:0727078eff2abaf1e5770b331ed8162d8e95cf2cf1de06de7540d034999d72ef": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/polkit-pkla-compat-0.1-12.el8.ppc64le.rpm"
+          },
+          "sha256:07c65a3efc2bb32027206df4f117b893268d028cbb3741208d73615a63525158": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-syspurpose-1.28.20-1.el8.ppc64le.rpm"
+          },
+          "sha256:07fb48b313f6d4c1c8b1ffd9c5226c68f99616e46bbd04b325527d817b500577": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libnfsidmap-2.3.3-46.el8.ppc64le.rpm"
+          },
+          "sha256:084d79ed3d7127e6d46e9ac6e654d8ef181a156435808dc8eb32968b6c1b4946": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/cracklib-dicts-2.9.6-15.el8.ppc64le.rpm"
+          },
+          "sha256:090563f18409c228274bb61dcf1001f63a55c1246fb2838a998cb3c5fd8c3874": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/dbus-daemon-1.12.8-14.el8.ppc64le.rpm"
+          },
+          "sha256:09096bc32e37443417cd625364df32674f9d5ff4ddbeb175e6d60637ed3d573f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/trousers-lib-0.3.15-1.el8.ppc64le.rpm"
+          },
+          "sha256:0ad85fe7a6b42dae9248268706940b12c01e83141858df79e43223e173fe9840": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/ppc64-diag-rtas-2.7.7-1.el8.ppc64le.rpm"
+          },
+          "sha256:0afac6f4f9ed1c59510675d87da45c7966c0f7aae6e8dd056961aceed8c4fe0a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libfdisk-2.32.1-28.el8.ppc64le.rpm"
+          },
+          "sha256:0bad67cd4773d94db37a39c77f44b6eb380febc0de33fa51cacc2140c9c699b9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/lorax-28.14.61-2.el8.ppc64le.rpm"
+          },
+          "sha256:0bc637f0d028043e8388b083cdd8d0a0acea7fdbc79c0bc9401dfb02c20fb817": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/python3-pexpect-4.3.1-3.el8.noarch.rpm"
+          },
+          "sha256:0e9a8a0f823bf0ef948862f0ccb62353460bd07931e756c98f23908c1c526578": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-decorator-4.2.1-2.el8.noarch.rpm"
+          },
+          "sha256:0eb36aba0f471119ccb001ea4f1819002ae535882df63e871be80e01f4f776bb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/lsvpd-1.7.12-1.el8.ppc64le.rpm"
+          },
+          "sha256:0edde19e0c027c8cff31b82e1f4b0b198c00bf924047fcf4dd610a7d4965ab52": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/python3-pytz-2017.2-9.el8.noarch.rpm"
+          },
+          "sha256:0f54422e17766a9e7385a553d941d1849c9e7ca4caea085305ba9fb1e15ae607": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/python3-markupsafe-0.23-19.el8.ppc64le.rpm"
+          },
+          "sha256:0f57b051654b6d75789b437dafd7040b6c90daee17827be24352c0f11a74bba7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libsigsegv-2.11-5.el8.ppc64le.rpm"
+          },
+          "sha256:0feac495306bbe6e3149a352025bea8d23cda512859a230cbd3f510cf48caaf7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/python3-jsonschema-2.6.0-4.el8.noarch.rpm"
+          },
+          "sha256:111d88db3a52121f04f2741cc72ce8dda6d6f6ef2cc36452c042e0141b316334": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-gpg-1.13.1-9.el8.ppc64le.rpm"
+          },
+          "sha256:11838afbfab4da7d5fa6e01046f76cce0b0a0c174a87c522eba440fce16e316f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/abattis-cantarell-fonts-0.0.25-6.el8.noarch.rpm"
+          },
+          "sha256:11ff811a72c82084c7c14700b23d29643e153442a34b3b486e270e5b40e38d0a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/gnupg2-2.2.20-2.el8.ppc64le.rpm"
+          },
+          "sha256:12696f5638ad2068c5c8940495d15c3bb1c57990000dbda7428b008e9e63ab5b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libffi-3.1-22.el8.ppc64le.rpm"
+          },
+          "sha256:12b0565d080311c7804d8fb1d697ecdef8807563ebeee4443e2fa6d35b1d958f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/iproute-5.12.0-2.el8.ppc64le.rpm"
+          },
+          "sha256:12fda64dea45a7b085a35a816a7d8035be6600cae38f7df04a3bc22ced4d4502": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/pinentry-1.1.0-2.el8.ppc64le.rpm"
+          },
+          "sha256:15554476d03595246aec194e63ec9db7469d5b3ed81a27a8a2720e82df1f8bf4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/polkit-libs-0.115-12.el8.ppc64le.rpm"
+          },
+          "sha256:15b17b95cf9cb9fb64e0c8e56110836bdcaf70de81b8cbdb60e181fc90456e06": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/centos-stream-release-8.5-3.el8.noarch.rpm"
+          },
+          "sha256:15cd74b4ad9d82417072fe867f086d68667afd4291b710b6c7feef985c492990": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/which-2.21-16.el8.ppc64le.rpm"
+          },
+          "sha256:1649f9d356cda961dd08dafa92475557ac398da9a657ee019de0c1f2c0593c8a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libsoup-2.62.3-2.el8.ppc64le.rpm"
+          },
+          "sha256:16b390c34ddb56c075fb6f4b77bf9a0fffab219fcb3f3588b9151215ab2b0ad4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/libxcb-1.13.1-1.el8.ppc64le.rpm"
+          },
+          "sha256:176ffcb2cf0fdcbdd2d8119cbd98eef60a30fdb0fb065a9382d2c95e90c79652": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-chardet-3.0.4-7.el8.noarch.rpm"
+          },
+          "sha256:17c615aa31cf2afa434d1d1d42e0db85b564fe416d346721bd38c0db75f73119": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/snappy-1.1.8-3.el8.ppc64le.rpm"
+          },
+          "sha256:17ffe1d683dbff48f9b2ef903401e471e5e51a992bf0890632bceb94561893de": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/ncurses-libs-6.1-9.20180224.el8.ppc64le.rpm"
+          },
+          "sha256:19061d12407c0c4bca6abcaef01695b70dcd3967ff102dd07178a2193a280e29": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/cpio-2.12-10.el8.ppc64le.rpm"
+          },
+          "sha256:194dbe332ccdb33d58f040da07667257e176975f6b2f17343bbf33fb99deb097": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libcroco-0.6.12-4.el8_2.1.ppc64le.rpm"
+          },
+          "sha256:1a4e44583a767289bb0d354db93c6a9132420e13376d4fcae866d69620bb11bb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/dbus-1.12.8-14.el8.ppc64le.rpm"
+          },
+          "sha256:1a968f65db066243cbd0a6e12d193ef674637f044299a15b5d6b910e91411812": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libxcrypt-4.1.1-6.el8.ppc64le.rpm"
+          },
+          "sha256:1aa321c66a3661e78d938b805e5c311d519f04bf3496545ffdacc7c152bc9b21": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libpwquality-1.4.4-3.el8.ppc64le.rpm"
+          },
+          "sha256:1b5136570cefb8273dd5affc73c1456cf239cc8b18be72d6c4d09794af7f3352": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libsmartcols-2.32.1-28.el8.ppc64le.rpm"
+          },
+          "sha256:1b53c868277dec628058b31b1a8a8a2ccd8efe832ce9694805b5f82564136eb3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/python3-prettytable-0.7.2-14.el8.noarch.rpm"
+          },
+          "sha256:1b95698d64dd299827f62cbe43d373e985da2d8900c4489a49475f53fa04f414": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libini_config-1.3.1-39.el8.ppc64le.rpm"
+          },
+          "sha256:1bd969e0521820374122f5132e5998d9bd2ab185be66565a7266096297419c8e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-configobj-5.0.6-11.el8.noarch.rpm"
+          },
+          "sha256:1cdd6c2abf0132da0d956398eb1dc736c0b93fd8e8465e7f1111ad05b2c322d8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/oddjob-mkhomedir-0.34.7-1.el8.ppc64le.rpm"
+          },
+          "sha256:1cfa672c25cb5849bb2aa652e045e4a4a272c025befb1fe5e58cb32823faa30d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/procps-ng-3.3.15-6.el8.ppc64le.rpm"
+          },
+          "sha256:1d6551bce8f8a1e53682fafe4f67fa830c333f0b37db7acbeaca0095b5ce870b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/kernel-modules-4.18.0-331.el8.ppc64le.rpm"
+          },
+          "sha256:1edcf2b441ddf21417ef2b33e1ab2a30900758819335d7fabafe3b16bb3eab62": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/perl-Time-Local-1.280-1.el8.noarch.rpm"
+          },
+          "sha256:1f2a096d6a75662a86a06ff2859e6ba916bbc8c6d8cb7b73810ffbb9fef4b089": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/c-ares-1.13.0-5.el8.ppc64le.rpm"
+          },
+          "sha256:1fad1d1f8b56e6967863aeb60f5fa3615e6a35b0f6532d8a23066e6823b50860": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/ca-certificates-2021.2.50-82.el8.noarch.rpm"
+          },
+          "sha256:20874a9d40b12125c9e5b97fe4ccda3f94acbc03da1dec7299123901f5b56631": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-oauthlib-2.1.0-1.el8.noarch.rpm"
+          },
+          "sha256:20c3abcc5556f09e557a398886684d1efe8ef59687bedbb78c130a7d1d55868a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/oddjob-0.34.7-1.el8.ppc64le.rpm"
+          },
+          "sha256:230731b577f8d29e7e8e8fd6d1ea02702fb4364fcc7034d838ccddc4d66da8c3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/kpartx-0.8.4-17.el8.ppc64le.rpm"
+          },
+          "sha256:233e5f78027b684e5aaac1395cc574aea3039059bf86eb4494422bc74216a396": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-slip-0.6.4-11.el8.noarch.rpm"
+          },
+          "sha256:2394d6a1ce4de90590e65111d870b172cb9d4e30e1e6f58a334b29e717fdd031": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/psmisc-23.1-5.el8.ppc64le.rpm"
+          },
+          "sha256:2451a475f248a4c66e64d149fefa8bfc195fcd7b3f369bae221a94f8ce4c2d67": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/grep-3.1-6.el8.ppc64le.rpm"
+          },
+          "sha256:24f5cd46a7395cd046b10d6ddc4de435ec6595d0dcdb2d179c94cc9082a12f14": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/gpgme-1.13.1-9.el8.ppc64le.rpm"
+          },
+          "sha256:24fcc5bc49b059b221075989f25875fb821079088dca694aec262446cde50cb7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/chrony-4.1-1.el8.ppc64le.rpm"
+          },
+          "sha256:257e086bb52086254fa8cc95a5c4998668b4fcb5203ad3c2275c1150816acc9b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/glibc-common-2.28-162.el8.ppc64le.rpm"
+          },
+          "sha256:2588ff56ab340c06ce8b5be22cbe23de89d4f336b38ae930daf11db1c6a24391": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/dracut-network-049-188.git20210802.el8.ppc64le.rpm"
+          },
+          "sha256:2669ab8439093418c6c437c1f2e931d4152f5ac371e5a0f2d20b18455483c3a1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libservicelog-1.1.19-2.el8.ppc64le.rpm"
+          },
+          "sha256:27f43a7a8d1b18f5ede27728ecded75e510195a78abd9f3d0c1965d341e5e45a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/setroubleshoot-server-3.3.24-3.el8.ppc64le.rpm"
+          },
+          "sha256:2812ae39c665069f4b27e9bd26dde9141d4f4e7802befb1b14ac4e27a8225b4b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libndp-1.7-6.el8.ppc64le.rpm"
+          },
+          "sha256:28c0f457d67213319f0313d993a3b2f8a778a077b202cd75bf45eb2792949d32": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-dnf-plugins-core-4.0.21-2.el8.noarch.rpm"
+          },
+          "sha256:29214e4bf64efb65d82bd3f318d0ac3b7a6b03f6f6abfd469148bc2f894c6846": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/libmaxminddb-1.2.0-10.el8.ppc64le.rpm"
+          },
+          "sha256:2975de6545b4ca7907ae368a1716c531764e4afccbf27fb0a694d90e983c38e2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/perl-Text-ParseWords-3.30-395.el8.noarch.rpm"
+          },
+          "sha256:297b8a7b336dfc298d86d76d400459d2fa63af8628f5e19e35314a33a6478234": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/bind-export-libs-9.11.26-4.el8_4.ppc64le.rpm"
+          },
+          "sha256:2a8f9e5119a034801904185dcbf1bc29db67e9e9b0cf5893615722d7bb33099c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/crypto-policies-20210617-1.gitc776d3e.el8.noarch.rpm"
+          },
+          "sha256:2b76d31dc0fdff399a5b1d396caff67b9eb2f5b8f6cfa8d7a430eeaf6a09104d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/centos-logos-85.8-1.el8.ppc64le.rpm"
+          },
+          "sha256:2c1baefd0f802507d9741da8da54f6eae42b04967f9d433d7f9e0f124434c70d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/acl-2.2.53-1.el8.ppc64le.rpm"
+          },
+          "sha256:2d1655f040141384ec8760e4a47e0455ce518989f7bb1a830ab9534bfb38a78a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libsss_autofs-2.5.2-2.el8.ppc64le.rpm"
+          },
+          "sha256:2d77f4a2166122e3f7c5ace1bbfe5319ec6c2d24fff1c6f3e22ccb3e8b2327e0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/ppc64-diag-2.7.7-1.el8.ppc64le.rpm"
+          },
+          "sha256:2dbfe3cb37c18b39393870baa77f3bbd42be53517abffdd990b13ed70ee3dd3e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libssh-0.9.4-3.el8.ppc64le.rpm"
+          },
+          "sha256:2f6c73fdcd5c5e5b6d8b58663e498a0099db8029386869a4aca670471f6c298e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libbasicobjects-0.1.1-39.el8.ppc64le.rpm"
+          },
+          "sha256:2fcacd153d4aa4ddddee3357b717e8d3f411382b180add28328c9faa94dd2ae4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/qemu-guest-agent-4.2.0-52.module_el8.5.0+853+a4d5519d.ppc64le.rpm"
+          },
+          "sha256:30ae4489980021a727f247d48b4d74d4c6c7667d00bd1a670f045ea24a885541": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libblkid-2.32.1-28.el8.ppc64le.rpm"
+          },
+          "sha256:30ceeb5a6cadaeccdbde088bfb52ba88190fa530c11f4a2aafd62b4b4ad6b404": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/elfutils-default-yama-scope-0.185-1.el8.noarch.rpm"
+          },
+          "sha256:30dd1d58b7b963d052341f4583a7417823cf4dbbe7ac4b536f3a5250c4d34582": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/kexec-tools-2.0.20-56.el8.ppc64le.rpm"
+          },
+          "sha256:30f37ca1fe1592e29d3e97c1dec0646015000d19bffc40f13dcfe73e15be66fc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/setroubleshoot-plugins-3.3.13-1.el8.noarch.rpm"
+          },
+          "sha256:31277c01ac529cc1c6a55fd87d6ce4dbb20290575d4e1e89cd40600eac9f3405": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/sqlite-libs-3.26.0-15.el8.ppc64le.rpm"
+          },
+          "sha256:31d924d1540dd4e927a4c3aa936cec4bfb54ed302d3e8acc1be8b52dd5deb10c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libidn2-2.2.0-1.el8.ppc64le.rpm"
+          },
+          "sha256:32ebba6472cdc331bd3366ca996ad3039b3a1b41c61a849b88074e1b722cad2c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libstdc++-8.5.0-3.el8.ppc64le.rpm"
+          },
+          "sha256:32ecf5a37bacbeec9451c4ad39672ac2816f9241d5a92f038b45059da2f3ebae": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/libXrender-0.9.10-7.el8.ppc64le.rpm"
+          },
+          "sha256:3303f41952491bad2b31ee507eaabaf13dabe5ec9624c4b58a4a8301c4cd89dd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libaio-0.3.112-1.el8.ppc64le.rpm"
+          },
+          "sha256:331b91a0928c05618c7fed3e12bbe9ecb9e4619d08c7e85d3de344a08d2f0f1a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/json-c-0.13.1-2.el8.ppc64le.rpm"
+          },
+          "sha256:33a92d88496e8aa410976f073e324f761b2ae02a94c20c0f291072df84f648be": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/zlib-1.2.11-17.el8.ppc64le.rpm"
+          },
+          "sha256:35983fb2e9104b81caaa9e6d40352ea8b2b987fb811f935602d04cc90fdee76a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/prefixdevname-0.1.0-6.el8.ppc64le.rpm"
+          },
+          "sha256:35bd989d63522f9699b1a90dd453f866818cc3d247096a910a27fd7e49b09ac2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libnl3-cli-3.5.0-1.el8.ppc64le.rpm"
+          },
+          "sha256:35eb77080d99941b137da8c6cb25305ad4ff64cf2a7ba1f8adbf8d0998b5fe45": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-librepo-1.14.0-2.el8.ppc64le.rpm"
+          },
+          "sha256:360be5b93e106d77a8f4e84b318ee8dc14349f223540e0e200e0dfce2676ec04": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libcollection-0.7.0-39.el8.ppc64le.rpm"
+          },
+          "sha256:368779f00f427680d954899dd73ad3b6a59c42baafb91cb100ea177f51185198": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/vim-minimal-8.0.1763-15.el8.ppc64le.rpm"
+          },
+          "sha256:36c05d62567b455f2722c6e5cf431071174adf4c1d3b7450f0c1aaa903210bc3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/json-glib-1.4.4-1.el8.ppc64le.rpm"
+          },
+          "sha256:3818fe6ec4996402b718827ba40ca01cc3c8276646d80030b652a26153aea2b7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/cockpit-system-250-1.el8.noarch.rpm"
+          },
+          "sha256:383a5e6bb9e94de53baaf5c7493cd50a68c893c6a30acfbe28407d33bb133efc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/coreutils-common-8.30-12.el8.ppc64le.rpm"
+          },
+          "sha256:3898e2ac4e04e80373bc7fe4092b26d502d4705177719117e25c083d44a9a150": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/systemd-udev-239-49.el8.ppc64le.rpm"
+          },
+          "sha256:38fe7db64baf2d4804a14466a6244f3c1de3bd5deca0ad4044e96d0d3f3751c7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/checkpolicy-2.9-1.el8.ppc64le.rpm"
+          },
+          "sha256:393e7bb9f93ffb3cbba620fbfeb229f2b8345454bc60ac0508f76735544ed289": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/lua-libs-5.3.4-11.el8.ppc64le.rpm"
+          },
+          "sha256:3973aa7ac4416f1d33ffa8f4e9a5b126e7e2f77ed1ec63a70312b509b4934a9d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/python36-3.6.8-37.module_el8.5.0+771+e5d9a225.ppc64le.rpm"
+          },
+          "sha256:3a438b53e8377eccf90cac0fd42ed2b513fc869bfb7b96e3d2a4f6984a287f90": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/bash-4.4.20-2.el8.ppc64le.rpm"
+          },
+          "sha256:3b00ac82c31b447e306fcb47b4469fdc4e6d87385b42358c2e76badb51b074a3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/popt-1.18-1.el8.ppc64le.rpm"
+          },
+          "sha256:3b5d31b89683be71c72b77cfceb59238f4c76a796de6ae85525b3d5cfe2a8f23": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-libselinux-2.9-5.el8.ppc64le.rpm"
+          },
+          "sha256:3c89b334988c0d1399d25baebe298d9e8cc768f28aefd581aae893aa1e69de84": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/yum-utils-4.0.21-2.el8.noarch.rpm"
+          },
+          "sha256:3c9de6673cb840c3c6925bd1df87da0ef3b118d35dbe8f30bbafd0dfc67a939c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/python3-kickstart-3.16.13-1.el8.noarch.rpm"
+          },
+          "sha256:3d175382237a94330d72af67ad2c41535dee7eade3e42178b86d2dc87478d030": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/systemd-libs-239-49.el8.ppc64le.rpm"
+          },
+          "sha256:3d4e54f6bb2f6ee5417613d5d9bef407343adc768a0841ea58f831ffa868cbd0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/cairo-1.15.12-3.el8.ppc64le.rpm"
+          },
+          "sha256:3dfffdadfb10def9a3671a255e4fa71d8b22231ccf2c929e96689101dda8ce2c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/librepo-1.14.0-2.el8.ppc64le.rpm"
+          },
+          "sha256:3eca41ba67f8121586709b6fa2c57b20b4fab73bbb8a4c133269d0cc964f362c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-policycoreutils-2.9-15.el8.noarch.rpm"
+          },
+          "sha256:3ed20aba45a8c175e818de998d906fb2759387c607bd9b15dbbefee8c73097ba": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/NetworkManager-team-1.32.8-1.el8.ppc64le.rpm"
+          },
+          "sha256:3ed319e31a9c38e5f4e336195b5cbd253b3f8b17f93f185829f078c5ef420305": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/pcre-8.42-6.el8.ppc64le.rpm"
+          },
+          "sha256:3edfdbc82f97ec12e59c80c67897fc1eeb44c3d16820f761a8f15272965ea3a1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/pigz-2.4-4.el8.ppc64le.rpm"
+          },
+          "sha256:401a2690658194fdd92994c29aa57c18cc5e3100fe7bbdba33d0fa26f2213eb3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/powerpc-utils-1.3.8-7.el8.ppc64le.rpm"
+          },
+          "sha256:405bda98fe97c1a5cf70511ae2d167256b25dd8721b88899465e9847525e2068": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-libs-3.6.8-39.el8.ppc64le.rpm"
+          },
+          "sha256:4079a1edf72a60c97ee48f0a98820b3b014575b402ea05a64cbc5f2b8af674de": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/man-db-2.7.6.1-18.el8.ppc64le.rpm"
+          },
+          "sha256:412f3eaa5f7e226fdc4678a3266edab76d8998f7d76763075f690a01362ef89c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/dracut-squash-049-188.git20210802.el8.ppc64le.rpm"
+          },
+          "sha256:41512b492c3020571b4d8c671160758ec0e4b78212d75808291a5c56224b644b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/lorax-templates-rhel-8.5-2.el8.noarch.rpm"
+          },
+          "sha256:4164089bf1754c0ef18ae051e047f11299907204839ad4b7978f146a543a2e91": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/trousers-0.3.15-1.el8.ppc64le.rpm"
+          },
+          "sha256:41716536ea16798238ac89fbc3041b3f9dc80f9a64ea4b19d6e67ad2c909269a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/ncurses-base-6.1-9.20180224.el8.noarch.rpm"
+          },
+          "sha256:419f9c08de110eee9b2ff0a61e9aa1bbb56939f9239739c17a753a0d9210d10f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libref_array-0.1.5-39.el8.ppc64le.rpm"
+          },
+          "sha256:42464424b9fa731f8122fe748aad0005519fc87b770dbbdb71f29f514ea0e889": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/dnf-4.7.0-2.el8.noarch.rpm"
+          },
+          "sha256:427eba707b42761a0ef57107ba5a22f80fc6379d1537c757fe1929d6d066b05c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/less-530-1.el8.ppc64le.rpm"
+          },
+          "sha256:42829311fe40b7487530ee432aeb8e1df86e5168373f038cccb60d0db94601d3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/audit-3.0-0.17.20191104git1c2f876.el8.ppc64le.rpm"
+          },
+          "sha256:42bb566be1936bdb40937f9c0a96c4acc93057379385f1807cba18f60443d3e4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/hardlink-1.3-6.el8.ppc64le.rpm"
+          },
+          "sha256:43bfc890caf7855f2fb55c24474b58cd5c8c7b51e4db4f40d1f302fffd31985b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libattr-2.4.48-3.el8.ppc64le.rpm"
+          },
+          "sha256:43d4db89cf7aa96d57be2847577cf1dba8cba99d5d43118ee54d0b97a4ef8b7e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/cloud-init-21.1-3.el8.noarch.rpm"
+          },
+          "sha256:441b3862f5a0fd504bbbba18d96d1b2b920fb95a79dc45a753a6a664ad285b07": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/device-mapper-1.02.177-6.el8.ppc64le.rpm"
+          },
+          "sha256:44999c555a6e4bb6cf5e6f6a79819e76912d036732cb50efaeefc20a180dd839": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/tzdata-2021a-1.el8.noarch.rpm"
+          },
+          "sha256:45c48d32120739734ae97479cc0f3ca19796ea47e360ba39d52b77ce3ada61d7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/dnf-data-4.7.0-2.el8.noarch.rpm"
+          },
+          "sha256:46606c1ed76a4da2a9d18016aeb50f4dddf58e1b45d665c983c58f8e605bf73e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/openssl-libs-1.1.1k-4.el8.ppc64le.rpm"
+          },
+          "sha256:466601cf2b7bebf49a6a8e936b32dffc844c9ed4cd82961d008d17cfccc596e8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libsss_nss_idmap-2.5.2-2.el8.ppc64le.rpm"
+          },
+          "sha256:46e371b6245113ebca446adcbd2db39f2887b67dc5a640f62f6d346ec9f6980f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/perl-IO-Socket-SSL-2.066-4.module_el8.4.0+517+be1595ff.noarch.rpm"
+          },
+          "sha256:4715730da2b4a5bf6cc2ab85208071f00c7b279e4b2f75df0bd954446185e14c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-hawkey-0.63.0-2.el8.ppc64le.rpm"
+          },
+          "sha256:47ad43730c8bc72c90f2fb3dbd3526d716ada2fad94e62cb443658e94c6503c5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/curl-7.61.1-18.el8_4.1.ppc64le.rpm"
+          },
+          "sha256:47b61754a278c4ca378871c874ccf6a0a07bffaef38505315cfa94f262887845": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/dnf-plugins-core-4.0.21-2.el8.noarch.rpm"
+          },
+          "sha256:47f414f515a2c3103d0e7dae67c47a3b2bc76ea2413d666052012b11dbdd0feb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/perl-threads-2.21-2.el8.ppc64le.rpm"
+          },
+          "sha256:480e0f1a9dcce6ed0728e9aba709e33f5522273da1e4b0859cf9d3bbe2216532": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/xfsprogs-5.0.0-9.el8.ppc64le.rpm"
+          },
+          "sha256:48226934763e4c412c1eb65df314e6879720b4b1ebcb3d07c126c9526639cb68": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/basesystem-11-5.el8.noarch.rpm"
+          },
+          "sha256:48f31b2798e2ebbf1a7b83f43c6aa2d2eb438a1e053906623c3a7391065c00d9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/sos-4.1-5.el8.noarch.rpm"
+          },
+          "sha256:4942002f6e3a471b8d51801047ea2584d5cd1dad5d4c4e44bce7af50c5b7cb14": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/glib-networking-2.56.1-1.1.el8.ppc64le.rpm"
+          },
+          "sha256:4966b1832e9eccd8f83ecc20143fb6f18215107bdecd7267b4605cdae4a6562a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/authselect-libs-1.2.2-3.el8.ppc64le.rpm"
+          },
+          "sha256:4992eb036c0797daf9b984af1a34fe27a30287ee5d2bd5e2f5a0df3a09bdbb59": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/fuse-libs-2.9.7-12.el8.ppc64le.rpm"
+          },
+          "sha256:499e48b35f3b5f5da45031fa78fba559fee6a480ecb106e6c300eb8344510958": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/python3-ptyprocess-0.5.2-4.el8.noarch.rpm"
+          },
+          "sha256:49c7c718cb4e2b6f0effd0dec4f4cb4e109d260c192b2b329a58a1da9a24ad1d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/kbd-2.0.4-10.el8.ppc64le.rpm"
+          },
+          "sha256:49e68a65bf87ae9ba812ffce76589c09f6766a0eaa5001d7e4a1c782e91d71c0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-cryptography-3.2.1-5.el8.ppc64le.rpm"
+          },
+          "sha256:4a08d5264e865548e65d31886c91b659b33a2c2ba39fd115b00af3ea0bc91a83": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/grub2-common-2.02-99.el8.noarch.rpm"
+          },
+          "sha256:4a167fa4a7238bd94b3134173f6267b19cdebc2fde98b583344749e1f4c9bf09": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libxml2-2.9.7-11.el8.ppc64le.rpm"
+          },
+          "sha256:4a8899d3b91a0f847ce793480700b26dc8336c5ee20d9b66067c76fe0dab2f17": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libbpf-0.3.0-1.el8.ppc64le.rpm"
+          },
+          "sha256:4aca3cee9de1a4cd7ac56a12550f286894a215cac593c18857278f7b0e48f328": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/kernel-core-4.18.0-331.el8.ppc64le.rpm"
+          },
+          "sha256:4b00562fa291e956d910bb056c6120f0079f30093ea107757758683a6d418206": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/squashfs-tools-4.3-20.el8.ppc64le.rpm"
+          },
+          "sha256:4b40402374fc4a9202a67d3ede77dedbe5ed1bab57479a5b5cb5cd6c45283bf4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/perl-libs-5.26.3-420.el8.ppc64le.rpm"
+          },
+          "sha256:4b81b6f8279b75714cbac2f77b2e006f65cd799c2ec3d1c9c40840b1ab60c885": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/libX11-1.6.8-4.el8.ppc64le.rpm"
+          },
+          "sha256:4c124ec5a10a5c32e390d848942a04baa8761f190a4a95d3ed7b5c626ca17fc8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-cffi-1.11.5-5.el8.ppc64le.rpm"
+          },
+          "sha256:4c5aabda0cd9edb40e141066d400d2e4b232bc22ab60e806a6399691c391cabc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/lzo-2.08-14.el8.ppc64le.rpm"
+          },
+          "sha256:4cc53ff12e7b8fcfafdd32eaac7b13266876766f22b3262b653eaa7b06fbbaaf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/rdma-core-35.0-1.el8.ppc64le.rpm"
+          },
+          "sha256:4e22015880d16cb7148d70895a2361f4fa05804f0391386e0e50554e6fd868b0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/rpm-libs-4.14.3-15.el8.ppc64le.rpm"
+          },
+          "sha256:4e3e93a3d2039c2a8305030b7960bd1100d7d20705a1afb1325a4ee79478a74a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/cracklib-2.9.6-15.el8.ppc64le.rpm"
+          },
+          "sha256:4e497225fe36781735cc92c0886f6858b19d4557ed9ecafe1247b8233c206075": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libmount-2.32.1-28.el8.ppc64le.rpm"
+          },
+          "sha256:4f92835a6e4ee4276df49019e068d1871b75821f52b405c699bd9f199df58b80": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/diffutils-3.6-6.el8.ppc64le.rpm"
+          },
+          "sha256:4fae16ca54207cb952e3904b8eb8cc424f3f056f400e5e802ab1a9ef3e575834": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/rpm-4.14.3-15.el8.ppc64le.rpm"
+          },
+          "sha256:4fb1b85fe3712a292f8dd8f1d65805607485dbf97307cf146bbc6e0293a7c725": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libsysfs-2.1.0-24.el8.ppc64le.rpm"
+          },
+          "sha256:4fc1c84b4434df8a5ccd960d906896e4094236f43ad4aea083a12fb5b8a824f9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/gdk-pixbuf2-2.36.12-5.el8.ppc64le.rpm"
+          },
+          "sha256:4fe264ed1cfd0c074f4601354b0128a9e5068f0fcde7382fd5429585f0d4cd2c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libselinux-utils-2.9-5.el8.ppc64le.rpm"
+          },
+          "sha256:51760acfb6ca87db5be7a9296d6a3d1220767956c576a26c6d46784e25db85bb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/gnutls-3.6.16-4.el8.ppc64le.rpm"
+          },
+          "sha256:51c3ee5d824bdde0a8faa10c99841c2590c0c26edfb17125aa97945a688c83ed": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/perl-Pod-Simple-3.35-395.el8.noarch.rpm"
+          },
+          "sha256:5374ef6981f9a29d08c3400488b010f477fe7722367fcd6d29244ba8bd29b89c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/genisoimage-1.1.11-39.el8.ppc64le.rpm"
+          },
+          "sha256:5418cf17fad308fe9a8d3acdf4ae10f433da50c32f10ae4089be2f8423dea4cf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/ipcalc-0.2.4-4.el8.ppc64le.rpm"
+          },
+          "sha256:545cd23ad8e4f71a5109551093668fd4b5e1a50d6a60364ce0f04f64eecd99d1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/perl-Pod-Escapes-1.07-395.el8.noarch.rpm"
+          },
+          "sha256:54f59ddb56e89a5330373e07ea05934fc58360eb7480615ede2a3ed6982e1eef": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/krb5-libs-1.18.2-13.el8.ppc64le.rpm"
+          },
+          "sha256:561a61d2d81bccb14d22a53b32301e0b6b9e9b9d80ad75991ee6ff796cae0ef7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/selinux-policy-3.14.3-76.el8.noarch.rpm"
+          },
+          "sha256:563b3741d26b6af963fdb7b0634e0791445a707d0b6093ac71c3224299241639": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-slip-dbus-0.6.4-11.el8.noarch.rpm"
+          },
+          "sha256:56650f8b8f2b01c1090d184d7d6d396f0109f8a02f915c97b081be73ea12df08": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/platform-python-pip-9.0.3-20.el8.noarch.rpm"
+          },
+          "sha256:56c3d429ea949467dc0bca882646cf40a58fb6f27750f5664ff2919f5d38ada5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/bzip2-libs-1.0.6-26.el8.ppc64le.rpm"
+          },
+          "sha256:56c866bcff69fd60b630841ff990296b26c2f45d8c6054311b5c476bc67466ac": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libselinux-2.9-5.el8.ppc64le.rpm"
+          },
+          "sha256:572bec3deb2f8ae7a6ad46976738c2630023eec1d9bd13ab1ccca7b54256daee": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libsss_idmap-2.5.2-2.el8.ppc64le.rpm"
+          },
+          "sha256:5796882ac3059835583bc399e8522c19646b717713ef553a71b20ca0535a1718": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/sssd-client-2.5.2-2.el8.ppc64le.rpm"
+          },
+          "sha256:588874c2fc18a927a479aac7affef52f52d09e5b20102dfab70836d420ae553e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/keyutils-1.5.10-9.el8.ppc64le.rpm"
+          },
+          "sha256:59008e3619cae0f40e183b7003e722cb312b00bdba775ec9f06cdd833b53c26a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libmnl-1.0.4-6.el8.ppc64le.rpm"
+          },
+          "sha256:594d8b368013caa4eaba4eade896fc1cec8ef569052bd491f493c193e07c6d80": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-libcomps-0.1.16-2.el8.ppc64le.rpm"
+          },
+          "sha256:5a0927d231fbafa8b865591922fc07d39d9b4b263a1e9c0bbef691282f706cd0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/grubby-8.40-41.el8.ppc64le.rpm"
+          },
+          "sha256:5b0f2f11c7d635630ced3cc6431b60d27a2c80f878420654df18a714b3df6c0e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-pyyaml-3.12-12.el8.ppc64le.rpm"
+          },
+          "sha256:5bcb506bd5559870631aa838711e683a5a2a07c6c0171be6bbeda9ba92dcdf5e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/numactl-libs-2.0.12-13.el8.ppc64le.rpm"
+          },
+          "sha256:5c0957decce3babef9864904be13190b0072aef720e9f4ca820bab6c02a20178": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-iniparse-0.4-31.el8.noarch.rpm"
+          },
+          "sha256:5c1940e1f173e22b053f3a89022903cea34a6af20dff81c65548c4e2ba3a8293": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/cyrus-sasl-lib-2.1.27-5.el8.ppc64le.rpm"
+          },
+          "sha256:5c46bef8c0e95e05716e9a53b77970c1378d93bcb9a800018a24f7e1763b45b9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/pcre2-10.32-2.el8.ppc64le.rpm"
+          },
+          "sha256:5c74a0e3005ea3cb90dff80cfa1e7d64c97f5c01612d253cf4e65aca962b7be4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libcomps-0.1.16-2.el8.ppc64le.rpm"
+          },
+          "sha256:5cf4db298bbda87532af2b2468a0692ec93d28393285ae157c1b4a18efbd1ba5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/python3-cairo-1.16.3-6.el8.ppc64le.rpm"
+          },
+          "sha256:5f068787bd9a0190b03e64cd770e44ace593c5aa09e3f4c470c44d8d484b4674": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/NetworkManager-tui-1.32.8-1.el8.ppc64le.rpm"
+          },
+          "sha256:5f445b2b2a4bdeabd555e25dfa10119d9f4e4e500d1c4492219dd8647f119ce2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/libX11-common-1.6.8-4.el8.noarch.rpm"
+          },
+          "sha256:5f76a72e58cd374ec83e26f42778adb3b90aacd091527a34c8a347089034d398": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libtalloc-2.3.2-1.el8.ppc64le.rpm"
+          },
+          "sha256:605033c50f750dad4c344495a0d6b18dcfb2a091bba072441a38cbf9001c0363": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/servicelog-1.1.15-1.el8.ppc64le.rpm"
+          },
+          "sha256:6051967b12b097d0027dc1a1aac68448c1bea901fd76c6ea0d43450f24605252": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libproxy-0.4.15-5.2.el8.ppc64le.rpm"
+          },
+          "sha256:60b0cbc5e435be346bb06f45f3336f8936d7362022d8bceda80ff16bc3fb7dd2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/python3-jsonpointer-1.10-11.el8.noarch.rpm"
+          },
+          "sha256:60eb345663d2f6ec4b5c304cd21685dc7148d34739477136d96ab6bc131d9c4d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libteam-1.31-2.el8.ppc64le.rpm"
+          },
+          "sha256:612c21ec8de299b7244b931b492f17e811ecde1450e359f112bc88d20b115d73": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/quota-4.04-14.el8.ppc64le.rpm"
+          },
+          "sha256:61b1d3440b078f35a3fe2b35c51d6d38498fb3dc8d8f5fedf52c7f0f8f6d8ecf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/sssd-nfs-idmap-2.5.2-2.el8.ppc64le.rpm"
+          },
+          "sha256:61ba252d7ee5d955b929f6d7d39d65d25c62e3d3cfc65ee6cf55c764b1c64a90": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libpcap-1.9.1-5.el8.ppc64le.rpm"
+          },
+          "sha256:61ee52dfdcbcd98acc765b45781ea5de94831f55675c0faaf615872f92268757": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/perl-Scalar-List-Utils-1.49-2.el8.ppc64le.rpm"
+          },
+          "sha256:627d792d7cca1e97c121be5f0808c9da96f54d6c986622af246c60354b9c316e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/perl-libnet-3.11-3.el8.noarch.rpm"
+          },
+          "sha256:62ac185c4d6d242b187022c8376469073c211e8deca2a7b2badf1d775e2fd5a3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libvpd-2.2.8-1.el8.ppc64le.rpm"
+          },
+          "sha256:62da6a936871ab7b8c3efc0332fe41b4ac10ff96b357fb2bd67deecb312f9277": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/perl-Net-SSLeay-1.88-1.module_el8.4.0+517+be1595ff.ppc64le.rpm"
+          },
+          "sha256:6495f3b729a1ceecd7cfdf318cfaa8ecf776ffa16293aad9f97cc542b6901ef7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/opal-prd-6.7.1-1.el8.ppc64le.rpm"
+          },
+          "sha256:654d9074dc8ebb93230fe258188a17ba3f7dbac2f360f9f79cc4fb1516953018": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/tuned-2.16.0-1.el8.noarch.rpm"
+          },
+          "sha256:65ecf1e479dc2b2f7f09c2e86d7457043b3470b3eab3c4ee8909b50b0a669fc2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/publicsuffix-list-dafsa-20180723-1.el8.noarch.rpm"
+          },
+          "sha256:67419432fe7d373f8e5ddaa7b0dd1c25389608bf2f4ee76dbabcc2d96eb8c9d0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/geolite2-country-20180605-1.el8.noarch.rpm"
+          },
+          "sha256:679724b45157b4d4c9ebe2eb32e188b9a65d47c23be886498d7a178caaf113bb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libsolv-0.7.19-1.el8.ppc64le.rpm"
+          },
+          "sha256:67f37cee02ba744dfc7957725f5ef9df229778f6a2f7afc659625b458da6167e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/crypto-policies-scripts-20210617-1.gitc776d3e.el8.noarch.rpm"
+          },
+          "sha256:685d8ca4ac9c909ac2daa8bf454d8ce1de993c8ae29a8c78417dfd5d1c3aa65e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/pixman-0.38.4-1.el8.ppc64le.rpm"
+          },
+          "sha256:697f5bf30fbe44dd4dcba8392b85680952b7a1be9a0221349f4fde011a8cdd3c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/sssd-common-2.5.2-2.el8.ppc64le.rpm"
+          },
+          "sha256:698e8ecaf71719dafacae79de05080d567b69fad3511e8b8d42b9af96a7c41db": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/dbus-tools-1.12.8-14.el8.ppc64le.rpm"
+          },
+          "sha256:6ac918d2bc175b3f356926ca96a998c29bffe256f7d802e8ef654b1226da3ef6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libdhash-0.5.0-39.el8.ppc64le.rpm"
+          },
+          "sha256:6b096b1da49230942e736576396091530cecb3f9bd8cc70b8b8a9f72a5148a0d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/python3-systemd-234-8.el8.ppc64le.rpm"
+          },
+          "sha256:6b312faed4a0508da2f15d3f31a6daccfc0ec6621e5fb7b20956027dce5fa395": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libkcapi-hmaccalc-1.2.0-2.el8.ppc64le.rpm"
+          },
+          "sha256:6b588ff47d46d33b02bc296e6e5cc263d6c8ff51ee97b59ca8b34d5c45d57912": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/perl-PathTools-3.74-1.el8.ppc64le.rpm"
+          },
+          "sha256:6b9875495111bcd2d3c5e9e380b3be17fb0a730891468fb45bdba3b3692b00ea": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libusbx-1.0.23-4.el8.ppc64le.rpm"
+          },
+          "sha256:6bbb721dd2c411c85c75f7477b14c54c776d78ee9b93557615e919ef47577440": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/perl-Term-Cap-1.17-395.el8.noarch.rpm"
+          },
+          "sha256:6bfc201a12dc7bba21069a663aa692a96c5e8920b0d94a4e355c332d7ead15ba": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libzstd-1.4.4-1.el8.ppc64le.rpm"
+          },
+          "sha256:6c9dfb73e199975275633f05d31388cd61c5a77dec5678db958b4e6624eb21ba": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-pip-wheel-9.0.3-20.el8.noarch.rpm"
+          },
+          "sha256:6d02615212a88eb204b8f6d2a7cfbf6183a12f29d72ca5dbfbe5c45c63068ef8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/iputils-20180629-7.el8.ppc64le.rpm"
+          },
+          "sha256:6d1ac29b3a38408f6d238d6718384e05be7346789c6200b354335b0e0c9c77df": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/info-6.5-6.el8.ppc64le.rpm"
+          },
+          "sha256:6faee589c5a7454502e5ec07586a4856e7f1376bd551741af2acf03afb9716e6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/cronie-anacron-1.5.2-4.el8.ppc64le.rpm"
+          },
+          "sha256:6fe1188081e441595ce29ebed4d1985e5890815158244f69f092ee930656f755": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/keyutils-libs-1.5.10-9.el8.ppc64le.rpm"
+          },
+          "sha256:700b9050aa490b5eca6d1f8630cbebceb122fce11c370689b5ccb37f5a43ee2f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/fontpackages-filesystem-1.44-22.el8.noarch.rpm"
+          },
+          "sha256:709ea71f36495ac2ac89d72d2eb603b6aa55b2c1a70633f23514dd897936f02b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libdb-utils-5.3.28-40.el8.ppc64le.rpm"
+          },
+          "sha256:70fe40ffb2fb3eb2c3626afbfdb200a2429e000c2fbb172886c23b1908000501": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libsss_sudo-2.5.2-2.el8.ppc64le.rpm"
+          },
+          "sha256:71c88f04921ae61a7009f9443f95c70ec3424a798429fc01e6c1432c1077aacb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/os-prober-1.74-6.el8.ppc64le.rpm"
+          },
+          "sha256:71d45853b0a8673e6354892df7a420ad77200a018ee5334b30b893862d030fa9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/dracut-config-generic-049-188.git20210802.el8.ppc64le.rpm"
+          },
+          "sha256:71f54759238edb9ae63dfc6ed893183a809e88321d8117dc40e0d403fc533585": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/tcpdump-4.9.3-2.el8.ppc64le.rpm"
+          },
+          "sha256:720088f184124166386634a523f3566a7fc56f802dbd6e6f816e959236542770": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/powerpc-utils-core-1.3.8-7.el8.ppc64le.rpm"
+          },
+          "sha256:74e11b9013f81bd30ec7934ea695d267d164967fec27a02652aa48602b94bc51": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/perl-IO-1.38-420.el8.ppc64le.rpm"
+          },
+          "sha256:754bf53a39cea727d9d89d59df32e020842dc71f6a0561ea36f8203aff2d5d69": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/gobject-introspection-1.56.1-1.el8.ppc64le.rpm"
+          },
+          "sha256:7559c097998db5e5d14dab1a7a1637a5749e9dab234ca68d17c9c21f8cfbf8d6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/perl-constant-1.33-396.el8.noarch.rpm"
+          },
+          "sha256:75e9ed16ace51ba04a62505aaed215bf9c722d6f4b1c33cc3e3962076c300ee8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libtasn1-4.13-3.el8.ppc64le.rpm"
+          },
+          "sha256:7632176e2d324ee98701f5d79024361379d510590e477f560a264aa6e8db233d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/python3-gobject-3.28.3-2.el8.ppc64le.rpm"
+          },
+          "sha256:767dd64d91c23adda537c7759ae3b4f720d3c76e03b52bc9231e52e0113db3ab": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libss-1.45.6-2.el8.ppc64le.rpm"
+          },
+          "sha256:76df9e0fc779fcd7d3ee836ae254ead30b5f9492022b55901d1f8bd914d38ef6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/selinux-policy-targeted-3.14.3-76.el8.noarch.rpm"
+          },
+          "sha256:77e4cfbc823e3764308822ccf03b257861f9360f3b948829f1d73148b321b00e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libcap-2.26-4.el8.ppc64le.rpm"
+          },
+          "sha256:78b2b9cbf041d4461daf7ac11a24d1e79a9c57f47aa265dba4d09067efe3d96b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/grub2-tools-2.02-99.el8.ppc64le.rpm"
+          },
+          "sha256:78c43d8a15ca018de1803e4baac5819e1baab1963fd31f1e44e54e8a573acbfc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-idna-2.5-5.el8.noarch.rpm"
+          },
+          "sha256:78d17ed089151e7fa3d1a3cdbbac8ca3b1b5c484fae5ba025642cc9107991037": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/perl-podlators-4.11-1.el8.noarch.rpm"
+          },
+          "sha256:78fd472a1c7f49b8a432788ea2dfc1119f155a394f41585b4e715d2585fc92ab": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/gettext-0.19.8.1-17.el8.ppc64le.rpm"
+          },
+          "sha256:791acd72bc40be9ba5fa6b77d78def5da623544408b72baa4c81181c03a205cb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/logrotate-3.14.0-4.el8.ppc64le.rpm"
+          },
+          "sha256:794f970f498af07b37f914c19ad5dedc6b6c2f89d343af9dd1768d17232555de": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/perl-Pod-Usage-1.69-395.el8.noarch.rpm"
+          },
+          "sha256:7962bed04e961194d64769b4b7d5c85836808361c606e943b013098fe53df782": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libtevent-0.11.0-0.el8.ppc64le.rpm"
+          },
+          "sha256:7a66928044c3478964aeaf6f9e981fdbcfa6b2ff7fad9f2ad57a8c09387cbbf2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/npth-1.5-4.el8.ppc64le.rpm"
+          },
+          "sha256:7abf49cabbaf996afc0c2604f10ea18f8f22a903fc4ba3728a18f5892353c5c9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/ncurses-6.1-9.20180224.el8.ppc64le.rpm"
+          },
+          "sha256:7adc584a7d43968d22706da5ffa127020536375f82beea5ef677cab39c5f64c5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libpipeline-1.5.0-2.el8.ppc64le.rpm"
+          },
+          "sha256:7aeb44195a1c984aff87cf8429d2aa40f6947b0a47d3603e1ca5c3cf8d284459": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/linux-firmware-20210702-103.gitd79c2677.el8.noarch.rpm"
+          },
+          "sha256:7b334d84bf03876c5738efa3857faaa35ede5c8eab30a5621ecfd4efa7ce39a5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/pciutils-3.7.0-1.el8.ppc64le.rpm"
+          },
+          "sha256:7baac88adafdc5958fb818c7685d3c6548f6e2e585e4435ceee4a168edc3597e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/dbus-common-1.12.8-14.el8.noarch.rpm"
+          },
+          "sha256:7bb5051dee5f6633a02cf5a3285dd86890cc6521e497526a8149dc5c5ebad062": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/kernel-4.18.0-331.el8.ppc64le.rpm"
+          },
+          "sha256:7cccedcc359f2a2542858088704bf3d0ec3e46cb7b72f602408fbab937a522d3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/grub2-ppc64le-2.02-99.el8.ppc64le.rpm"
+          },
+          "sha256:7cced5f47c4035e01fffce0989b62113a75016e5220e7b207c4b96be7ed90403": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/gsettings-desktop-schemas-3.32.0-6.el8.ppc64le.rpm"
+          },
+          "sha256:7d4c363f4a746f3a0946d19f303fe9c60c5fe178892528ec4f34d8ddd2c4c359": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/sg3_utils-1.44-5.el8.ppc64le.rpm"
+          },
+          "sha256:7e50a5d0f2fbd8c95375f72f5772c7731186e999a447121b8247f448b065a4ef": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/perl-Text-Tabs+Wrap-2013.0523-395.el8.noarch.rpm"
+          },
+          "sha256:7e67dba2509f90064325e62e49412d5284a55f09b7b6878b9c8222692c500dde": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/perl-Digest-1.17-395.el8.noarch.rpm"
+          },
+          "sha256:7edc503f5a919c489b651757095d8031982d530cc88088fdaeb743188364e9b0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/perl-Exporter-5.72-396.el8.noarch.rpm"
+          },
+          "sha256:7f506879c64e0bb4d98782d025f46fb9a07517487ae4cbebbb3985a98f4e2154": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-pysocks-1.6.8-3.el8.noarch.rpm"
+          },
+          "sha256:80f3973c07c06dd095203553abbb95d6ce1c24ccc92f24f46659bf05416f4778": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/cloud-utils-growpart-0.31-3.el8.noarch.rpm"
+          },
+          "sha256:8119d276749b35cd9c283c1a8d970b3528bea58427eb37eafc22b6093a978f08": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/ima-evm-utils-1.3.2-12.el8.ppc64le.rpm"
+          },
+          "sha256:82ce159a9e4e4b6b4fdce9ad954aa507f67108430bd261a4dcd826e44d0152a4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/python3-pyserial-3.1.1-8.el8.noarch.rpm"
+          },
+          "sha256:83cb349e65d5b783518b735d8fb477264f0a6bd7cdd6f4096f8493dbd45f2ff7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/kernel-tools-libs-4.18.0-331.el8.ppc64le.rpm"
+          },
+          "sha256:8403cfc97e0e72e37639b8c54d92f1ee427e48a70d52d5260a37fa104f2df20d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/nettle-3.4.1-7.el8.ppc64le.rpm"
+          },
+          "sha256:842ff55b80ac9a5c3357bf52646a5761a4c4786bb3e64b56d8fa5d8fe34ef8bb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/centos-gpg-keys-8-2.el8.noarch.rpm"
+          },
+          "sha256:8540be85295735194e0053eb2ab6b2bda2e27119b9b030877eff43f9272a20cf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/sg3_utils-libs-1.44-5.el8.ppc64le.rpm"
+          },
+          "sha256:8571a2aa115d42f8b5e87ef58d10e9c24e6fbe5470fc2612df96f8740f3d960f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/python3-unbound-1.7.3-17.el8.ppc64le.rpm"
+          },
+          "sha256:85eb614fc608f3b3f4bbd08d4a3b0ff6af188677ea4e009be021680c521cedae": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/python3-jsonpatch-1.21-2.el8.noarch.rpm"
+          },
+          "sha256:8623975eac20e039a7ba14323490db10169cf205ec98f5df2f55f7d410202663": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/cairo-gobject-1.15.12-3.el8.ppc64le.rpm"
+          },
+          "sha256:864f5bf99bf805c3e1143f78a78012d2f910f0d5627519b1f263a4d5cc6fa45e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/isomd5sum-1.2.3-3.el8.ppc64le.rpm"
+          },
+          "sha256:8729b157f0925feccdaef8aacd91c6aebe0109e621675bcc15e1830673b0e19d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/brotli-1.0.6-3.el8.ppc64le.rpm"
+          },
+          "sha256:8781993942f622945aefe59e449a5ff4608f969db79fbe893040890ff08fc1f9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-gobject-base-3.28.3-2.el8.ppc64le.rpm"
+          },
+          "sha256:881b28a3a37d114bc3f046605b24663560009b13a507217e007643f5682efdd5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/dracut-049-188.git20210802.el8.ppc64le.rpm"
+          },
+          "sha256:882a327cb5e2d809bfe695e9622caced76e7d89c96dcb40203ad8b7d281630fa": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-libsemanage-2.9-6.el8.ppc64le.rpm"
+          },
+          "sha256:8891a9a4707611c13a5693b195201dd940254ffdb03cf5742952329282bb8cb7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-pycparser-2.14-14.el8.noarch.rpm"
+          },
+          "sha256:88be5116908aa5013f540c767f6811774342780bb72d3ec197b3429bfb2f9862": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/expat-2.2.5-4.el8.ppc64le.rpm"
+          },
+          "sha256:88ff01f3d3812bc3fb3d18970ecefde7ac8f1a6a29409946ed85173cf8645a3a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/rsync-3.1.3-12.el8.ppc64le.rpm"
+          },
+          "sha256:8904fdb492f34e5242ba483fb6b7b158342662575b3d5ac9abbc380568840d4a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libyaml-0.1.7-5.el8.ppc64le.rpm"
+          },
+          "sha256:8945279d57ad510e018f92571ba8e5d811cf8a3165adf930b0d4015c5a077a35": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/rsyslog-8.2102.0-5.el8.ppc64le.rpm"
+          },
+          "sha256:8a501b9d8016eee68ce62a93a65842b15c8a57192b9f8189ebc85a11f2f47f9e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/systemd-239-49.el8.ppc64le.rpm"
+          },
+          "sha256:8ab06f608f45445bdef489cedb40d419aa7282e127ee26dbfcf417350a3f1630": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libibverbs-35.0-1.el8.ppc64le.rpm"
+          },
+          "sha256:8b73e398f5a3cdc8a7ded303586ca7a50b26cc76213a3cebe36fdfdca769b316": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/PackageKit-1.1.12-6.el8.ppc64le.rpm"
+          },
+          "sha256:8c05fe038c7792203afa47f4534318f6c674672999b444909706ce0826bf1b8f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/hdparm-9.54-4.el8.ppc64le.rpm"
+          },
+          "sha256:8c26cce4231f781db7b37d51ded377f9cfa01a5e6833d967082795f1220e2860": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/tar-1.30-5.el8.ppc64le.rpm"
+          },
+          "sha256:8c893a8300f812ca179e1f8863eff109e1b8f1c70044bc5f08eb38a592ffdecd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/libXau-1.0.9-3.el8.ppc64le.rpm"
+          },
+          "sha256:8cb953ea9ea1bd262bef00112e2c433583929cd7aec86ae60f1a725c6dcf7c09": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/rpm-plugin-systemd-inhibit-4.14.3-15.el8.ppc64le.rpm"
+          },
+          "sha256:8cd6ef9902851f07cfd9682e2d6873648690f0c2ec65345276b557ede042d8b9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/gdbm-1.18-1.el8.ppc64le.rpm"
+          },
+          "sha256:8d19cdf57ba61fecd9e07f24fe88768f58196543f7c032adada8a0cc48eee6b3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/perl-Socket-2.027-3.el8.ppc64le.rpm"
+          },
+          "sha256:8d7777da3f54f965cf3058cabf987c01b93a1dd041e8359eb7822eba57d8c8df": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libnsl2-1.2.0-2.20180605git4a062cf.el8.ppc64le.rpm"
+          },
+          "sha256:906bffa419bdb1a6d3094d7a6f2308527f5ece250bfcb962df79e9867f28236d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/lshw-B.02.19.2-6.el8.ppc64le.rpm"
+          },
+          "sha256:926ce547a03e1bd2aac94b1792d7ccea16d1e6bd91903458e63a095268e1b02f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/perl-macros-5.26.3-420.el8.ppc64le.rpm"
+          },
+          "sha256:946ba273a3a3b6fdf140f3c03112918c0a556a5871c477f5dbbb98600e6ca557": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/platform-python-setuptools-39.2.0-6.el8.noarch.rpm"
+          },
+          "sha256:94e73ee7b1a5e6791a7cdce615f8a7e23fe1e6359b22ee366b71f45a5ef13483": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/lorax-templates-generic-28.14.61-2.el8.ppc64le.rpm"
+          },
+          "sha256:95103f7c339aec4b485b7f569aa8a5e1a54286b3d2acde427328c49e4d8d80d1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libsemanage-2.9-6.el8.ppc64le.rpm"
+          },
+          "sha256:95cb9c201ee3b54fe6331bd7e74f43485632e95448d31fd340ffaa84a32b41ab": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/python3-jinja2-2.10.1-3.el8.noarch.rpm"
+          },
+          "sha256:965dca9dc74ed26f4204debe15b8e4dd1b8e41a80b8608287a9ef22f0b6f507e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/openssh-8.0p1-9.el8.ppc64le.rpm"
+          },
+          "sha256:965ec1b760513e1ae539747624bd241d6575675e8a04c5caa572faadb54007c7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/jansson-2.11-3.el8.ppc64le.rpm"
+          },
+          "sha256:98c28a91d41f634edb8c1f001dbc45c0de534332d059a2e8feff448fb7235c49": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/librtas-2.0.2-1.el8.ppc64le.rpm"
+          },
+          "sha256:9936485ac7111967d6962bc539de7b08807e310117adb78b11c21a5db0f0f890": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/memstrack-0.1.11-1.el8.ppc64le.rpm"
+          },
+          "sha256:9b1018a43b1a9245cdc71a342b962aa32fb799bd0ce66ee59b496cdd75200de9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/rpm-plugin-selinux-4.14.3-15.el8.ppc64le.rpm"
+          },
+          "sha256:9b69a221cf9395a110849bb428bb1cfe9fb489322df0fa6017f5978a827ee0e9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libcap-ng-0.7.11-1.el8.ppc64le.rpm"
+          },
+          "sha256:9b8a8a843fe9a972f6433e11b95b5a8d1d2971ed40fe1acda6807e34f0773c62": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libpsl-0.20.2-6.el8.ppc64le.rpm"
+          },
+          "sha256:9c4cd61b98253904436180f58c564bda61be1fa1b5523e4ecbbdc174d0c2a9aa": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libassuan-2.5.1-3.el8.ppc64le.rpm"
+          },
+          "sha256:9dc236a8124d1fcbb41b970b5a4c45d6f7f97430c933c775121cae27f5f352a7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/timedatex-0.5-3.el8.ppc64le.rpm"
+          },
+          "sha256:9dc5c484c7821cc737f872973764203376106d643b9adc4ef66bece1b0cc8fdc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/python3-mako-1.0.6-13.el8.noarch.rpm"
+          },
+          "sha256:9e2ef90cb484b37232e829ec400dcddd3f9f0d189eb6f0074b3b5874d4553d1c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/parted-3.2-39.el8.ppc64le.rpm"
+          },
+          "sha256:9e540fe1fcf866ba1e738e012eef5459d34cca30385df73973e6fc7c6eadb55f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/setup-2.12.2-6.el8.noarch.rpm"
+          },
+          "sha256:9e67ac5948125dd165c9a74ec848d48b313ef4264bbbb89630a782dbd972d72c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/e2fsprogs-1.45.6-2.el8.ppc64le.rpm"
+          },
+          "sha256:9ea4e52636b010504bfff1662c57988feb81cdfe97ba7c092f6efe3abdbe2dd7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/qemu-img-4.2.0-52.module_el8.5.0+853+a4d5519d.ppc64le.rpm"
+          },
+          "sha256:9f1a745b208091d4b009ec321a6fdc72c8a5e89167effed81c50571a13f1c87d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/perl-Digest-MD5-2.55-396.el8.ppc64le.rpm"
+          },
+          "sha256:9fb07c2324cccbbc19e3ffade50ee7da41909b2f6c24f49ffd9978ba375de193": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/e2fsprogs-libs-1.45.6-2.el8.ppc64le.rpm"
+          },
+          "sha256:9feaf80c733951790bc3578db42ea2abef65643ebb36779e46dccdaf4c76b525": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/perl-URI-1.73-3.el8.noarch.rpm"
+          },
+          "sha256:a04cb3117395b962edc32bf45d8411f240632476b0706b2df7f4a1a87b2ce34b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-six-1.11.0-8.el8.noarch.rpm"
+          },
+          "sha256:a0a8e31422da7d695a3788a7cae3f929d42cb4982889422588904ecc6879182e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libldb-2.3.0-2.el8.ppc64le.rpm"
+          },
+          "sha256:a0b8a6b2c8dad75290228086dd0af342979604bbf4b9500029e25d766835c0f4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libevent-2.1.8-5.el8.ppc64le.rpm"
+          },
+          "sha256:a1af93a1b62e8ca05b7597d5749a2b3d28735a86928f0432064fec61db1ff844": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/perl-HTTP-Tiny-0.074-1.el8.noarch.rpm"
+          },
+          "sha256:a2aeabb3962859069a78acc288bc3bffb35485428e162caafec8134f5ce6ca67": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/xkeyboard-config-2.28-1.el8.noarch.rpm"
+          },
+          "sha256:a2d96efed83ab31d21481af044835a940673ee4ade2763af78c06d2df87b94f7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/gnupg2-smime-2.2.20-2.el8.ppc64le.rpm"
+          },
+          "sha256:a34e0c5859e5e8757afafba47d83396226b646f32954ef7ecda4ad3be464bed6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/perl-Data-Dumper-2.167-399.el8.ppc64le.rpm"
+          },
+          "sha256:a388c955ace01f09f522c0ccf3afd47e682b22a87756e185f9134bdff72fb2ff": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/GConf2-3.2.6-22.el8.ppc64le.rpm"
+          },
+          "sha256:a3ef96219165bfc64d4f5d50f51fbd43e803c500619240ffe4db1f9f8e337f83": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/kbd-legacy-2.0.4-10.el8.noarch.rpm"
+          },
+          "sha256:a42de8ce71380b1f4e8ac5b4ce720bf565c99a0b09ef983c0550a91a467bc155": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/device-mapper-libs-1.02.177-6.el8.ppc64le.rpm"
+          },
+          "sha256:a4577841148e7e2bf481447ae141eff319007e70a24295a22787bbfaecf4c4fe": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/xz-libs-5.2.4-3.el8.ppc64le.rpm"
+          },
+          "sha256:a49b922f117b9bfb0b07e9848151f8a2948345328ebc534cd28ac187d7ed3f94": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/filesystem-3.8-6.el8.ppc64le.rpm"
+          },
+          "sha256:a571c94456b9a1743e94f4f72159de52bb13fe93437b81da675351553a881a17": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/hostname-3.20-7.el8.0.1.ppc64le.rpm"
+          },
+          "sha256:a5f9f2c4f39f393971f268aebb1b55d18d0d96693d08a9ed70403e8565807bb6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libksba-1.3.5-7.el8.ppc64le.rpm"
+          },
+          "sha256:a6ef8e56d53c29e92b46a7ad62c22380056153b2d5810c39c0cc1658a4250d5b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/NetworkManager-1.32.8-1.el8.ppc64le.rpm"
+          },
+          "sha256:a80c1d6d32db7ce8fdd58bb4f3f488b74e94261a38512dc8a15179ae33697e63": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/kmod-25-18.el8.ppc64le.rpm"
+          },
+          "sha256:a81afd94bec26037880bccdb97937c7662ecb6c1006a8bbf657d8ffafc7c4614": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/rpcbind-1.2.5-8.el8.ppc64le.rpm"
+          },
+          "sha256:a82958266d292f4725fc1981ea57a861b7fc7feeb7a9551d0b61b98ca51a5662": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/centos-stream-repos-8-2.el8.noarch.rpm"
+          },
+          "sha256:a8a27e1ffbb92356d6376334687b9eaa0cb5f2eece2670128f3a01e391e9f3bb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/dejavu-sans-mono-fonts-2.35-7.el8.noarch.rpm"
+          },
+          "sha256:a9d4dd71786b3147d53da1aa44f134e61b1e5527b6c7ece6c2b19474b6ca9270": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/policycoreutils-python-utils-2.9-15.el8.noarch.rpm"
+          },
+          "sha256:aa0007192287faeaecc72d9fa48efdb3108c764d450dc8fea65474476da32c45": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-pyudev-0.21.0-7.el8.noarch.rpm"
+          },
+          "sha256:aa1835fd302a37b84ac256db5dd0de09bd9883a5a07775aedb491faf46b18ee0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-urllib3-1.24.2-5.el8.noarch.rpm"
+          },
+          "sha256:ab2988acbe3a2580703de6070646324e95efe982598a386e69ed9857ab123855": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/sscg-2.3.3-14.el8.ppc64le.rpm"
+          },
+          "sha256:abc36bf7797a427b64c3c99b4f74714bfa66b906b62358be6fdafe493a66415e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-libdnf-0.63.0-2.el8.ppc64le.rpm"
+          },
+          "sha256:ac3b306c193bd20658950da402ae0cbdd8337110117de5e5d7eba970822671fd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/grub2-tools-extra-2.02-99.el8.ppc64le.rpm"
+          },
+          "sha256:ad338b7a3f3bed96300d9ce7f0307e09d758962b8496c10fb3554bf62405d153": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/glib2-2.56.4-156.el8.ppc64le.rpm"
+          },
+          "sha256:adc56041458e556df5663e7da264e151c24aaf1c2a94e49df9790ba191ea1b37": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libsepol-2.9-2.el8.ppc64le.rpm"
+          },
+          "sha256:aea253461d1a34a239b445ee07cb34398a9cbb6ed40e252182a91cddcf59004b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libdnf-0.63.0-2.el8.ppc64le.rpm"
+          },
+          "sha256:af0a4287e302baa7c85655ddfe5a7049b8eaf31aff03886f4fc57c920d26d491": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/gmp-6.1.2-10.el8.ppc64le.rpm"
+          },
+          "sha256:b01c567dbd2b9bf82301b254a8962a8fb8f30d12a8f566145eee0f3936f47b5d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/python3-ordered-set-2.0.2-4.el8.noarch.rpm"
+          },
+          "sha256:b10d8521963a2494fdb2b5f8fb0de837dc86d4016c3b10019fb8970a09582451": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/cryptsetup-libs-2.3.3-4.el8.ppc64le.rpm"
+          },
+          "sha256:b19bd4f106ce301ee21c860183cc1c2ef9c09bdf495059bdf16e8d8ccc71bbe8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-setuptools-wheel-39.2.0-6.el8.noarch.rpm"
+          },
+          "sha256:b29c8cb61ef138fdf00a458f0646cf9390e0f39783f02f6b81a956585dc6b302": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libuser-0.62-23.el8.ppc64le.rpm"
+          },
+          "sha256:b437a08d4670ef440ba6dbaae4ccb39f989f0c2a3d280ea66d6fd9532a313286": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/kmod-libs-25-18.el8.ppc64le.rpm"
+          },
+          "sha256:b4a1ac1ff5cd22a5dab6c96dfc2dbd7cd6ba750691ad5c53a97a1f088fc42abc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libseccomp-2.5.1-1.el8.ppc64le.rpm"
+          },
+          "sha256:b55df489f643b495984915a0671e74262192813e07cff5812d778c8cf4c0b9d1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/libfastjson-0.99.9-1.el8.ppc64le.rpm"
+          },
+          "sha256:b566154cc9b2b1996716def297d58101f3015a1b868187f1f9e4cd3074ae9988": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/perl-threads-shared-1.58-2.el8.ppc64le.rpm"
+          },
+          "sha256:b58be8f7685340b35e61945b1ab499bc1030b0b021b2ac5576897cf079ff7812": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libpng-1.6.34-5.el8.ppc64le.rpm"
+          },
+          "sha256:b5bd11b47b5b690dc667dc486941331d7cd3aaa4f0e5c4d638ec7b294bcc5012": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/libxkbcommon-0.9.1-1.el8.ppc64le.rpm"
+          },
+          "sha256:b615599db3ac6249e7b18e0c66474e080dc71ee72612bfa0268ea36b1a74e8da": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/python3-pip-9.0.3-20.el8.noarch.rpm"
+          },
+          "sha256:b64219f2278bf3f032b71593da63f563920778230946b66f1037bef2f2a7358b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/newt-0.52.20-11.el8.ppc64le.rpm"
+          },
+          "sha256:b7330d40f75b8ec786e41c45a202e44f0e49ec29ddf8944120fbdb373a6c6617": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/p11-kit-trust-0.23.22-1.el8.ppc64le.rpm"
+          },
+          "sha256:b83a0199c3d471151f07f6de626a1a4a362dd6aa29d84cf1c0ada2c966ce29c9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libdb-5.3.28-40.el8.ppc64le.rpm"
+          },
+          "sha256:bb4b6716669e27c7619f63751770cb87e7cfecd4e302e2ce6588035509168352": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/openssh-clients-8.0p1-9.el8.ppc64le.rpm"
+          },
+          "sha256:bb82b10a91493d745dc533b5de5335db650adb0c8a90548fdf5dad13569a16f4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/pam-1.3.1-15.el8.ppc64le.rpm"
+          },
+          "sha256:bba1cd75958b43df5e3ceb820449008c19ed5fa562d54c2d46c5c57e79aa6b2a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/sudo-1.8.29-7.el8.ppc64le.rpm"
+          },
+          "sha256:bc3e4dd9194760500ce9731d792f46afa049667185487bae88c23a38fdb10c37": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/yum-4.7.0-2.el8.noarch.rpm"
+          },
+          "sha256:bc7fc2028a29ac7a406719ed4f6740f6bf12c20961223c1e839a2a39069af38d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/quota-nls-4.04-14.el8.noarch.rpm"
+          },
+          "sha256:bcf25aae89f7368b16346bc1ec92850175bcc2312bf7a5e74bc3c512bcd345b0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/crontabs-1.11-17.20190603git.el8.noarch.rpm"
+          },
+          "sha256:bd9a6c7fe7405aaeeeb7d351ca1def52737b8ec2344021263aed64c6dc363d56": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/nfs-utils-2.3.3-46.el8.ppc64le.rpm"
+          },
+          "sha256:be49b69bc5de947ee2151f397993a691a57bc53952058c32cde0fca674da7d8c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/audit-libs-3.0-0.17.20191104git1c2f876.el8.ppc64le.rpm"
+          },
+          "sha256:bf994cb2e5c367d78483662c7de6e69950aaf04bc6cfdbbef4d1ef7ce153717c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/p11-kit-0.23.22-1.el8.ppc64le.rpm"
+          },
+          "sha256:bfa39369bd3c36833126b6f46b747de0736a66835d97196195c0810161c24549": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/python3-pydbus-0.6.0-5.el8.noarch.rpm"
+          },
+          "sha256:bfb45644212cfbbe48b05149f8d53e77d7bd02ca9fc9045cc37115101175a3a0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/glibc-2.28-162.el8.ppc64le.rpm"
+          },
+          "sha256:bff39fef1fc01564156123fcade75b4bc50402a2971a031d9a426c7014b1e681": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libunistring-0.9.9-3.el8.ppc64le.rpm"
+          },
+          "sha256:c1291b69a65a860069195a33cf6640df8667e960f9f030ceeea4497c47858b94": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libuuid-2.32.1-28.el8.ppc64le.rpm"
+          },
+          "sha256:c12c7dc6676c6ccc5ca08ceddfb1b4e46c9f1ed49cbc241292ae6d1fdb0d9d62": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/bc-1.07.1-5.el8.ppc64le.rpm"
+          },
+          "sha256:c238e0a5472c59c54093ffa23af6a963b4ae437eedfb6b9ebbcb482752c6d16b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/perl-Storable-3.11-3.el8.ppc64le.rpm"
+          },
+          "sha256:c2479eb811f4d9b8624ef20119e1abdc109f639c2cf576eb945b340362d87b05": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/openssl-1.1.1k-4.el8.ppc64le.rpm"
+          },
+          "sha256:c24b21415b737f18fad7aeb192e60f7d323f7ba69434ecc1e78b3af0003be8dc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/openldap-2.4.46-18.el8.ppc64le.rpm"
+          },
+          "sha256:c2776b30c82ad5566fdbcce83fcf9c699ad83dae57c6499eb64f8b8a7bc00b60": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-setools-4.3.0-2.el8.ppc64le.rpm"
+          },
+          "sha256:c3c1c42a41ab18dc09214bcd3a567bb7ba9b9c2191a6e1079b9770dfe2d3a338": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libtdb-1.4.3-1.el8.ppc64le.rpm"
+          },
+          "sha256:c477e45fe5f8f5bab1ec1711210dd357392ad19eab48cda18d89b60df5067970": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/sssd-kcm-2.5.2-2.el8.ppc64le.rpm"
+          },
+          "sha256:c58b0b900a7ffc778980461d74dc236bf2c790d2e5e8c04e28876e221b48a1c8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/dbus-glib-0.110-2.el8.ppc64le.rpm"
+          },
+          "sha256:c59538d646715fdb1f94c6be3fa0949871b8c860d5c54db4640a1197663a130b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-dbus-1.2.4-15.el8.ppc64le.rpm"
+          },
+          "sha256:c5a60ffb80cd1f9b90c797f1d1ac80e5536eb32a5b276871445e7279ac701c5f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libgcrypt-1.8.5-6.el8.ppc64le.rpm"
+          },
+          "sha256:c5b5967a094ced90899052a82e2c245529b75ba3f46e0ce1a89cfc95edb935ea": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-dateutil-2.6.1-6.el8.noarch.rpm"
+          },
+          "sha256:c5c61536e768553067cee488830c64866d109cade24917dbe23f82c861af07c5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libreport-filesystem-2.9.5-15.el8.ppc64le.rpm"
+          },
+          "sha256:c62991989974533b86a29586b799623a908add501287f2c890be4fc8a6af2c7d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/mozjs60-60.9.0-4.el8.ppc64le.rpm"
+          },
+          "sha256:c64632c85c3a49dc82222cdb3d0ee87eafa64f3096ffeba5bcc16c49ee2d260e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/policycoreutils-2.9-15.el8.ppc64le.rpm"
+          },
+          "sha256:c6f27b6e01d80e756408e3c1451e4af00e7d02da0aa24402644c0785118753fe": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-setuptools-39.2.0-6.el8.noarch.rpm"
+          },
+          "sha256:c7dfa7d5a4917eed3b44af87ffb9c6e18242ecd847a8edd140bcdd178cc8946a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/perl-IO-Socket-IP-0.39-5.el8.noarch.rpm"
+          },
+          "sha256:ca5d70414653e1b769124582699bc2400f05b5382a9a8dc6bb4ab4f28dac9c20": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/dhcp-client-4.3.6-45.el8.ppc64le.rpm"
+          },
+          "sha256:caa0bd6617a8d5e535faedec5f6f3ea7c5e6da1898751f6c9c34a89a95c286ff": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/findutils-4.6.0-20.el8.ppc64le.rpm"
+          },
+          "sha256:caabc61e9aa83275f9d2fefcfda56fddf19e7031bcf9f9b84f858bb1f040e24c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libnl3-3.5.0-1.el8.ppc64le.rpm"
+          },
+          "sha256:cad86777bcb265db0da766952ff63e8d33f0fd4f3b90b22d0a1da587a785db44": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/geolite2-city-20180605-1.el8.noarch.rpm"
+          },
+          "sha256:cb21226326a5a695c993daba749f5d758658d58612b05280a04cca98cba3f83a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-perf-4.18.0-331.el8.ppc64le.rpm"
+          },
+          "sha256:cbe98d6dcf93449d9c2fbf95de75f065f8da67a23f13401c672d78b28c6b7f6a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/irqbalance-1.4.0-6.el8.ppc64le.rpm"
+          },
+          "sha256:cc5f8dd4e061da3a73aa67112e24f2cc5c0ad0cd4334dc798b8834cf6259a779": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/dbus-libs-1.12.8-14.el8.ppc64le.rpm"
+          },
+          "sha256:cc662127a17d4e08e90f75703f376067eed48f5d6b5b8d106fa3824397f1978e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libedit-3.1-23.20170329cvs.el8.ppc64le.rpm"
+          },
+          "sha256:ccf848b42acc0f691b4cb6e2830dc4263c7ce4df89b3f4002c3d6b9cd99b362b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-rpm-4.14.3-15.el8.ppc64le.rpm"
+          },
+          "sha256:ccfa1810aa19fae08aefd29cffe28b65d5123cd17bd7d2d4207f03cf9795594c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-dnf-4.7.0-2.el8.noarch.rpm"
+          },
+          "sha256:cd603035aa26b9d12e6b23680e3f1a908341fd9f2086eb540834aee45b4c8604": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libstemmer-0-10.585svn.el8.ppc64le.rpm"
+          },
+          "sha256:cd8b0adfc4d2467a61ab2aa2b3e617bbd2a2592176da249365eef014faef827c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/xz-5.2.4-3.el8.ppc64le.rpm"
+          },
+          "sha256:cdd6594a3bca71d32a5061b85457cc8148611e7f042ba6e812a1c0a2faebac92": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/platform-python-3.6.8-39.el8.ppc64le.rpm"
+          },
+          "sha256:ce954d3900cb547aea14df6ad5f310ea96bb5e83a155b93e2e64b2c13b686193": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/util-linux-2.32.1-28.el8.ppc64le.rpm"
+          },
+          "sha256:cea5d052286c0a120f6cdd0f3e559f13b0eedf9f83d2538e4369b6e05526d43d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/perl-Mozilla-CA-20160104-7.module_el8.3.0+416+dee7bcef.noarch.rpm"
+          },
+          "sha256:cff4b4ac50fed2ceab6add52a66513ed9ca04b024f07a25c53df49f762eea2d2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/groff-base-1.22.3-18.el8.ppc64le.rpm"
+          },
+          "sha256:cffc31e10891c58edc89cebd211bc0be69d99f54f67682c91f97dc53e6381f0f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/perl-Errno-1.28-420.el8.ppc64le.rpm"
+          },
+          "sha256:d03b9f4b9848e3a88d62bcf6e536d659c325b2dc03b2136be7342b5fe5e2b6a9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/perl-Carp-1.42-396.el8.noarch.rpm"
+          },
+          "sha256:d150e53fa73c3786da9e4f6e23d374100b0dd2923485d4a08e9a56ac2786cf83": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/elfutils-libs-0.185-1.el8.ppc64le.rpm"
+          },
+          "sha256:d1cf2d973db2f1af46f124776b9ab4bd782e7065c8c8428a4ddef60989e4225d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/freetype-2.9.1-4.el8_3.1.ppc64le.rpm"
+          },
+          "sha256:d1d362fd4f8022ad05171efe40e84d15ec6c5e5f419d6099ebc8e46e7da632c1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/gdbm-libs-1.18-1.el8.ppc64le.rpm"
+          },
+          "sha256:d1e8c7a00924d1a6dee44ade189025853a501d4f77c73f3bfc006aa907d97daf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-ply-3.9-9.el8.noarch.rpm"
+          },
+          "sha256:d2748115958b57c9c5125e23bad9462edbabb33c81197424a33d8060745ff646": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/python3-babel-2.5.1-7.el8.noarch.rpm"
+          },
+          "sha256:d2e9ef1d33330a14155d5bd6a8cf122f9390cceb8a7a12c0364ae8e44410fb8d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/net-tools-2.0-0.52.20160912git.el8.ppc64le.rpm"
+          },
+          "sha256:d3a4f367a9c5ba936b1bb5480db390889a303e5ec8ff34bb4274c1d840a1784d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libnghttp2-1.33.0-3.el8_2.1.ppc64le.rpm"
+          },
+          "sha256:d3ad718b08b44e1fca355abd46a6c315a9d73ab38f9f3c3d551642b55866e182": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/NetworkManager-libnm-1.32.8-1.el8.ppc64le.rpm"
+          },
+          "sha256:d3e95ed161acd1ba957b1864e7ca2102d9c39380bbdd56eddebf11d5219b3a04": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libsss_certmap-2.5.2-2.el8.ppc64le.rpm"
+          },
+          "sha256:d46ef49f8ddba1ee8cce6c9764014851cce2dbfb5dcb2457a31495393e6566c1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/tpm2-tss-2.3.2-4.el8.ppc64le.rpm"
+          },
+          "sha256:d539404dafd8ad5d785ab3da6f8bd5a2bf5dff9e01be0ff1bc1d251786dda25c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libtirpc-1.1.4-5.el8.ppc64le.rpm"
+          },
+          "sha256:d5ee453757bd1b479881f0a57b968427404b81d9fed07d04afebcbcfcbf536ab": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/perl-interpreter-5.26.3-420.el8.ppc64le.rpm"
+          },
+          "sha256:d64da85b0e013679fb06eeadad74465d9556d7ad21e97beb1b5f61fb0658cd10": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/dhcp-common-4.3.6-45.el8.noarch.rpm"
+          },
+          "sha256:d6eb27d158b6397e52ab6a952fec4e3c414638a08750a6c011d32eb117accd82": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libmodulemd-2.12.1-1.el8.ppc64le.rpm"
+          },
+          "sha256:d751a4fdecc0dc3c5ff897e3ff4c25e7addc698d590e2bfc4c893e693be7d558": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/initscripts-10.00.15-1.el8.ppc64le.rpm"
+          },
+          "sha256:d77a7b1602a9ab7543171091dcb37100552f4738d40389028cbf2992c3152f52": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-libxml2-2.9.7-11.el8.ppc64le.rpm"
+          },
+          "sha256:d7bacff8f9be89871c6ec98c3356de11008ae574da852bdc15cee7ebb9ac39be": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libmodman-2.0.1-17.el8.ppc64le.rpm"
+          },
+          "sha256:d807e7fb8bf24be50642a6dced954c6ea208199daab2d27c9f73d789ba82fa37": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/gawk-4.2.1-2.el8.ppc64le.rpm"
+          },
+          "sha256:d816e850877d0fdbc5ee0951dbd78ca79613602aa5cccd1b324c10d700968d3b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-audit-3.0-0.17.20191104git1c2f876.el8.ppc64le.rpm"
+          },
+          "sha256:d87f7fa5e637442eb638bcaafdc44ca3895d91a153015ff9af6a87219f0dc372": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/openssl-pkcs11-0.4.10-2.el8.ppc64le.rpm"
+          },
+          "sha256:d8c00baf46e33f9e5f1b9e139bbea9fe0f27badb432c992b9cf8c4f7017094bf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libverto-0.3.0-5.el8.ppc64le.rpm"
+          },
+          "sha256:d8dad22276baffe9496d5e05ef35d21dd6f9d8f910339daced2c3ff42d7a28c5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/grub2-ppc64le-modules-2.02-99.el8.noarch.rpm"
+          },
+          "sha256:d909f0e1b6ddb29ad2d3da21208077e3c976212e07471114745859f70be9738d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libverto-libevent-0.3.0-5.el8.ppc64le.rpm"
+          },
+          "sha256:d967d6bbb33bf7a295a64807f81875c84e82a8ecc59b6c72fe955141b1660d39": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/rootfiles-8.1-22.el8.noarch.rpm"
+          },
+          "sha256:da4c6daa0d5406bc967cc89b02a69689491f42c543aceea1a31136f0f1a8d991": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/perl-Getopt-Long-2.50-4.el8.noarch.rpm"
+          },
+          "sha256:dbc730cf810cc886667a7a9b17883ba15bc40e933a38dd820f2f026cf8007805": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/cockpit-bridge-250-1.el8.ppc64le.rpm"
+          },
+          "sha256:dbde46224833f804d8b92212fa3618ea53d0e0cb84ff07132a5ba36c1bc0b9df": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/sed-4.5-2.el8.ppc64le.rpm"
+          },
+          "sha256:dc1d4f59ba0728e65433bc7f903b3799d61545ed3eed7427ad0fe36dcd0f831b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/perl-MIME-Base64-3.15-396.el8.ppc64le.rpm"
+          },
+          "sha256:dc835194ecfa6ebda81e0a764c953eff3422a61863e9a3e0dc74ea4cae7a4d94": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-linux-procfs-0.6.3-1.el8.noarch.rpm"
+          },
+          "sha256:dd80a8169e27959a27651616e998be8b49ffdca141744177cb42126ff0ae12b5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/dejavu-fonts-common-2.35-7.el8.noarch.rpm"
+          },
+          "sha256:dd8998fa42db6769700a41203f5ef0efe523ed24734636ef0dc0d2a4d4a94747": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/slang-2.3.2-3.el8.ppc64le.rpm"
+          },
+          "sha256:dd96950b4282e64ce3e37f0bd1a51834beb286037184f3796f9889bfa1ed0d72": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/pciutils-libs-3.7.0-1.el8.ppc64le.rpm"
+          },
+          "sha256:de9a24cdb3260850b49086745ba6f724aecff0bf7993729ae063c116da6915a4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/teamd-1.31-2.el8.ppc64le.rpm"
+          },
+          "sha256:deeeab9fcf6b9cb47235974158561967e299344e040c408e6b5d7464af2f3882": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/lsscsi-0.32-2.el8.ppc64le.rpm"
+          },
+          "sha256:df40cada982b04336fe8b250b4fdd576ddd03a014bb519a69b34640369bef661": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libarchive-3.3.3-1.el8.ppc64le.rpm"
+          },
+          "sha256:dfb7add4926f9a350755294af3c20f114ac59f32e00cadc9ec625b2a51703ad0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/passwd-0.80-3.el8.ppc64le.rpm"
+          },
+          "sha256:dfecfa1299d11d6a77503e626a2e9a14e1a75666bc8ea2abaf7ff515d2c86332": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/hwdata-0.314-8.9.el8.noarch.rpm"
+          },
+          "sha256:e0a7b9f3b56b4737f5711dc6b03f256fbf2488656b8874acabb494b58ba0c1c1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libcom_err-1.45.6-2.el8.ppc64le.rpm"
+          },
+          "sha256:e1153055b6ea57ee81e6fb41b03023279059513d0fec728517ae0805186a5118": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/shadow-utils-4.6-14.el8.ppc64le.rpm"
+          },
+          "sha256:e14ef6f934d9a20645b9eb781902d6a03b7c8123985c88536e06205b240ba509": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/libusal-1.1.11-39.el8.ppc64le.rpm"
+          },
+          "sha256:e156e6fa9ef6a483f8505ce0eeadbcab12b887c4996233ce5d6258076f6bce50": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/file-5.33-20.el8.ppc64le.rpm"
+          },
+          "sha256:e1e28504928648404a3b652440091eba010cd99221183ef78601cbd152261d91": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/gzip-1.9-12.el8.ppc64le.rpm"
+          },
+          "sha256:e217c2687212d931ad9a6a02afb20cc34f6d051786d136e337f91079c9f73d22": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libutempter-1.1.6-14.el8.ppc64le.rpm"
+          },
+          "sha256:e21a84107568047432e474e08da24aea2340409d57ea8cf170182927dc76de12": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libcurl-7.61.1-18.el8_4.1.ppc64le.rpm"
+          },
+          "sha256:e269f7d33abbb790311ffa95fa7df9766cac8bf31ace24fce6ed732ba0db19ae": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/perl-File-Temp-0.230.600-1.el8.noarch.rpm"
+          },
+          "sha256:e392a6b41381ffad04626d092fd2af9477c72e197a74efddf987832c3bfa521f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/gettext-libs-0.19.8.1-17.el8.ppc64le.rpm"
+          },
+          "sha256:e403c9839742c4b13e715541237f79ffe52870d59867bebd39e19e7080948db1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/fontconfig-2.13.1-3.el8.ppc64le.rpm"
+          },
+          "sha256:e45848a3fbfa1d46709448593fa7929fee4c5a83d2168c0d41d498251e4b5dae": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/kernel-tools-4.18.0-331.el8.ppc64le.rpm"
+          },
+          "sha256:e525544166da577edcd03c6596f1e8787a257caaa19eef98c3a481681d2d978a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/libestr-0.1.10-1.el8.ppc64le.rpm"
+          },
+          "sha256:e526de1fefb832b3e6a025642c77ac2527595925933412a7921606eb072e5ca9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/authselect-compat-1.2.2-3.el8.ppc64le.rpm"
+          },
+          "sha256:e65f7d7c8def6b168e013914bc0d1137aed65c3010e9796df3b823854472f3e1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/file-libs-5.33-20.el8.ppc64le.rpm"
+          },
+          "sha256:e716fd0130980916f4b1aeac8f98dbcd8ced81e2c119b7877204cc6b1a058418": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/polkit-0.115-12.el8.ppc64le.rpm"
+          },
+          "sha256:e778fc7e5d62fe488e250a1916cdb7f692e98e23d0c2b4264672b2574ff416e5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libappstream-glib-0.7.14-3.el8.ppc64le.rpm"
+          },
+          "sha256:e83928bd4552ecdf8e71d283e2358c7eccd006d284ba31fbc9c89e407989fd60": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/perl-File-Path-2.15-2.el8.noarch.rpm"
+          },
+          "sha256:e87acf226a9511b3a5f83e7fed9c5c20addbbdae47ab67c614404a9392b77e50": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/elfutils-libelf-0.185-1.el8.ppc64le.rpm"
+          },
+          "sha256:e8b7968fe6613c4cd6324436089cc9c1558cd63fb7da87fd46cc7c15c4ab7f66": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/ethtool-5.8-6.el8.ppc64le.rpm"
+          },
+          "sha256:e95bb05fa5defeb16dd0e0957de676374b22b9daaf405273e636d1ce91001574": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/systemd-pam-239-49.el8.ppc64le.rpm"
+          },
+          "sha256:ebd64ac5cc7b9f58a40072fe9afefa2fd835e0eb18cdeaf085395c7e84affac3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/unbound-libs-1.7.3-17.el8.ppc64le.rpm"
+          },
+          "sha256:ebeb05a4a9cdd5d060859eabac1349029c0120615c98fc939e26664c030655c1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-jwt-1.6.1-2.el8.noarch.rpm"
+          },
+          "sha256:ec85355744a8b37aa7fbe48d6f8afd8d0538129b70e82d238c3b57ae08559430": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/cockpit-ws-250-1.el8.ppc64le.rpm"
+          },
+          "sha256:ed40678aa26d63b71a122bd394b46b362df083c8f4ae3267f205a7d77ff69fdf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/dhcp-libs-4.3.6-45.el8.ppc64le.rpm"
+          },
+          "sha256:edf00207b603cbfe86b07f8be5c4ee14ff1dd85ec4b7d82d760483ffcea43891": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/cronie-1.5.2-4.el8.ppc64le.rpm"
+          },
+          "sha256:eee92733e8989029929d5cb1f673b15fdb814dac32e148d5bc02378b44c8699a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/chkconfig-1.19.1-1.el8.ppc64le.rpm"
+          },
+          "sha256:ef86061338fa321c959cadc75ecbdfd405eebaa1042eec9d9c737d4d9d92568f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/kbd-misc-2.0.4-10.el8.noarch.rpm"
+          },
+          "sha256:f0c20dff5211f9c133ad5703daedcbe148528c634b0a1eea7887b420da4dc00c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/virt-what-1.18-12.el8.ppc64le.rpm"
+          },
+          "sha256:f14cc62cf70a187384adff6bedf8b09858b8f441a9be87ebf3ae975c4e6b0d73": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/authselect-1.2.2-3.el8.ppc64le.rpm"
+          },
+          "sha256:f24bce642ec88622490b2f09a45fa3985da7f6511a1aae131853c4ea4c309e6b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/lz4-libs-1.8.3-3.el8_4.ppc64le.rpm"
+          },
+          "sha256:f3d9ccb762146dc97f2d201d979fbb0e9171d1203fb985f3ef48b5c2a176c2a9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libgcc-8.5.0-3.el8.ppc64le.rpm"
+          },
+          "sha256:f4e3607f242bbca7ec2379822ca961860e6d9c276da51c6e2dfd17a29469ec78": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/perl-Term-ANSIColor-4.06-396.el8.noarch.rpm"
+          },
+          "sha256:f4eca686b314edb06d3fe1c526f573c7248c811af70cba76132cdc9c541cadc1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/elfutils-debuginfod-client-0.185-1.el8.ppc64le.rpm"
+          },
+          "sha256:f5bcb82a732c02d6f31bbf156887049883c76cedc9c6a11b049358a74f4d45d0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libssh-config-0.9.4-3.el8.noarch.rpm"
+          },
+          "sha256:f5e73bbd776a2426a796971d8d38664f2e94898479fb76947dccdd28cf9fe1d0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/perl-parent-0.237-1.el8.noarch.rpm"
+          },
+          "sha256:f6cd5ed6305952c1cd842fbca0e5d9613f736646cfac2082a2db37f5d065468c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/lmdb-libs-0.9.24-1.el8.ppc64le.rpm"
+          },
+          "sha256:f7a2eddcda47cb75108add34c0ce919ceb847605830ad33aeb4bd64d6bed24f3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libdaemon-0.14-15.el8.ppc64le.rpm"
+          },
+          "sha256:f8130aecd446f997d0e2011481275db0552bf57bd7af0d7a655eded5f52ca94e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/openssh-server-8.0p1-9.el8.ppc64le.rpm"
+          },
+          "sha256:f97b5915b3f75d2878104c198f205841813712103f1b3657d71d2c8d079cc947": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/shared-mime-info-1.9-3.el8.ppc64le.rpm"
+          },
+          "sha256:fa7bef727ba8657208bb3df95916f0bc912332cb8534c695facef32ffbd72f20": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/glibc-all-langpacks-2.28-162.el8.ppc64le.rpm"
+          },
+          "sha256:fb276cc0ebc6bd27d344f7e0811f26cb3f0e59da09182489095724bdf2a075f8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/grub2-tools-minimal-2.02-99.el8.ppc64le.rpm"
+          },
+          "sha256:fb6e437a24450106c03f25dc1c3f6b78549b82c2d0bd4387dce1350ca3c5f1f5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libpath_utils-0.2.1-39.el8.ppc64le.rpm"
+          },
+          "sha256:fc8e4e96da6ee6201a5126473666831314938e98bf699677be296e7811f6b7dd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/libXext-1.3.4-1.el8.ppc64le.rpm"
+          },
+          "sha256:fc9d3ee3946b87efcd9531f876d23a9e8d5769aab3e0ad6007ac2cdb4068499c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/perl-Encode-2.97-3.el8.ppc64le.rpm"
+          },
+          "sha256:fd6e1803ff367036da5b52b2183e1408691b379cc1320971bb664737507f89a4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libkcapi-1.2.0-2.el8.ppc64le.rpm"
+          },
+          "sha256:ff02d15997cec2391c7d49203e49f88068993252ac1f496a11e182c92d9d0e88": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/PackageKit-glib-1.1.12-6.el8.ppc64le.rpm"
+          },
+          "sha256:ff1580bd4ec5841d4937b383917fa30f318b4f419b8067a77468eb4a9630ba10": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libacl-2.2.53-1.el8.ppc64le.rpm"
+          },
+          "sha256:ff8b51c6a8bacc5ef6b5da0f049d170ab1c1ecebad50ded3c04ed384eca9a2c0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/coreutils-8.30-12.el8.ppc64le.rpm"
+          },
+          "sha256:ffb6d471f5c82b0407cc41a25aea25bf83d6779b3ef20f0557c4fd0da6111bb7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/gssproxy-0.8.0-19.el8.ppc64le.rpm"
+          }
+        }
+      }
+    }
+  },
+  "rpmmd": {
+    "blueprint": [
+      {
+        "name": "acl",
+        "epoch": 0,
+        "version": "2.2.53",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/acl-2.2.53-1.el8.ppc64le.rpm",
+        "checksum": "sha256:2c1baefd0f802507d9741da8da54f6eae42b04967f9d433d7f9e0f124434c70d",
+        "check_gpg": true
+      },
+      {
+        "name": "audit-libs",
+        "epoch": 0,
+        "version": "3.0",
+        "release": "0.17.20191104git1c2f876.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/audit-libs-3.0-0.17.20191104git1c2f876.el8.ppc64le.rpm",
+        "checksum": "sha256:be49b69bc5de947ee2151f397993a691a57bc53952058c32cde0fca674da7d8c",
+        "check_gpg": true
+      },
+      {
+        "name": "basesystem",
+        "epoch": 0,
+        "version": "11",
+        "release": "5.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/basesystem-11-5.el8.noarch.rpm",
+        "checksum": "sha256:48226934763e4c412c1eb65df314e6879720b4b1ebcb3d07c126c9526639cb68",
+        "check_gpg": true
+      },
+      {
+        "name": "bash",
+        "epoch": 0,
+        "version": "4.4.20",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/bash-4.4.20-2.el8.ppc64le.rpm",
+        "checksum": "sha256:3a438b53e8377eccf90cac0fd42ed2b513fc869bfb7b96e3d2a4f6984a287f90",
+        "check_gpg": true
+      },
+      {
+        "name": "brotli",
+        "epoch": 0,
+        "version": "1.0.6",
+        "release": "3.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/brotli-1.0.6-3.el8.ppc64le.rpm",
+        "checksum": "sha256:8729b157f0925feccdaef8aacd91c6aebe0109e621675bcc15e1830673b0e19d",
+        "check_gpg": true
+      },
+      {
+        "name": "bzip2-libs",
+        "epoch": 0,
+        "version": "1.0.6",
+        "release": "26.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/bzip2-libs-1.0.6-26.el8.ppc64le.rpm",
+        "checksum": "sha256:56c3d429ea949467dc0bca882646cf40a58fb6f27750f5664ff2919f5d38ada5",
+        "check_gpg": true
+      },
+      {
+        "name": "ca-certificates",
+        "epoch": 0,
+        "version": "2021.2.50",
+        "release": "82.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/ca-certificates-2021.2.50-82.el8.noarch.rpm",
+        "checksum": "sha256:1fad1d1f8b56e6967863aeb60f5fa3615e6a35b0f6532d8a23066e6823b50860",
+        "check_gpg": true
+      },
+      {
+        "name": "centos-gpg-keys",
+        "epoch": 1,
+        "version": "8",
+        "release": "2.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/centos-gpg-keys-8-2.el8.noarch.rpm",
+        "checksum": "sha256:842ff55b80ac9a5c3357bf52646a5761a4c4786bb3e64b56d8fa5d8fe34ef8bb",
+        "check_gpg": true
+      },
+      {
+        "name": "centos-stream-release",
+        "epoch": 0,
+        "version": "8.5",
+        "release": "3.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/centos-stream-release-8.5-3.el8.noarch.rpm",
+        "checksum": "sha256:15b17b95cf9cb9fb64e0c8e56110836bdcaf70de81b8cbdb60e181fc90456e06",
+        "check_gpg": true
+      },
+      {
+        "name": "centos-stream-repos",
+        "epoch": 0,
+        "version": "8",
+        "release": "2.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/centos-stream-repos-8-2.el8.noarch.rpm",
+        "checksum": "sha256:a82958266d292f4725fc1981ea57a861b7fc7feeb7a9551d0b61b98ca51a5662",
+        "check_gpg": true
+      },
+      {
+        "name": "chkconfig",
+        "epoch": 0,
+        "version": "1.19.1",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/chkconfig-1.19.1-1.el8.ppc64le.rpm",
+        "checksum": "sha256:eee92733e8989029929d5cb1f673b15fdb814dac32e148d5bc02378b44c8699a",
+        "check_gpg": true
+      },
+      {
+        "name": "coreutils",
+        "epoch": 0,
+        "version": "8.30",
+        "release": "12.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/coreutils-8.30-12.el8.ppc64le.rpm",
+        "checksum": "sha256:ff8b51c6a8bacc5ef6b5da0f049d170ab1c1ecebad50ded3c04ed384eca9a2c0",
+        "check_gpg": true
+      },
+      {
+        "name": "coreutils-common",
+        "epoch": 0,
+        "version": "8.30",
+        "release": "12.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/coreutils-common-8.30-12.el8.ppc64le.rpm",
+        "checksum": "sha256:383a5e6bb9e94de53baaf5c7493cd50a68c893c6a30acfbe28407d33bb133efc",
+        "check_gpg": true
+      },
+      {
+        "name": "cpio",
+        "epoch": 0,
+        "version": "2.12",
+        "release": "10.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/cpio-2.12-10.el8.ppc64le.rpm",
+        "checksum": "sha256:19061d12407c0c4bca6abcaef01695b70dcd3967ff102dd07178a2193a280e29",
+        "check_gpg": true
+      },
+      {
+        "name": "cracklib",
+        "epoch": 0,
+        "version": "2.9.6",
+        "release": "15.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/cracklib-2.9.6-15.el8.ppc64le.rpm",
+        "checksum": "sha256:4e3e93a3d2039c2a8305030b7960bd1100d7d20705a1afb1325a4ee79478a74a",
+        "check_gpg": true
+      },
+      {
+        "name": "cracklib-dicts",
+        "epoch": 0,
+        "version": "2.9.6",
+        "release": "15.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/cracklib-dicts-2.9.6-15.el8.ppc64le.rpm",
+        "checksum": "sha256:084d79ed3d7127e6d46e9ac6e654d8ef181a156435808dc8eb32968b6c1b4946",
+        "check_gpg": true
+      },
+      {
+        "name": "crypto-policies",
+        "epoch": 0,
+        "version": "20210617",
+        "release": "1.gitc776d3e.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/crypto-policies-20210617-1.gitc776d3e.el8.noarch.rpm",
+        "checksum": "sha256:2a8f9e5119a034801904185dcbf1bc29db67e9e9b0cf5893615722d7bb33099c",
+        "check_gpg": true
+      },
+      {
+        "name": "crypto-policies-scripts",
+        "epoch": 0,
+        "version": "20210617",
+        "release": "1.gitc776d3e.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/crypto-policies-scripts-20210617-1.gitc776d3e.el8.noarch.rpm",
+        "checksum": "sha256:67f37cee02ba744dfc7957725f5ef9df229778f6a2f7afc659625b458da6167e",
+        "check_gpg": true
+      },
+      {
+        "name": "cryptsetup-libs",
+        "epoch": 0,
+        "version": "2.3.3",
+        "release": "4.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/cryptsetup-libs-2.3.3-4.el8.ppc64le.rpm",
+        "checksum": "sha256:b10d8521963a2494fdb2b5f8fb0de837dc86d4016c3b10019fb8970a09582451",
+        "check_gpg": true
+      },
+      {
+        "name": "curl",
+        "epoch": 0,
+        "version": "7.61.1",
+        "release": "18.el8_4.1",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/curl-7.61.1-18.el8_4.1.ppc64le.rpm",
+        "checksum": "sha256:47ad43730c8bc72c90f2fb3dbd3526d716ada2fad94e62cb443658e94c6503c5",
+        "check_gpg": true
+      },
+      {
+        "name": "cyrus-sasl-lib",
+        "epoch": 0,
+        "version": "2.1.27",
+        "release": "5.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/cyrus-sasl-lib-2.1.27-5.el8.ppc64le.rpm",
+        "checksum": "sha256:5c1940e1f173e22b053f3a89022903cea34a6af20dff81c65548c4e2ba3a8293",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus",
+        "epoch": 1,
+        "version": "1.12.8",
+        "release": "14.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/dbus-1.12.8-14.el8.ppc64le.rpm",
+        "checksum": "sha256:1a4e44583a767289bb0d354db93c6a9132420e13376d4fcae866d69620bb11bb",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-common",
+        "epoch": 1,
+        "version": "1.12.8",
+        "release": "14.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/dbus-common-1.12.8-14.el8.noarch.rpm",
+        "checksum": "sha256:7baac88adafdc5958fb818c7685d3c6548f6e2e585e4435ceee4a168edc3597e",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-daemon",
+        "epoch": 1,
+        "version": "1.12.8",
+        "release": "14.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/dbus-daemon-1.12.8-14.el8.ppc64le.rpm",
+        "checksum": "sha256:090563f18409c228274bb61dcf1001f63a55c1246fb2838a998cb3c5fd8c3874",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-libs",
+        "epoch": 1,
+        "version": "1.12.8",
+        "release": "14.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/dbus-libs-1.12.8-14.el8.ppc64le.rpm",
+        "checksum": "sha256:cc5f8dd4e061da3a73aa67112e24f2cc5c0ad0cd4334dc798b8834cf6259a779",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-tools",
+        "epoch": 1,
+        "version": "1.12.8",
+        "release": "14.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/dbus-tools-1.12.8-14.el8.ppc64le.rpm",
+        "checksum": "sha256:698e8ecaf71719dafacae79de05080d567b69fad3511e8b8d42b9af96a7c41db",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper",
+        "epoch": 8,
+        "version": "1.02.177",
+        "release": "6.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/device-mapper-1.02.177-6.el8.ppc64le.rpm",
+        "checksum": "sha256:441b3862f5a0fd504bbbba18d96d1b2b920fb95a79dc45a753a6a664ad285b07",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper-libs",
+        "epoch": 8,
+        "version": "1.02.177",
+        "release": "6.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/device-mapper-libs-1.02.177-6.el8.ppc64le.rpm",
+        "checksum": "sha256:a42de8ce71380b1f4e8ac5b4ce720bf565c99a0b09ef983c0550a91a467bc155",
+        "check_gpg": true
+      },
+      {
+        "name": "diffutils",
+        "epoch": 0,
+        "version": "3.6",
+        "release": "6.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/diffutils-3.6-6.el8.ppc64le.rpm",
+        "checksum": "sha256:4f92835a6e4ee4276df49019e068d1871b75821f52b405c699bd9f199df58b80",
+        "check_gpg": true
+      },
+      {
+        "name": "dracut",
+        "epoch": 0,
+        "version": "049",
+        "release": "188.git20210802.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/dracut-049-188.git20210802.el8.ppc64le.rpm",
+        "checksum": "sha256:881b28a3a37d114bc3f046605b24663560009b13a507217e007643f5682efdd5",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-debuginfod-client",
+        "epoch": 0,
+        "version": "0.185",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/elfutils-debuginfod-client-0.185-1.el8.ppc64le.rpm",
+        "checksum": "sha256:f4eca686b314edb06d3fe1c526f573c7248c811af70cba76132cdc9c541cadc1",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-default-yama-scope",
+        "epoch": 0,
+        "version": "0.185",
+        "release": "1.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/elfutils-default-yama-scope-0.185-1.el8.noarch.rpm",
+        "checksum": "sha256:30ceeb5a6cadaeccdbde088bfb52ba88190fa530c11f4a2aafd62b4b4ad6b404",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-libelf",
+        "epoch": 0,
+        "version": "0.185",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/elfutils-libelf-0.185-1.el8.ppc64le.rpm",
+        "checksum": "sha256:e87acf226a9511b3a5f83e7fed9c5c20addbbdae47ab67c614404a9392b77e50",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-libs",
+        "epoch": 0,
+        "version": "0.185",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/elfutils-libs-0.185-1.el8.ppc64le.rpm",
+        "checksum": "sha256:d150e53fa73c3786da9e4f6e23d374100b0dd2923485d4a08e9a56ac2786cf83",
+        "check_gpg": true
+      },
+      {
+        "name": "expat",
+        "epoch": 0,
+        "version": "2.2.5",
+        "release": "4.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/expat-2.2.5-4.el8.ppc64le.rpm",
+        "checksum": "sha256:88be5116908aa5013f540c767f6811774342780bb72d3ec197b3429bfb2f9862",
+        "check_gpg": true
+      },
+      {
+        "name": "file",
+        "epoch": 0,
+        "version": "5.33",
+        "release": "20.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/file-5.33-20.el8.ppc64le.rpm",
+        "checksum": "sha256:e156e6fa9ef6a483f8505ce0eeadbcab12b887c4996233ce5d6258076f6bce50",
+        "check_gpg": true
+      },
+      {
+        "name": "file-libs",
+        "epoch": 0,
+        "version": "5.33",
+        "release": "20.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/file-libs-5.33-20.el8.ppc64le.rpm",
+        "checksum": "sha256:e65f7d7c8def6b168e013914bc0d1137aed65c3010e9796df3b823854472f3e1",
+        "check_gpg": true
+      },
+      {
+        "name": "filesystem",
+        "epoch": 0,
+        "version": "3.8",
+        "release": "6.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/filesystem-3.8-6.el8.ppc64le.rpm",
+        "checksum": "sha256:a49b922f117b9bfb0b07e9848151f8a2948345328ebc534cd28ac187d7ed3f94",
+        "check_gpg": true
+      },
+      {
+        "name": "findutils",
+        "epoch": 1,
+        "version": "4.6.0",
+        "release": "20.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/findutils-4.6.0-20.el8.ppc64le.rpm",
+        "checksum": "sha256:caa0bd6617a8d5e535faedec5f6f3ea7c5e6da1898751f6c9c34a89a95c286ff",
+        "check_gpg": true
+      },
+      {
+        "name": "gawk",
+        "epoch": 0,
+        "version": "4.2.1",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/gawk-4.2.1-2.el8.ppc64le.rpm",
+        "checksum": "sha256:d807e7fb8bf24be50642a6dced954c6ea208199daab2d27c9f73d789ba82fa37",
+        "check_gpg": true
+      },
+      {
+        "name": "gdbm",
+        "epoch": 1,
+        "version": "1.18",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/gdbm-1.18-1.el8.ppc64le.rpm",
+        "checksum": "sha256:8cd6ef9902851f07cfd9682e2d6873648690f0c2ec65345276b557ede042d8b9",
+        "check_gpg": true
+      },
+      {
+        "name": "gdbm-libs",
+        "epoch": 1,
+        "version": "1.18",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/gdbm-libs-1.18-1.el8.ppc64le.rpm",
+        "checksum": "sha256:d1d362fd4f8022ad05171efe40e84d15ec6c5e5f419d6099ebc8e46e7da632c1",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext",
+        "epoch": 0,
+        "version": "0.19.8.1",
+        "release": "17.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/gettext-0.19.8.1-17.el8.ppc64le.rpm",
+        "checksum": "sha256:78fd472a1c7f49b8a432788ea2dfc1119f155a394f41585b4e715d2585fc92ab",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext-libs",
+        "epoch": 0,
+        "version": "0.19.8.1",
+        "release": "17.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/gettext-libs-0.19.8.1-17.el8.ppc64le.rpm",
+        "checksum": "sha256:e392a6b41381ffad04626d092fd2af9477c72e197a74efddf987832c3bfa521f",
+        "check_gpg": true
+      },
+      {
+        "name": "glib2",
+        "epoch": 0,
+        "version": "2.56.4",
+        "release": "156.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/glib2-2.56.4-156.el8.ppc64le.rpm",
+        "checksum": "sha256:ad338b7a3f3bed96300d9ce7f0307e09d758962b8496c10fb3554bf62405d153",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc",
+        "epoch": 0,
+        "version": "2.28",
+        "release": "162.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/glibc-2.28-162.el8.ppc64le.rpm",
+        "checksum": "sha256:bfb45644212cfbbe48b05149f8d53e77d7bd02ca9fc9045cc37115101175a3a0",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-all-langpacks",
+        "epoch": 0,
+        "version": "2.28",
+        "release": "162.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/glibc-all-langpacks-2.28-162.el8.ppc64le.rpm",
+        "checksum": "sha256:fa7bef727ba8657208bb3df95916f0bc912332cb8534c695facef32ffbd72f20",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-common",
+        "epoch": 0,
+        "version": "2.28",
+        "release": "162.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/glibc-common-2.28-162.el8.ppc64le.rpm",
+        "checksum": "sha256:257e086bb52086254fa8cc95a5c4998668b4fcb5203ad3c2275c1150816acc9b",
+        "check_gpg": true
+      },
+      {
+        "name": "gmp",
+        "epoch": 1,
+        "version": "6.1.2",
+        "release": "10.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/gmp-6.1.2-10.el8.ppc64le.rpm",
+        "checksum": "sha256:af0a4287e302baa7c85655ddfe5a7049b8eaf31aff03886f4fc57c920d26d491",
+        "check_gpg": true
+      },
+      {
+        "name": "gnutls",
+        "epoch": 0,
+        "version": "3.6.16",
+        "release": "4.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/gnutls-3.6.16-4.el8.ppc64le.rpm",
+        "checksum": "sha256:51760acfb6ca87db5be7a9296d6a3d1220767956c576a26c6d46784e25db85bb",
+        "check_gpg": true
+      },
+      {
+        "name": "grep",
+        "epoch": 0,
+        "version": "3.1",
+        "release": "6.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/grep-3.1-6.el8.ppc64le.rpm",
+        "checksum": "sha256:2451a475f248a4c66e64d149fefa8bfc195fcd7b3f369bae221a94f8ce4c2d67",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-common",
+        "epoch": 1,
+        "version": "2.02",
+        "release": "99.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/grub2-common-2.02-99.el8.noarch.rpm",
+        "checksum": "sha256:4a08d5264e865548e65d31886c91b659b33a2c2ba39fd115b00af3ea0bc91a83",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-tools",
+        "epoch": 1,
+        "version": "2.02",
+        "release": "99.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/grub2-tools-2.02-99.el8.ppc64le.rpm",
+        "checksum": "sha256:78b2b9cbf041d4461daf7ac11a24d1e79a9c57f47aa265dba4d09067efe3d96b",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-tools-minimal",
+        "epoch": 1,
+        "version": "2.02",
+        "release": "99.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/grub2-tools-minimal-2.02-99.el8.ppc64le.rpm",
+        "checksum": "sha256:fb276cc0ebc6bd27d344f7e0811f26cb3f0e59da09182489095724bdf2a075f8",
+        "check_gpg": true
+      },
+      {
+        "name": "grubby",
+        "epoch": 0,
+        "version": "8.40",
+        "release": "41.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/grubby-8.40-41.el8.ppc64le.rpm",
+        "checksum": "sha256:5a0927d231fbafa8b865591922fc07d39d9b4b263a1e9c0bbef691282f706cd0",
+        "check_gpg": true
+      },
+      {
+        "name": "gzip",
+        "epoch": 0,
+        "version": "1.9",
+        "release": "12.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/gzip-1.9-12.el8.ppc64le.rpm",
+        "checksum": "sha256:e1e28504928648404a3b652440091eba010cd99221183ef78601cbd152261d91",
+        "check_gpg": true
+      },
+      {
+        "name": "hardlink",
+        "epoch": 1,
+        "version": "1.3",
+        "release": "6.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/hardlink-1.3-6.el8.ppc64le.rpm",
+        "checksum": "sha256:42bb566be1936bdb40937f9c0a96c4acc93057379385f1807cba18f60443d3e4",
+        "check_gpg": true
+      },
+      {
+        "name": "info",
+        "epoch": 0,
+        "version": "6.5",
+        "release": "6.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/info-6.5-6.el8.ppc64le.rpm",
+        "checksum": "sha256:6d1ac29b3a38408f6d238d6718384e05be7346789c6200b354335b0e0c9c77df",
+        "check_gpg": true
+      },
+      {
+        "name": "json-c",
+        "epoch": 0,
+        "version": "0.13.1",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/json-c-0.13.1-2.el8.ppc64le.rpm",
+        "checksum": "sha256:331b91a0928c05618c7fed3e12bbe9ecb9e4619d08c7e85d3de344a08d2f0f1a",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd",
+        "epoch": 0,
+        "version": "2.0.4",
+        "release": "10.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/kbd-2.0.4-10.el8.ppc64le.rpm",
+        "checksum": "sha256:49c7c718cb4e2b6f0effd0dec4f4cb4e109d260c192b2b329a58a1da9a24ad1d",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd-legacy",
+        "epoch": 0,
+        "version": "2.0.4",
+        "release": "10.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/kbd-legacy-2.0.4-10.el8.noarch.rpm",
+        "checksum": "sha256:a3ef96219165bfc64d4f5d50f51fbd43e803c500619240ffe4db1f9f8e337f83",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd-misc",
+        "epoch": 0,
+        "version": "2.0.4",
+        "release": "10.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/kbd-misc-2.0.4-10.el8.noarch.rpm",
+        "checksum": "sha256:ef86061338fa321c959cadc75ecbdfd405eebaa1042eec9d9c737d4d9d92568f",
+        "check_gpg": true
+      },
+      {
+        "name": "kernel",
+        "epoch": 0,
+        "version": "4.18.0",
+        "release": "331.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/kernel-4.18.0-331.el8.ppc64le.rpm",
+        "checksum": "sha256:7bb5051dee5f6633a02cf5a3285dd86890cc6521e497526a8149dc5c5ebad062",
+        "check_gpg": true
+      },
+      {
+        "name": "kernel-core",
+        "epoch": 0,
+        "version": "4.18.0",
+        "release": "331.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/kernel-core-4.18.0-331.el8.ppc64le.rpm",
+        "checksum": "sha256:4aca3cee9de1a4cd7ac56a12550f286894a215cac593c18857278f7b0e48f328",
+        "check_gpg": true
+      },
+      {
+        "name": "kernel-modules",
+        "epoch": 0,
+        "version": "4.18.0",
+        "release": "331.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/kernel-modules-4.18.0-331.el8.ppc64le.rpm",
+        "checksum": "sha256:1d6551bce8f8a1e53682fafe4f67fa830c333f0b37db7acbeaca0095b5ce870b",
+        "check_gpg": true
+      },
+      {
+        "name": "keyutils-libs",
+        "epoch": 0,
+        "version": "1.5.10",
+        "release": "9.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/keyutils-libs-1.5.10-9.el8.ppc64le.rpm",
+        "checksum": "sha256:6fe1188081e441595ce29ebed4d1985e5890815158244f69f092ee930656f755",
+        "check_gpg": true
+      },
+      {
+        "name": "kmod",
+        "epoch": 0,
+        "version": "25",
+        "release": "18.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/kmod-25-18.el8.ppc64le.rpm",
+        "checksum": "sha256:a80c1d6d32db7ce8fdd58bb4f3f488b74e94261a38512dc8a15179ae33697e63",
+        "check_gpg": true
+      },
+      {
+        "name": "kmod-libs",
+        "epoch": 0,
+        "version": "25",
+        "release": "18.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/kmod-libs-25-18.el8.ppc64le.rpm",
+        "checksum": "sha256:b437a08d4670ef440ba6dbaae4ccb39f989f0c2a3d280ea66d6fd9532a313286",
+        "check_gpg": true
+      },
+      {
+        "name": "kpartx",
+        "epoch": 0,
+        "version": "0.8.4",
+        "release": "17.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/kpartx-0.8.4-17.el8.ppc64le.rpm",
+        "checksum": "sha256:230731b577f8d29e7e8e8fd6d1ea02702fb4364fcc7034d838ccddc4d66da8c3",
+        "check_gpg": true
+      },
+      {
+        "name": "krb5-libs",
+        "epoch": 0,
+        "version": "1.18.2",
+        "release": "13.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/krb5-libs-1.18.2-13.el8.ppc64le.rpm",
+        "checksum": "sha256:54f59ddb56e89a5330373e07ea05934fc58360eb7480615ede2a3ed6982e1eef",
+        "check_gpg": true
+      },
+      {
+        "name": "libacl",
+        "epoch": 0,
+        "version": "2.2.53",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libacl-2.2.53-1.el8.ppc64le.rpm",
+        "checksum": "sha256:ff1580bd4ec5841d4937b383917fa30f318b4f419b8067a77468eb4a9630ba10",
+        "check_gpg": true
+      },
+      {
+        "name": "libarchive",
+        "epoch": 0,
+        "version": "3.3.3",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libarchive-3.3.3-1.el8.ppc64le.rpm",
+        "checksum": "sha256:df40cada982b04336fe8b250b4fdd576ddd03a014bb519a69b34640369bef661",
+        "check_gpg": true
+      },
+      {
+        "name": "libattr",
+        "epoch": 0,
+        "version": "2.4.48",
+        "release": "3.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libattr-2.4.48-3.el8.ppc64le.rpm",
+        "checksum": "sha256:43bfc890caf7855f2fb55c24474b58cd5c8c7b51e4db4f40d1f302fffd31985b",
+        "check_gpg": true
+      },
+      {
+        "name": "libblkid",
+        "epoch": 0,
+        "version": "2.32.1",
+        "release": "28.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libblkid-2.32.1-28.el8.ppc64le.rpm",
+        "checksum": "sha256:30ae4489980021a727f247d48b4d74d4c6c7667d00bd1a670f045ea24a885541",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap",
+        "epoch": 0,
+        "version": "2.26",
+        "release": "4.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libcap-2.26-4.el8.ppc64le.rpm",
+        "checksum": "sha256:77e4cfbc823e3764308822ccf03b257861f9360f3b948829f1d73148b321b00e",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap-ng",
+        "epoch": 0,
+        "version": "0.7.11",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libcap-ng-0.7.11-1.el8.ppc64le.rpm",
+        "checksum": "sha256:9b69a221cf9395a110849bb428bb1cfe9fb489322df0fa6017f5978a827ee0e9",
+        "check_gpg": true
+      },
+      {
+        "name": "libcom_err",
+        "epoch": 0,
+        "version": "1.45.6",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libcom_err-1.45.6-2.el8.ppc64le.rpm",
+        "checksum": "sha256:e0a7b9f3b56b4737f5711dc6b03f256fbf2488656b8874acabb494b58ba0c1c1",
+        "check_gpg": true
+      },
+      {
+        "name": "libcroco",
+        "epoch": 0,
+        "version": "0.6.12",
+        "release": "4.el8_2.1",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libcroco-0.6.12-4.el8_2.1.ppc64le.rpm",
+        "checksum": "sha256:194dbe332ccdb33d58f040da07667257e176975f6b2f17343bbf33fb99deb097",
+        "check_gpg": true
+      },
+      {
+        "name": "libcurl",
+        "epoch": 0,
+        "version": "7.61.1",
+        "release": "18.el8_4.1",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libcurl-7.61.1-18.el8_4.1.ppc64le.rpm",
+        "checksum": "sha256:e21a84107568047432e474e08da24aea2340409d57ea8cf170182927dc76de12",
+        "check_gpg": true
+      },
+      {
+        "name": "libdb",
+        "epoch": 0,
+        "version": "5.3.28",
+        "release": "40.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libdb-5.3.28-40.el8.ppc64le.rpm",
+        "checksum": "sha256:b83a0199c3d471151f07f6de626a1a4a362dd6aa29d84cf1c0ada2c966ce29c9",
+        "check_gpg": true
+      },
+      {
+        "name": "libdb-utils",
+        "epoch": 0,
+        "version": "5.3.28",
+        "release": "40.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libdb-utils-5.3.28-40.el8.ppc64le.rpm",
+        "checksum": "sha256:709ea71f36495ac2ac89d72d2eb603b6aa55b2c1a70633f23514dd897936f02b",
+        "check_gpg": true
+      },
+      {
+        "name": "libfdisk",
+        "epoch": 0,
+        "version": "2.32.1",
+        "release": "28.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libfdisk-2.32.1-28.el8.ppc64le.rpm",
+        "checksum": "sha256:0afac6f4f9ed1c59510675d87da45c7966c0f7aae6e8dd056961aceed8c4fe0a",
+        "check_gpg": true
+      },
+      {
+        "name": "libffi",
+        "epoch": 0,
+        "version": "3.1",
+        "release": "22.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libffi-3.1-22.el8.ppc64le.rpm",
+        "checksum": "sha256:12696f5638ad2068c5c8940495d15c3bb1c57990000dbda7428b008e9e63ab5b",
+        "check_gpg": true
+      },
+      {
+        "name": "libgcc",
+        "epoch": 0,
+        "version": "8.5.0",
+        "release": "3.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libgcc-8.5.0-3.el8.ppc64le.rpm",
+        "checksum": "sha256:f3d9ccb762146dc97f2d201d979fbb0e9171d1203fb985f3ef48b5c2a176c2a9",
+        "check_gpg": true
+      },
+      {
+        "name": "libgcrypt",
+        "epoch": 0,
+        "version": "1.8.5",
+        "release": "6.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libgcrypt-1.8.5-6.el8.ppc64le.rpm",
+        "checksum": "sha256:c5a60ffb80cd1f9b90c797f1d1ac80e5536eb32a5b276871445e7279ac701c5f",
+        "check_gpg": true
+      },
+      {
+        "name": "libgomp",
+        "epoch": 0,
+        "version": "8.5.0",
+        "release": "3.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libgomp-8.5.0-3.el8.ppc64le.rpm",
+        "checksum": "sha256:0515afdac097ad54cf4b24e0644f0789cab5535a54107aa44940ffd991a6cef3",
+        "check_gpg": true
+      },
+      {
+        "name": "libgpg-error",
+        "epoch": 0,
+        "version": "1.31",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libgpg-error-1.31-1.el8.ppc64le.rpm",
+        "checksum": "sha256:020abac486839c7be29fae37a686dc7749398c333cb8ba94b3390b386ffcbff7",
+        "check_gpg": true
+      },
+      {
+        "name": "libidn2",
+        "epoch": 0,
+        "version": "2.2.0",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libidn2-2.2.0-1.el8.ppc64le.rpm",
+        "checksum": "sha256:31d924d1540dd4e927a4c3aa936cec4bfb54ed302d3e8acc1be8b52dd5deb10c",
+        "check_gpg": true
+      },
+      {
+        "name": "libkcapi",
+        "epoch": 0,
+        "version": "1.2.0",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libkcapi-1.2.0-2.el8.ppc64le.rpm",
+        "checksum": "sha256:fd6e1803ff367036da5b52b2183e1408691b379cc1320971bb664737507f89a4",
+        "check_gpg": true
+      },
+      {
+        "name": "libkcapi-hmaccalc",
+        "epoch": 0,
+        "version": "1.2.0",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libkcapi-hmaccalc-1.2.0-2.el8.ppc64le.rpm",
+        "checksum": "sha256:6b312faed4a0508da2f15d3f31a6daccfc0ec6621e5fb7b20956027dce5fa395",
+        "check_gpg": true
+      },
+      {
+        "name": "libmount",
+        "epoch": 0,
+        "version": "2.32.1",
+        "release": "28.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libmount-2.32.1-28.el8.ppc64le.rpm",
+        "checksum": "sha256:4e497225fe36781735cc92c0886f6858b19d4557ed9ecafe1247b8233c206075",
+        "check_gpg": true
+      },
+      {
+        "name": "libnghttp2",
+        "epoch": 0,
+        "version": "1.33.0",
+        "release": "3.el8_2.1",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libnghttp2-1.33.0-3.el8_2.1.ppc64le.rpm",
+        "checksum": "sha256:d3a4f367a9c5ba936b1bb5480db390889a303e5ec8ff34bb4274c1d840a1784d",
+        "check_gpg": true
+      },
+      {
+        "name": "libnsl2",
+        "epoch": 0,
+        "version": "1.2.0",
+        "release": "2.20180605git4a062cf.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libnsl2-1.2.0-2.20180605git4a062cf.el8.ppc64le.rpm",
+        "checksum": "sha256:8d7777da3f54f965cf3058cabf987c01b93a1dd041e8359eb7822eba57d8c8df",
+        "check_gpg": true
+      },
+      {
+        "name": "libpsl",
+        "epoch": 0,
+        "version": "0.20.2",
+        "release": "6.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libpsl-0.20.2-6.el8.ppc64le.rpm",
+        "checksum": "sha256:9b8a8a843fe9a972f6433e11b95b5a8d1d2971ed40fe1acda6807e34f0773c62",
+        "check_gpg": true
+      },
+      {
+        "name": "libpwquality",
+        "epoch": 0,
+        "version": "1.4.4",
+        "release": "3.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libpwquality-1.4.4-3.el8.ppc64le.rpm",
+        "checksum": "sha256:1aa321c66a3661e78d938b805e5c311d519f04bf3496545ffdacc7c152bc9b21",
+        "check_gpg": true
+      },
+      {
+        "name": "librtas",
+        "epoch": 0,
+        "version": "2.0.2",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/librtas-2.0.2-1.el8.ppc64le.rpm",
+        "checksum": "sha256:98c28a91d41f634edb8c1f001dbc45c0de534332d059a2e8feff448fb7235c49",
+        "check_gpg": true
+      },
+      {
+        "name": "libseccomp",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libseccomp-2.5.1-1.el8.ppc64le.rpm",
+        "checksum": "sha256:b4a1ac1ff5cd22a5dab6c96dfc2dbd7cd6ba750691ad5c53a97a1f088fc42abc",
+        "check_gpg": true
+      },
+      {
+        "name": "libselinux",
+        "epoch": 0,
+        "version": "2.9",
+        "release": "5.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libselinux-2.9-5.el8.ppc64le.rpm",
+        "checksum": "sha256:56c866bcff69fd60b630841ff990296b26c2f45d8c6054311b5c476bc67466ac",
+        "check_gpg": true
+      },
+      {
+        "name": "libsemanage",
+        "epoch": 0,
+        "version": "2.9",
+        "release": "6.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libsemanage-2.9-6.el8.ppc64le.rpm",
+        "checksum": "sha256:95103f7c339aec4b485b7f569aa8a5e1a54286b3d2acde427328c49e4d8d80d1",
+        "check_gpg": true
+      },
+      {
+        "name": "libsepol",
+        "epoch": 0,
+        "version": "2.9",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libsepol-2.9-2.el8.ppc64le.rpm",
+        "checksum": "sha256:adc56041458e556df5663e7da264e151c24aaf1c2a94e49df9790ba191ea1b37",
+        "check_gpg": true
+      },
+      {
+        "name": "libsigsegv",
+        "epoch": 0,
+        "version": "2.11",
+        "release": "5.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libsigsegv-2.11-5.el8.ppc64le.rpm",
+        "checksum": "sha256:0f57b051654b6d75789b437dafd7040b6c90daee17827be24352c0f11a74bba7",
+        "check_gpg": true
+      },
+      {
+        "name": "libsmartcols",
+        "epoch": 0,
+        "version": "2.32.1",
+        "release": "28.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libsmartcols-2.32.1-28.el8.ppc64le.rpm",
+        "checksum": "sha256:1b5136570cefb8273dd5affc73c1456cf239cc8b18be72d6c4d09794af7f3352",
+        "check_gpg": true
+      },
+      {
+        "name": "libssh",
+        "epoch": 0,
+        "version": "0.9.4",
+        "release": "3.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libssh-0.9.4-3.el8.ppc64le.rpm",
+        "checksum": "sha256:2dbfe3cb37c18b39393870baa77f3bbd42be53517abffdd990b13ed70ee3dd3e",
+        "check_gpg": true
+      },
+      {
+        "name": "libssh-config",
+        "epoch": 0,
+        "version": "0.9.4",
+        "release": "3.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libssh-config-0.9.4-3.el8.noarch.rpm",
+        "checksum": "sha256:f5bcb82a732c02d6f31bbf156887049883c76cedc9c6a11b049358a74f4d45d0",
+        "check_gpg": true
+      },
+      {
+        "name": "libstdc++",
+        "epoch": 0,
+        "version": "8.5.0",
+        "release": "3.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libstdc++-8.5.0-3.el8.ppc64le.rpm",
+        "checksum": "sha256:32ebba6472cdc331bd3366ca996ad3039b3a1b41c61a849b88074e1b722cad2c",
+        "check_gpg": true
+      },
+      {
+        "name": "libtasn1",
+        "epoch": 0,
+        "version": "4.13",
+        "release": "3.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libtasn1-4.13-3.el8.ppc64le.rpm",
+        "checksum": "sha256:75e9ed16ace51ba04a62505aaed215bf9c722d6f4b1c33cc3e3962076c300ee8",
+        "check_gpg": true
+      },
+      {
+        "name": "libtirpc",
+        "epoch": 0,
+        "version": "1.1.4",
+        "release": "5.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libtirpc-1.1.4-5.el8.ppc64le.rpm",
+        "checksum": "sha256:d539404dafd8ad5d785ab3da6f8bd5a2bf5dff9e01be0ff1bc1d251786dda25c",
+        "check_gpg": true
+      },
+      {
+        "name": "libunistring",
+        "epoch": 0,
+        "version": "0.9.9",
+        "release": "3.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libunistring-0.9.9-3.el8.ppc64le.rpm",
+        "checksum": "sha256:bff39fef1fc01564156123fcade75b4bc50402a2971a031d9a426c7014b1e681",
+        "check_gpg": true
+      },
+      {
+        "name": "libutempter",
+        "epoch": 0,
+        "version": "1.1.6",
+        "release": "14.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libutempter-1.1.6-14.el8.ppc64le.rpm",
+        "checksum": "sha256:e217c2687212d931ad9a6a02afb20cc34f6d051786d136e337f91079c9f73d22",
+        "check_gpg": true
+      },
+      {
+        "name": "libuuid",
+        "epoch": 0,
+        "version": "2.32.1",
+        "release": "28.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libuuid-2.32.1-28.el8.ppc64le.rpm",
+        "checksum": "sha256:c1291b69a65a860069195a33cf6640df8667e960f9f030ceeea4497c47858b94",
+        "check_gpg": true
+      },
+      {
+        "name": "libverto",
+        "epoch": 0,
+        "version": "0.3.0",
+        "release": "5.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libverto-0.3.0-5.el8.ppc64le.rpm",
+        "checksum": "sha256:d8c00baf46e33f9e5f1b9e139bbea9fe0f27badb432c992b9cf8c4f7017094bf",
+        "check_gpg": true
+      },
+      {
+        "name": "libxcrypt",
+        "epoch": 0,
+        "version": "4.1.1",
+        "release": "6.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libxcrypt-4.1.1-6.el8.ppc64le.rpm",
+        "checksum": "sha256:1a968f65db066243cbd0a6e12d193ef674637f044299a15b5d6b910e91411812",
+        "check_gpg": true
+      },
+      {
+        "name": "libxml2",
+        "epoch": 0,
+        "version": "2.9.7",
+        "release": "11.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libxml2-2.9.7-11.el8.ppc64le.rpm",
+        "checksum": "sha256:4a167fa4a7238bd94b3134173f6267b19cdebc2fde98b583344749e1f4c9bf09",
+        "check_gpg": true
+      },
+      {
+        "name": "libzstd",
+        "epoch": 0,
+        "version": "1.4.4",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libzstd-1.4.4-1.el8.ppc64le.rpm",
+        "checksum": "sha256:6bfc201a12dc7bba21069a663aa692a96c5e8920b0d94a4e355c332d7ead15ba",
+        "check_gpg": true
+      },
+      {
+        "name": "linux-firmware",
+        "epoch": 0,
+        "version": "20210702",
+        "release": "103.gitd79c2677.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/linux-firmware-20210702-103.gitd79c2677.el8.noarch.rpm",
+        "checksum": "sha256:7aeb44195a1c984aff87cf8429d2aa40f6947b0a47d3603e1ca5c3cf8d284459",
+        "check_gpg": true
+      },
+      {
+        "name": "lua-libs",
+        "epoch": 0,
+        "version": "5.3.4",
+        "release": "11.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/lua-libs-5.3.4-11.el8.ppc64le.rpm",
+        "checksum": "sha256:393e7bb9f93ffb3cbba620fbfeb229f2b8345454bc60ac0508f76735544ed289",
+        "check_gpg": true
+      },
+      {
+        "name": "lz4-libs",
+        "epoch": 0,
+        "version": "1.8.3",
+        "release": "3.el8_4",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/lz4-libs-1.8.3-3.el8_4.ppc64le.rpm",
+        "checksum": "sha256:f24bce642ec88622490b2f09a45fa3985da7f6511a1aae131853c4ea4c309e6b",
+        "check_gpg": true
+      },
+      {
+        "name": "memstrack",
+        "epoch": 0,
+        "version": "0.1.11",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/memstrack-0.1.11-1.el8.ppc64le.rpm",
+        "checksum": "sha256:9936485ac7111967d6962bc539de7b08807e310117adb78b11c21a5db0f0f890",
+        "check_gpg": true
+      },
+      {
+        "name": "mpfr",
+        "epoch": 0,
+        "version": "3.1.6",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/mpfr-3.1.6-1.el8.ppc64le.rpm",
+        "checksum": "sha256:0230acdbc9da4b36da812f0e585a7602eda4982c899b3b3a4c2bc9b4546d8e74",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses",
+        "epoch": 0,
+        "version": "6.1",
+        "release": "9.20180224.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/ncurses-6.1-9.20180224.el8.ppc64le.rpm",
+        "checksum": "sha256:7abf49cabbaf996afc0c2604f10ea18f8f22a903fc4ba3728a18f5892353c5c9",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses-base",
+        "epoch": 0,
+        "version": "6.1",
+        "release": "9.20180224.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/ncurses-base-6.1-9.20180224.el8.noarch.rpm",
+        "checksum": "sha256:41716536ea16798238ac89fbc3041b3f9dc80f9a64ea4b19d6e67ad2c909269a",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses-libs",
+        "epoch": 0,
+        "version": "6.1",
+        "release": "9.20180224.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/ncurses-libs-6.1-9.20180224.el8.ppc64le.rpm",
+        "checksum": "sha256:17ffe1d683dbff48f9b2ef903401e471e5e51a992bf0890632bceb94561893de",
+        "check_gpg": true
+      },
+      {
+        "name": "nettle",
+        "epoch": 0,
+        "version": "3.4.1",
+        "release": "7.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/nettle-3.4.1-7.el8.ppc64le.rpm",
+        "checksum": "sha256:8403cfc97e0e72e37639b8c54d92f1ee427e48a70d52d5260a37fa104f2df20d",
+        "check_gpg": true
+      },
+      {
+        "name": "openldap",
+        "epoch": 0,
+        "version": "2.4.46",
+        "release": "18.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/openldap-2.4.46-18.el8.ppc64le.rpm",
+        "checksum": "sha256:c24b21415b737f18fad7aeb192e60f7d323f7ba69434ecc1e78b3af0003be8dc",
+        "check_gpg": true
+      },
+      {
+        "name": "openssl",
+        "epoch": 1,
+        "version": "1.1.1k",
+        "release": "4.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/openssl-1.1.1k-4.el8.ppc64le.rpm",
+        "checksum": "sha256:c2479eb811f4d9b8624ef20119e1abdc109f639c2cf576eb945b340362d87b05",
+        "check_gpg": true
+      },
+      {
+        "name": "openssl-libs",
+        "epoch": 1,
+        "version": "1.1.1k",
+        "release": "4.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/openssl-libs-1.1.1k-4.el8.ppc64le.rpm",
+        "checksum": "sha256:46606c1ed76a4da2a9d18016aeb50f4dddf58e1b45d665c983c58f8e605bf73e",
+        "check_gpg": true
+      },
+      {
+        "name": "openssl-pkcs11",
+        "epoch": 0,
+        "version": "0.4.10",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/openssl-pkcs11-0.4.10-2.el8.ppc64le.rpm",
+        "checksum": "sha256:d87f7fa5e637442eb638bcaafdc44ca3895d91a153015ff9af6a87219f0dc372",
+        "check_gpg": true
+      },
+      {
+        "name": "os-prober",
+        "epoch": 0,
+        "version": "1.74",
+        "release": "6.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/os-prober-1.74-6.el8.ppc64le.rpm",
+        "checksum": "sha256:71c88f04921ae61a7009f9443f95c70ec3424a798429fc01e6c1432c1077aacb",
+        "check_gpg": true
+      },
+      {
+        "name": "p11-kit",
+        "epoch": 0,
+        "version": "0.23.22",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/p11-kit-0.23.22-1.el8.ppc64le.rpm",
+        "checksum": "sha256:bf994cb2e5c367d78483662c7de6e69950aaf04bc6cfdbbef4d1ef7ce153717c",
+        "check_gpg": true
+      },
+      {
+        "name": "p11-kit-trust",
+        "epoch": 0,
+        "version": "0.23.22",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/p11-kit-trust-0.23.22-1.el8.ppc64le.rpm",
+        "checksum": "sha256:b7330d40f75b8ec786e41c45a202e44f0e49ec29ddf8944120fbdb373a6c6617",
+        "check_gpg": true
+      },
+      {
+        "name": "pam",
+        "epoch": 0,
+        "version": "1.3.1",
+        "release": "15.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/pam-1.3.1-15.el8.ppc64le.rpm",
+        "checksum": "sha256:bb82b10a91493d745dc533b5de5335db650adb0c8a90548fdf5dad13569a16f4",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre",
+        "epoch": 0,
+        "version": "8.42",
+        "release": "6.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/pcre-8.42-6.el8.ppc64le.rpm",
+        "checksum": "sha256:3ed319e31a9c38e5f4e336195b5cbd253b3f8b17f93f185829f078c5ef420305",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre2",
+        "epoch": 0,
+        "version": "10.32",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/pcre2-10.32-2.el8.ppc64le.rpm",
+        "checksum": "sha256:5c46bef8c0e95e05716e9a53b77970c1378d93bcb9a800018a24f7e1763b45b9",
+        "check_gpg": true
+      },
+      {
+        "name": "pigz",
+        "epoch": 0,
+        "version": "2.4",
+        "release": "4.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/pigz-2.4-4.el8.ppc64le.rpm",
+        "checksum": "sha256:3edfdbc82f97ec12e59c80c67897fc1eeb44c3d16820f761a8f15272965ea3a1",
+        "check_gpg": true
+      },
+      {
+        "name": "platform-python",
+        "epoch": 0,
+        "version": "3.6.8",
+        "release": "39.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/platform-python-3.6.8-39.el8.ppc64le.rpm",
+        "checksum": "sha256:cdd6594a3bca71d32a5061b85457cc8148611e7f042ba6e812a1c0a2faebac92",
+        "check_gpg": true
+      },
+      {
+        "name": "platform-python-pip",
+        "epoch": 0,
+        "version": "9.0.3",
+        "release": "20.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/platform-python-pip-9.0.3-20.el8.noarch.rpm",
+        "checksum": "sha256:56650f8b8f2b01c1090d184d7d6d396f0109f8a02f915c97b081be73ea12df08",
+        "check_gpg": true
+      },
+      {
+        "name": "platform-python-setuptools",
+        "epoch": 0,
+        "version": "39.2.0",
+        "release": "6.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/platform-python-setuptools-39.2.0-6.el8.noarch.rpm",
+        "checksum": "sha256:946ba273a3a3b6fdf140f3c03112918c0a556a5871c477f5dbbb98600e6ca557",
+        "check_gpg": true
+      },
+      {
+        "name": "popt",
+        "epoch": 0,
+        "version": "1.18",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/popt-1.18-1.el8.ppc64le.rpm",
+        "checksum": "sha256:3b00ac82c31b447e306fcb47b4469fdc4e6d87385b42358c2e76badb51b074a3",
+        "check_gpg": true
+      },
+      {
+        "name": "procps-ng",
+        "epoch": 0,
+        "version": "3.3.15",
+        "release": "6.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/procps-ng-3.3.15-6.el8.ppc64le.rpm",
+        "checksum": "sha256:1cfa672c25cb5849bb2aa652e045e4a4a272c025befb1fe5e58cb32823faa30d",
+        "check_gpg": true
+      },
+      {
+        "name": "publicsuffix-list-dafsa",
+        "epoch": 0,
+        "version": "20180723",
+        "release": "1.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/publicsuffix-list-dafsa-20180723-1.el8.noarch.rpm",
+        "checksum": "sha256:65ecf1e479dc2b2f7f09c2e86d7457043b3470b3eab3c4ee8909b50b0a669fc2",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libs",
+        "epoch": 0,
+        "version": "3.6.8",
+        "release": "39.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-libs-3.6.8-39.el8.ppc64le.rpm",
+        "checksum": "sha256:405bda98fe97c1a5cf70511ae2d167256b25dd8721b88899465e9847525e2068",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-pip-wheel",
+        "epoch": 0,
+        "version": "9.0.3",
+        "release": "20.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-pip-wheel-9.0.3-20.el8.noarch.rpm",
+        "checksum": "sha256:6c9dfb73e199975275633f05d31388cd61c5a77dec5678db958b4e6624eb21ba",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-setuptools-wheel",
+        "epoch": 0,
+        "version": "39.2.0",
+        "release": "6.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-setuptools-wheel-39.2.0-6.el8.noarch.rpm",
+        "checksum": "sha256:b19bd4f106ce301ee21c860183cc1c2ef9c09bdf495059bdf16e8d8ccc71bbe8",
+        "check_gpg": true
+      },
+      {
+        "name": "readline",
+        "epoch": 0,
+        "version": "7.0",
+        "release": "10.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/readline-7.0-10.el8.ppc64le.rpm",
+        "checksum": "sha256:0320663709136d07690fe299903700cc1dcc526d574fe8b952a01e1d24024ae4",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm",
+        "epoch": 0,
+        "version": "4.14.3",
+        "release": "15.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/rpm-4.14.3-15.el8.ppc64le.rpm",
+        "checksum": "sha256:4fae16ca54207cb952e3904b8eb8cc424f3f056f400e5e802ab1a9ef3e575834",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-libs",
+        "epoch": 0,
+        "version": "4.14.3",
+        "release": "15.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/rpm-libs-4.14.3-15.el8.ppc64le.rpm",
+        "checksum": "sha256:4e22015880d16cb7148d70895a2361f4fa05804f0391386e0e50554e6fd868b0",
+        "check_gpg": true
+      },
+      {
+        "name": "sed",
+        "epoch": 0,
+        "version": "4.5",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/sed-4.5-2.el8.ppc64le.rpm",
+        "checksum": "sha256:dbde46224833f804d8b92212fa3618ea53d0e0cb84ff07132a5ba36c1bc0b9df",
+        "check_gpg": true
+      },
+      {
+        "name": "setup",
+        "epoch": 0,
+        "version": "2.12.2",
+        "release": "6.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/setup-2.12.2-6.el8.noarch.rpm",
+        "checksum": "sha256:9e540fe1fcf866ba1e738e012eef5459d34cca30385df73973e6fc7c6eadb55f",
+        "check_gpg": true
+      },
+      {
+        "name": "shadow-utils",
+        "epoch": 2,
+        "version": "4.6",
+        "release": "14.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/shadow-utils-4.6-14.el8.ppc64le.rpm",
+        "checksum": "sha256:e1153055b6ea57ee81e6fb41b03023279059513d0fec728517ae0805186a5118",
+        "check_gpg": true
+      },
+      {
+        "name": "shared-mime-info",
+        "epoch": 0,
+        "version": "1.9",
+        "release": "3.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/shared-mime-info-1.9-3.el8.ppc64le.rpm",
+        "checksum": "sha256:f97b5915b3f75d2878104c198f205841813712103f1b3657d71d2c8d079cc947",
+        "check_gpg": true
+      },
+      {
+        "name": "sqlite-libs",
+        "epoch": 0,
+        "version": "3.26.0",
+        "release": "15.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/sqlite-libs-3.26.0-15.el8.ppc64le.rpm",
+        "checksum": "sha256:31277c01ac529cc1c6a55fd87d6ce4dbb20290575d4e1e89cd40600eac9f3405",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd",
+        "epoch": 0,
+        "version": "239",
+        "release": "49.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/systemd-239-49.el8.ppc64le.rpm",
+        "checksum": "sha256:8a501b9d8016eee68ce62a93a65842b15c8a57192b9f8189ebc85a11f2f47f9e",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-libs",
+        "epoch": 0,
+        "version": "239",
+        "release": "49.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/systemd-libs-239-49.el8.ppc64le.rpm",
+        "checksum": "sha256:3d175382237a94330d72af67ad2c41535dee7eade3e42178b86d2dc87478d030",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-pam",
+        "epoch": 0,
+        "version": "239",
+        "release": "49.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/systemd-pam-239-49.el8.ppc64le.rpm",
+        "checksum": "sha256:e95bb05fa5defeb16dd0e0957de676374b22b9daaf405273e636d1ce91001574",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-udev",
+        "epoch": 0,
+        "version": "239",
+        "release": "49.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/systemd-udev-239-49.el8.ppc64le.rpm",
+        "checksum": "sha256:3898e2ac4e04e80373bc7fe4092b26d502d4705177719117e25c083d44a9a150",
+        "check_gpg": true
+      },
+      {
+        "name": "trousers",
+        "epoch": 0,
+        "version": "0.3.15",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/trousers-0.3.15-1.el8.ppc64le.rpm",
+        "checksum": "sha256:4164089bf1754c0ef18ae051e047f11299907204839ad4b7978f146a543a2e91",
+        "check_gpg": true
+      },
+      {
+        "name": "trousers-lib",
+        "epoch": 0,
+        "version": "0.3.15",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/trousers-lib-0.3.15-1.el8.ppc64le.rpm",
+        "checksum": "sha256:09096bc32e37443417cd625364df32674f9d5ff4ddbeb175e6d60637ed3d573f",
+        "check_gpg": true
+      },
+      {
+        "name": "tzdata",
+        "epoch": 0,
+        "version": "2021a",
+        "release": "1.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/tzdata-2021a-1.el8.noarch.rpm",
+        "checksum": "sha256:44999c555a6e4bb6cf5e6f6a79819e76912d036732cb50efaeefc20a180dd839",
+        "check_gpg": true
+      },
+      {
+        "name": "util-linux",
+        "epoch": 0,
+        "version": "2.32.1",
+        "release": "28.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/util-linux-2.32.1-28.el8.ppc64le.rpm",
+        "checksum": "sha256:ce954d3900cb547aea14df6ad5f310ea96bb5e83a155b93e2e64b2c13b686193",
+        "check_gpg": true
+      },
+      {
+        "name": "which",
+        "epoch": 0,
+        "version": "2.21",
+        "release": "16.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/which-2.21-16.el8.ppc64le.rpm",
+        "checksum": "sha256:15cd74b4ad9d82417072fe867f086d68667afd4291b710b6c7feef985c492990",
+        "check_gpg": true
+      },
+      {
+        "name": "xz",
+        "epoch": 0,
+        "version": "5.2.4",
+        "release": "3.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/xz-5.2.4-3.el8.ppc64le.rpm",
+        "checksum": "sha256:cd8b0adfc4d2467a61ab2aa2b3e617bbd2a2592176da249365eef014faef827c",
+        "check_gpg": true
+      },
+      {
+        "name": "xz-libs",
+        "epoch": 0,
+        "version": "5.2.4",
+        "release": "3.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/xz-libs-5.2.4-3.el8.ppc64le.rpm",
+        "checksum": "sha256:a4577841148e7e2bf481447ae141eff319007e70a24295a22787bbfaecf4c4fe",
+        "check_gpg": true
+      },
+      {
+        "name": "zlib",
+        "epoch": 0,
+        "version": "1.2.11",
+        "release": "17.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/zlib-1.2.11-17.el8.ppc64le.rpm",
+        "checksum": "sha256:33a92d88496e8aa410976f073e324f761b2ae02a94c20c0f291072df84f648be",
+        "check_gpg": true
+      },
+      {
+        "name": "libxkbcommon",
+        "epoch": 0,
+        "version": "0.9.1",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/libxkbcommon-0.9.1-1.el8.ppc64le.rpm",
+        "checksum": "sha256:b5bd11b47b5b690dc667dc486941331d7cd3aaa4f0e5c4d638ec7b294bcc5012",
+        "check_gpg": true
+      },
+      {
+        "name": "xkeyboard-config",
+        "epoch": 0,
+        "version": "2.28",
+        "release": "1.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/xkeyboard-config-2.28-1.el8.noarch.rpm",
+        "checksum": "sha256:a2aeabb3962859069a78acc288bc3bffb35485428e162caafec8134f5ce6ca67",
+        "check_gpg": true
+      }
+    ],
+    "build": [
+      {
+        "name": "acl",
+        "epoch": 0,
+        "version": "2.2.53",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/acl-2.2.53-1.el8.ppc64le.rpm",
+        "checksum": "sha256:2c1baefd0f802507d9741da8da54f6eae42b04967f9d433d7f9e0f124434c70d",
+        "check_gpg": true
+      },
+      {
+        "name": "audit-libs",
+        "epoch": 0,
+        "version": "3.0",
+        "release": "0.17.20191104git1c2f876.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/audit-libs-3.0-0.17.20191104git1c2f876.el8.ppc64le.rpm",
+        "checksum": "sha256:be49b69bc5de947ee2151f397993a691a57bc53952058c32cde0fca674da7d8c",
+        "check_gpg": true
+      },
+      {
+        "name": "basesystem",
+        "epoch": 0,
+        "version": "11",
+        "release": "5.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/basesystem-11-5.el8.noarch.rpm",
+        "checksum": "sha256:48226934763e4c412c1eb65df314e6879720b4b1ebcb3d07c126c9526639cb68",
+        "check_gpg": true
+      },
+      {
+        "name": "bash",
+        "epoch": 0,
+        "version": "4.4.20",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/bash-4.4.20-2.el8.ppc64le.rpm",
+        "checksum": "sha256:3a438b53e8377eccf90cac0fd42ed2b513fc869bfb7b96e3d2a4f6984a287f90",
+        "check_gpg": true
+      },
+      {
+        "name": "brotli",
+        "epoch": 0,
+        "version": "1.0.6",
+        "release": "3.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/brotli-1.0.6-3.el8.ppc64le.rpm",
+        "checksum": "sha256:8729b157f0925feccdaef8aacd91c6aebe0109e621675bcc15e1830673b0e19d",
+        "check_gpg": true
+      },
+      {
+        "name": "bzip2-libs",
+        "epoch": 0,
+        "version": "1.0.6",
+        "release": "26.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/bzip2-libs-1.0.6-26.el8.ppc64le.rpm",
+        "checksum": "sha256:56c3d429ea949467dc0bca882646cf40a58fb6f27750f5664ff2919f5d38ada5",
+        "check_gpg": true
+      },
+      {
+        "name": "ca-certificates",
+        "epoch": 0,
+        "version": "2021.2.50",
+        "release": "82.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/ca-certificates-2021.2.50-82.el8.noarch.rpm",
+        "checksum": "sha256:1fad1d1f8b56e6967863aeb60f5fa3615e6a35b0f6532d8a23066e6823b50860",
+        "check_gpg": true
+      },
+      {
+        "name": "centos-gpg-keys",
+        "epoch": 1,
+        "version": "8",
+        "release": "2.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/centos-gpg-keys-8-2.el8.noarch.rpm",
+        "checksum": "sha256:842ff55b80ac9a5c3357bf52646a5761a4c4786bb3e64b56d8fa5d8fe34ef8bb",
+        "check_gpg": true
+      },
+      {
+        "name": "centos-stream-release",
+        "epoch": 0,
+        "version": "8.5",
+        "release": "3.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/centos-stream-release-8.5-3.el8.noarch.rpm",
+        "checksum": "sha256:15b17b95cf9cb9fb64e0c8e56110836bdcaf70de81b8cbdb60e181fc90456e06",
+        "check_gpg": true
+      },
+      {
+        "name": "centos-stream-repos",
+        "epoch": 0,
+        "version": "8",
+        "release": "2.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/centos-stream-repos-8-2.el8.noarch.rpm",
+        "checksum": "sha256:a82958266d292f4725fc1981ea57a861b7fc7feeb7a9551d0b61b98ca51a5662",
+        "check_gpg": true
+      },
+      {
+        "name": "chkconfig",
+        "epoch": 0,
+        "version": "1.19.1",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/chkconfig-1.19.1-1.el8.ppc64le.rpm",
+        "checksum": "sha256:eee92733e8989029929d5cb1f673b15fdb814dac32e148d5bc02378b44c8699a",
+        "check_gpg": true
+      },
+      {
+        "name": "coreutils",
+        "epoch": 0,
+        "version": "8.30",
+        "release": "12.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/coreutils-8.30-12.el8.ppc64le.rpm",
+        "checksum": "sha256:ff8b51c6a8bacc5ef6b5da0f049d170ab1c1ecebad50ded3c04ed384eca9a2c0",
+        "check_gpg": true
+      },
+      {
+        "name": "coreutils-common",
+        "epoch": 0,
+        "version": "8.30",
+        "release": "12.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/coreutils-common-8.30-12.el8.ppc64le.rpm",
+        "checksum": "sha256:383a5e6bb9e94de53baaf5c7493cd50a68c893c6a30acfbe28407d33bb133efc",
+        "check_gpg": true
+      },
+      {
+        "name": "cpio",
+        "epoch": 0,
+        "version": "2.12",
+        "release": "10.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/cpio-2.12-10.el8.ppc64le.rpm",
+        "checksum": "sha256:19061d12407c0c4bca6abcaef01695b70dcd3967ff102dd07178a2193a280e29",
+        "check_gpg": true
+      },
+      {
+        "name": "cracklib",
+        "epoch": 0,
+        "version": "2.9.6",
+        "release": "15.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/cracklib-2.9.6-15.el8.ppc64le.rpm",
+        "checksum": "sha256:4e3e93a3d2039c2a8305030b7960bd1100d7d20705a1afb1325a4ee79478a74a",
+        "check_gpg": true
+      },
+      {
+        "name": "cracklib-dicts",
+        "epoch": 0,
+        "version": "2.9.6",
+        "release": "15.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/cracklib-dicts-2.9.6-15.el8.ppc64le.rpm",
+        "checksum": "sha256:084d79ed3d7127e6d46e9ac6e654d8ef181a156435808dc8eb32968b6c1b4946",
+        "check_gpg": true
+      },
+      {
+        "name": "crypto-policies",
+        "epoch": 0,
+        "version": "20210617",
+        "release": "1.gitc776d3e.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/crypto-policies-20210617-1.gitc776d3e.el8.noarch.rpm",
+        "checksum": "sha256:2a8f9e5119a034801904185dcbf1bc29db67e9e9b0cf5893615722d7bb33099c",
+        "check_gpg": true
+      },
+      {
+        "name": "crypto-policies-scripts",
+        "epoch": 0,
+        "version": "20210617",
+        "release": "1.gitc776d3e.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/crypto-policies-scripts-20210617-1.gitc776d3e.el8.noarch.rpm",
+        "checksum": "sha256:67f37cee02ba744dfc7957725f5ef9df229778f6a2f7afc659625b458da6167e",
+        "check_gpg": true
+      },
+      {
+        "name": "cryptsetup-libs",
+        "epoch": 0,
+        "version": "2.3.3",
+        "release": "4.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/cryptsetup-libs-2.3.3-4.el8.ppc64le.rpm",
+        "checksum": "sha256:b10d8521963a2494fdb2b5f8fb0de837dc86d4016c3b10019fb8970a09582451",
+        "check_gpg": true
+      },
+      {
+        "name": "curl",
+        "epoch": 0,
+        "version": "7.61.1",
+        "release": "18.el8_4.1",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/curl-7.61.1-18.el8_4.1.ppc64le.rpm",
+        "checksum": "sha256:47ad43730c8bc72c90f2fb3dbd3526d716ada2fad94e62cb443658e94c6503c5",
+        "check_gpg": true
+      },
+      {
+        "name": "cyrus-sasl-lib",
+        "epoch": 0,
+        "version": "2.1.27",
+        "release": "5.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/cyrus-sasl-lib-2.1.27-5.el8.ppc64le.rpm",
+        "checksum": "sha256:5c1940e1f173e22b053f3a89022903cea34a6af20dff81c65548c4e2ba3a8293",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus",
+        "epoch": 1,
+        "version": "1.12.8",
+        "release": "14.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/dbus-1.12.8-14.el8.ppc64le.rpm",
+        "checksum": "sha256:1a4e44583a767289bb0d354db93c6a9132420e13376d4fcae866d69620bb11bb",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-common",
+        "epoch": 1,
+        "version": "1.12.8",
+        "release": "14.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/dbus-common-1.12.8-14.el8.noarch.rpm",
+        "checksum": "sha256:7baac88adafdc5958fb818c7685d3c6548f6e2e585e4435ceee4a168edc3597e",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-daemon",
+        "epoch": 1,
+        "version": "1.12.8",
+        "release": "14.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/dbus-daemon-1.12.8-14.el8.ppc64le.rpm",
+        "checksum": "sha256:090563f18409c228274bb61dcf1001f63a55c1246fb2838a998cb3c5fd8c3874",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-glib",
+        "epoch": 0,
+        "version": "0.110",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/dbus-glib-0.110-2.el8.ppc64le.rpm",
+        "checksum": "sha256:c58b0b900a7ffc778980461d74dc236bf2c790d2e5e8c04e28876e221b48a1c8",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-libs",
+        "epoch": 1,
+        "version": "1.12.8",
+        "release": "14.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/dbus-libs-1.12.8-14.el8.ppc64le.rpm",
+        "checksum": "sha256:cc5f8dd4e061da3a73aa67112e24f2cc5c0ad0cd4334dc798b8834cf6259a779",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-tools",
+        "epoch": 1,
+        "version": "1.12.8",
+        "release": "14.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/dbus-tools-1.12.8-14.el8.ppc64le.rpm",
+        "checksum": "sha256:698e8ecaf71719dafacae79de05080d567b69fad3511e8b8d42b9af96a7c41db",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper",
+        "epoch": 8,
+        "version": "1.02.177",
+        "release": "6.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/device-mapper-1.02.177-6.el8.ppc64le.rpm",
+        "checksum": "sha256:441b3862f5a0fd504bbbba18d96d1b2b920fb95a79dc45a753a6a664ad285b07",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper-libs",
+        "epoch": 8,
+        "version": "1.02.177",
+        "release": "6.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/device-mapper-libs-1.02.177-6.el8.ppc64le.rpm",
+        "checksum": "sha256:a42de8ce71380b1f4e8ac5b4ce720bf565c99a0b09ef983c0550a91a467bc155",
+        "check_gpg": true
+      },
+      {
+        "name": "diffutils",
+        "epoch": 0,
+        "version": "3.6",
+        "release": "6.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/diffutils-3.6-6.el8.ppc64le.rpm",
+        "checksum": "sha256:4f92835a6e4ee4276df49019e068d1871b75821f52b405c699bd9f199df58b80",
+        "check_gpg": true
+      },
+      {
+        "name": "dnf",
+        "epoch": 0,
+        "version": "4.7.0",
+        "release": "2.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/dnf-4.7.0-2.el8.noarch.rpm",
+        "checksum": "sha256:42464424b9fa731f8122fe748aad0005519fc87b770dbbdb71f29f514ea0e889",
+        "check_gpg": true
+      },
+      {
+        "name": "dnf-data",
+        "epoch": 0,
+        "version": "4.7.0",
+        "release": "2.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/dnf-data-4.7.0-2.el8.noarch.rpm",
+        "checksum": "sha256:45c48d32120739734ae97479cc0f3ca19796ea47e360ba39d52b77ce3ada61d7",
+        "check_gpg": true
+      },
+      {
+        "name": "dosfstools",
+        "epoch": 0,
+        "version": "4.1",
+        "release": "6.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/dosfstools-4.1-6.el8.ppc64le.rpm",
+        "checksum": "sha256:04eee0a9c079186aa58b5536ac8bcbd2a360700b83fa7b9f6eb127c1386b7ef4",
+        "check_gpg": true
+      },
+      {
+        "name": "dracut",
+        "epoch": 0,
+        "version": "049",
+        "release": "188.git20210802.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/dracut-049-188.git20210802.el8.ppc64le.rpm",
+        "checksum": "sha256:881b28a3a37d114bc3f046605b24663560009b13a507217e007643f5682efdd5",
+        "check_gpg": true
+      },
+      {
+        "name": "e2fsprogs",
+        "epoch": 0,
+        "version": "1.45.6",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/e2fsprogs-1.45.6-2.el8.ppc64le.rpm",
+        "checksum": "sha256:9e67ac5948125dd165c9a74ec848d48b313ef4264bbbb89630a782dbd972d72c",
+        "check_gpg": true
+      },
+      {
+        "name": "e2fsprogs-libs",
+        "epoch": 0,
+        "version": "1.45.6",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/e2fsprogs-libs-1.45.6-2.el8.ppc64le.rpm",
+        "checksum": "sha256:9fb07c2324cccbbc19e3ffade50ee7da41909b2f6c24f49ffd9978ba375de193",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-debuginfod-client",
+        "epoch": 0,
+        "version": "0.185",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/elfutils-debuginfod-client-0.185-1.el8.ppc64le.rpm",
+        "checksum": "sha256:f4eca686b314edb06d3fe1c526f573c7248c811af70cba76132cdc9c541cadc1",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-default-yama-scope",
+        "epoch": 0,
+        "version": "0.185",
+        "release": "1.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/elfutils-default-yama-scope-0.185-1.el8.noarch.rpm",
+        "checksum": "sha256:30ceeb5a6cadaeccdbde088bfb52ba88190fa530c11f4a2aafd62b4b4ad6b404",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-libelf",
+        "epoch": 0,
+        "version": "0.185",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/elfutils-libelf-0.185-1.el8.ppc64le.rpm",
+        "checksum": "sha256:e87acf226a9511b3a5f83e7fed9c5c20addbbdae47ab67c614404a9392b77e50",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-libs",
+        "epoch": 0,
+        "version": "0.185",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/elfutils-libs-0.185-1.el8.ppc64le.rpm",
+        "checksum": "sha256:d150e53fa73c3786da9e4f6e23d374100b0dd2923485d4a08e9a56ac2786cf83",
+        "check_gpg": true
+      },
+      {
+        "name": "expat",
+        "epoch": 0,
+        "version": "2.2.5",
+        "release": "4.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/expat-2.2.5-4.el8.ppc64le.rpm",
+        "checksum": "sha256:88be5116908aa5013f540c767f6811774342780bb72d3ec197b3429bfb2f9862",
+        "check_gpg": true
+      },
+      {
+        "name": "file",
+        "epoch": 0,
+        "version": "5.33",
+        "release": "20.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/file-5.33-20.el8.ppc64le.rpm",
+        "checksum": "sha256:e156e6fa9ef6a483f8505ce0eeadbcab12b887c4996233ce5d6258076f6bce50",
+        "check_gpg": true
+      },
+      {
+        "name": "file-libs",
+        "epoch": 0,
+        "version": "5.33",
+        "release": "20.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/file-libs-5.33-20.el8.ppc64le.rpm",
+        "checksum": "sha256:e65f7d7c8def6b168e013914bc0d1137aed65c3010e9796df3b823854472f3e1",
+        "check_gpg": true
+      },
+      {
+        "name": "filesystem",
+        "epoch": 0,
+        "version": "3.8",
+        "release": "6.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/filesystem-3.8-6.el8.ppc64le.rpm",
+        "checksum": "sha256:a49b922f117b9bfb0b07e9848151f8a2948345328ebc534cd28ac187d7ed3f94",
+        "check_gpg": true
+      },
+      {
+        "name": "findutils",
+        "epoch": 1,
+        "version": "4.6.0",
+        "release": "20.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/findutils-4.6.0-20.el8.ppc64le.rpm",
+        "checksum": "sha256:caa0bd6617a8d5e535faedec5f6f3ea7c5e6da1898751f6c9c34a89a95c286ff",
+        "check_gpg": true
+      },
+      {
+        "name": "freetype",
+        "epoch": 0,
+        "version": "2.9.1",
+        "release": "4.el8_3.1",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/freetype-2.9.1-4.el8_3.1.ppc64le.rpm",
+        "checksum": "sha256:d1cf2d973db2f1af46f124776b9ab4bd782e7065c8c8428a4ddef60989e4225d",
+        "check_gpg": true
+      },
+      {
+        "name": "fuse-libs",
+        "epoch": 0,
+        "version": "2.9.7",
+        "release": "12.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/fuse-libs-2.9.7-12.el8.ppc64le.rpm",
+        "checksum": "sha256:4992eb036c0797daf9b984af1a34fe27a30287ee5d2bd5e2f5a0df3a09bdbb59",
+        "check_gpg": true
+      },
+      {
+        "name": "gawk",
+        "epoch": 0,
+        "version": "4.2.1",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/gawk-4.2.1-2.el8.ppc64le.rpm",
+        "checksum": "sha256:d807e7fb8bf24be50642a6dced954c6ea208199daab2d27c9f73d789ba82fa37",
+        "check_gpg": true
+      },
+      {
+        "name": "gdbm",
+        "epoch": 1,
+        "version": "1.18",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/gdbm-1.18-1.el8.ppc64le.rpm",
+        "checksum": "sha256:8cd6ef9902851f07cfd9682e2d6873648690f0c2ec65345276b557ede042d8b9",
+        "check_gpg": true
+      },
+      {
+        "name": "gdbm-libs",
+        "epoch": 1,
+        "version": "1.18",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/gdbm-libs-1.18-1.el8.ppc64le.rpm",
+        "checksum": "sha256:d1d362fd4f8022ad05171efe40e84d15ec6c5e5f419d6099ebc8e46e7da632c1",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext",
+        "epoch": 0,
+        "version": "0.19.8.1",
+        "release": "17.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/gettext-0.19.8.1-17.el8.ppc64le.rpm",
+        "checksum": "sha256:78fd472a1c7f49b8a432788ea2dfc1119f155a394f41585b4e715d2585fc92ab",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext-libs",
+        "epoch": 0,
+        "version": "0.19.8.1",
+        "release": "17.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/gettext-libs-0.19.8.1-17.el8.ppc64le.rpm",
+        "checksum": "sha256:e392a6b41381ffad04626d092fd2af9477c72e197a74efddf987832c3bfa521f",
+        "check_gpg": true
+      },
+      {
+        "name": "glib2",
+        "epoch": 0,
+        "version": "2.56.4",
+        "release": "156.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/glib2-2.56.4-156.el8.ppc64le.rpm",
+        "checksum": "sha256:ad338b7a3f3bed96300d9ce7f0307e09d758962b8496c10fb3554bf62405d153",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc",
+        "epoch": 0,
+        "version": "2.28",
+        "release": "162.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/glibc-2.28-162.el8.ppc64le.rpm",
+        "checksum": "sha256:bfb45644212cfbbe48b05149f8d53e77d7bd02ca9fc9045cc37115101175a3a0",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-all-langpacks",
+        "epoch": 0,
+        "version": "2.28",
+        "release": "162.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/glibc-all-langpacks-2.28-162.el8.ppc64le.rpm",
+        "checksum": "sha256:fa7bef727ba8657208bb3df95916f0bc912332cb8534c695facef32ffbd72f20",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-common",
+        "epoch": 0,
+        "version": "2.28",
+        "release": "162.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/glibc-common-2.28-162.el8.ppc64le.rpm",
+        "checksum": "sha256:257e086bb52086254fa8cc95a5c4998668b4fcb5203ad3c2275c1150816acc9b",
+        "check_gpg": true
+      },
+      {
+        "name": "gmp",
+        "epoch": 1,
+        "version": "6.1.2",
+        "release": "10.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/gmp-6.1.2-10.el8.ppc64le.rpm",
+        "checksum": "sha256:af0a4287e302baa7c85655ddfe5a7049b8eaf31aff03886f4fc57c920d26d491",
+        "check_gpg": true
+      },
+      {
+        "name": "gnupg2",
+        "epoch": 0,
+        "version": "2.2.20",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/gnupg2-2.2.20-2.el8.ppc64le.rpm",
+        "checksum": "sha256:11ff811a72c82084c7c14700b23d29643e153442a34b3b486e270e5b40e38d0a",
+        "check_gpg": true
+      },
+      {
+        "name": "gnupg2-smime",
+        "epoch": 0,
+        "version": "2.2.20",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/gnupg2-smime-2.2.20-2.el8.ppc64le.rpm",
+        "checksum": "sha256:a2d96efed83ab31d21481af044835a940673ee4ade2763af78c06d2df87b94f7",
+        "check_gpg": true
+      },
+      {
+        "name": "gnutls",
+        "epoch": 0,
+        "version": "3.6.16",
+        "release": "4.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/gnutls-3.6.16-4.el8.ppc64le.rpm",
+        "checksum": "sha256:51760acfb6ca87db5be7a9296d6a3d1220767956c576a26c6d46784e25db85bb",
+        "check_gpg": true
+      },
+      {
+        "name": "gpgme",
+        "epoch": 0,
+        "version": "1.13.1",
+        "release": "9.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/gpgme-1.13.1-9.el8.ppc64le.rpm",
+        "checksum": "sha256:24f5cd46a7395cd046b10d6ddc4de435ec6595d0dcdb2d179c94cc9082a12f14",
+        "check_gpg": true
+      },
+      {
+        "name": "grep",
+        "epoch": 0,
+        "version": "3.1",
+        "release": "6.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/grep-3.1-6.el8.ppc64le.rpm",
+        "checksum": "sha256:2451a475f248a4c66e64d149fefa8bfc195fcd7b3f369bae221a94f8ce4c2d67",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-common",
+        "epoch": 1,
+        "version": "2.02",
+        "release": "99.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/grub2-common-2.02-99.el8.noarch.rpm",
+        "checksum": "sha256:4a08d5264e865548e65d31886c91b659b33a2c2ba39fd115b00af3ea0bc91a83",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-ppc64le",
+        "epoch": 1,
+        "version": "2.02",
+        "release": "99.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/grub2-ppc64le-2.02-99.el8.ppc64le.rpm",
+        "checksum": "sha256:7cccedcc359f2a2542858088704bf3d0ec3e46cb7b72f602408fbab937a522d3",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-ppc64le-modules",
+        "epoch": 1,
+        "version": "2.02",
+        "release": "99.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/grub2-ppc64le-modules-2.02-99.el8.noarch.rpm",
+        "checksum": "sha256:d8dad22276baffe9496d5e05ef35d21dd6f9d8f910339daced2c3ff42d7a28c5",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-tools",
+        "epoch": 1,
+        "version": "2.02",
+        "release": "99.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/grub2-tools-2.02-99.el8.ppc64le.rpm",
+        "checksum": "sha256:78b2b9cbf041d4461daf7ac11a24d1e79a9c57f47aa265dba4d09067efe3d96b",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-tools-extra",
+        "epoch": 1,
+        "version": "2.02",
+        "release": "99.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/grub2-tools-extra-2.02-99.el8.ppc64le.rpm",
+        "checksum": "sha256:ac3b306c193bd20658950da402ae0cbdd8337110117de5e5d7eba970822671fd",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-tools-minimal",
+        "epoch": 1,
+        "version": "2.02",
+        "release": "99.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/grub2-tools-minimal-2.02-99.el8.ppc64le.rpm",
+        "checksum": "sha256:fb276cc0ebc6bd27d344f7e0811f26cb3f0e59da09182489095724bdf2a075f8",
+        "check_gpg": true
+      },
+      {
+        "name": "grubby",
+        "epoch": 0,
+        "version": "8.40",
+        "release": "41.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/grubby-8.40-41.el8.ppc64le.rpm",
+        "checksum": "sha256:5a0927d231fbafa8b865591922fc07d39d9b4b263a1e9c0bbef691282f706cd0",
+        "check_gpg": true
+      },
+      {
+        "name": "gzip",
+        "epoch": 0,
+        "version": "1.9",
+        "release": "12.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/gzip-1.9-12.el8.ppc64le.rpm",
+        "checksum": "sha256:e1e28504928648404a3b652440091eba010cd99221183ef78601cbd152261d91",
+        "check_gpg": true
+      },
+      {
+        "name": "hardlink",
+        "epoch": 1,
+        "version": "1.3",
+        "release": "6.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/hardlink-1.3-6.el8.ppc64le.rpm",
+        "checksum": "sha256:42bb566be1936bdb40937f9c0a96c4acc93057379385f1807cba18f60443d3e4",
+        "check_gpg": true
+      },
+      {
+        "name": "ima-evm-utils",
+        "epoch": 0,
+        "version": "1.3.2",
+        "release": "12.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/ima-evm-utils-1.3.2-12.el8.ppc64le.rpm",
+        "checksum": "sha256:8119d276749b35cd9c283c1a8d970b3528bea58427eb37eafc22b6093a978f08",
+        "check_gpg": true
+      },
+      {
+        "name": "info",
+        "epoch": 0,
+        "version": "6.5",
+        "release": "6.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/info-6.5-6.el8.ppc64le.rpm",
+        "checksum": "sha256:6d1ac29b3a38408f6d238d6718384e05be7346789c6200b354335b0e0c9c77df",
+        "check_gpg": true
+      },
+      {
+        "name": "json-c",
+        "epoch": 0,
+        "version": "0.13.1",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/json-c-0.13.1-2.el8.ppc64le.rpm",
+        "checksum": "sha256:331b91a0928c05618c7fed3e12bbe9ecb9e4619d08c7e85d3de344a08d2f0f1a",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd",
+        "epoch": 0,
+        "version": "2.0.4",
+        "release": "10.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/kbd-2.0.4-10.el8.ppc64le.rpm",
+        "checksum": "sha256:49c7c718cb4e2b6f0effd0dec4f4cb4e109d260c192b2b329a58a1da9a24ad1d",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd-legacy",
+        "epoch": 0,
+        "version": "2.0.4",
+        "release": "10.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/kbd-legacy-2.0.4-10.el8.noarch.rpm",
+        "checksum": "sha256:a3ef96219165bfc64d4f5d50f51fbd43e803c500619240ffe4db1f9f8e337f83",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd-misc",
+        "epoch": 0,
+        "version": "2.0.4",
+        "release": "10.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/kbd-misc-2.0.4-10.el8.noarch.rpm",
+        "checksum": "sha256:ef86061338fa321c959cadc75ecbdfd405eebaa1042eec9d9c737d4d9d92568f",
+        "check_gpg": true
+      },
+      {
+        "name": "keyutils-libs",
+        "epoch": 0,
+        "version": "1.5.10",
+        "release": "9.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/keyutils-libs-1.5.10-9.el8.ppc64le.rpm",
+        "checksum": "sha256:6fe1188081e441595ce29ebed4d1985e5890815158244f69f092ee930656f755",
+        "check_gpg": true
+      },
+      {
+        "name": "kmod",
+        "epoch": 0,
+        "version": "25",
+        "release": "18.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/kmod-25-18.el8.ppc64le.rpm",
+        "checksum": "sha256:a80c1d6d32db7ce8fdd58bb4f3f488b74e94261a38512dc8a15179ae33697e63",
+        "check_gpg": true
+      },
+      {
+        "name": "kmod-libs",
+        "epoch": 0,
+        "version": "25",
+        "release": "18.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/kmod-libs-25-18.el8.ppc64le.rpm",
+        "checksum": "sha256:b437a08d4670ef440ba6dbaae4ccb39f989f0c2a3d280ea66d6fd9532a313286",
+        "check_gpg": true
+      },
+      {
+        "name": "kpartx",
+        "epoch": 0,
+        "version": "0.8.4",
+        "release": "17.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/kpartx-0.8.4-17.el8.ppc64le.rpm",
+        "checksum": "sha256:230731b577f8d29e7e8e8fd6d1ea02702fb4364fcc7034d838ccddc4d66da8c3",
+        "check_gpg": true
+      },
+      {
+        "name": "krb5-libs",
+        "epoch": 0,
+        "version": "1.18.2",
+        "release": "13.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/krb5-libs-1.18.2-13.el8.ppc64le.rpm",
+        "checksum": "sha256:54f59ddb56e89a5330373e07ea05934fc58360eb7480615ede2a3ed6982e1eef",
+        "check_gpg": true
+      },
+      {
+        "name": "libacl",
+        "epoch": 0,
+        "version": "2.2.53",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libacl-2.2.53-1.el8.ppc64le.rpm",
+        "checksum": "sha256:ff1580bd4ec5841d4937b383917fa30f318b4f419b8067a77468eb4a9630ba10",
+        "check_gpg": true
+      },
+      {
+        "name": "libaio",
+        "epoch": 0,
+        "version": "0.3.112",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libaio-0.3.112-1.el8.ppc64le.rpm",
+        "checksum": "sha256:3303f41952491bad2b31ee507eaabaf13dabe5ec9624c4b58a4a8301c4cd89dd",
+        "check_gpg": true
+      },
+      {
+        "name": "libarchive",
+        "epoch": 0,
+        "version": "3.3.3",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libarchive-3.3.3-1.el8.ppc64le.rpm",
+        "checksum": "sha256:df40cada982b04336fe8b250b4fdd576ddd03a014bb519a69b34640369bef661",
+        "check_gpg": true
+      },
+      {
+        "name": "libassuan",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "3.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libassuan-2.5.1-3.el8.ppc64le.rpm",
+        "checksum": "sha256:9c4cd61b98253904436180f58c564bda61be1fa1b5523e4ecbbdc174d0c2a9aa",
+        "check_gpg": true
+      },
+      {
+        "name": "libattr",
+        "epoch": 0,
+        "version": "2.4.48",
+        "release": "3.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libattr-2.4.48-3.el8.ppc64le.rpm",
+        "checksum": "sha256:43bfc890caf7855f2fb55c24474b58cd5c8c7b51e4db4f40d1f302fffd31985b",
+        "check_gpg": true
+      },
+      {
+        "name": "libblkid",
+        "epoch": 0,
+        "version": "2.32.1",
+        "release": "28.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libblkid-2.32.1-28.el8.ppc64le.rpm",
+        "checksum": "sha256:30ae4489980021a727f247d48b4d74d4c6c7667d00bd1a670f045ea24a885541",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap",
+        "epoch": 0,
+        "version": "2.26",
+        "release": "4.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libcap-2.26-4.el8.ppc64le.rpm",
+        "checksum": "sha256:77e4cfbc823e3764308822ccf03b257861f9360f3b948829f1d73148b321b00e",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap-ng",
+        "epoch": 0,
+        "version": "0.7.11",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libcap-ng-0.7.11-1.el8.ppc64le.rpm",
+        "checksum": "sha256:9b69a221cf9395a110849bb428bb1cfe9fb489322df0fa6017f5978a827ee0e9",
+        "check_gpg": true
+      },
+      {
+        "name": "libcom_err",
+        "epoch": 0,
+        "version": "1.45.6",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libcom_err-1.45.6-2.el8.ppc64le.rpm",
+        "checksum": "sha256:e0a7b9f3b56b4737f5711dc6b03f256fbf2488656b8874acabb494b58ba0c1c1",
+        "check_gpg": true
+      },
+      {
+        "name": "libcomps",
+        "epoch": 0,
+        "version": "0.1.16",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libcomps-0.1.16-2.el8.ppc64le.rpm",
+        "checksum": "sha256:5c74a0e3005ea3cb90dff80cfa1e7d64c97f5c01612d253cf4e65aca962b7be4",
+        "check_gpg": true
+      },
+      {
+        "name": "libcroco",
+        "epoch": 0,
+        "version": "0.6.12",
+        "release": "4.el8_2.1",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libcroco-0.6.12-4.el8_2.1.ppc64le.rpm",
+        "checksum": "sha256:194dbe332ccdb33d58f040da07667257e176975f6b2f17343bbf33fb99deb097",
+        "check_gpg": true
+      },
+      {
+        "name": "libcurl",
+        "epoch": 0,
+        "version": "7.61.1",
+        "release": "18.el8_4.1",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libcurl-7.61.1-18.el8_4.1.ppc64le.rpm",
+        "checksum": "sha256:e21a84107568047432e474e08da24aea2340409d57ea8cf170182927dc76de12",
+        "check_gpg": true
+      },
+      {
+        "name": "libdb",
+        "epoch": 0,
+        "version": "5.3.28",
+        "release": "40.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libdb-5.3.28-40.el8.ppc64le.rpm",
+        "checksum": "sha256:b83a0199c3d471151f07f6de626a1a4a362dd6aa29d84cf1c0ada2c966ce29c9",
+        "check_gpg": true
+      },
+      {
+        "name": "libdb-utils",
+        "epoch": 0,
+        "version": "5.3.28",
+        "release": "40.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libdb-utils-5.3.28-40.el8.ppc64le.rpm",
+        "checksum": "sha256:709ea71f36495ac2ac89d72d2eb603b6aa55b2c1a70633f23514dd897936f02b",
+        "check_gpg": true
+      },
+      {
+        "name": "libdnf",
+        "epoch": 0,
+        "version": "0.63.0",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libdnf-0.63.0-2.el8.ppc64le.rpm",
+        "checksum": "sha256:aea253461d1a34a239b445ee07cb34398a9cbb6ed40e252182a91cddcf59004b",
+        "check_gpg": true
+      },
+      {
+        "name": "libevent",
+        "epoch": 0,
+        "version": "2.1.8",
+        "release": "5.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libevent-2.1.8-5.el8.ppc64le.rpm",
+        "checksum": "sha256:a0b8a6b2c8dad75290228086dd0af342979604bbf4b9500029e25d766835c0f4",
+        "check_gpg": true
+      },
+      {
+        "name": "libfdisk",
+        "epoch": 0,
+        "version": "2.32.1",
+        "release": "28.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libfdisk-2.32.1-28.el8.ppc64le.rpm",
+        "checksum": "sha256:0afac6f4f9ed1c59510675d87da45c7966c0f7aae6e8dd056961aceed8c4fe0a",
+        "check_gpg": true
+      },
+      {
+        "name": "libffi",
+        "epoch": 0,
+        "version": "3.1",
+        "release": "22.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libffi-3.1-22.el8.ppc64le.rpm",
+        "checksum": "sha256:12696f5638ad2068c5c8940495d15c3bb1c57990000dbda7428b008e9e63ab5b",
+        "check_gpg": true
+      },
+      {
+        "name": "libgcc",
+        "epoch": 0,
+        "version": "8.5.0",
+        "release": "3.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libgcc-8.5.0-3.el8.ppc64le.rpm",
+        "checksum": "sha256:f3d9ccb762146dc97f2d201d979fbb0e9171d1203fb985f3ef48b5c2a176c2a9",
+        "check_gpg": true
+      },
+      {
+        "name": "libgcrypt",
+        "epoch": 0,
+        "version": "1.8.5",
+        "release": "6.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libgcrypt-1.8.5-6.el8.ppc64le.rpm",
+        "checksum": "sha256:c5a60ffb80cd1f9b90c797f1d1ac80e5536eb32a5b276871445e7279ac701c5f",
+        "check_gpg": true
+      },
+      {
+        "name": "libgomp",
+        "epoch": 0,
+        "version": "8.5.0",
+        "release": "3.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libgomp-8.5.0-3.el8.ppc64le.rpm",
+        "checksum": "sha256:0515afdac097ad54cf4b24e0644f0789cab5535a54107aa44940ffd991a6cef3",
+        "check_gpg": true
+      },
+      {
+        "name": "libgpg-error",
+        "epoch": 0,
+        "version": "1.31",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libgpg-error-1.31-1.el8.ppc64le.rpm",
+        "checksum": "sha256:020abac486839c7be29fae37a686dc7749398c333cb8ba94b3390b386ffcbff7",
+        "check_gpg": true
+      },
+      {
+        "name": "libidn2",
+        "epoch": 0,
+        "version": "2.2.0",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libidn2-2.2.0-1.el8.ppc64le.rpm",
+        "checksum": "sha256:31d924d1540dd4e927a4c3aa936cec4bfb54ed302d3e8acc1be8b52dd5deb10c",
+        "check_gpg": true
+      },
+      {
+        "name": "libkcapi",
+        "epoch": 0,
+        "version": "1.2.0",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libkcapi-1.2.0-2.el8.ppc64le.rpm",
+        "checksum": "sha256:fd6e1803ff367036da5b52b2183e1408691b379cc1320971bb664737507f89a4",
+        "check_gpg": true
+      },
+      {
+        "name": "libkcapi-hmaccalc",
+        "epoch": 0,
+        "version": "1.2.0",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libkcapi-hmaccalc-1.2.0-2.el8.ppc64le.rpm",
+        "checksum": "sha256:6b312faed4a0508da2f15d3f31a6daccfc0ec6621e5fb7b20956027dce5fa395",
+        "check_gpg": true
+      },
+      {
+        "name": "libksba",
+        "epoch": 0,
+        "version": "1.3.5",
+        "release": "7.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libksba-1.3.5-7.el8.ppc64le.rpm",
+        "checksum": "sha256:a5f9f2c4f39f393971f268aebb1b55d18d0d96693d08a9ed70403e8565807bb6",
+        "check_gpg": true
+      },
+      {
+        "name": "libmodulemd",
+        "epoch": 0,
+        "version": "2.12.1",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libmodulemd-2.12.1-1.el8.ppc64le.rpm",
+        "checksum": "sha256:d6eb27d158b6397e52ab6a952fec4e3c414638a08750a6c011d32eb117accd82",
+        "check_gpg": true
+      },
+      {
+        "name": "libmount",
+        "epoch": 0,
+        "version": "2.32.1",
+        "release": "28.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libmount-2.32.1-28.el8.ppc64le.rpm",
+        "checksum": "sha256:4e497225fe36781735cc92c0886f6858b19d4557ed9ecafe1247b8233c206075",
+        "check_gpg": true
+      },
+      {
+        "name": "libnghttp2",
+        "epoch": 0,
+        "version": "1.33.0",
+        "release": "3.el8_2.1",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libnghttp2-1.33.0-3.el8_2.1.ppc64le.rpm",
+        "checksum": "sha256:d3a4f367a9c5ba936b1bb5480db390889a303e5ec8ff34bb4274c1d840a1784d",
+        "check_gpg": true
+      },
+      {
+        "name": "libnsl2",
+        "epoch": 0,
+        "version": "1.2.0",
+        "release": "2.20180605git4a062cf.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libnsl2-1.2.0-2.20180605git4a062cf.el8.ppc64le.rpm",
+        "checksum": "sha256:8d7777da3f54f965cf3058cabf987c01b93a1dd041e8359eb7822eba57d8c8df",
+        "check_gpg": true
+      },
+      {
+        "name": "libpng",
+        "epoch": 2,
+        "version": "1.6.34",
+        "release": "5.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libpng-1.6.34-5.el8.ppc64le.rpm",
+        "checksum": "sha256:b58be8f7685340b35e61945b1ab499bc1030b0b021b2ac5576897cf079ff7812",
+        "check_gpg": true
+      },
+      {
+        "name": "libpsl",
+        "epoch": 0,
+        "version": "0.20.2",
+        "release": "6.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libpsl-0.20.2-6.el8.ppc64le.rpm",
+        "checksum": "sha256:9b8a8a843fe9a972f6433e11b95b5a8d1d2971ed40fe1acda6807e34f0773c62",
+        "check_gpg": true
+      },
+      {
+        "name": "libpwquality",
+        "epoch": 0,
+        "version": "1.4.4",
+        "release": "3.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libpwquality-1.4.4-3.el8.ppc64le.rpm",
+        "checksum": "sha256:1aa321c66a3661e78d938b805e5c311d519f04bf3496545ffdacc7c152bc9b21",
+        "check_gpg": true
+      },
+      {
+        "name": "librepo",
+        "epoch": 0,
+        "version": "1.14.0",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/librepo-1.14.0-2.el8.ppc64le.rpm",
+        "checksum": "sha256:3dfffdadfb10def9a3671a255e4fa71d8b22231ccf2c929e96689101dda8ce2c",
+        "check_gpg": true
+      },
+      {
+        "name": "libreport-filesystem",
+        "epoch": 0,
+        "version": "2.9.5",
+        "release": "15.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libreport-filesystem-2.9.5-15.el8.ppc64le.rpm",
+        "checksum": "sha256:c5c61536e768553067cee488830c64866d109cade24917dbe23f82c861af07c5",
+        "check_gpg": true
+      },
+      {
+        "name": "librtas",
+        "epoch": 0,
+        "version": "2.0.2",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/librtas-2.0.2-1.el8.ppc64le.rpm",
+        "checksum": "sha256:98c28a91d41f634edb8c1f001dbc45c0de534332d059a2e8feff448fb7235c49",
+        "check_gpg": true
+      },
+      {
+        "name": "libseccomp",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libseccomp-2.5.1-1.el8.ppc64le.rpm",
+        "checksum": "sha256:b4a1ac1ff5cd22a5dab6c96dfc2dbd7cd6ba750691ad5c53a97a1f088fc42abc",
+        "check_gpg": true
+      },
+      {
+        "name": "libsecret",
+        "epoch": 0,
+        "version": "0.18.6",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libsecret-0.18.6-1.el8.ppc64le.rpm",
+        "checksum": "sha256:01b0562b890a80c202fff9175dc845500660c7f1655292d4ee13ca667acab081",
+        "check_gpg": true
+      },
+      {
+        "name": "libselinux",
+        "epoch": 0,
+        "version": "2.9",
+        "release": "5.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libselinux-2.9-5.el8.ppc64le.rpm",
+        "checksum": "sha256:56c866bcff69fd60b630841ff990296b26c2f45d8c6054311b5c476bc67466ac",
+        "check_gpg": true
+      },
+      {
+        "name": "libselinux-utils",
+        "epoch": 0,
+        "version": "2.9",
+        "release": "5.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libselinux-utils-2.9-5.el8.ppc64le.rpm",
+        "checksum": "sha256:4fe264ed1cfd0c074f4601354b0128a9e5068f0fcde7382fd5429585f0d4cd2c",
+        "check_gpg": true
+      },
+      {
+        "name": "libsemanage",
+        "epoch": 0,
+        "version": "2.9",
+        "release": "6.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libsemanage-2.9-6.el8.ppc64le.rpm",
+        "checksum": "sha256:95103f7c339aec4b485b7f569aa8a5e1a54286b3d2acde427328c49e4d8d80d1",
+        "check_gpg": true
+      },
+      {
+        "name": "libsepol",
+        "epoch": 0,
+        "version": "2.9",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libsepol-2.9-2.el8.ppc64le.rpm",
+        "checksum": "sha256:adc56041458e556df5663e7da264e151c24aaf1c2a94e49df9790ba191ea1b37",
+        "check_gpg": true
+      },
+      {
+        "name": "libsigsegv",
+        "epoch": 0,
+        "version": "2.11",
+        "release": "5.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libsigsegv-2.11-5.el8.ppc64le.rpm",
+        "checksum": "sha256:0f57b051654b6d75789b437dafd7040b6c90daee17827be24352c0f11a74bba7",
+        "check_gpg": true
+      },
+      {
+        "name": "libsmartcols",
+        "epoch": 0,
+        "version": "2.32.1",
+        "release": "28.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libsmartcols-2.32.1-28.el8.ppc64le.rpm",
+        "checksum": "sha256:1b5136570cefb8273dd5affc73c1456cf239cc8b18be72d6c4d09794af7f3352",
+        "check_gpg": true
+      },
+      {
+        "name": "libsolv",
+        "epoch": 0,
+        "version": "0.7.19",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libsolv-0.7.19-1.el8.ppc64le.rpm",
+        "checksum": "sha256:679724b45157b4d4c9ebe2eb32e188b9a65d47c23be886498d7a178caaf113bb",
+        "check_gpg": true
+      },
+      {
+        "name": "libss",
+        "epoch": 0,
+        "version": "1.45.6",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libss-1.45.6-2.el8.ppc64le.rpm",
+        "checksum": "sha256:767dd64d91c23adda537c7759ae3b4f720d3c76e03b52bc9231e52e0113db3ab",
+        "check_gpg": true
+      },
+      {
+        "name": "libssh",
+        "epoch": 0,
+        "version": "0.9.4",
+        "release": "3.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libssh-0.9.4-3.el8.ppc64le.rpm",
+        "checksum": "sha256:2dbfe3cb37c18b39393870baa77f3bbd42be53517abffdd990b13ed70ee3dd3e",
+        "check_gpg": true
+      },
+      {
+        "name": "libssh-config",
+        "epoch": 0,
+        "version": "0.9.4",
+        "release": "3.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libssh-config-0.9.4-3.el8.noarch.rpm",
+        "checksum": "sha256:f5bcb82a732c02d6f31bbf156887049883c76cedc9c6a11b049358a74f4d45d0",
+        "check_gpg": true
+      },
+      {
+        "name": "libstdc++",
+        "epoch": 0,
+        "version": "8.5.0",
+        "release": "3.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libstdc++-8.5.0-3.el8.ppc64le.rpm",
+        "checksum": "sha256:32ebba6472cdc331bd3366ca996ad3039b3a1b41c61a849b88074e1b722cad2c",
+        "check_gpg": true
+      },
+      {
+        "name": "libtasn1",
+        "epoch": 0,
+        "version": "4.13",
+        "release": "3.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libtasn1-4.13-3.el8.ppc64le.rpm",
+        "checksum": "sha256:75e9ed16ace51ba04a62505aaed215bf9c722d6f4b1c33cc3e3962076c300ee8",
+        "check_gpg": true
+      },
+      {
+        "name": "libtirpc",
+        "epoch": 0,
+        "version": "1.1.4",
+        "release": "5.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libtirpc-1.1.4-5.el8.ppc64le.rpm",
+        "checksum": "sha256:d539404dafd8ad5d785ab3da6f8bd5a2bf5dff9e01be0ff1bc1d251786dda25c",
+        "check_gpg": true
+      },
+      {
+        "name": "libunistring",
+        "epoch": 0,
+        "version": "0.9.9",
+        "release": "3.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libunistring-0.9.9-3.el8.ppc64le.rpm",
+        "checksum": "sha256:bff39fef1fc01564156123fcade75b4bc50402a2971a031d9a426c7014b1e681",
+        "check_gpg": true
+      },
+      {
+        "name": "libusbx",
+        "epoch": 0,
+        "version": "1.0.23",
+        "release": "4.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libusbx-1.0.23-4.el8.ppc64le.rpm",
+        "checksum": "sha256:6b9875495111bcd2d3c5e9e380b3be17fb0a730891468fb45bdba3b3692b00ea",
+        "check_gpg": true
+      },
+      {
+        "name": "libutempter",
+        "epoch": 0,
+        "version": "1.1.6",
+        "release": "14.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libutempter-1.1.6-14.el8.ppc64le.rpm",
+        "checksum": "sha256:e217c2687212d931ad9a6a02afb20cc34f6d051786d136e337f91079c9f73d22",
+        "check_gpg": true
+      },
+      {
+        "name": "libuuid",
+        "epoch": 0,
+        "version": "2.32.1",
+        "release": "28.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libuuid-2.32.1-28.el8.ppc64le.rpm",
+        "checksum": "sha256:c1291b69a65a860069195a33cf6640df8667e960f9f030ceeea4497c47858b94",
+        "check_gpg": true
+      },
+      {
+        "name": "libverto",
+        "epoch": 0,
+        "version": "0.3.0",
+        "release": "5.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libverto-0.3.0-5.el8.ppc64le.rpm",
+        "checksum": "sha256:d8c00baf46e33f9e5f1b9e139bbea9fe0f27badb432c992b9cf8c4f7017094bf",
+        "check_gpg": true
+      },
+      {
+        "name": "libxcrypt",
+        "epoch": 0,
+        "version": "4.1.1",
+        "release": "6.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libxcrypt-4.1.1-6.el8.ppc64le.rpm",
+        "checksum": "sha256:1a968f65db066243cbd0a6e12d193ef674637f044299a15b5d6b910e91411812",
+        "check_gpg": true
+      },
+      {
+        "name": "libxml2",
+        "epoch": 0,
+        "version": "2.9.7",
+        "release": "11.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libxml2-2.9.7-11.el8.ppc64le.rpm",
+        "checksum": "sha256:4a167fa4a7238bd94b3134173f6267b19cdebc2fde98b583344749e1f4c9bf09",
+        "check_gpg": true
+      },
+      {
+        "name": "libyaml",
+        "epoch": 0,
+        "version": "0.1.7",
+        "release": "5.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libyaml-0.1.7-5.el8.ppc64le.rpm",
+        "checksum": "sha256:8904fdb492f34e5242ba483fb6b7b158342662575b3d5ac9abbc380568840d4a",
+        "check_gpg": true
+      },
+      {
+        "name": "libzstd",
+        "epoch": 0,
+        "version": "1.4.4",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libzstd-1.4.4-1.el8.ppc64le.rpm",
+        "checksum": "sha256:6bfc201a12dc7bba21069a663aa692a96c5e8920b0d94a4e355c332d7ead15ba",
+        "check_gpg": true
+      },
+      {
+        "name": "lua-libs",
+        "epoch": 0,
+        "version": "5.3.4",
+        "release": "11.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/lua-libs-5.3.4-11.el8.ppc64le.rpm",
+        "checksum": "sha256:393e7bb9f93ffb3cbba620fbfeb229f2b8345454bc60ac0508f76735544ed289",
+        "check_gpg": true
+      },
+      {
+        "name": "lz4-libs",
+        "epoch": 0,
+        "version": "1.8.3",
+        "release": "3.el8_4",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/lz4-libs-1.8.3-3.el8_4.ppc64le.rpm",
+        "checksum": "sha256:f24bce642ec88622490b2f09a45fa3985da7f6511a1aae131853c4ea4c309e6b",
+        "check_gpg": true
+      },
+      {
+        "name": "lzo",
+        "epoch": 0,
+        "version": "2.08",
+        "release": "14.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/lzo-2.08-14.el8.ppc64le.rpm",
+        "checksum": "sha256:4c5aabda0cd9edb40e141066d400d2e4b232bc22ab60e806a6399691c391cabc",
+        "check_gpg": true
+      },
+      {
+        "name": "memstrack",
+        "epoch": 0,
+        "version": "0.1.11",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/memstrack-0.1.11-1.el8.ppc64le.rpm",
+        "checksum": "sha256:9936485ac7111967d6962bc539de7b08807e310117adb78b11c21a5db0f0f890",
+        "check_gpg": true
+      },
+      {
+        "name": "mpfr",
+        "epoch": 0,
+        "version": "3.1.6",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/mpfr-3.1.6-1.el8.ppc64le.rpm",
+        "checksum": "sha256:0230acdbc9da4b36da812f0e585a7602eda4982c899b3b3a4c2bc9b4546d8e74",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses",
+        "epoch": 0,
+        "version": "6.1",
+        "release": "9.20180224.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/ncurses-6.1-9.20180224.el8.ppc64le.rpm",
+        "checksum": "sha256:7abf49cabbaf996afc0c2604f10ea18f8f22a903fc4ba3728a18f5892353c5c9",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses-base",
+        "epoch": 0,
+        "version": "6.1",
+        "release": "9.20180224.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/ncurses-base-6.1-9.20180224.el8.noarch.rpm",
+        "checksum": "sha256:41716536ea16798238ac89fbc3041b3f9dc80f9a64ea4b19d6e67ad2c909269a",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses-libs",
+        "epoch": 0,
+        "version": "6.1",
+        "release": "9.20180224.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/ncurses-libs-6.1-9.20180224.el8.ppc64le.rpm",
+        "checksum": "sha256:17ffe1d683dbff48f9b2ef903401e471e5e51a992bf0890632bceb94561893de",
+        "check_gpg": true
+      },
+      {
+        "name": "nettle",
+        "epoch": 0,
+        "version": "3.4.1",
+        "release": "7.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/nettle-3.4.1-7.el8.ppc64le.rpm",
+        "checksum": "sha256:8403cfc97e0e72e37639b8c54d92f1ee427e48a70d52d5260a37fa104f2df20d",
+        "check_gpg": true
+      },
+      {
+        "name": "npth",
+        "epoch": 0,
+        "version": "1.5",
+        "release": "4.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/npth-1.5-4.el8.ppc64le.rpm",
+        "checksum": "sha256:7a66928044c3478964aeaf6f9e981fdbcfa6b2ff7fad9f2ad57a8c09387cbbf2",
+        "check_gpg": true
+      },
+      {
+        "name": "openldap",
+        "epoch": 0,
+        "version": "2.4.46",
+        "release": "18.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/openldap-2.4.46-18.el8.ppc64le.rpm",
+        "checksum": "sha256:c24b21415b737f18fad7aeb192e60f7d323f7ba69434ecc1e78b3af0003be8dc",
+        "check_gpg": true
+      },
+      {
+        "name": "openssl",
+        "epoch": 1,
+        "version": "1.1.1k",
+        "release": "4.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/openssl-1.1.1k-4.el8.ppc64le.rpm",
+        "checksum": "sha256:c2479eb811f4d9b8624ef20119e1abdc109f639c2cf576eb945b340362d87b05",
+        "check_gpg": true
+      },
+      {
+        "name": "openssl-libs",
+        "epoch": 1,
+        "version": "1.1.1k",
+        "release": "4.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/openssl-libs-1.1.1k-4.el8.ppc64le.rpm",
+        "checksum": "sha256:46606c1ed76a4da2a9d18016aeb50f4dddf58e1b45d665c983c58f8e605bf73e",
+        "check_gpg": true
+      },
+      {
+        "name": "openssl-pkcs11",
+        "epoch": 0,
+        "version": "0.4.10",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/openssl-pkcs11-0.4.10-2.el8.ppc64le.rpm",
+        "checksum": "sha256:d87f7fa5e637442eb638bcaafdc44ca3895d91a153015ff9af6a87219f0dc372",
+        "check_gpg": true
+      },
+      {
+        "name": "os-prober",
+        "epoch": 0,
+        "version": "1.74",
+        "release": "6.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/os-prober-1.74-6.el8.ppc64le.rpm",
+        "checksum": "sha256:71c88f04921ae61a7009f9443f95c70ec3424a798429fc01e6c1432c1077aacb",
+        "check_gpg": true
+      },
+      {
+        "name": "p11-kit",
+        "epoch": 0,
+        "version": "0.23.22",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/p11-kit-0.23.22-1.el8.ppc64le.rpm",
+        "checksum": "sha256:bf994cb2e5c367d78483662c7de6e69950aaf04bc6cfdbbef4d1ef7ce153717c",
+        "check_gpg": true
+      },
+      {
+        "name": "p11-kit-trust",
+        "epoch": 0,
+        "version": "0.23.22",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/p11-kit-trust-0.23.22-1.el8.ppc64le.rpm",
+        "checksum": "sha256:b7330d40f75b8ec786e41c45a202e44f0e49ec29ddf8944120fbdb373a6c6617",
+        "check_gpg": true
+      },
+      {
+        "name": "pam",
+        "epoch": 0,
+        "version": "1.3.1",
+        "release": "15.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/pam-1.3.1-15.el8.ppc64le.rpm",
+        "checksum": "sha256:bb82b10a91493d745dc533b5de5335db650adb0c8a90548fdf5dad13569a16f4",
+        "check_gpg": true
+      },
+      {
+        "name": "parted",
+        "epoch": 0,
+        "version": "3.2",
+        "release": "39.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/parted-3.2-39.el8.ppc64le.rpm",
+        "checksum": "sha256:9e2ef90cb484b37232e829ec400dcddd3f9f0d189eb6f0074b3b5874d4553d1c",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre",
+        "epoch": 0,
+        "version": "8.42",
+        "release": "6.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/pcre-8.42-6.el8.ppc64le.rpm",
+        "checksum": "sha256:3ed319e31a9c38e5f4e336195b5cbd253b3f8b17f93f185829f078c5ef420305",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre2",
+        "epoch": 0,
+        "version": "10.32",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/pcre2-10.32-2.el8.ppc64le.rpm",
+        "checksum": "sha256:5c46bef8c0e95e05716e9a53b77970c1378d93bcb9a800018a24f7e1763b45b9",
+        "check_gpg": true
+      },
+      {
+        "name": "pigz",
+        "epoch": 0,
+        "version": "2.4",
+        "release": "4.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/pigz-2.4-4.el8.ppc64le.rpm",
+        "checksum": "sha256:3edfdbc82f97ec12e59c80c67897fc1eeb44c3d16820f761a8f15272965ea3a1",
+        "check_gpg": true
+      },
+      {
+        "name": "platform-python",
+        "epoch": 0,
+        "version": "3.6.8",
+        "release": "39.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/platform-python-3.6.8-39.el8.ppc64le.rpm",
+        "checksum": "sha256:cdd6594a3bca71d32a5061b85457cc8148611e7f042ba6e812a1c0a2faebac92",
+        "check_gpg": true
+      },
+      {
+        "name": "platform-python-pip",
+        "epoch": 0,
+        "version": "9.0.3",
+        "release": "20.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/platform-python-pip-9.0.3-20.el8.noarch.rpm",
+        "checksum": "sha256:56650f8b8f2b01c1090d184d7d6d396f0109f8a02f915c97b081be73ea12df08",
+        "check_gpg": true
+      },
+      {
+        "name": "platform-python-setuptools",
+        "epoch": 0,
+        "version": "39.2.0",
+        "release": "6.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/platform-python-setuptools-39.2.0-6.el8.noarch.rpm",
+        "checksum": "sha256:946ba273a3a3b6fdf140f3c03112918c0a556a5871c477f5dbbb98600e6ca557",
+        "check_gpg": true
+      },
+      {
+        "name": "policycoreutils",
+        "epoch": 0,
+        "version": "2.9",
+        "release": "15.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/policycoreutils-2.9-15.el8.ppc64le.rpm",
+        "checksum": "sha256:c64632c85c3a49dc82222cdb3d0ee87eafa64f3096ffeba5bcc16c49ee2d260e",
+        "check_gpg": true
+      },
+      {
+        "name": "polkit-libs",
+        "epoch": 0,
+        "version": "0.115",
+        "release": "12.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/polkit-libs-0.115-12.el8.ppc64le.rpm",
+        "checksum": "sha256:15554476d03595246aec194e63ec9db7469d5b3ed81a27a8a2720e82df1f8bf4",
+        "check_gpg": true
+      },
+      {
+        "name": "popt",
+        "epoch": 0,
+        "version": "1.18",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/popt-1.18-1.el8.ppc64le.rpm",
+        "checksum": "sha256:3b00ac82c31b447e306fcb47b4469fdc4e6d87385b42358c2e76badb51b074a3",
+        "check_gpg": true
+      },
+      {
+        "name": "procps-ng",
+        "epoch": 0,
+        "version": "3.3.15",
+        "release": "6.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/procps-ng-3.3.15-6.el8.ppc64le.rpm",
+        "checksum": "sha256:1cfa672c25cb5849bb2aa652e045e4a4a272c025befb1fe5e58cb32823faa30d",
+        "check_gpg": true
+      },
+      {
+        "name": "psmisc",
+        "epoch": 0,
+        "version": "23.1",
+        "release": "5.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/psmisc-23.1-5.el8.ppc64le.rpm",
+        "checksum": "sha256:2394d6a1ce4de90590e65111d870b172cb9d4e30e1e6f58a334b29e717fdd031",
+        "check_gpg": true
+      },
+      {
+        "name": "publicsuffix-list-dafsa",
+        "epoch": 0,
+        "version": "20180723",
+        "release": "1.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/publicsuffix-list-dafsa-20180723-1.el8.noarch.rpm",
+        "checksum": "sha256:65ecf1e479dc2b2f7f09c2e86d7457043b3470b3eab3c4ee8909b50b0a669fc2",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-chardet",
+        "epoch": 0,
+        "version": "3.0.4",
+        "release": "7.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-chardet-3.0.4-7.el8.noarch.rpm",
+        "checksum": "sha256:176ffcb2cf0fdcbdd2d8119cbd98eef60a30fdb0fb065a9382d2c95e90c79652",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-dnf",
+        "epoch": 0,
+        "version": "4.7.0",
+        "release": "2.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-dnf-4.7.0-2.el8.noarch.rpm",
+        "checksum": "sha256:ccfa1810aa19fae08aefd29cffe28b65d5123cd17bd7d2d4207f03cf9795594c",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-gpg",
+        "epoch": 0,
+        "version": "1.13.1",
+        "release": "9.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-gpg-1.13.1-9.el8.ppc64le.rpm",
+        "checksum": "sha256:111d88db3a52121f04f2741cc72ce8dda6d6f6ef2cc36452c042e0141b316334",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-hawkey",
+        "epoch": 0,
+        "version": "0.63.0",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-hawkey-0.63.0-2.el8.ppc64le.rpm",
+        "checksum": "sha256:4715730da2b4a5bf6cc2ab85208071f00c7b279e4b2f75df0bd954446185e14c",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-idna",
+        "epoch": 0,
+        "version": "2.5",
+        "release": "5.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-idna-2.5-5.el8.noarch.rpm",
+        "checksum": "sha256:78c43d8a15ca018de1803e4baac5819e1baab1963fd31f1e44e54e8a573acbfc",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-iniparse",
+        "epoch": 0,
+        "version": "0.4",
+        "release": "31.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-iniparse-0.4-31.el8.noarch.rpm",
+        "checksum": "sha256:5c0957decce3babef9864904be13190b0072aef720e9f4ca820bab6c02a20178",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libcomps",
+        "epoch": 0,
+        "version": "0.1.16",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-libcomps-0.1.16-2.el8.ppc64le.rpm",
+        "checksum": "sha256:594d8b368013caa4eaba4eade896fc1cec8ef569052bd491f493c193e07c6d80",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libdnf",
+        "epoch": 0,
+        "version": "0.63.0",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-libdnf-0.63.0-2.el8.ppc64le.rpm",
+        "checksum": "sha256:abc36bf7797a427b64c3c99b4f74714bfa66b906b62358be6fdafe493a66415e",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-librepo",
+        "epoch": 0,
+        "version": "1.14.0",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-librepo-1.14.0-2.el8.ppc64le.rpm",
+        "checksum": "sha256:35eb77080d99941b137da8c6cb25305ad4ff64cf2a7ba1f8adbf8d0998b5fe45",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libs",
+        "epoch": 0,
+        "version": "3.6.8",
+        "release": "39.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-libs-3.6.8-39.el8.ppc64le.rpm",
+        "checksum": "sha256:405bda98fe97c1a5cf70511ae2d167256b25dd8721b88899465e9847525e2068",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libselinux",
+        "epoch": 0,
+        "version": "2.9",
+        "release": "5.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-libselinux-2.9-5.el8.ppc64le.rpm",
+        "checksum": "sha256:3b5d31b89683be71c72b77cfceb59238f4c76a796de6ae85525b3d5cfe2a8f23",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-pip-wheel",
+        "epoch": 0,
+        "version": "9.0.3",
+        "release": "20.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-pip-wheel-9.0.3-20.el8.noarch.rpm",
+        "checksum": "sha256:6c9dfb73e199975275633f05d31388cd61c5a77dec5678db958b4e6624eb21ba",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-pysocks",
+        "epoch": 0,
+        "version": "1.6.8",
+        "release": "3.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-pysocks-1.6.8-3.el8.noarch.rpm",
+        "checksum": "sha256:7f506879c64e0bb4d98782d025f46fb9a07517487ae4cbebbb3985a98f4e2154",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-requests",
+        "epoch": 0,
+        "version": "2.20.0",
+        "release": "2.1.el8_1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-requests-2.20.0-2.1.el8_1.noarch.rpm",
+        "checksum": "sha256:003ee19ec5b88de212c3246bdfdb3e97a9910a25a219fd7cf5030b7bc666fea9",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-rpm",
+        "epoch": 0,
+        "version": "4.14.3",
+        "release": "15.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-rpm-4.14.3-15.el8.ppc64le.rpm",
+        "checksum": "sha256:ccf848b42acc0f691b4cb6e2830dc4263c7ce4df89b3f4002c3d6b9cd99b362b",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-setuptools",
+        "epoch": 0,
+        "version": "39.2.0",
+        "release": "6.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-setuptools-39.2.0-6.el8.noarch.rpm",
+        "checksum": "sha256:c6f27b6e01d80e756408e3c1451e4af00e7d02da0aa24402644c0785118753fe",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-setuptools-wheel",
+        "epoch": 0,
+        "version": "39.2.0",
+        "release": "6.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-setuptools-wheel-39.2.0-6.el8.noarch.rpm",
+        "checksum": "sha256:b19bd4f106ce301ee21c860183cc1c2ef9c09bdf495059bdf16e8d8ccc71bbe8",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-six",
+        "epoch": 0,
+        "version": "1.11.0",
+        "release": "8.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-six-1.11.0-8.el8.noarch.rpm",
+        "checksum": "sha256:a04cb3117395b962edc32bf45d8411f240632476b0706b2df7f4a1a87b2ce34b",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-urllib3",
+        "epoch": 0,
+        "version": "1.24.2",
+        "release": "5.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-urllib3-1.24.2-5.el8.noarch.rpm",
+        "checksum": "sha256:aa1835fd302a37b84ac256db5dd0de09bd9883a5a07775aedb491faf46b18ee0",
+        "check_gpg": true
+      },
+      {
+        "name": "readline",
+        "epoch": 0,
+        "version": "7.0",
+        "release": "10.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/readline-7.0-10.el8.ppc64le.rpm",
+        "checksum": "sha256:0320663709136d07690fe299903700cc1dcc526d574fe8b952a01e1d24024ae4",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm",
+        "epoch": 0,
+        "version": "4.14.3",
+        "release": "15.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/rpm-4.14.3-15.el8.ppc64le.rpm",
+        "checksum": "sha256:4fae16ca54207cb952e3904b8eb8cc424f3f056f400e5e802ab1a9ef3e575834",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-build-libs",
+        "epoch": 0,
+        "version": "4.14.3",
+        "release": "15.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/rpm-build-libs-4.14.3-15.el8.ppc64le.rpm",
+        "checksum": "sha256:03ba1e86a04d912fd2878b457b06a6a7abad0ce96cd9a6932bf58cb4641b8fb7",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-libs",
+        "epoch": 0,
+        "version": "4.14.3",
+        "release": "15.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/rpm-libs-4.14.3-15.el8.ppc64le.rpm",
+        "checksum": "sha256:4e22015880d16cb7148d70895a2361f4fa05804f0391386e0e50554e6fd868b0",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-plugin-selinux",
+        "epoch": 0,
+        "version": "4.14.3",
+        "release": "15.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/rpm-plugin-selinux-4.14.3-15.el8.ppc64le.rpm",
+        "checksum": "sha256:9b1018a43b1a9245cdc71a342b962aa32fb799bd0ce66ee59b496cdd75200de9",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-plugin-systemd-inhibit",
+        "epoch": 0,
+        "version": "4.14.3",
+        "release": "15.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/rpm-plugin-systemd-inhibit-4.14.3-15.el8.ppc64le.rpm",
+        "checksum": "sha256:8cb953ea9ea1bd262bef00112e2c433583929cd7aec86ae60f1a725c6dcf7c09",
+        "check_gpg": true
+      },
+      {
+        "name": "sed",
+        "epoch": 0,
+        "version": "4.5",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/sed-4.5-2.el8.ppc64le.rpm",
+        "checksum": "sha256:dbde46224833f804d8b92212fa3618ea53d0e0cb84ff07132a5ba36c1bc0b9df",
+        "check_gpg": true
+      },
+      {
+        "name": "selinux-policy",
+        "epoch": 0,
+        "version": "3.14.3",
+        "release": "76.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/selinux-policy-3.14.3-76.el8.noarch.rpm",
+        "checksum": "sha256:561a61d2d81bccb14d22a53b32301e0b6b9e9b9d80ad75991ee6ff796cae0ef7",
+        "check_gpg": true
+      },
+      {
+        "name": "selinux-policy-targeted",
+        "epoch": 0,
+        "version": "3.14.3",
+        "release": "76.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/selinux-policy-targeted-3.14.3-76.el8.noarch.rpm",
+        "checksum": "sha256:76df9e0fc779fcd7d3ee836ae254ead30b5f9492022b55901d1f8bd914d38ef6",
+        "check_gpg": true
+      },
+      {
+        "name": "setup",
+        "epoch": 0,
+        "version": "2.12.2",
+        "release": "6.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/setup-2.12.2-6.el8.noarch.rpm",
+        "checksum": "sha256:9e540fe1fcf866ba1e738e012eef5459d34cca30385df73973e6fc7c6eadb55f",
+        "check_gpg": true
+      },
+      {
+        "name": "shadow-utils",
+        "epoch": 2,
+        "version": "4.6",
+        "release": "14.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/shadow-utils-4.6-14.el8.ppc64le.rpm",
+        "checksum": "sha256:e1153055b6ea57ee81e6fb41b03023279059513d0fec728517ae0805186a5118",
+        "check_gpg": true
+      },
+      {
+        "name": "shared-mime-info",
+        "epoch": 0,
+        "version": "1.9",
+        "release": "3.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/shared-mime-info-1.9-3.el8.ppc64le.rpm",
+        "checksum": "sha256:f97b5915b3f75d2878104c198f205841813712103f1b3657d71d2c8d079cc947",
+        "check_gpg": true
+      },
+      {
+        "name": "sqlite-libs",
+        "epoch": 0,
+        "version": "3.26.0",
+        "release": "15.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/sqlite-libs-3.26.0-15.el8.ppc64le.rpm",
+        "checksum": "sha256:31277c01ac529cc1c6a55fd87d6ce4dbb20290575d4e1e89cd40600eac9f3405",
+        "check_gpg": true
+      },
+      {
+        "name": "squashfs-tools",
+        "epoch": 0,
+        "version": "4.3",
+        "release": "20.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/squashfs-tools-4.3-20.el8.ppc64le.rpm",
+        "checksum": "sha256:4b00562fa291e956d910bb056c6120f0079f30093ea107757758683a6d418206",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd",
+        "epoch": 0,
+        "version": "239",
+        "release": "49.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/systemd-239-49.el8.ppc64le.rpm",
+        "checksum": "sha256:8a501b9d8016eee68ce62a93a65842b15c8a57192b9f8189ebc85a11f2f47f9e",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-libs",
+        "epoch": 0,
+        "version": "239",
+        "release": "49.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/systemd-libs-239-49.el8.ppc64le.rpm",
+        "checksum": "sha256:3d175382237a94330d72af67ad2c41535dee7eade3e42178b86d2dc87478d030",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-pam",
+        "epoch": 0,
+        "version": "239",
+        "release": "49.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/systemd-pam-239-49.el8.ppc64le.rpm",
+        "checksum": "sha256:e95bb05fa5defeb16dd0e0957de676374b22b9daaf405273e636d1ce91001574",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-udev",
+        "epoch": 0,
+        "version": "239",
+        "release": "49.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/systemd-udev-239-49.el8.ppc64le.rpm",
+        "checksum": "sha256:3898e2ac4e04e80373bc7fe4092b26d502d4705177719117e25c083d44a9a150",
+        "check_gpg": true
+      },
+      {
+        "name": "tar",
+        "epoch": 2,
+        "version": "1.30",
+        "release": "5.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/tar-1.30-5.el8.ppc64le.rpm",
+        "checksum": "sha256:8c26cce4231f781db7b37d51ded377f9cfa01a5e6833d967082795f1220e2860",
+        "check_gpg": true
+      },
+      {
+        "name": "tpm2-tss",
+        "epoch": 0,
+        "version": "2.3.2",
+        "release": "4.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/tpm2-tss-2.3.2-4.el8.ppc64le.rpm",
+        "checksum": "sha256:d46ef49f8ddba1ee8cce6c9764014851cce2dbfb5dcb2457a31495393e6566c1",
+        "check_gpg": true
+      },
+      {
+        "name": "trousers",
+        "epoch": 0,
+        "version": "0.3.15",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/trousers-0.3.15-1.el8.ppc64le.rpm",
+        "checksum": "sha256:4164089bf1754c0ef18ae051e047f11299907204839ad4b7978f146a543a2e91",
+        "check_gpg": true
+      },
+      {
+        "name": "trousers-lib",
+        "epoch": 0,
+        "version": "0.3.15",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/trousers-lib-0.3.15-1.el8.ppc64le.rpm",
+        "checksum": "sha256:09096bc32e37443417cd625364df32674f9d5ff4ddbeb175e6d60637ed3d573f",
+        "check_gpg": true
+      },
+      {
+        "name": "tzdata",
+        "epoch": 0,
+        "version": "2021a",
+        "release": "1.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/tzdata-2021a-1.el8.noarch.rpm",
+        "checksum": "sha256:44999c555a6e4bb6cf5e6f6a79819e76912d036732cb50efaeefc20a180dd839",
+        "check_gpg": true
+      },
+      {
+        "name": "util-linux",
+        "epoch": 0,
+        "version": "2.32.1",
+        "release": "28.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/util-linux-2.32.1-28.el8.ppc64le.rpm",
+        "checksum": "sha256:ce954d3900cb547aea14df6ad5f310ea96bb5e83a155b93e2e64b2c13b686193",
+        "check_gpg": true
+      },
+      {
+        "name": "which",
+        "epoch": 0,
+        "version": "2.21",
+        "release": "16.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/which-2.21-16.el8.ppc64le.rpm",
+        "checksum": "sha256:15cd74b4ad9d82417072fe867f086d68667afd4291b710b6c7feef985c492990",
+        "check_gpg": true
+      },
+      {
+        "name": "xfsprogs",
+        "epoch": 0,
+        "version": "5.0.0",
+        "release": "9.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/xfsprogs-5.0.0-9.el8.ppc64le.rpm",
+        "checksum": "sha256:480e0f1a9dcce6ed0728e9aba709e33f5522273da1e4b0859cf9d3bbe2216532",
+        "check_gpg": true
+      },
+      {
+        "name": "xz",
+        "epoch": 0,
+        "version": "5.2.4",
+        "release": "3.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/xz-5.2.4-3.el8.ppc64le.rpm",
+        "checksum": "sha256:cd8b0adfc4d2467a61ab2aa2b3e617bbd2a2592176da249365eef014faef827c",
+        "check_gpg": true
+      },
+      {
+        "name": "xz-libs",
+        "epoch": 0,
+        "version": "5.2.4",
+        "release": "3.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/xz-libs-5.2.4-3.el8.ppc64le.rpm",
+        "checksum": "sha256:a4577841148e7e2bf481447ae141eff319007e70a24295a22787bbfaecf4c4fe",
+        "check_gpg": true
+      },
+      {
+        "name": "zlib",
+        "epoch": 0,
+        "version": "1.2.11",
+        "release": "17.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/zlib-1.2.11-17.el8.ppc64le.rpm",
+        "checksum": "sha256:33a92d88496e8aa410976f073e324f761b2ae02a94c20c0f291072df84f648be",
+        "check_gpg": true
+      },
+      {
+        "name": "GConf2",
+        "epoch": 0,
+        "version": "3.2.6",
+        "release": "22.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/GConf2-3.2.6-22.el8.ppc64le.rpm",
+        "checksum": "sha256:a388c955ace01f09f522c0ccf3afd47e682b22a87756e185f9134bdff72fb2ff",
+        "check_gpg": true
+      },
+      {
+        "name": "genisoimage",
+        "epoch": 0,
+        "version": "1.1.11",
+        "release": "39.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/genisoimage-1.1.11-39.el8.ppc64le.rpm",
+        "checksum": "sha256:5374ef6981f9a29d08c3400488b010f477fe7722367fcd6d29244ba8bd29b89c",
+        "check_gpg": true
+      },
+      {
+        "name": "isomd5sum",
+        "epoch": 1,
+        "version": "1.2.3",
+        "release": "3.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/isomd5sum-1.2.3-3.el8.ppc64le.rpm",
+        "checksum": "sha256:864f5bf99bf805c3e1143f78a78012d2f910f0d5627519b1f263a4d5cc6fa45e",
+        "check_gpg": true
+      },
+      {
+        "name": "libusal",
+        "epoch": 0,
+        "version": "1.1.11",
+        "release": "39.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/libusal-1.1.11-39.el8.ppc64le.rpm",
+        "checksum": "sha256:e14ef6f934d9a20645b9eb781902d6a03b7c8123985c88536e06205b240ba509",
+        "check_gpg": true
+      },
+      {
+        "name": "libxkbcommon",
+        "epoch": 0,
+        "version": "0.9.1",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/libxkbcommon-0.9.1-1.el8.ppc64le.rpm",
+        "checksum": "sha256:b5bd11b47b5b690dc667dc486941331d7cd3aaa4f0e5c4d638ec7b294bcc5012",
+        "check_gpg": true
+      },
+      {
+        "name": "lorax",
+        "epoch": 0,
+        "version": "28.14.61",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/lorax-28.14.61-2.el8.ppc64le.rpm",
+        "checksum": "sha256:0bad67cd4773d94db37a39c77f44b6eb380febc0de33fa51cacc2140c9c699b9",
+        "check_gpg": true
+      },
+      {
+        "name": "lorax-templates-generic",
+        "epoch": 0,
+        "version": "28.14.61",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/lorax-templates-generic-28.14.61-2.el8.ppc64le.rpm",
+        "checksum": "sha256:94e73ee7b1a5e6791a7cdce615f8a7e23fe1e6359b22ee366b71f45a5ef13483",
+        "check_gpg": true
+      },
+      {
+        "name": "lorax-templates-rhel",
+        "epoch": 0,
+        "version": "8.5",
+        "release": "2.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/lorax-templates-rhel-8.5-2.el8.noarch.rpm",
+        "checksum": "sha256:41512b492c3020571b4d8c671160758ec0e4b78212d75808291a5c56224b644b",
+        "check_gpg": true
+      },
+      {
+        "name": "pinentry",
+        "epoch": 0,
+        "version": "1.1.0",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/pinentry-1.1.0-2.el8.ppc64le.rpm",
+        "checksum": "sha256:12fda64dea45a7b085a35a816a7d8035be6600cae38f7df04a3bc22ced4d4502",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-kickstart",
+        "epoch": 0,
+        "version": "3.16.13",
+        "release": "1.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/python3-kickstart-3.16.13-1.el8.noarch.rpm",
+        "checksum": "sha256:3c9de6673cb840c3c6925bd1df87da0ef3b118d35dbe8f30bbafd0dfc67a939c",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-mako",
+        "epoch": 0,
+        "version": "1.0.6",
+        "release": "13.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/python3-mako-1.0.6-13.el8.noarch.rpm",
+        "checksum": "sha256:9dc5c484c7821cc737f872973764203376106d643b9adc4ef66bece1b0cc8fdc",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-markupsafe",
+        "epoch": 0,
+        "version": "0.23",
+        "release": "19.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/python3-markupsafe-0.23-19.el8.ppc64le.rpm",
+        "checksum": "sha256:0f54422e17766a9e7385a553d941d1849c9e7ca4caea085305ba9fb1e15ae607",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-ordered-set",
+        "epoch": 0,
+        "version": "2.0.2",
+        "release": "4.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/python3-ordered-set-2.0.2-4.el8.noarch.rpm",
+        "checksum": "sha256:b01c567dbd2b9bf82301b254a8962a8fb8f30d12a8f566145eee0f3936f47b5d",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-pip",
+        "epoch": 0,
+        "version": "9.0.3",
+        "release": "20.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/python3-pip-9.0.3-20.el8.noarch.rpm",
+        "checksum": "sha256:b615599db3ac6249e7b18e0c66474e080dc71ee72612bfa0268ea36b1a74e8da",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-unbound",
+        "epoch": 0,
+        "version": "1.7.3",
+        "release": "17.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/python3-unbound-1.7.3-17.el8.ppc64le.rpm",
+        "checksum": "sha256:8571a2aa115d42f8b5e87ef58d10e9c24e6fbe5470fc2612df96f8740f3d960f",
+        "check_gpg": true
+      },
+      {
+        "name": "python36",
+        "epoch": 0,
+        "version": "3.6.8",
+        "release": "37.module_el8.5.0+771+e5d9a225",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/python36-3.6.8-37.module_el8.5.0+771+e5d9a225.ppc64le.rpm",
+        "checksum": "sha256:3973aa7ac4416f1d33ffa8f4e9a5b126e7e2f77ed1ec63a70312b509b4934a9d",
+        "check_gpg": true
+      },
+      {
+        "name": "qemu-img",
+        "epoch": 15,
+        "version": "4.2.0",
+        "release": "52.module_el8.5.0+853+a4d5519d",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/qemu-img-4.2.0-52.module_el8.5.0+853+a4d5519d.ppc64le.rpm",
+        "checksum": "sha256:9ea4e52636b010504bfff1662c57988feb81cdfe97ba7c092f6efe3abdbe2dd7",
+        "check_gpg": true
+      },
+      {
+        "name": "unbound-libs",
+        "epoch": 0,
+        "version": "1.7.3",
+        "release": "17.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/unbound-libs-1.7.3-17.el8.ppc64le.rpm",
+        "checksum": "sha256:ebd64ac5cc7b9f58a40072fe9afefa2fd835e0eb18cdeaf085395c7e84affac3",
+        "check_gpg": true
+      },
+      {
+        "name": "xkeyboard-config",
+        "epoch": 0,
+        "version": "2.28",
+        "release": "1.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/xkeyboard-config-2.28-1.el8.noarch.rpm",
+        "checksum": "sha256:a2aeabb3962859069a78acc288bc3bffb35485428e162caafec8134f5ce6ca67",
+        "check_gpg": true
+      }
+    ],
+    "packages": [
+      {
+        "name": "NetworkManager",
+        "epoch": 1,
+        "version": "1.32.8",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/NetworkManager-1.32.8-1.el8.ppc64le.rpm",
+        "checksum": "sha256:a6ef8e56d53c29e92b46a7ad62c22380056153b2d5810c39c0cc1658a4250d5b",
+        "check_gpg": true
+      },
+      {
+        "name": "NetworkManager-libnm",
+        "epoch": 1,
+        "version": "1.32.8",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/NetworkManager-libnm-1.32.8-1.el8.ppc64le.rpm",
+        "checksum": "sha256:d3ad718b08b44e1fca355abd46a6c315a9d73ab38f9f3c3d551642b55866e182",
+        "check_gpg": true
+      },
+      {
+        "name": "NetworkManager-team",
+        "epoch": 1,
+        "version": "1.32.8",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/NetworkManager-team-1.32.8-1.el8.ppc64le.rpm",
+        "checksum": "sha256:3ed20aba45a8c175e818de998d906fb2759387c607bd9b15dbbefee8c73097ba",
+        "check_gpg": true
+      },
+      {
+        "name": "NetworkManager-tui",
+        "epoch": 1,
+        "version": "1.32.8",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/NetworkManager-tui-1.32.8-1.el8.ppc64le.rpm",
+        "checksum": "sha256:5f068787bd9a0190b03e64cd770e44ace593c5aa09e3f4c470c44d8d484b4674",
+        "check_gpg": true
+      },
+      {
+        "name": "acl",
+        "epoch": 0,
+        "version": "2.2.53",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/acl-2.2.53-1.el8.ppc64le.rpm",
+        "checksum": "sha256:2c1baefd0f802507d9741da8da54f6eae42b04967f9d433d7f9e0f124434c70d",
+        "check_gpg": true
+      },
+      {
+        "name": "audit",
+        "epoch": 0,
+        "version": "3.0",
+        "release": "0.17.20191104git1c2f876.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/audit-3.0-0.17.20191104git1c2f876.el8.ppc64le.rpm",
+        "checksum": "sha256:42829311fe40b7487530ee432aeb8e1df86e5168373f038cccb60d0db94601d3",
+        "check_gpg": true
+      },
+      {
+        "name": "audit-libs",
+        "epoch": 0,
+        "version": "3.0",
+        "release": "0.17.20191104git1c2f876.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/audit-libs-3.0-0.17.20191104git1c2f876.el8.ppc64le.rpm",
+        "checksum": "sha256:be49b69bc5de947ee2151f397993a691a57bc53952058c32cde0fca674da7d8c",
+        "check_gpg": true
+      },
+      {
+        "name": "authselect",
+        "epoch": 0,
+        "version": "1.2.2",
+        "release": "3.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/authselect-1.2.2-3.el8.ppc64le.rpm",
+        "checksum": "sha256:f14cc62cf70a187384adff6bedf8b09858b8f441a9be87ebf3ae975c4e6b0d73",
+        "check_gpg": true
+      },
+      {
+        "name": "authselect-libs",
+        "epoch": 0,
+        "version": "1.2.2",
+        "release": "3.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/authselect-libs-1.2.2-3.el8.ppc64le.rpm",
+        "checksum": "sha256:4966b1832e9eccd8f83ecc20143fb6f18215107bdecd7267b4605cdae4a6562a",
+        "check_gpg": true
+      },
+      {
+        "name": "basesystem",
+        "epoch": 0,
+        "version": "11",
+        "release": "5.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/basesystem-11-5.el8.noarch.rpm",
+        "checksum": "sha256:48226934763e4c412c1eb65df314e6879720b4b1ebcb3d07c126c9526639cb68",
+        "check_gpg": true
+      },
+      {
+        "name": "bash",
+        "epoch": 0,
+        "version": "4.4.20",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/bash-4.4.20-2.el8.ppc64le.rpm",
+        "checksum": "sha256:3a438b53e8377eccf90cac0fd42ed2b513fc869bfb7b96e3d2a4f6984a287f90",
+        "check_gpg": true
+      },
+      {
+        "name": "bc",
+        "epoch": 0,
+        "version": "1.07.1",
+        "release": "5.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/bc-1.07.1-5.el8.ppc64le.rpm",
+        "checksum": "sha256:c12c7dc6676c6ccc5ca08ceddfb1b4e46c9f1ed49cbc241292ae6d1fdb0d9d62",
+        "check_gpg": true
+      },
+      {
+        "name": "bind-export-libs",
+        "epoch": 32,
+        "version": "9.11.26",
+        "release": "4.el8_4",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/bind-export-libs-9.11.26-4.el8_4.ppc64le.rpm",
+        "checksum": "sha256:297b8a7b336dfc298d86d76d400459d2fa63af8628f5e19e35314a33a6478234",
+        "check_gpg": true
+      },
+      {
+        "name": "brotli",
+        "epoch": 0,
+        "version": "1.0.6",
+        "release": "3.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/brotli-1.0.6-3.el8.ppc64le.rpm",
+        "checksum": "sha256:8729b157f0925feccdaef8aacd91c6aebe0109e621675bcc15e1830673b0e19d",
+        "check_gpg": true
+      },
+      {
+        "name": "bzip2",
+        "epoch": 0,
+        "version": "1.0.6",
+        "release": "26.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/bzip2-1.0.6-26.el8.ppc64le.rpm",
+        "checksum": "sha256:06c8c530fb914e07375c183f13b8431456377cec33376423f6589d1047277587",
+        "check_gpg": true
+      },
+      {
+        "name": "bzip2-libs",
+        "epoch": 0,
+        "version": "1.0.6",
+        "release": "26.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/bzip2-libs-1.0.6-26.el8.ppc64le.rpm",
+        "checksum": "sha256:56c3d429ea949467dc0bca882646cf40a58fb6f27750f5664ff2919f5d38ada5",
+        "check_gpg": true
+      },
+      {
+        "name": "c-ares",
+        "epoch": 0,
+        "version": "1.13.0",
+        "release": "5.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/c-ares-1.13.0-5.el8.ppc64le.rpm",
+        "checksum": "sha256:1f2a096d6a75662a86a06ff2859e6ba916bbc8c6d8cb7b73810ffbb9fef4b089",
+        "check_gpg": true
+      },
+      {
+        "name": "ca-certificates",
+        "epoch": 0,
+        "version": "2021.2.50",
+        "release": "82.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/ca-certificates-2021.2.50-82.el8.noarch.rpm",
+        "checksum": "sha256:1fad1d1f8b56e6967863aeb60f5fa3615e6a35b0f6532d8a23066e6823b50860",
+        "check_gpg": true
+      },
+      {
+        "name": "centos-gpg-keys",
+        "epoch": 1,
+        "version": "8",
+        "release": "2.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/centos-gpg-keys-8-2.el8.noarch.rpm",
+        "checksum": "sha256:842ff55b80ac9a5c3357bf52646a5761a4c4786bb3e64b56d8fa5d8fe34ef8bb",
+        "check_gpg": true
+      },
+      {
+        "name": "centos-stream-release",
+        "epoch": 0,
+        "version": "8.5",
+        "release": "3.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/centos-stream-release-8.5-3.el8.noarch.rpm",
+        "checksum": "sha256:15b17b95cf9cb9fb64e0c8e56110836bdcaf70de81b8cbdb60e181fc90456e06",
+        "check_gpg": true
+      },
+      {
+        "name": "centos-stream-repos",
+        "epoch": 0,
+        "version": "8",
+        "release": "2.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/centos-stream-repos-8-2.el8.noarch.rpm",
+        "checksum": "sha256:a82958266d292f4725fc1981ea57a861b7fc7feeb7a9551d0b61b98ca51a5662",
+        "check_gpg": true
+      },
+      {
+        "name": "checkpolicy",
+        "epoch": 0,
+        "version": "2.9",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/checkpolicy-2.9-1.el8.ppc64le.rpm",
+        "checksum": "sha256:38fe7db64baf2d4804a14466a6244f3c1de3bd5deca0ad4044e96d0d3f3751c7",
+        "check_gpg": true
+      },
+      {
+        "name": "chkconfig",
+        "epoch": 0,
+        "version": "1.19.1",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/chkconfig-1.19.1-1.el8.ppc64le.rpm",
+        "checksum": "sha256:eee92733e8989029929d5cb1f673b15fdb814dac32e148d5bc02378b44c8699a",
+        "check_gpg": true
+      },
+      {
+        "name": "chrony",
+        "epoch": 0,
+        "version": "4.1",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/chrony-4.1-1.el8.ppc64le.rpm",
+        "checksum": "sha256:24fcc5bc49b059b221075989f25875fb821079088dca694aec262446cde50cb7",
+        "check_gpg": true
+      },
+      {
+        "name": "cockpit-bridge",
+        "epoch": 0,
+        "version": "250",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/cockpit-bridge-250-1.el8.ppc64le.rpm",
+        "checksum": "sha256:dbc730cf810cc886667a7a9b17883ba15bc40e933a38dd820f2f026cf8007805",
+        "check_gpg": true
+      },
+      {
+        "name": "cockpit-system",
+        "epoch": 0,
+        "version": "250",
+        "release": "1.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/cockpit-system-250-1.el8.noarch.rpm",
+        "checksum": "sha256:3818fe6ec4996402b718827ba40ca01cc3c8276646d80030b652a26153aea2b7",
+        "check_gpg": true
+      },
+      {
+        "name": "cockpit-ws",
+        "epoch": 0,
+        "version": "250",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/cockpit-ws-250-1.el8.ppc64le.rpm",
+        "checksum": "sha256:ec85355744a8b37aa7fbe48d6f8afd8d0538129b70e82d238c3b57ae08559430",
+        "check_gpg": true
+      },
+      {
+        "name": "coreutils",
+        "epoch": 0,
+        "version": "8.30",
+        "release": "12.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/coreutils-8.30-12.el8.ppc64le.rpm",
+        "checksum": "sha256:ff8b51c6a8bacc5ef6b5da0f049d170ab1c1ecebad50ded3c04ed384eca9a2c0",
+        "check_gpg": true
+      },
+      {
+        "name": "coreutils-common",
+        "epoch": 0,
+        "version": "8.30",
+        "release": "12.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/coreutils-common-8.30-12.el8.ppc64le.rpm",
+        "checksum": "sha256:383a5e6bb9e94de53baaf5c7493cd50a68c893c6a30acfbe28407d33bb133efc",
+        "check_gpg": true
+      },
+      {
+        "name": "cpio",
+        "epoch": 0,
+        "version": "2.12",
+        "release": "10.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/cpio-2.12-10.el8.ppc64le.rpm",
+        "checksum": "sha256:19061d12407c0c4bca6abcaef01695b70dcd3967ff102dd07178a2193a280e29",
+        "check_gpg": true
+      },
+      {
+        "name": "cracklib",
+        "epoch": 0,
+        "version": "2.9.6",
+        "release": "15.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/cracklib-2.9.6-15.el8.ppc64le.rpm",
+        "checksum": "sha256:4e3e93a3d2039c2a8305030b7960bd1100d7d20705a1afb1325a4ee79478a74a",
+        "check_gpg": true
+      },
+      {
+        "name": "cracklib-dicts",
+        "epoch": 0,
+        "version": "2.9.6",
+        "release": "15.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/cracklib-dicts-2.9.6-15.el8.ppc64le.rpm",
+        "checksum": "sha256:084d79ed3d7127e6d46e9ac6e654d8ef181a156435808dc8eb32968b6c1b4946",
+        "check_gpg": true
+      },
+      {
+        "name": "cronie",
+        "epoch": 0,
+        "version": "1.5.2",
+        "release": "4.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/cronie-1.5.2-4.el8.ppc64le.rpm",
+        "checksum": "sha256:edf00207b603cbfe86b07f8be5c4ee14ff1dd85ec4b7d82d760483ffcea43891",
+        "check_gpg": true
+      },
+      {
+        "name": "cronie-anacron",
+        "epoch": 0,
+        "version": "1.5.2",
+        "release": "4.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/cronie-anacron-1.5.2-4.el8.ppc64le.rpm",
+        "checksum": "sha256:6faee589c5a7454502e5ec07586a4856e7f1376bd551741af2acf03afb9716e6",
+        "check_gpg": true
+      },
+      {
+        "name": "crontabs",
+        "epoch": 0,
+        "version": "1.11",
+        "release": "17.20190603git.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/crontabs-1.11-17.20190603git.el8.noarch.rpm",
+        "checksum": "sha256:bcf25aae89f7368b16346bc1ec92850175bcc2312bf7a5e74bc3c512bcd345b0",
+        "check_gpg": true
+      },
+      {
+        "name": "crypto-policies",
+        "epoch": 0,
+        "version": "20210617",
+        "release": "1.gitc776d3e.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/crypto-policies-20210617-1.gitc776d3e.el8.noarch.rpm",
+        "checksum": "sha256:2a8f9e5119a034801904185dcbf1bc29db67e9e9b0cf5893615722d7bb33099c",
+        "check_gpg": true
+      },
+      {
+        "name": "crypto-policies-scripts",
+        "epoch": 0,
+        "version": "20210617",
+        "release": "1.gitc776d3e.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/crypto-policies-scripts-20210617-1.gitc776d3e.el8.noarch.rpm",
+        "checksum": "sha256:67f37cee02ba744dfc7957725f5ef9df229778f6a2f7afc659625b458da6167e",
+        "check_gpg": true
+      },
+      {
+        "name": "cryptsetup-libs",
+        "epoch": 0,
+        "version": "2.3.3",
+        "release": "4.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/cryptsetup-libs-2.3.3-4.el8.ppc64le.rpm",
+        "checksum": "sha256:b10d8521963a2494fdb2b5f8fb0de837dc86d4016c3b10019fb8970a09582451",
+        "check_gpg": true
+      },
+      {
+        "name": "curl",
+        "epoch": 0,
+        "version": "7.61.1",
+        "release": "18.el8_4.1",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/curl-7.61.1-18.el8_4.1.ppc64le.rpm",
+        "checksum": "sha256:47ad43730c8bc72c90f2fb3dbd3526d716ada2fad94e62cb443658e94c6503c5",
+        "check_gpg": true
+      },
+      {
+        "name": "cyrus-sasl-lib",
+        "epoch": 0,
+        "version": "2.1.27",
+        "release": "5.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/cyrus-sasl-lib-2.1.27-5.el8.ppc64le.rpm",
+        "checksum": "sha256:5c1940e1f173e22b053f3a89022903cea34a6af20dff81c65548c4e2ba3a8293",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus",
+        "epoch": 1,
+        "version": "1.12.8",
+        "release": "14.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/dbus-1.12.8-14.el8.ppc64le.rpm",
+        "checksum": "sha256:1a4e44583a767289bb0d354db93c6a9132420e13376d4fcae866d69620bb11bb",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-common",
+        "epoch": 1,
+        "version": "1.12.8",
+        "release": "14.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/dbus-common-1.12.8-14.el8.noarch.rpm",
+        "checksum": "sha256:7baac88adafdc5958fb818c7685d3c6548f6e2e585e4435ceee4a168edc3597e",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-daemon",
+        "epoch": 1,
+        "version": "1.12.8",
+        "release": "14.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/dbus-daemon-1.12.8-14.el8.ppc64le.rpm",
+        "checksum": "sha256:090563f18409c228274bb61dcf1001f63a55c1246fb2838a998cb3c5fd8c3874",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-glib",
+        "epoch": 0,
+        "version": "0.110",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/dbus-glib-0.110-2.el8.ppc64le.rpm",
+        "checksum": "sha256:c58b0b900a7ffc778980461d74dc236bf2c790d2e5e8c04e28876e221b48a1c8",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-libs",
+        "epoch": 1,
+        "version": "1.12.8",
+        "release": "14.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/dbus-libs-1.12.8-14.el8.ppc64le.rpm",
+        "checksum": "sha256:cc5f8dd4e061da3a73aa67112e24f2cc5c0ad0cd4334dc798b8834cf6259a779",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-tools",
+        "epoch": 1,
+        "version": "1.12.8",
+        "release": "14.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/dbus-tools-1.12.8-14.el8.ppc64le.rpm",
+        "checksum": "sha256:698e8ecaf71719dafacae79de05080d567b69fad3511e8b8d42b9af96a7c41db",
+        "check_gpg": true
+      },
+      {
+        "name": "dejavu-fonts-common",
+        "epoch": 0,
+        "version": "2.35",
+        "release": "7.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/dejavu-fonts-common-2.35-7.el8.noarch.rpm",
+        "checksum": "sha256:dd80a8169e27959a27651616e998be8b49ffdca141744177cb42126ff0ae12b5",
+        "check_gpg": true
+      },
+      {
+        "name": "dejavu-sans-mono-fonts",
+        "epoch": 0,
+        "version": "2.35",
+        "release": "7.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/dejavu-sans-mono-fonts-2.35-7.el8.noarch.rpm",
+        "checksum": "sha256:a8a27e1ffbb92356d6376334687b9eaa0cb5f2eece2670128f3a01e391e9f3bb",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper",
+        "epoch": 8,
+        "version": "1.02.177",
+        "release": "6.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/device-mapper-1.02.177-6.el8.ppc64le.rpm",
+        "checksum": "sha256:441b3862f5a0fd504bbbba18d96d1b2b920fb95a79dc45a753a6a664ad285b07",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper-libs",
+        "epoch": 8,
+        "version": "1.02.177",
+        "release": "6.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/device-mapper-libs-1.02.177-6.el8.ppc64le.rpm",
+        "checksum": "sha256:a42de8ce71380b1f4e8ac5b4ce720bf565c99a0b09ef983c0550a91a467bc155",
+        "check_gpg": true
+      },
+      {
+        "name": "dhcp-client",
+        "epoch": 12,
+        "version": "4.3.6",
+        "release": "45.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/dhcp-client-4.3.6-45.el8.ppc64le.rpm",
+        "checksum": "sha256:ca5d70414653e1b769124582699bc2400f05b5382a9a8dc6bb4ab4f28dac9c20",
+        "check_gpg": true
+      },
+      {
+        "name": "dhcp-common",
+        "epoch": 12,
+        "version": "4.3.6",
+        "release": "45.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/dhcp-common-4.3.6-45.el8.noarch.rpm",
+        "checksum": "sha256:d64da85b0e013679fb06eeadad74465d9556d7ad21e97beb1b5f61fb0658cd10",
+        "check_gpg": true
+      },
+      {
+        "name": "dhcp-libs",
+        "epoch": 12,
+        "version": "4.3.6",
+        "release": "45.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/dhcp-libs-4.3.6-45.el8.ppc64le.rpm",
+        "checksum": "sha256:ed40678aa26d63b71a122bd394b46b362df083c8f4ae3267f205a7d77ff69fdf",
+        "check_gpg": true
+      },
+      {
+        "name": "diffutils",
+        "epoch": 0,
+        "version": "3.6",
+        "release": "6.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/diffutils-3.6-6.el8.ppc64le.rpm",
+        "checksum": "sha256:4f92835a6e4ee4276df49019e068d1871b75821f52b405c699bd9f199df58b80",
+        "check_gpg": true
+      },
+      {
+        "name": "dnf",
+        "epoch": 0,
+        "version": "4.7.0",
+        "release": "2.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/dnf-4.7.0-2.el8.noarch.rpm",
+        "checksum": "sha256:42464424b9fa731f8122fe748aad0005519fc87b770dbbdb71f29f514ea0e889",
+        "check_gpg": true
+      },
+      {
+        "name": "dnf-data",
+        "epoch": 0,
+        "version": "4.7.0",
+        "release": "2.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/dnf-data-4.7.0-2.el8.noarch.rpm",
+        "checksum": "sha256:45c48d32120739734ae97479cc0f3ca19796ea47e360ba39d52b77ce3ada61d7",
+        "check_gpg": true
+      },
+      {
+        "name": "dnf-plugins-core",
+        "epoch": 0,
+        "version": "4.0.21",
+        "release": "2.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/dnf-plugins-core-4.0.21-2.el8.noarch.rpm",
+        "checksum": "sha256:47b61754a278c4ca378871c874ccf6a0a07bffaef38505315cfa94f262887845",
+        "check_gpg": true
+      },
+      {
+        "name": "dosfstools",
+        "epoch": 0,
+        "version": "4.1",
+        "release": "6.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/dosfstools-4.1-6.el8.ppc64le.rpm",
+        "checksum": "sha256:04eee0a9c079186aa58b5536ac8bcbd2a360700b83fa7b9f6eb127c1386b7ef4",
+        "check_gpg": true
+      },
+      {
+        "name": "dracut",
+        "epoch": 0,
+        "version": "049",
+        "release": "188.git20210802.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/dracut-049-188.git20210802.el8.ppc64le.rpm",
+        "checksum": "sha256:881b28a3a37d114bc3f046605b24663560009b13a507217e007643f5682efdd5",
+        "check_gpg": true
+      },
+      {
+        "name": "dracut-config-generic",
+        "epoch": 0,
+        "version": "049",
+        "release": "188.git20210802.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/dracut-config-generic-049-188.git20210802.el8.ppc64le.rpm",
+        "checksum": "sha256:71d45853b0a8673e6354892df7a420ad77200a018ee5334b30b893862d030fa9",
+        "check_gpg": true
+      },
+      {
+        "name": "dracut-network",
+        "epoch": 0,
+        "version": "049",
+        "release": "188.git20210802.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/dracut-network-049-188.git20210802.el8.ppc64le.rpm",
+        "checksum": "sha256:2588ff56ab340c06ce8b5be22cbe23de89d4f336b38ae930daf11db1c6a24391",
+        "check_gpg": true
+      },
+      {
+        "name": "dracut-squash",
+        "epoch": 0,
+        "version": "049",
+        "release": "188.git20210802.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/dracut-squash-049-188.git20210802.el8.ppc64le.rpm",
+        "checksum": "sha256:412f3eaa5f7e226fdc4678a3266edab76d8998f7d76763075f690a01362ef89c",
+        "check_gpg": true
+      },
+      {
+        "name": "e2fsprogs",
+        "epoch": 0,
+        "version": "1.45.6",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/e2fsprogs-1.45.6-2.el8.ppc64le.rpm",
+        "checksum": "sha256:9e67ac5948125dd165c9a74ec848d48b313ef4264bbbb89630a782dbd972d72c",
+        "check_gpg": true
+      },
+      {
+        "name": "e2fsprogs-libs",
+        "epoch": 0,
+        "version": "1.45.6",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/e2fsprogs-libs-1.45.6-2.el8.ppc64le.rpm",
+        "checksum": "sha256:9fb07c2324cccbbc19e3ffade50ee7da41909b2f6c24f49ffd9978ba375de193",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-debuginfod-client",
+        "epoch": 0,
+        "version": "0.185",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/elfutils-debuginfod-client-0.185-1.el8.ppc64le.rpm",
+        "checksum": "sha256:f4eca686b314edb06d3fe1c526f573c7248c811af70cba76132cdc9c541cadc1",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-default-yama-scope",
+        "epoch": 0,
+        "version": "0.185",
+        "release": "1.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/elfutils-default-yama-scope-0.185-1.el8.noarch.rpm",
+        "checksum": "sha256:30ceeb5a6cadaeccdbde088bfb52ba88190fa530c11f4a2aafd62b4b4ad6b404",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-libelf",
+        "epoch": 0,
+        "version": "0.185",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/elfutils-libelf-0.185-1.el8.ppc64le.rpm",
+        "checksum": "sha256:e87acf226a9511b3a5f83e7fed9c5c20addbbdae47ab67c614404a9392b77e50",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-libs",
+        "epoch": 0,
+        "version": "0.185",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/elfutils-libs-0.185-1.el8.ppc64le.rpm",
+        "checksum": "sha256:d150e53fa73c3786da9e4f6e23d374100b0dd2923485d4a08e9a56ac2786cf83",
+        "check_gpg": true
+      },
+      {
+        "name": "ethtool",
+        "epoch": 2,
+        "version": "5.8",
+        "release": "6.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/ethtool-5.8-6.el8.ppc64le.rpm",
+        "checksum": "sha256:e8b7968fe6613c4cd6324436089cc9c1558cd63fb7da87fd46cc7c15c4ab7f66",
+        "check_gpg": true
+      },
+      {
+        "name": "expat",
+        "epoch": 0,
+        "version": "2.2.5",
+        "release": "4.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/expat-2.2.5-4.el8.ppc64le.rpm",
+        "checksum": "sha256:88be5116908aa5013f540c767f6811774342780bb72d3ec197b3429bfb2f9862",
+        "check_gpg": true
+      },
+      {
+        "name": "file",
+        "epoch": 0,
+        "version": "5.33",
+        "release": "20.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/file-5.33-20.el8.ppc64le.rpm",
+        "checksum": "sha256:e156e6fa9ef6a483f8505ce0eeadbcab12b887c4996233ce5d6258076f6bce50",
+        "check_gpg": true
+      },
+      {
+        "name": "file-libs",
+        "epoch": 0,
+        "version": "5.33",
+        "release": "20.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/file-libs-5.33-20.el8.ppc64le.rpm",
+        "checksum": "sha256:e65f7d7c8def6b168e013914bc0d1137aed65c3010e9796df3b823854472f3e1",
+        "check_gpg": true
+      },
+      {
+        "name": "filesystem",
+        "epoch": 0,
+        "version": "3.8",
+        "release": "6.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/filesystem-3.8-6.el8.ppc64le.rpm",
+        "checksum": "sha256:a49b922f117b9bfb0b07e9848151f8a2948345328ebc534cd28ac187d7ed3f94",
+        "check_gpg": true
+      },
+      {
+        "name": "findutils",
+        "epoch": 1,
+        "version": "4.6.0",
+        "release": "20.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/findutils-4.6.0-20.el8.ppc64le.rpm",
+        "checksum": "sha256:caa0bd6617a8d5e535faedec5f6f3ea7c5e6da1898751f6c9c34a89a95c286ff",
+        "check_gpg": true
+      },
+      {
+        "name": "fontconfig",
+        "epoch": 0,
+        "version": "2.13.1",
+        "release": "3.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/fontconfig-2.13.1-3.el8.ppc64le.rpm",
+        "checksum": "sha256:e403c9839742c4b13e715541237f79ffe52870d59867bebd39e19e7080948db1",
+        "check_gpg": true
+      },
+      {
+        "name": "fontpackages-filesystem",
+        "epoch": 0,
+        "version": "1.44",
+        "release": "22.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/fontpackages-filesystem-1.44-22.el8.noarch.rpm",
+        "checksum": "sha256:700b9050aa490b5eca6d1f8630cbebceb122fce11c370689b5ccb37f5a43ee2f",
+        "check_gpg": true
+      },
+      {
+        "name": "freetype",
+        "epoch": 0,
+        "version": "2.9.1",
+        "release": "4.el8_3.1",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/freetype-2.9.1-4.el8_3.1.ppc64le.rpm",
+        "checksum": "sha256:d1cf2d973db2f1af46f124776b9ab4bd782e7065c8c8428a4ddef60989e4225d",
+        "check_gpg": true
+      },
+      {
+        "name": "fuse-libs",
+        "epoch": 0,
+        "version": "2.9.7",
+        "release": "12.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/fuse-libs-2.9.7-12.el8.ppc64le.rpm",
+        "checksum": "sha256:4992eb036c0797daf9b984af1a34fe27a30287ee5d2bd5e2f5a0df3a09bdbb59",
+        "check_gpg": true
+      },
+      {
+        "name": "gawk",
+        "epoch": 0,
+        "version": "4.2.1",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/gawk-4.2.1-2.el8.ppc64le.rpm",
+        "checksum": "sha256:d807e7fb8bf24be50642a6dced954c6ea208199daab2d27c9f73d789ba82fa37",
+        "check_gpg": true
+      },
+      {
+        "name": "gdbm",
+        "epoch": 1,
+        "version": "1.18",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/gdbm-1.18-1.el8.ppc64le.rpm",
+        "checksum": "sha256:8cd6ef9902851f07cfd9682e2d6873648690f0c2ec65345276b557ede042d8b9",
+        "check_gpg": true
+      },
+      {
+        "name": "gdbm-libs",
+        "epoch": 1,
+        "version": "1.18",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/gdbm-libs-1.18-1.el8.ppc64le.rpm",
+        "checksum": "sha256:d1d362fd4f8022ad05171efe40e84d15ec6c5e5f419d6099ebc8e46e7da632c1",
+        "check_gpg": true
+      },
+      {
+        "name": "gdk-pixbuf2",
+        "epoch": 0,
+        "version": "2.36.12",
+        "release": "5.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/gdk-pixbuf2-2.36.12-5.el8.ppc64le.rpm",
+        "checksum": "sha256:4fc1c84b4434df8a5ccd960d906896e4094236f43ad4aea083a12fb5b8a824f9",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext",
+        "epoch": 0,
+        "version": "0.19.8.1",
+        "release": "17.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/gettext-0.19.8.1-17.el8.ppc64le.rpm",
+        "checksum": "sha256:78fd472a1c7f49b8a432788ea2dfc1119f155a394f41585b4e715d2585fc92ab",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext-libs",
+        "epoch": 0,
+        "version": "0.19.8.1",
+        "release": "17.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/gettext-libs-0.19.8.1-17.el8.ppc64le.rpm",
+        "checksum": "sha256:e392a6b41381ffad04626d092fd2af9477c72e197a74efddf987832c3bfa521f",
+        "check_gpg": true
+      },
+      {
+        "name": "glib-networking",
+        "epoch": 0,
+        "version": "2.56.1",
+        "release": "1.1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/glib-networking-2.56.1-1.1.el8.ppc64le.rpm",
+        "checksum": "sha256:4942002f6e3a471b8d51801047ea2584d5cd1dad5d4c4e44bce7af50c5b7cb14",
+        "check_gpg": true
+      },
+      {
+        "name": "glib2",
+        "epoch": 0,
+        "version": "2.56.4",
+        "release": "156.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/glib2-2.56.4-156.el8.ppc64le.rpm",
+        "checksum": "sha256:ad338b7a3f3bed96300d9ce7f0307e09d758962b8496c10fb3554bf62405d153",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc",
+        "epoch": 0,
+        "version": "2.28",
+        "release": "162.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/glibc-2.28-162.el8.ppc64le.rpm",
+        "checksum": "sha256:bfb45644212cfbbe48b05149f8d53e77d7bd02ca9fc9045cc37115101175a3a0",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-all-langpacks",
+        "epoch": 0,
+        "version": "2.28",
+        "release": "162.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/glibc-all-langpacks-2.28-162.el8.ppc64le.rpm",
+        "checksum": "sha256:fa7bef727ba8657208bb3df95916f0bc912332cb8534c695facef32ffbd72f20",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-common",
+        "epoch": 0,
+        "version": "2.28",
+        "release": "162.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/glibc-common-2.28-162.el8.ppc64le.rpm",
+        "checksum": "sha256:257e086bb52086254fa8cc95a5c4998668b4fcb5203ad3c2275c1150816acc9b",
+        "check_gpg": true
+      },
+      {
+        "name": "gmp",
+        "epoch": 1,
+        "version": "6.1.2",
+        "release": "10.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/gmp-6.1.2-10.el8.ppc64le.rpm",
+        "checksum": "sha256:af0a4287e302baa7c85655ddfe5a7049b8eaf31aff03886f4fc57c920d26d491",
+        "check_gpg": true
+      },
+      {
+        "name": "gnupg2",
+        "epoch": 0,
+        "version": "2.2.20",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/gnupg2-2.2.20-2.el8.ppc64le.rpm",
+        "checksum": "sha256:11ff811a72c82084c7c14700b23d29643e153442a34b3b486e270e5b40e38d0a",
+        "check_gpg": true
+      },
+      {
+        "name": "gnupg2-smime",
+        "epoch": 0,
+        "version": "2.2.20",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/gnupg2-smime-2.2.20-2.el8.ppc64le.rpm",
+        "checksum": "sha256:a2d96efed83ab31d21481af044835a940673ee4ade2763af78c06d2df87b94f7",
+        "check_gpg": true
+      },
+      {
+        "name": "gnutls",
+        "epoch": 0,
+        "version": "3.6.16",
+        "release": "4.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/gnutls-3.6.16-4.el8.ppc64le.rpm",
+        "checksum": "sha256:51760acfb6ca87db5be7a9296d6a3d1220767956c576a26c6d46784e25db85bb",
+        "check_gpg": true
+      },
+      {
+        "name": "gobject-introspection",
+        "epoch": 0,
+        "version": "1.56.1",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/gobject-introspection-1.56.1-1.el8.ppc64le.rpm",
+        "checksum": "sha256:754bf53a39cea727d9d89d59df32e020842dc71f6a0561ea36f8203aff2d5d69",
+        "check_gpg": true
+      },
+      {
+        "name": "gpgme",
+        "epoch": 0,
+        "version": "1.13.1",
+        "release": "9.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/gpgme-1.13.1-9.el8.ppc64le.rpm",
+        "checksum": "sha256:24f5cd46a7395cd046b10d6ddc4de435ec6595d0dcdb2d179c94cc9082a12f14",
+        "check_gpg": true
+      },
+      {
+        "name": "grep",
+        "epoch": 0,
+        "version": "3.1",
+        "release": "6.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/grep-3.1-6.el8.ppc64le.rpm",
+        "checksum": "sha256:2451a475f248a4c66e64d149fefa8bfc195fcd7b3f369bae221a94f8ce4c2d67",
+        "check_gpg": true
+      },
+      {
+        "name": "groff-base",
+        "epoch": 0,
+        "version": "1.22.3",
+        "release": "18.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/groff-base-1.22.3-18.el8.ppc64le.rpm",
+        "checksum": "sha256:cff4b4ac50fed2ceab6add52a66513ed9ca04b024f07a25c53df49f762eea2d2",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-common",
+        "epoch": 1,
+        "version": "2.02",
+        "release": "99.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/grub2-common-2.02-99.el8.noarch.rpm",
+        "checksum": "sha256:4a08d5264e865548e65d31886c91b659b33a2c2ba39fd115b00af3ea0bc91a83",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-ppc64le",
+        "epoch": 1,
+        "version": "2.02",
+        "release": "99.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/grub2-ppc64le-2.02-99.el8.ppc64le.rpm",
+        "checksum": "sha256:7cccedcc359f2a2542858088704bf3d0ec3e46cb7b72f602408fbab937a522d3",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-ppc64le-modules",
+        "epoch": 1,
+        "version": "2.02",
+        "release": "99.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/grub2-ppc64le-modules-2.02-99.el8.noarch.rpm",
+        "checksum": "sha256:d8dad22276baffe9496d5e05ef35d21dd6f9d8f910339daced2c3ff42d7a28c5",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-tools",
+        "epoch": 1,
+        "version": "2.02",
+        "release": "99.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/grub2-tools-2.02-99.el8.ppc64le.rpm",
+        "checksum": "sha256:78b2b9cbf041d4461daf7ac11a24d1e79a9c57f47aa265dba4d09067efe3d96b",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-tools-extra",
+        "epoch": 1,
+        "version": "2.02",
+        "release": "99.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/grub2-tools-extra-2.02-99.el8.ppc64le.rpm",
+        "checksum": "sha256:ac3b306c193bd20658950da402ae0cbdd8337110117de5e5d7eba970822671fd",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-tools-minimal",
+        "epoch": 1,
+        "version": "2.02",
+        "release": "99.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/grub2-tools-minimal-2.02-99.el8.ppc64le.rpm",
+        "checksum": "sha256:fb276cc0ebc6bd27d344f7e0811f26cb3f0e59da09182489095724bdf2a075f8",
+        "check_gpg": true
+      },
+      {
+        "name": "grubby",
+        "epoch": 0,
+        "version": "8.40",
+        "release": "41.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/grubby-8.40-41.el8.ppc64le.rpm",
+        "checksum": "sha256:5a0927d231fbafa8b865591922fc07d39d9b4b263a1e9c0bbef691282f706cd0",
+        "check_gpg": true
+      },
+      {
+        "name": "gsettings-desktop-schemas",
+        "epoch": 0,
+        "version": "3.32.0",
+        "release": "6.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/gsettings-desktop-schemas-3.32.0-6.el8.ppc64le.rpm",
+        "checksum": "sha256:7cced5f47c4035e01fffce0989b62113a75016e5220e7b207c4b96be7ed90403",
+        "check_gpg": true
+      },
+      {
+        "name": "gssproxy",
+        "epoch": 0,
+        "version": "0.8.0",
+        "release": "19.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/gssproxy-0.8.0-19.el8.ppc64le.rpm",
+        "checksum": "sha256:ffb6d471f5c82b0407cc41a25aea25bf83d6779b3ef20f0557c4fd0da6111bb7",
+        "check_gpg": true
+      },
+      {
+        "name": "gzip",
+        "epoch": 0,
+        "version": "1.9",
+        "release": "12.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/gzip-1.9-12.el8.ppc64le.rpm",
+        "checksum": "sha256:e1e28504928648404a3b652440091eba010cd99221183ef78601cbd152261d91",
+        "check_gpg": true
+      },
+      {
+        "name": "hardlink",
+        "epoch": 1,
+        "version": "1.3",
+        "release": "6.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/hardlink-1.3-6.el8.ppc64le.rpm",
+        "checksum": "sha256:42bb566be1936bdb40937f9c0a96c4acc93057379385f1807cba18f60443d3e4",
+        "check_gpg": true
+      },
+      {
+        "name": "hdparm",
+        "epoch": 0,
+        "version": "9.54",
+        "release": "4.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/hdparm-9.54-4.el8.ppc64le.rpm",
+        "checksum": "sha256:8c05fe038c7792203afa47f4534318f6c674672999b444909706ce0826bf1b8f",
+        "check_gpg": true
+      },
+      {
+        "name": "hostname",
+        "epoch": 0,
+        "version": "3.20",
+        "release": "7.el8.0.1",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/hostname-3.20-7.el8.0.1.ppc64le.rpm",
+        "checksum": "sha256:a571c94456b9a1743e94f4f72159de52bb13fe93437b81da675351553a881a17",
+        "check_gpg": true
+      },
+      {
+        "name": "hwdata",
+        "epoch": 0,
+        "version": "0.314",
+        "release": "8.9.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/hwdata-0.314-8.9.el8.noarch.rpm",
+        "checksum": "sha256:dfecfa1299d11d6a77503e626a2e9a14e1a75666bc8ea2abaf7ff515d2c86332",
+        "check_gpg": true
+      },
+      {
+        "name": "ima-evm-utils",
+        "epoch": 0,
+        "version": "1.3.2",
+        "release": "12.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/ima-evm-utils-1.3.2-12.el8.ppc64le.rpm",
+        "checksum": "sha256:8119d276749b35cd9c283c1a8d970b3528bea58427eb37eafc22b6093a978f08",
+        "check_gpg": true
+      },
+      {
+        "name": "info",
+        "epoch": 0,
+        "version": "6.5",
+        "release": "6.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/info-6.5-6.el8.ppc64le.rpm",
+        "checksum": "sha256:6d1ac29b3a38408f6d238d6718384e05be7346789c6200b354335b0e0c9c77df",
+        "check_gpg": true
+      },
+      {
+        "name": "initscripts",
+        "epoch": 0,
+        "version": "10.00.15",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/initscripts-10.00.15-1.el8.ppc64le.rpm",
+        "checksum": "sha256:d751a4fdecc0dc3c5ff897e3ff4c25e7addc698d590e2bfc4c893e693be7d558",
+        "check_gpg": true
+      },
+      {
+        "name": "ipcalc",
+        "epoch": 0,
+        "version": "0.2.4",
+        "release": "4.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/ipcalc-0.2.4-4.el8.ppc64le.rpm",
+        "checksum": "sha256:5418cf17fad308fe9a8d3acdf4ae10f433da50c32f10ae4089be2f8423dea4cf",
+        "check_gpg": true
+      },
+      {
+        "name": "iproute",
+        "epoch": 0,
+        "version": "5.12.0",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/iproute-5.12.0-2.el8.ppc64le.rpm",
+        "checksum": "sha256:12b0565d080311c7804d8fb1d697ecdef8807563ebeee4443e2fa6d35b1d958f",
+        "check_gpg": true
+      },
+      {
+        "name": "iputils",
+        "epoch": 0,
+        "version": "20180629",
+        "release": "7.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/iputils-20180629-7.el8.ppc64le.rpm",
+        "checksum": "sha256:6d02615212a88eb204b8f6d2a7cfbf6183a12f29d72ca5dbfbe5c45c63068ef8",
+        "check_gpg": true
+      },
+      {
+        "name": "irqbalance",
+        "epoch": 2,
+        "version": "1.4.0",
+        "release": "6.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/irqbalance-1.4.0-6.el8.ppc64le.rpm",
+        "checksum": "sha256:cbe98d6dcf93449d9c2fbf95de75f065f8da67a23f13401c672d78b28c6b7f6a",
+        "check_gpg": true
+      },
+      {
+        "name": "jansson",
+        "epoch": 0,
+        "version": "2.11",
+        "release": "3.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/jansson-2.11-3.el8.ppc64le.rpm",
+        "checksum": "sha256:965ec1b760513e1ae539747624bd241d6575675e8a04c5caa572faadb54007c7",
+        "check_gpg": true
+      },
+      {
+        "name": "json-c",
+        "epoch": 0,
+        "version": "0.13.1",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/json-c-0.13.1-2.el8.ppc64le.rpm",
+        "checksum": "sha256:331b91a0928c05618c7fed3e12bbe9ecb9e4619d08c7e85d3de344a08d2f0f1a",
+        "check_gpg": true
+      },
+      {
+        "name": "json-glib",
+        "epoch": 0,
+        "version": "1.4.4",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/json-glib-1.4.4-1.el8.ppc64le.rpm",
+        "checksum": "sha256:36c05d62567b455f2722c6e5cf431071174adf4c1d3b7450f0c1aaa903210bc3",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd",
+        "epoch": 0,
+        "version": "2.0.4",
+        "release": "10.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/kbd-2.0.4-10.el8.ppc64le.rpm",
+        "checksum": "sha256:49c7c718cb4e2b6f0effd0dec4f4cb4e109d260c192b2b329a58a1da9a24ad1d",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd-legacy",
+        "epoch": 0,
+        "version": "2.0.4",
+        "release": "10.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/kbd-legacy-2.0.4-10.el8.noarch.rpm",
+        "checksum": "sha256:a3ef96219165bfc64d4f5d50f51fbd43e803c500619240ffe4db1f9f8e337f83",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd-misc",
+        "epoch": 0,
+        "version": "2.0.4",
+        "release": "10.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/kbd-misc-2.0.4-10.el8.noarch.rpm",
+        "checksum": "sha256:ef86061338fa321c959cadc75ecbdfd405eebaa1042eec9d9c737d4d9d92568f",
+        "check_gpg": true
+      },
+      {
+        "name": "kernel",
+        "epoch": 0,
+        "version": "4.18.0",
+        "release": "331.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/kernel-4.18.0-331.el8.ppc64le.rpm",
+        "checksum": "sha256:7bb5051dee5f6633a02cf5a3285dd86890cc6521e497526a8149dc5c5ebad062",
+        "check_gpg": true
+      },
+      {
+        "name": "kernel-core",
+        "epoch": 0,
+        "version": "4.18.0",
+        "release": "331.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/kernel-core-4.18.0-331.el8.ppc64le.rpm",
+        "checksum": "sha256:4aca3cee9de1a4cd7ac56a12550f286894a215cac593c18857278f7b0e48f328",
+        "check_gpg": true
+      },
+      {
+        "name": "kernel-modules",
+        "epoch": 0,
+        "version": "4.18.0",
+        "release": "331.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/kernel-modules-4.18.0-331.el8.ppc64le.rpm",
+        "checksum": "sha256:1d6551bce8f8a1e53682fafe4f67fa830c333f0b37db7acbeaca0095b5ce870b",
+        "check_gpg": true
+      },
+      {
+        "name": "kernel-tools",
+        "epoch": 0,
+        "version": "4.18.0",
+        "release": "331.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/kernel-tools-4.18.0-331.el8.ppc64le.rpm",
+        "checksum": "sha256:e45848a3fbfa1d46709448593fa7929fee4c5a83d2168c0d41d498251e4b5dae",
+        "check_gpg": true
+      },
+      {
+        "name": "kernel-tools-libs",
+        "epoch": 0,
+        "version": "4.18.0",
+        "release": "331.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/kernel-tools-libs-4.18.0-331.el8.ppc64le.rpm",
+        "checksum": "sha256:83cb349e65d5b783518b735d8fb477264f0a6bd7cdd6f4096f8493dbd45f2ff7",
+        "check_gpg": true
+      },
+      {
+        "name": "kexec-tools",
+        "epoch": 0,
+        "version": "2.0.20",
+        "release": "56.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/kexec-tools-2.0.20-56.el8.ppc64le.rpm",
+        "checksum": "sha256:30dd1d58b7b963d052341f4583a7417823cf4dbbe7ac4b536f3a5250c4d34582",
+        "check_gpg": true
+      },
+      {
+        "name": "keyutils",
+        "epoch": 0,
+        "version": "1.5.10",
+        "release": "9.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/keyutils-1.5.10-9.el8.ppc64le.rpm",
+        "checksum": "sha256:588874c2fc18a927a479aac7affef52f52d09e5b20102dfab70836d420ae553e",
+        "check_gpg": true
+      },
+      {
+        "name": "keyutils-libs",
+        "epoch": 0,
+        "version": "1.5.10",
+        "release": "9.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/keyutils-libs-1.5.10-9.el8.ppc64le.rpm",
+        "checksum": "sha256:6fe1188081e441595ce29ebed4d1985e5890815158244f69f092ee930656f755",
+        "check_gpg": true
+      },
+      {
+        "name": "kmod",
+        "epoch": 0,
+        "version": "25",
+        "release": "18.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/kmod-25-18.el8.ppc64le.rpm",
+        "checksum": "sha256:a80c1d6d32db7ce8fdd58bb4f3f488b74e94261a38512dc8a15179ae33697e63",
+        "check_gpg": true
+      },
+      {
+        "name": "kmod-libs",
+        "epoch": 0,
+        "version": "25",
+        "release": "18.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/kmod-libs-25-18.el8.ppc64le.rpm",
+        "checksum": "sha256:b437a08d4670ef440ba6dbaae4ccb39f989f0c2a3d280ea66d6fd9532a313286",
+        "check_gpg": true
+      },
+      {
+        "name": "kpartx",
+        "epoch": 0,
+        "version": "0.8.4",
+        "release": "17.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/kpartx-0.8.4-17.el8.ppc64le.rpm",
+        "checksum": "sha256:230731b577f8d29e7e8e8fd6d1ea02702fb4364fcc7034d838ccddc4d66da8c3",
+        "check_gpg": true
+      },
+      {
+        "name": "krb5-libs",
+        "epoch": 0,
+        "version": "1.18.2",
+        "release": "13.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/krb5-libs-1.18.2-13.el8.ppc64le.rpm",
+        "checksum": "sha256:54f59ddb56e89a5330373e07ea05934fc58360eb7480615ede2a3ed6982e1eef",
+        "check_gpg": true
+      },
+      {
+        "name": "less",
+        "epoch": 0,
+        "version": "530",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/less-530-1.el8.ppc64le.rpm",
+        "checksum": "sha256:427eba707b42761a0ef57107ba5a22f80fc6379d1537c757fe1929d6d066b05c",
+        "check_gpg": true
+      },
+      {
+        "name": "libacl",
+        "epoch": 0,
+        "version": "2.2.53",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libacl-2.2.53-1.el8.ppc64le.rpm",
+        "checksum": "sha256:ff1580bd4ec5841d4937b383917fa30f318b4f419b8067a77468eb4a9630ba10",
+        "check_gpg": true
+      },
+      {
+        "name": "libappstream-glib",
+        "epoch": 0,
+        "version": "0.7.14",
+        "release": "3.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libappstream-glib-0.7.14-3.el8.ppc64le.rpm",
+        "checksum": "sha256:e778fc7e5d62fe488e250a1916cdb7f692e98e23d0c2b4264672b2574ff416e5",
+        "check_gpg": true
+      },
+      {
+        "name": "libarchive",
+        "epoch": 0,
+        "version": "3.3.3",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libarchive-3.3.3-1.el8.ppc64le.rpm",
+        "checksum": "sha256:df40cada982b04336fe8b250b4fdd576ddd03a014bb519a69b34640369bef661",
+        "check_gpg": true
+      },
+      {
+        "name": "libassuan",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "3.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libassuan-2.5.1-3.el8.ppc64le.rpm",
+        "checksum": "sha256:9c4cd61b98253904436180f58c564bda61be1fa1b5523e4ecbbdc174d0c2a9aa",
+        "check_gpg": true
+      },
+      {
+        "name": "libattr",
+        "epoch": 0,
+        "version": "2.4.48",
+        "release": "3.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libattr-2.4.48-3.el8.ppc64le.rpm",
+        "checksum": "sha256:43bfc890caf7855f2fb55c24474b58cd5c8c7b51e4db4f40d1f302fffd31985b",
+        "check_gpg": true
+      },
+      {
+        "name": "libbasicobjects",
+        "epoch": 0,
+        "version": "0.1.1",
+        "release": "39.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libbasicobjects-0.1.1-39.el8.ppc64le.rpm",
+        "checksum": "sha256:2f6c73fdcd5c5e5b6d8b58663e498a0099db8029386869a4aca670471f6c298e",
+        "check_gpg": true
+      },
+      {
+        "name": "libblkid",
+        "epoch": 0,
+        "version": "2.32.1",
+        "release": "28.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libblkid-2.32.1-28.el8.ppc64le.rpm",
+        "checksum": "sha256:30ae4489980021a727f247d48b4d74d4c6c7667d00bd1a670f045ea24a885541",
+        "check_gpg": true
+      },
+      {
+        "name": "libbpf",
+        "epoch": 0,
+        "version": "0.3.0",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libbpf-0.3.0-1.el8.ppc64le.rpm",
+        "checksum": "sha256:4a8899d3b91a0f847ce793480700b26dc8336c5ee20d9b66067c76fe0dab2f17",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap",
+        "epoch": 0,
+        "version": "2.26",
+        "release": "4.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libcap-2.26-4.el8.ppc64le.rpm",
+        "checksum": "sha256:77e4cfbc823e3764308822ccf03b257861f9360f3b948829f1d73148b321b00e",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap-ng",
+        "epoch": 0,
+        "version": "0.7.11",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libcap-ng-0.7.11-1.el8.ppc64le.rpm",
+        "checksum": "sha256:9b69a221cf9395a110849bb428bb1cfe9fb489322df0fa6017f5978a827ee0e9",
+        "check_gpg": true
+      },
+      {
+        "name": "libcollection",
+        "epoch": 0,
+        "version": "0.7.0",
+        "release": "39.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libcollection-0.7.0-39.el8.ppc64le.rpm",
+        "checksum": "sha256:360be5b93e106d77a8f4e84b318ee8dc14349f223540e0e200e0dfce2676ec04",
+        "check_gpg": true
+      },
+      {
+        "name": "libcom_err",
+        "epoch": 0,
+        "version": "1.45.6",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libcom_err-1.45.6-2.el8.ppc64le.rpm",
+        "checksum": "sha256:e0a7b9f3b56b4737f5711dc6b03f256fbf2488656b8874acabb494b58ba0c1c1",
+        "check_gpg": true
+      },
+      {
+        "name": "libcomps",
+        "epoch": 0,
+        "version": "0.1.16",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libcomps-0.1.16-2.el8.ppc64le.rpm",
+        "checksum": "sha256:5c74a0e3005ea3cb90dff80cfa1e7d64c97f5c01612d253cf4e65aca962b7be4",
+        "check_gpg": true
+      },
+      {
+        "name": "libcroco",
+        "epoch": 0,
+        "version": "0.6.12",
+        "release": "4.el8_2.1",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libcroco-0.6.12-4.el8_2.1.ppc64le.rpm",
+        "checksum": "sha256:194dbe332ccdb33d58f040da07667257e176975f6b2f17343bbf33fb99deb097",
+        "check_gpg": true
+      },
+      {
+        "name": "libcurl",
+        "epoch": 0,
+        "version": "7.61.1",
+        "release": "18.el8_4.1",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libcurl-7.61.1-18.el8_4.1.ppc64le.rpm",
+        "checksum": "sha256:e21a84107568047432e474e08da24aea2340409d57ea8cf170182927dc76de12",
+        "check_gpg": true
+      },
+      {
+        "name": "libdaemon",
+        "epoch": 0,
+        "version": "0.14",
+        "release": "15.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libdaemon-0.14-15.el8.ppc64le.rpm",
+        "checksum": "sha256:f7a2eddcda47cb75108add34c0ce919ceb847605830ad33aeb4bd64d6bed24f3",
+        "check_gpg": true
+      },
+      {
+        "name": "libdb",
+        "epoch": 0,
+        "version": "5.3.28",
+        "release": "40.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libdb-5.3.28-40.el8.ppc64le.rpm",
+        "checksum": "sha256:b83a0199c3d471151f07f6de626a1a4a362dd6aa29d84cf1c0ada2c966ce29c9",
+        "check_gpg": true
+      },
+      {
+        "name": "libdb-utils",
+        "epoch": 0,
+        "version": "5.3.28",
+        "release": "40.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libdb-utils-5.3.28-40.el8.ppc64le.rpm",
+        "checksum": "sha256:709ea71f36495ac2ac89d72d2eb603b6aa55b2c1a70633f23514dd897936f02b",
+        "check_gpg": true
+      },
+      {
+        "name": "libdhash",
+        "epoch": 0,
+        "version": "0.5.0",
+        "release": "39.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libdhash-0.5.0-39.el8.ppc64le.rpm",
+        "checksum": "sha256:6ac918d2bc175b3f356926ca96a998c29bffe256f7d802e8ef654b1226da3ef6",
+        "check_gpg": true
+      },
+      {
+        "name": "libdnf",
+        "epoch": 0,
+        "version": "0.63.0",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libdnf-0.63.0-2.el8.ppc64le.rpm",
+        "checksum": "sha256:aea253461d1a34a239b445ee07cb34398a9cbb6ed40e252182a91cddcf59004b",
+        "check_gpg": true
+      },
+      {
+        "name": "libedit",
+        "epoch": 0,
+        "version": "3.1",
+        "release": "23.20170329cvs.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libedit-3.1-23.20170329cvs.el8.ppc64le.rpm",
+        "checksum": "sha256:cc662127a17d4e08e90f75703f376067eed48f5d6b5b8d106fa3824397f1978e",
+        "check_gpg": true
+      },
+      {
+        "name": "libevent",
+        "epoch": 0,
+        "version": "2.1.8",
+        "release": "5.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libevent-2.1.8-5.el8.ppc64le.rpm",
+        "checksum": "sha256:a0b8a6b2c8dad75290228086dd0af342979604bbf4b9500029e25d766835c0f4",
+        "check_gpg": true
+      },
+      {
+        "name": "libfdisk",
+        "epoch": 0,
+        "version": "2.32.1",
+        "release": "28.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libfdisk-2.32.1-28.el8.ppc64le.rpm",
+        "checksum": "sha256:0afac6f4f9ed1c59510675d87da45c7966c0f7aae6e8dd056961aceed8c4fe0a",
+        "check_gpg": true
+      },
+      {
+        "name": "libffi",
+        "epoch": 0,
+        "version": "3.1",
+        "release": "22.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libffi-3.1-22.el8.ppc64le.rpm",
+        "checksum": "sha256:12696f5638ad2068c5c8940495d15c3bb1c57990000dbda7428b008e9e63ab5b",
+        "check_gpg": true
+      },
+      {
+        "name": "libgcc",
+        "epoch": 0,
+        "version": "8.5.0",
+        "release": "3.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libgcc-8.5.0-3.el8.ppc64le.rpm",
+        "checksum": "sha256:f3d9ccb762146dc97f2d201d979fbb0e9171d1203fb985f3ef48b5c2a176c2a9",
+        "check_gpg": true
+      },
+      {
+        "name": "libgcrypt",
+        "epoch": 0,
+        "version": "1.8.5",
+        "release": "6.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libgcrypt-1.8.5-6.el8.ppc64le.rpm",
+        "checksum": "sha256:c5a60ffb80cd1f9b90c797f1d1ac80e5536eb32a5b276871445e7279ac701c5f",
+        "check_gpg": true
+      },
+      {
+        "name": "libgomp",
+        "epoch": 0,
+        "version": "8.5.0",
+        "release": "3.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libgomp-8.5.0-3.el8.ppc64le.rpm",
+        "checksum": "sha256:0515afdac097ad54cf4b24e0644f0789cab5535a54107aa44940ffd991a6cef3",
+        "check_gpg": true
+      },
+      {
+        "name": "libgpg-error",
+        "epoch": 0,
+        "version": "1.31",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libgpg-error-1.31-1.el8.ppc64le.rpm",
+        "checksum": "sha256:020abac486839c7be29fae37a686dc7749398c333cb8ba94b3390b386ffcbff7",
+        "check_gpg": true
+      },
+      {
+        "name": "libibverbs",
+        "epoch": 0,
+        "version": "35.0",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libibverbs-35.0-1.el8.ppc64le.rpm",
+        "checksum": "sha256:8ab06f608f45445bdef489cedb40d419aa7282e127ee26dbfcf417350a3f1630",
+        "check_gpg": true
+      },
+      {
+        "name": "libidn2",
+        "epoch": 0,
+        "version": "2.2.0",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libidn2-2.2.0-1.el8.ppc64le.rpm",
+        "checksum": "sha256:31d924d1540dd4e927a4c3aa936cec4bfb54ed302d3e8acc1be8b52dd5deb10c",
+        "check_gpg": true
+      },
+      {
+        "name": "libini_config",
+        "epoch": 0,
+        "version": "1.3.1",
+        "release": "39.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libini_config-1.3.1-39.el8.ppc64le.rpm",
+        "checksum": "sha256:1b95698d64dd299827f62cbe43d373e985da2d8900c4489a49475f53fa04f414",
+        "check_gpg": true
+      },
+      {
+        "name": "libkcapi",
+        "epoch": 0,
+        "version": "1.2.0",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libkcapi-1.2.0-2.el8.ppc64le.rpm",
+        "checksum": "sha256:fd6e1803ff367036da5b52b2183e1408691b379cc1320971bb664737507f89a4",
+        "check_gpg": true
+      },
+      {
+        "name": "libkcapi-hmaccalc",
+        "epoch": 0,
+        "version": "1.2.0",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libkcapi-hmaccalc-1.2.0-2.el8.ppc64le.rpm",
+        "checksum": "sha256:6b312faed4a0508da2f15d3f31a6daccfc0ec6621e5fb7b20956027dce5fa395",
+        "check_gpg": true
+      },
+      {
+        "name": "libksba",
+        "epoch": 0,
+        "version": "1.3.5",
+        "release": "7.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libksba-1.3.5-7.el8.ppc64le.rpm",
+        "checksum": "sha256:a5f9f2c4f39f393971f268aebb1b55d18d0d96693d08a9ed70403e8565807bb6",
+        "check_gpg": true
+      },
+      {
+        "name": "libldb",
+        "epoch": 0,
+        "version": "2.3.0",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libldb-2.3.0-2.el8.ppc64le.rpm",
+        "checksum": "sha256:a0a8e31422da7d695a3788a7cae3f929d42cb4982889422588904ecc6879182e",
+        "check_gpg": true
+      },
+      {
+        "name": "libmnl",
+        "epoch": 0,
+        "version": "1.0.4",
+        "release": "6.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libmnl-1.0.4-6.el8.ppc64le.rpm",
+        "checksum": "sha256:59008e3619cae0f40e183b7003e722cb312b00bdba775ec9f06cdd833b53c26a",
+        "check_gpg": true
+      },
+      {
+        "name": "libmodman",
+        "epoch": 0,
+        "version": "2.0.1",
+        "release": "17.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libmodman-2.0.1-17.el8.ppc64le.rpm",
+        "checksum": "sha256:d7bacff8f9be89871c6ec98c3356de11008ae574da852bdc15cee7ebb9ac39be",
+        "check_gpg": true
+      },
+      {
+        "name": "libmodulemd",
+        "epoch": 0,
+        "version": "2.12.1",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libmodulemd-2.12.1-1.el8.ppc64le.rpm",
+        "checksum": "sha256:d6eb27d158b6397e52ab6a952fec4e3c414638a08750a6c011d32eb117accd82",
+        "check_gpg": true
+      },
+      {
+        "name": "libmount",
+        "epoch": 0,
+        "version": "2.32.1",
+        "release": "28.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libmount-2.32.1-28.el8.ppc64le.rpm",
+        "checksum": "sha256:4e497225fe36781735cc92c0886f6858b19d4557ed9ecafe1247b8233c206075",
+        "check_gpg": true
+      },
+      {
+        "name": "libndp",
+        "epoch": 0,
+        "version": "1.7",
+        "release": "6.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libndp-1.7-6.el8.ppc64le.rpm",
+        "checksum": "sha256:2812ae39c665069f4b27e9bd26dde9141d4f4e7802befb1b14ac4e27a8225b4b",
+        "check_gpg": true
+      },
+      {
+        "name": "libnfsidmap",
+        "epoch": 1,
+        "version": "2.3.3",
+        "release": "46.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libnfsidmap-2.3.3-46.el8.ppc64le.rpm",
+        "checksum": "sha256:07fb48b313f6d4c1c8b1ffd9c5226c68f99616e46bbd04b325527d817b500577",
+        "check_gpg": true
+      },
+      {
+        "name": "libnghttp2",
+        "epoch": 0,
+        "version": "1.33.0",
+        "release": "3.el8_2.1",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libnghttp2-1.33.0-3.el8_2.1.ppc64le.rpm",
+        "checksum": "sha256:d3a4f367a9c5ba936b1bb5480db390889a303e5ec8ff34bb4274c1d840a1784d",
+        "check_gpg": true
+      },
+      {
+        "name": "libnl3",
+        "epoch": 0,
+        "version": "3.5.0",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libnl3-3.5.0-1.el8.ppc64le.rpm",
+        "checksum": "sha256:caabc61e9aa83275f9d2fefcfda56fddf19e7031bcf9f9b84f858bb1f040e24c",
+        "check_gpg": true
+      },
+      {
+        "name": "libnl3-cli",
+        "epoch": 0,
+        "version": "3.5.0",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libnl3-cli-3.5.0-1.el8.ppc64le.rpm",
+        "checksum": "sha256:35bd989d63522f9699b1a90dd453f866818cc3d247096a910a27fd7e49b09ac2",
+        "check_gpg": true
+      },
+      {
+        "name": "libnsl2",
+        "epoch": 0,
+        "version": "1.2.0",
+        "release": "2.20180605git4a062cf.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libnsl2-1.2.0-2.20180605git4a062cf.el8.ppc64le.rpm",
+        "checksum": "sha256:8d7777da3f54f965cf3058cabf987c01b93a1dd041e8359eb7822eba57d8c8df",
+        "check_gpg": true
+      },
+      {
+        "name": "libpath_utils",
+        "epoch": 0,
+        "version": "0.2.1",
+        "release": "39.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libpath_utils-0.2.1-39.el8.ppc64le.rpm",
+        "checksum": "sha256:fb6e437a24450106c03f25dc1c3f6b78549b82c2d0bd4387dce1350ca3c5f1f5",
+        "check_gpg": true
+      },
+      {
+        "name": "libpcap",
+        "epoch": 14,
+        "version": "1.9.1",
+        "release": "5.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libpcap-1.9.1-5.el8.ppc64le.rpm",
+        "checksum": "sha256:61ba252d7ee5d955b929f6d7d39d65d25c62e3d3cfc65ee6cf55c764b1c64a90",
+        "check_gpg": true
+      },
+      {
+        "name": "libpipeline",
+        "epoch": 0,
+        "version": "1.5.0",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libpipeline-1.5.0-2.el8.ppc64le.rpm",
+        "checksum": "sha256:7adc584a7d43968d22706da5ffa127020536375f82beea5ef677cab39c5f64c5",
+        "check_gpg": true
+      },
+      {
+        "name": "libpng",
+        "epoch": 2,
+        "version": "1.6.34",
+        "release": "5.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libpng-1.6.34-5.el8.ppc64le.rpm",
+        "checksum": "sha256:b58be8f7685340b35e61945b1ab499bc1030b0b021b2ac5576897cf079ff7812",
+        "check_gpg": true
+      },
+      {
+        "name": "libproxy",
+        "epoch": 0,
+        "version": "0.4.15",
+        "release": "5.2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libproxy-0.4.15-5.2.el8.ppc64le.rpm",
+        "checksum": "sha256:6051967b12b097d0027dc1a1aac68448c1bea901fd76c6ea0d43450f24605252",
+        "check_gpg": true
+      },
+      {
+        "name": "libpsl",
+        "epoch": 0,
+        "version": "0.20.2",
+        "release": "6.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libpsl-0.20.2-6.el8.ppc64le.rpm",
+        "checksum": "sha256:9b8a8a843fe9a972f6433e11b95b5a8d1d2971ed40fe1acda6807e34f0773c62",
+        "check_gpg": true
+      },
+      {
+        "name": "libpwquality",
+        "epoch": 0,
+        "version": "1.4.4",
+        "release": "3.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libpwquality-1.4.4-3.el8.ppc64le.rpm",
+        "checksum": "sha256:1aa321c66a3661e78d938b805e5c311d519f04bf3496545ffdacc7c152bc9b21",
+        "check_gpg": true
+      },
+      {
+        "name": "libref_array",
+        "epoch": 0,
+        "version": "0.1.5",
+        "release": "39.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libref_array-0.1.5-39.el8.ppc64le.rpm",
+        "checksum": "sha256:419f9c08de110eee9b2ff0a61e9aa1bbb56939f9239739c17a753a0d9210d10f",
+        "check_gpg": true
+      },
+      {
+        "name": "librepo",
+        "epoch": 0,
+        "version": "1.14.0",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/librepo-1.14.0-2.el8.ppc64le.rpm",
+        "checksum": "sha256:3dfffdadfb10def9a3671a255e4fa71d8b22231ccf2c929e96689101dda8ce2c",
+        "check_gpg": true
+      },
+      {
+        "name": "libreport-filesystem",
+        "epoch": 0,
+        "version": "2.9.5",
+        "release": "15.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libreport-filesystem-2.9.5-15.el8.ppc64le.rpm",
+        "checksum": "sha256:c5c61536e768553067cee488830c64866d109cade24917dbe23f82c861af07c5",
+        "check_gpg": true
+      },
+      {
+        "name": "librtas",
+        "epoch": 0,
+        "version": "2.0.2",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/librtas-2.0.2-1.el8.ppc64le.rpm",
+        "checksum": "sha256:98c28a91d41f634edb8c1f001dbc45c0de534332d059a2e8feff448fb7235c49",
+        "check_gpg": true
+      },
+      {
+        "name": "libseccomp",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libseccomp-2.5.1-1.el8.ppc64le.rpm",
+        "checksum": "sha256:b4a1ac1ff5cd22a5dab6c96dfc2dbd7cd6ba750691ad5c53a97a1f088fc42abc",
+        "check_gpg": true
+      },
+      {
+        "name": "libsecret",
+        "epoch": 0,
+        "version": "0.18.6",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libsecret-0.18.6-1.el8.ppc64le.rpm",
+        "checksum": "sha256:01b0562b890a80c202fff9175dc845500660c7f1655292d4ee13ca667acab081",
+        "check_gpg": true
+      },
+      {
+        "name": "libselinux",
+        "epoch": 0,
+        "version": "2.9",
+        "release": "5.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libselinux-2.9-5.el8.ppc64le.rpm",
+        "checksum": "sha256:56c866bcff69fd60b630841ff990296b26c2f45d8c6054311b5c476bc67466ac",
+        "check_gpg": true
+      },
+      {
+        "name": "libselinux-utils",
+        "epoch": 0,
+        "version": "2.9",
+        "release": "5.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libselinux-utils-2.9-5.el8.ppc64le.rpm",
+        "checksum": "sha256:4fe264ed1cfd0c074f4601354b0128a9e5068f0fcde7382fd5429585f0d4cd2c",
+        "check_gpg": true
+      },
+      {
+        "name": "libsemanage",
+        "epoch": 0,
+        "version": "2.9",
+        "release": "6.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libsemanage-2.9-6.el8.ppc64le.rpm",
+        "checksum": "sha256:95103f7c339aec4b485b7f569aa8a5e1a54286b3d2acde427328c49e4d8d80d1",
+        "check_gpg": true
+      },
+      {
+        "name": "libsepol",
+        "epoch": 0,
+        "version": "2.9",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libsepol-2.9-2.el8.ppc64le.rpm",
+        "checksum": "sha256:adc56041458e556df5663e7da264e151c24aaf1c2a94e49df9790ba191ea1b37",
+        "check_gpg": true
+      },
+      {
+        "name": "libservicelog",
+        "epoch": 0,
+        "version": "1.1.19",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libservicelog-1.1.19-2.el8.ppc64le.rpm",
+        "checksum": "sha256:2669ab8439093418c6c437c1f2e931d4152f5ac371e5a0f2d20b18455483c3a1",
+        "check_gpg": true
+      },
+      {
+        "name": "libsigsegv",
+        "epoch": 0,
+        "version": "2.11",
+        "release": "5.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libsigsegv-2.11-5.el8.ppc64le.rpm",
+        "checksum": "sha256:0f57b051654b6d75789b437dafd7040b6c90daee17827be24352c0f11a74bba7",
+        "check_gpg": true
+      },
+      {
+        "name": "libsmartcols",
+        "epoch": 0,
+        "version": "2.32.1",
+        "release": "28.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libsmartcols-2.32.1-28.el8.ppc64le.rpm",
+        "checksum": "sha256:1b5136570cefb8273dd5affc73c1456cf239cc8b18be72d6c4d09794af7f3352",
+        "check_gpg": true
+      },
+      {
+        "name": "libsolv",
+        "epoch": 0,
+        "version": "0.7.19",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libsolv-0.7.19-1.el8.ppc64le.rpm",
+        "checksum": "sha256:679724b45157b4d4c9ebe2eb32e188b9a65d47c23be886498d7a178caaf113bb",
+        "check_gpg": true
+      },
+      {
+        "name": "libsoup",
+        "epoch": 0,
+        "version": "2.62.3",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libsoup-2.62.3-2.el8.ppc64le.rpm",
+        "checksum": "sha256:1649f9d356cda961dd08dafa92475557ac398da9a657ee019de0c1f2c0593c8a",
+        "check_gpg": true
+      },
+      {
+        "name": "libss",
+        "epoch": 0,
+        "version": "1.45.6",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libss-1.45.6-2.el8.ppc64le.rpm",
+        "checksum": "sha256:767dd64d91c23adda537c7759ae3b4f720d3c76e03b52bc9231e52e0113db3ab",
+        "check_gpg": true
+      },
+      {
+        "name": "libssh",
+        "epoch": 0,
+        "version": "0.9.4",
+        "release": "3.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libssh-0.9.4-3.el8.ppc64le.rpm",
+        "checksum": "sha256:2dbfe3cb37c18b39393870baa77f3bbd42be53517abffdd990b13ed70ee3dd3e",
+        "check_gpg": true
+      },
+      {
+        "name": "libssh-config",
+        "epoch": 0,
+        "version": "0.9.4",
+        "release": "3.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libssh-config-0.9.4-3.el8.noarch.rpm",
+        "checksum": "sha256:f5bcb82a732c02d6f31bbf156887049883c76cedc9c6a11b049358a74f4d45d0",
+        "check_gpg": true
+      },
+      {
+        "name": "libsss_autofs",
+        "epoch": 0,
+        "version": "2.5.2",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libsss_autofs-2.5.2-2.el8.ppc64le.rpm",
+        "checksum": "sha256:2d1655f040141384ec8760e4a47e0455ce518989f7bb1a830ab9534bfb38a78a",
+        "check_gpg": true
+      },
+      {
+        "name": "libsss_certmap",
+        "epoch": 0,
+        "version": "2.5.2",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libsss_certmap-2.5.2-2.el8.ppc64le.rpm",
+        "checksum": "sha256:d3e95ed161acd1ba957b1864e7ca2102d9c39380bbdd56eddebf11d5219b3a04",
+        "check_gpg": true
+      },
+      {
+        "name": "libsss_idmap",
+        "epoch": 0,
+        "version": "2.5.2",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libsss_idmap-2.5.2-2.el8.ppc64le.rpm",
+        "checksum": "sha256:572bec3deb2f8ae7a6ad46976738c2630023eec1d9bd13ab1ccca7b54256daee",
+        "check_gpg": true
+      },
+      {
+        "name": "libsss_nss_idmap",
+        "epoch": 0,
+        "version": "2.5.2",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libsss_nss_idmap-2.5.2-2.el8.ppc64le.rpm",
+        "checksum": "sha256:466601cf2b7bebf49a6a8e936b32dffc844c9ed4cd82961d008d17cfccc596e8",
+        "check_gpg": true
+      },
+      {
+        "name": "libsss_sudo",
+        "epoch": 0,
+        "version": "2.5.2",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libsss_sudo-2.5.2-2.el8.ppc64le.rpm",
+        "checksum": "sha256:70fe40ffb2fb3eb2c3626afbfdb200a2429e000c2fbb172886c23b1908000501",
+        "check_gpg": true
+      },
+      {
+        "name": "libstdc++",
+        "epoch": 0,
+        "version": "8.5.0",
+        "release": "3.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libstdc++-8.5.0-3.el8.ppc64le.rpm",
+        "checksum": "sha256:32ebba6472cdc331bd3366ca996ad3039b3a1b41c61a849b88074e1b722cad2c",
+        "check_gpg": true
+      },
+      {
+        "name": "libstemmer",
+        "epoch": 0,
+        "version": "0",
+        "release": "10.585svn.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libstemmer-0-10.585svn.el8.ppc64le.rpm",
+        "checksum": "sha256:cd603035aa26b9d12e6b23680e3f1a908341fd9f2086eb540834aee45b4c8604",
+        "check_gpg": true
+      },
+      {
+        "name": "libsysfs",
+        "epoch": 0,
+        "version": "2.1.0",
+        "release": "24.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libsysfs-2.1.0-24.el8.ppc64le.rpm",
+        "checksum": "sha256:4fb1b85fe3712a292f8dd8f1d65805607485dbf97307cf146bbc6e0293a7c725",
+        "check_gpg": true
+      },
+      {
+        "name": "libtalloc",
+        "epoch": 0,
+        "version": "2.3.2",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libtalloc-2.3.2-1.el8.ppc64le.rpm",
+        "checksum": "sha256:5f76a72e58cd374ec83e26f42778adb3b90aacd091527a34c8a347089034d398",
+        "check_gpg": true
+      },
+      {
+        "name": "libtasn1",
+        "epoch": 0,
+        "version": "4.13",
+        "release": "3.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libtasn1-4.13-3.el8.ppc64le.rpm",
+        "checksum": "sha256:75e9ed16ace51ba04a62505aaed215bf9c722d6f4b1c33cc3e3962076c300ee8",
+        "check_gpg": true
+      },
+      {
+        "name": "libtdb",
+        "epoch": 0,
+        "version": "1.4.3",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libtdb-1.4.3-1.el8.ppc64le.rpm",
+        "checksum": "sha256:c3c1c42a41ab18dc09214bcd3a567bb7ba9b9c2191a6e1079b9770dfe2d3a338",
+        "check_gpg": true
+      },
+      {
+        "name": "libteam",
+        "epoch": 0,
+        "version": "1.31",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libteam-1.31-2.el8.ppc64le.rpm",
+        "checksum": "sha256:60eb345663d2f6ec4b5c304cd21685dc7148d34739477136d96ab6bc131d9c4d",
+        "check_gpg": true
+      },
+      {
+        "name": "libtevent",
+        "epoch": 0,
+        "version": "0.11.0",
+        "release": "0.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libtevent-0.11.0-0.el8.ppc64le.rpm",
+        "checksum": "sha256:7962bed04e961194d64769b4b7d5c85836808361c606e943b013098fe53df782",
+        "check_gpg": true
+      },
+      {
+        "name": "libtirpc",
+        "epoch": 0,
+        "version": "1.1.4",
+        "release": "5.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libtirpc-1.1.4-5.el8.ppc64le.rpm",
+        "checksum": "sha256:d539404dafd8ad5d785ab3da6f8bd5a2bf5dff9e01be0ff1bc1d251786dda25c",
+        "check_gpg": true
+      },
+      {
+        "name": "libunistring",
+        "epoch": 0,
+        "version": "0.9.9",
+        "release": "3.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libunistring-0.9.9-3.el8.ppc64le.rpm",
+        "checksum": "sha256:bff39fef1fc01564156123fcade75b4bc50402a2971a031d9a426c7014b1e681",
+        "check_gpg": true
+      },
+      {
+        "name": "libusbx",
+        "epoch": 0,
+        "version": "1.0.23",
+        "release": "4.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libusbx-1.0.23-4.el8.ppc64le.rpm",
+        "checksum": "sha256:6b9875495111bcd2d3c5e9e380b3be17fb0a730891468fb45bdba3b3692b00ea",
+        "check_gpg": true
+      },
+      {
+        "name": "libuser",
+        "epoch": 0,
+        "version": "0.62",
+        "release": "23.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libuser-0.62-23.el8.ppc64le.rpm",
+        "checksum": "sha256:b29c8cb61ef138fdf00a458f0646cf9390e0f39783f02f6b81a956585dc6b302",
+        "check_gpg": true
+      },
+      {
+        "name": "libutempter",
+        "epoch": 0,
+        "version": "1.1.6",
+        "release": "14.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libutempter-1.1.6-14.el8.ppc64le.rpm",
+        "checksum": "sha256:e217c2687212d931ad9a6a02afb20cc34f6d051786d136e337f91079c9f73d22",
+        "check_gpg": true
+      },
+      {
+        "name": "libuuid",
+        "epoch": 0,
+        "version": "2.32.1",
+        "release": "28.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libuuid-2.32.1-28.el8.ppc64le.rpm",
+        "checksum": "sha256:c1291b69a65a860069195a33cf6640df8667e960f9f030ceeea4497c47858b94",
+        "check_gpg": true
+      },
+      {
+        "name": "libverto",
+        "epoch": 0,
+        "version": "0.3.0",
+        "release": "5.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libverto-0.3.0-5.el8.ppc64le.rpm",
+        "checksum": "sha256:d8c00baf46e33f9e5f1b9e139bbea9fe0f27badb432c992b9cf8c4f7017094bf",
+        "check_gpg": true
+      },
+      {
+        "name": "libverto-libevent",
+        "epoch": 0,
+        "version": "0.3.0",
+        "release": "5.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libverto-libevent-0.3.0-5.el8.ppc64le.rpm",
+        "checksum": "sha256:d909f0e1b6ddb29ad2d3da21208077e3c976212e07471114745859f70be9738d",
+        "check_gpg": true
+      },
+      {
+        "name": "libvpd",
+        "epoch": 0,
+        "version": "2.2.8",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libvpd-2.2.8-1.el8.ppc64le.rpm",
+        "checksum": "sha256:62ac185c4d6d242b187022c8376469073c211e8deca2a7b2badf1d775e2fd5a3",
+        "check_gpg": true
+      },
+      {
+        "name": "libxcrypt",
+        "epoch": 0,
+        "version": "4.1.1",
+        "release": "6.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libxcrypt-4.1.1-6.el8.ppc64le.rpm",
+        "checksum": "sha256:1a968f65db066243cbd0a6e12d193ef674637f044299a15b5d6b910e91411812",
+        "check_gpg": true
+      },
+      {
+        "name": "libxml2",
+        "epoch": 0,
+        "version": "2.9.7",
+        "release": "11.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libxml2-2.9.7-11.el8.ppc64le.rpm",
+        "checksum": "sha256:4a167fa4a7238bd94b3134173f6267b19cdebc2fde98b583344749e1f4c9bf09",
+        "check_gpg": true
+      },
+      {
+        "name": "libyaml",
+        "epoch": 0,
+        "version": "0.1.7",
+        "release": "5.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libyaml-0.1.7-5.el8.ppc64le.rpm",
+        "checksum": "sha256:8904fdb492f34e5242ba483fb6b7b158342662575b3d5ac9abbc380568840d4a",
+        "check_gpg": true
+      },
+      {
+        "name": "libzstd",
+        "epoch": 0,
+        "version": "1.4.4",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libzstd-1.4.4-1.el8.ppc64le.rpm",
+        "checksum": "sha256:6bfc201a12dc7bba21069a663aa692a96c5e8920b0d94a4e355c332d7ead15ba",
+        "check_gpg": true
+      },
+      {
+        "name": "linux-firmware",
+        "epoch": 0,
+        "version": "20210702",
+        "release": "103.gitd79c2677.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/linux-firmware-20210702-103.gitd79c2677.el8.noarch.rpm",
+        "checksum": "sha256:7aeb44195a1c984aff87cf8429d2aa40f6947b0a47d3603e1ca5c3cf8d284459",
+        "check_gpg": true
+      },
+      {
+        "name": "lmdb-libs",
+        "epoch": 0,
+        "version": "0.9.24",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/lmdb-libs-0.9.24-1.el8.ppc64le.rpm",
+        "checksum": "sha256:f6cd5ed6305952c1cd842fbca0e5d9613f736646cfac2082a2db37f5d065468c",
+        "check_gpg": true
+      },
+      {
+        "name": "logrotate",
+        "epoch": 0,
+        "version": "3.14.0",
+        "release": "4.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/logrotate-3.14.0-4.el8.ppc64le.rpm",
+        "checksum": "sha256:791acd72bc40be9ba5fa6b77d78def5da623544408b72baa4c81181c03a205cb",
+        "check_gpg": true
+      },
+      {
+        "name": "lshw",
+        "epoch": 0,
+        "version": "B.02.19.2",
+        "release": "6.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/lshw-B.02.19.2-6.el8.ppc64le.rpm",
+        "checksum": "sha256:906bffa419bdb1a6d3094d7a6f2308527f5ece250bfcb962df79e9867f28236d",
+        "check_gpg": true
+      },
+      {
+        "name": "lsscsi",
+        "epoch": 0,
+        "version": "0.32",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/lsscsi-0.32-2.el8.ppc64le.rpm",
+        "checksum": "sha256:deeeab9fcf6b9cb47235974158561967e299344e040c408e6b5d7464af2f3882",
+        "check_gpg": true
+      },
+      {
+        "name": "lsvpd",
+        "epoch": 0,
+        "version": "1.7.12",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/lsvpd-1.7.12-1.el8.ppc64le.rpm",
+        "checksum": "sha256:0eb36aba0f471119ccb001ea4f1819002ae535882df63e871be80e01f4f776bb",
+        "check_gpg": true
+      },
+      {
+        "name": "lua-libs",
+        "epoch": 0,
+        "version": "5.3.4",
+        "release": "11.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/lua-libs-5.3.4-11.el8.ppc64le.rpm",
+        "checksum": "sha256:393e7bb9f93ffb3cbba620fbfeb229f2b8345454bc60ac0508f76735544ed289",
+        "check_gpg": true
+      },
+      {
+        "name": "lz4-libs",
+        "epoch": 0,
+        "version": "1.8.3",
+        "release": "3.el8_4",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/lz4-libs-1.8.3-3.el8_4.ppc64le.rpm",
+        "checksum": "sha256:f24bce642ec88622490b2f09a45fa3985da7f6511a1aae131853c4ea4c309e6b",
+        "check_gpg": true
+      },
+      {
+        "name": "lzo",
+        "epoch": 0,
+        "version": "2.08",
+        "release": "14.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/lzo-2.08-14.el8.ppc64le.rpm",
+        "checksum": "sha256:4c5aabda0cd9edb40e141066d400d2e4b232bc22ab60e806a6399691c391cabc",
+        "check_gpg": true
+      },
+      {
+        "name": "man-db",
+        "epoch": 0,
+        "version": "2.7.6.1",
+        "release": "18.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/man-db-2.7.6.1-18.el8.ppc64le.rpm",
+        "checksum": "sha256:4079a1edf72a60c97ee48f0a98820b3b014575b402ea05a64cbc5f2b8af674de",
+        "check_gpg": true
+      },
+      {
+        "name": "memstrack",
+        "epoch": 0,
+        "version": "0.1.11",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/memstrack-0.1.11-1.el8.ppc64le.rpm",
+        "checksum": "sha256:9936485ac7111967d6962bc539de7b08807e310117adb78b11c21a5db0f0f890",
+        "check_gpg": true
+      },
+      {
+        "name": "mozjs60",
+        "epoch": 0,
+        "version": "60.9.0",
+        "release": "4.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/mozjs60-60.9.0-4.el8.ppc64le.rpm",
+        "checksum": "sha256:c62991989974533b86a29586b799623a908add501287f2c890be4fc8a6af2c7d",
+        "check_gpg": true
+      },
+      {
+        "name": "mpfr",
+        "epoch": 0,
+        "version": "3.1.6",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/mpfr-3.1.6-1.el8.ppc64le.rpm",
+        "checksum": "sha256:0230acdbc9da4b36da812f0e585a7602eda4982c899b3b3a4c2bc9b4546d8e74",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses",
+        "epoch": 0,
+        "version": "6.1",
+        "release": "9.20180224.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/ncurses-6.1-9.20180224.el8.ppc64le.rpm",
+        "checksum": "sha256:7abf49cabbaf996afc0c2604f10ea18f8f22a903fc4ba3728a18f5892353c5c9",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses-base",
+        "epoch": 0,
+        "version": "6.1",
+        "release": "9.20180224.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/ncurses-base-6.1-9.20180224.el8.noarch.rpm",
+        "checksum": "sha256:41716536ea16798238ac89fbc3041b3f9dc80f9a64ea4b19d6e67ad2c909269a",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses-libs",
+        "epoch": 0,
+        "version": "6.1",
+        "release": "9.20180224.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/ncurses-libs-6.1-9.20180224.el8.ppc64le.rpm",
+        "checksum": "sha256:17ffe1d683dbff48f9b2ef903401e471e5e51a992bf0890632bceb94561893de",
+        "check_gpg": true
+      },
+      {
+        "name": "net-tools",
+        "epoch": 0,
+        "version": "2.0",
+        "release": "0.52.20160912git.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/net-tools-2.0-0.52.20160912git.el8.ppc64le.rpm",
+        "checksum": "sha256:d2e9ef1d33330a14155d5bd6a8cf122f9390cceb8a7a12c0364ae8e44410fb8d",
+        "check_gpg": true
+      },
+      {
+        "name": "nettle",
+        "epoch": 0,
+        "version": "3.4.1",
+        "release": "7.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/nettle-3.4.1-7.el8.ppc64le.rpm",
+        "checksum": "sha256:8403cfc97e0e72e37639b8c54d92f1ee427e48a70d52d5260a37fa104f2df20d",
+        "check_gpg": true
+      },
+      {
+        "name": "newt",
+        "epoch": 0,
+        "version": "0.52.20",
+        "release": "11.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/newt-0.52.20-11.el8.ppc64le.rpm",
+        "checksum": "sha256:b64219f2278bf3f032b71593da63f563920778230946b66f1037bef2f2a7358b",
+        "check_gpg": true
+      },
+      {
+        "name": "nfs-utils",
+        "epoch": 1,
+        "version": "2.3.3",
+        "release": "46.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/nfs-utils-2.3.3-46.el8.ppc64le.rpm",
+        "checksum": "sha256:bd9a6c7fe7405aaeeeb7d351ca1def52737b8ec2344021263aed64c6dc363d56",
+        "check_gpg": true
+      },
+      {
+        "name": "npth",
+        "epoch": 0,
+        "version": "1.5",
+        "release": "4.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/npth-1.5-4.el8.ppc64le.rpm",
+        "checksum": "sha256:7a66928044c3478964aeaf6f9e981fdbcfa6b2ff7fad9f2ad57a8c09387cbbf2",
+        "check_gpg": true
+      },
+      {
+        "name": "numactl-libs",
+        "epoch": 0,
+        "version": "2.0.12",
+        "release": "13.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/numactl-libs-2.0.12-13.el8.ppc64le.rpm",
+        "checksum": "sha256:5bcb506bd5559870631aa838711e683a5a2a07c6c0171be6bbeda9ba92dcdf5e",
+        "check_gpg": true
+      },
+      {
+        "name": "opal-prd",
+        "epoch": 0,
+        "version": "6.7.1",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/opal-prd-6.7.1-1.el8.ppc64le.rpm",
+        "checksum": "sha256:6495f3b729a1ceecd7cfdf318cfaa8ecf776ffa16293aad9f97cc542b6901ef7",
+        "check_gpg": true
+      },
+      {
+        "name": "openldap",
+        "epoch": 0,
+        "version": "2.4.46",
+        "release": "18.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/openldap-2.4.46-18.el8.ppc64le.rpm",
+        "checksum": "sha256:c24b21415b737f18fad7aeb192e60f7d323f7ba69434ecc1e78b3af0003be8dc",
+        "check_gpg": true
+      },
+      {
+        "name": "openssh",
+        "epoch": 0,
+        "version": "8.0p1",
+        "release": "9.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/openssh-8.0p1-9.el8.ppc64le.rpm",
+        "checksum": "sha256:965dca9dc74ed26f4204debe15b8e4dd1b8e41a80b8608287a9ef22f0b6f507e",
+        "check_gpg": true
+      },
+      {
+        "name": "openssh-clients",
+        "epoch": 0,
+        "version": "8.0p1",
+        "release": "9.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/openssh-clients-8.0p1-9.el8.ppc64le.rpm",
+        "checksum": "sha256:bb4b6716669e27c7619f63751770cb87e7cfecd4e302e2ce6588035509168352",
+        "check_gpg": true
+      },
+      {
+        "name": "openssh-server",
+        "epoch": 0,
+        "version": "8.0p1",
+        "release": "9.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/openssh-server-8.0p1-9.el8.ppc64le.rpm",
+        "checksum": "sha256:f8130aecd446f997d0e2011481275db0552bf57bd7af0d7a655eded5f52ca94e",
+        "check_gpg": true
+      },
+      {
+        "name": "openssl",
+        "epoch": 1,
+        "version": "1.1.1k",
+        "release": "4.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/openssl-1.1.1k-4.el8.ppc64le.rpm",
+        "checksum": "sha256:c2479eb811f4d9b8624ef20119e1abdc109f639c2cf576eb945b340362d87b05",
+        "check_gpg": true
+      },
+      {
+        "name": "openssl-libs",
+        "epoch": 1,
+        "version": "1.1.1k",
+        "release": "4.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/openssl-libs-1.1.1k-4.el8.ppc64le.rpm",
+        "checksum": "sha256:46606c1ed76a4da2a9d18016aeb50f4dddf58e1b45d665c983c58f8e605bf73e",
+        "check_gpg": true
+      },
+      {
+        "name": "openssl-pkcs11",
+        "epoch": 0,
+        "version": "0.4.10",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/openssl-pkcs11-0.4.10-2.el8.ppc64le.rpm",
+        "checksum": "sha256:d87f7fa5e637442eb638bcaafdc44ca3895d91a153015ff9af6a87219f0dc372",
+        "check_gpg": true
+      },
+      {
+        "name": "os-prober",
+        "epoch": 0,
+        "version": "1.74",
+        "release": "6.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/os-prober-1.74-6.el8.ppc64le.rpm",
+        "checksum": "sha256:71c88f04921ae61a7009f9443f95c70ec3424a798429fc01e6c1432c1077aacb",
+        "check_gpg": true
+      },
+      {
+        "name": "p11-kit",
+        "epoch": 0,
+        "version": "0.23.22",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/p11-kit-0.23.22-1.el8.ppc64le.rpm",
+        "checksum": "sha256:bf994cb2e5c367d78483662c7de6e69950aaf04bc6cfdbbef4d1ef7ce153717c",
+        "check_gpg": true
+      },
+      {
+        "name": "p11-kit-trust",
+        "epoch": 0,
+        "version": "0.23.22",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/p11-kit-trust-0.23.22-1.el8.ppc64le.rpm",
+        "checksum": "sha256:b7330d40f75b8ec786e41c45a202e44f0e49ec29ddf8944120fbdb373a6c6617",
+        "check_gpg": true
+      },
+      {
+        "name": "pam",
+        "epoch": 0,
+        "version": "1.3.1",
+        "release": "15.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/pam-1.3.1-15.el8.ppc64le.rpm",
+        "checksum": "sha256:bb82b10a91493d745dc533b5de5335db650adb0c8a90548fdf5dad13569a16f4",
+        "check_gpg": true
+      },
+      {
+        "name": "parted",
+        "epoch": 0,
+        "version": "3.2",
+        "release": "39.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/parted-3.2-39.el8.ppc64le.rpm",
+        "checksum": "sha256:9e2ef90cb484b37232e829ec400dcddd3f9f0d189eb6f0074b3b5874d4553d1c",
+        "check_gpg": true
+      },
+      {
+        "name": "passwd",
+        "epoch": 0,
+        "version": "0.80",
+        "release": "3.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/passwd-0.80-3.el8.ppc64le.rpm",
+        "checksum": "sha256:dfb7add4926f9a350755294af3c20f114ac59f32e00cadc9ec625b2a51703ad0",
+        "check_gpg": true
+      },
+      {
+        "name": "pciutils",
+        "epoch": 0,
+        "version": "3.7.0",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/pciutils-3.7.0-1.el8.ppc64le.rpm",
+        "checksum": "sha256:7b334d84bf03876c5738efa3857faaa35ede5c8eab30a5621ecfd4efa7ce39a5",
+        "check_gpg": true
+      },
+      {
+        "name": "pciutils-libs",
+        "epoch": 0,
+        "version": "3.7.0",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/pciutils-libs-3.7.0-1.el8.ppc64le.rpm",
+        "checksum": "sha256:dd96950b4282e64ce3e37f0bd1a51834beb286037184f3796f9889bfa1ed0d72",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre",
+        "epoch": 0,
+        "version": "8.42",
+        "release": "6.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/pcre-8.42-6.el8.ppc64le.rpm",
+        "checksum": "sha256:3ed319e31a9c38e5f4e336195b5cbd253b3f8b17f93f185829f078c5ef420305",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre2",
+        "epoch": 0,
+        "version": "10.32",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/pcre2-10.32-2.el8.ppc64le.rpm",
+        "checksum": "sha256:5c46bef8c0e95e05716e9a53b77970c1378d93bcb9a800018a24f7e1763b45b9",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Carp",
+        "epoch": 0,
+        "version": "1.42",
+        "release": "396.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/perl-Carp-1.42-396.el8.noarch.rpm",
+        "checksum": "sha256:d03b9f4b9848e3a88d62bcf6e536d659c325b2dc03b2136be7342b5fe5e2b6a9",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Data-Dumper",
+        "epoch": 0,
+        "version": "2.167",
+        "release": "399.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/perl-Data-Dumper-2.167-399.el8.ppc64le.rpm",
+        "checksum": "sha256:a34e0c5859e5e8757afafba47d83396226b646f32954ef7ecda4ad3be464bed6",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Encode",
+        "epoch": 4,
+        "version": "2.97",
+        "release": "3.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/perl-Encode-2.97-3.el8.ppc64le.rpm",
+        "checksum": "sha256:fc9d3ee3946b87efcd9531f876d23a9e8d5769aab3e0ad6007ac2cdb4068499c",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Errno",
+        "epoch": 0,
+        "version": "1.28",
+        "release": "420.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/perl-Errno-1.28-420.el8.ppc64le.rpm",
+        "checksum": "sha256:cffc31e10891c58edc89cebd211bc0be69d99f54f67682c91f97dc53e6381f0f",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Exporter",
+        "epoch": 0,
+        "version": "5.72",
+        "release": "396.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/perl-Exporter-5.72-396.el8.noarch.rpm",
+        "checksum": "sha256:7edc503f5a919c489b651757095d8031982d530cc88088fdaeb743188364e9b0",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-File-Path",
+        "epoch": 0,
+        "version": "2.15",
+        "release": "2.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/perl-File-Path-2.15-2.el8.noarch.rpm",
+        "checksum": "sha256:e83928bd4552ecdf8e71d283e2358c7eccd006d284ba31fbc9c89e407989fd60",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-File-Temp",
+        "epoch": 0,
+        "version": "0.230.600",
+        "release": "1.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/perl-File-Temp-0.230.600-1.el8.noarch.rpm",
+        "checksum": "sha256:e269f7d33abbb790311ffa95fa7df9766cac8bf31ace24fce6ed732ba0db19ae",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Getopt-Long",
+        "epoch": 1,
+        "version": "2.50",
+        "release": "4.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/perl-Getopt-Long-2.50-4.el8.noarch.rpm",
+        "checksum": "sha256:da4c6daa0d5406bc967cc89b02a69689491f42c543aceea1a31136f0f1a8d991",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-HTTP-Tiny",
+        "epoch": 0,
+        "version": "0.074",
+        "release": "1.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/perl-HTTP-Tiny-0.074-1.el8.noarch.rpm",
+        "checksum": "sha256:a1af93a1b62e8ca05b7597d5749a2b3d28735a86928f0432064fec61db1ff844",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-IO",
+        "epoch": 0,
+        "version": "1.38",
+        "release": "420.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/perl-IO-1.38-420.el8.ppc64le.rpm",
+        "checksum": "sha256:74e11b9013f81bd30ec7934ea695d267d164967fec27a02652aa48602b94bc51",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-MIME-Base64",
+        "epoch": 0,
+        "version": "3.15",
+        "release": "396.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/perl-MIME-Base64-3.15-396.el8.ppc64le.rpm",
+        "checksum": "sha256:dc1d4f59ba0728e65433bc7f903b3799d61545ed3eed7427ad0fe36dcd0f831b",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-PathTools",
+        "epoch": 0,
+        "version": "3.74",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/perl-PathTools-3.74-1.el8.ppc64le.rpm",
+        "checksum": "sha256:6b588ff47d46d33b02bc296e6e5cc263d6c8ff51ee97b59ca8b34d5c45d57912",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Pod-Escapes",
+        "epoch": 1,
+        "version": "1.07",
+        "release": "395.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/perl-Pod-Escapes-1.07-395.el8.noarch.rpm",
+        "checksum": "sha256:545cd23ad8e4f71a5109551093668fd4b5e1a50d6a60364ce0f04f64eecd99d1",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Pod-Perldoc",
+        "epoch": 0,
+        "version": "3.28",
+        "release": "396.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/perl-Pod-Perldoc-3.28-396.el8.noarch.rpm",
+        "checksum": "sha256:0225dc3999e3d7b1bb57186a2fc93c98bd1e4e08e062fb51c966e1f2a2c91bb4",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Pod-Simple",
+        "epoch": 1,
+        "version": "3.35",
+        "release": "395.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/perl-Pod-Simple-3.35-395.el8.noarch.rpm",
+        "checksum": "sha256:51c3ee5d824bdde0a8faa10c99841c2590c0c26edfb17125aa97945a688c83ed",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Pod-Usage",
+        "epoch": 4,
+        "version": "1.69",
+        "release": "395.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/perl-Pod-Usage-1.69-395.el8.noarch.rpm",
+        "checksum": "sha256:794f970f498af07b37f914c19ad5dedc6b6c2f89d343af9dd1768d17232555de",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Scalar-List-Utils",
+        "epoch": 3,
+        "version": "1.49",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/perl-Scalar-List-Utils-1.49-2.el8.ppc64le.rpm",
+        "checksum": "sha256:61ee52dfdcbcd98acc765b45781ea5de94831f55675c0faaf615872f92268757",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Socket",
+        "epoch": 4,
+        "version": "2.027",
+        "release": "3.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/perl-Socket-2.027-3.el8.ppc64le.rpm",
+        "checksum": "sha256:8d19cdf57ba61fecd9e07f24fe88768f58196543f7c032adada8a0cc48eee6b3",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Storable",
+        "epoch": 1,
+        "version": "3.11",
+        "release": "3.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/perl-Storable-3.11-3.el8.ppc64le.rpm",
+        "checksum": "sha256:c238e0a5472c59c54093ffa23af6a963b4ae437eedfb6b9ebbcb482752c6d16b",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Term-ANSIColor",
+        "epoch": 0,
+        "version": "4.06",
+        "release": "396.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/perl-Term-ANSIColor-4.06-396.el8.noarch.rpm",
+        "checksum": "sha256:f4e3607f242bbca7ec2379822ca961860e6d9c276da51c6e2dfd17a29469ec78",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Term-Cap",
+        "epoch": 0,
+        "version": "1.17",
+        "release": "395.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/perl-Term-Cap-1.17-395.el8.noarch.rpm",
+        "checksum": "sha256:6bbb721dd2c411c85c75f7477b14c54c776d78ee9b93557615e919ef47577440",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Text-ParseWords",
+        "epoch": 0,
+        "version": "3.30",
+        "release": "395.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/perl-Text-ParseWords-3.30-395.el8.noarch.rpm",
+        "checksum": "sha256:2975de6545b4ca7907ae368a1716c531764e4afccbf27fb0a694d90e983c38e2",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Text-Tabs+Wrap",
+        "epoch": 0,
+        "version": "2013.0523",
+        "release": "395.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/perl-Text-Tabs+Wrap-2013.0523-395.el8.noarch.rpm",
+        "checksum": "sha256:7e50a5d0f2fbd8c95375f72f5772c7731186e999a447121b8247f448b065a4ef",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Time-Local",
+        "epoch": 1,
+        "version": "1.280",
+        "release": "1.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/perl-Time-Local-1.280-1.el8.noarch.rpm",
+        "checksum": "sha256:1edcf2b441ddf21417ef2b33e1ab2a30900758819335d7fabafe3b16bb3eab62",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Unicode-Normalize",
+        "epoch": 0,
+        "version": "1.25",
+        "release": "396.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/perl-Unicode-Normalize-1.25-396.el8.ppc64le.rpm",
+        "checksum": "sha256:04ee771fad226ade609b0e879d15c32898379360db27ef1bc6d9f5a77127d5a8",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-constant",
+        "epoch": 0,
+        "version": "1.33",
+        "release": "396.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/perl-constant-1.33-396.el8.noarch.rpm",
+        "checksum": "sha256:7559c097998db5e5d14dab1a7a1637a5749e9dab234ca68d17c9c21f8cfbf8d6",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-interpreter",
+        "epoch": 4,
+        "version": "5.26.3",
+        "release": "420.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/perl-interpreter-5.26.3-420.el8.ppc64le.rpm",
+        "checksum": "sha256:d5ee453757bd1b479881f0a57b968427404b81d9fed07d04afebcbcfcbf536ab",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-libs",
+        "epoch": 4,
+        "version": "5.26.3",
+        "release": "420.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/perl-libs-5.26.3-420.el8.ppc64le.rpm",
+        "checksum": "sha256:4b40402374fc4a9202a67d3ede77dedbe5ed1bab57479a5b5cb5cd6c45283bf4",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-macros",
+        "epoch": 4,
+        "version": "5.26.3",
+        "release": "420.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/perl-macros-5.26.3-420.el8.ppc64le.rpm",
+        "checksum": "sha256:926ce547a03e1bd2aac94b1792d7ccea16d1e6bd91903458e63a095268e1b02f",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-parent",
+        "epoch": 1,
+        "version": "0.237",
+        "release": "1.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/perl-parent-0.237-1.el8.noarch.rpm",
+        "checksum": "sha256:f5e73bbd776a2426a796971d8d38664f2e94898479fb76947dccdd28cf9fe1d0",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-podlators",
+        "epoch": 0,
+        "version": "4.11",
+        "release": "1.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/perl-podlators-4.11-1.el8.noarch.rpm",
+        "checksum": "sha256:78d17ed089151e7fa3d1a3cdbbac8ca3b1b5c484fae5ba025642cc9107991037",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-threads",
+        "epoch": 1,
+        "version": "2.21",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/perl-threads-2.21-2.el8.ppc64le.rpm",
+        "checksum": "sha256:47f414f515a2c3103d0e7dae67c47a3b2bc76ea2413d666052012b11dbdd0feb",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-threads-shared",
+        "epoch": 0,
+        "version": "1.58",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/perl-threads-shared-1.58-2.el8.ppc64le.rpm",
+        "checksum": "sha256:b566154cc9b2b1996716def297d58101f3015a1b868187f1f9e4cd3074ae9988",
+        "check_gpg": true
+      },
+      {
+        "name": "pigz",
+        "epoch": 0,
+        "version": "2.4",
+        "release": "4.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/pigz-2.4-4.el8.ppc64le.rpm",
+        "checksum": "sha256:3edfdbc82f97ec12e59c80c67897fc1eeb44c3d16820f761a8f15272965ea3a1",
+        "check_gpg": true
+      },
+      {
+        "name": "platform-python",
+        "epoch": 0,
+        "version": "3.6.8",
+        "release": "39.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/platform-python-3.6.8-39.el8.ppc64le.rpm",
+        "checksum": "sha256:cdd6594a3bca71d32a5061b85457cc8148611e7f042ba6e812a1c0a2faebac92",
+        "check_gpg": true
+      },
+      {
+        "name": "platform-python-pip",
+        "epoch": 0,
+        "version": "9.0.3",
+        "release": "20.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/platform-python-pip-9.0.3-20.el8.noarch.rpm",
+        "checksum": "sha256:56650f8b8f2b01c1090d184d7d6d396f0109f8a02f915c97b081be73ea12df08",
+        "check_gpg": true
+      },
+      {
+        "name": "platform-python-setuptools",
+        "epoch": 0,
+        "version": "39.2.0",
+        "release": "6.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/platform-python-setuptools-39.2.0-6.el8.noarch.rpm",
+        "checksum": "sha256:946ba273a3a3b6fdf140f3c03112918c0a556a5871c477f5dbbb98600e6ca557",
+        "check_gpg": true
+      },
+      {
+        "name": "policycoreutils",
+        "epoch": 0,
+        "version": "2.9",
+        "release": "15.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/policycoreutils-2.9-15.el8.ppc64le.rpm",
+        "checksum": "sha256:c64632c85c3a49dc82222cdb3d0ee87eafa64f3096ffeba5bcc16c49ee2d260e",
+        "check_gpg": true
+      },
+      {
+        "name": "policycoreutils-python-utils",
+        "epoch": 0,
+        "version": "2.9",
+        "release": "15.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/policycoreutils-python-utils-2.9-15.el8.noarch.rpm",
+        "checksum": "sha256:a9d4dd71786b3147d53da1aa44f134e61b1e5527b6c7ece6c2b19474b6ca9270",
+        "check_gpg": true
+      },
+      {
+        "name": "polkit",
+        "epoch": 0,
+        "version": "0.115",
+        "release": "12.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/polkit-0.115-12.el8.ppc64le.rpm",
+        "checksum": "sha256:e716fd0130980916f4b1aeac8f98dbcd8ced81e2c119b7877204cc6b1a058418",
+        "check_gpg": true
+      },
+      {
+        "name": "polkit-libs",
+        "epoch": 0,
+        "version": "0.115",
+        "release": "12.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/polkit-libs-0.115-12.el8.ppc64le.rpm",
+        "checksum": "sha256:15554476d03595246aec194e63ec9db7469d5b3ed81a27a8a2720e82df1f8bf4",
+        "check_gpg": true
+      },
+      {
+        "name": "polkit-pkla-compat",
+        "epoch": 0,
+        "version": "0.1",
+        "release": "12.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/polkit-pkla-compat-0.1-12.el8.ppc64le.rpm",
+        "checksum": "sha256:0727078eff2abaf1e5770b331ed8162d8e95cf2cf1de06de7540d034999d72ef",
+        "check_gpg": true
+      },
+      {
+        "name": "popt",
+        "epoch": 0,
+        "version": "1.18",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/popt-1.18-1.el8.ppc64le.rpm",
+        "checksum": "sha256:3b00ac82c31b447e306fcb47b4469fdc4e6d87385b42358c2e76badb51b074a3",
+        "check_gpg": true
+      },
+      {
+        "name": "powerpc-utils",
+        "epoch": 0,
+        "version": "1.3.8",
+        "release": "7.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/powerpc-utils-1.3.8-7.el8.ppc64le.rpm",
+        "checksum": "sha256:401a2690658194fdd92994c29aa57c18cc5e3100fe7bbdba33d0fa26f2213eb3",
+        "check_gpg": true
+      },
+      {
+        "name": "powerpc-utils-core",
+        "epoch": 0,
+        "version": "1.3.8",
+        "release": "7.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/powerpc-utils-core-1.3.8-7.el8.ppc64le.rpm",
+        "checksum": "sha256:720088f184124166386634a523f3566a7fc56f802dbd6e6f816e959236542770",
+        "check_gpg": true
+      },
+      {
+        "name": "ppc64-diag",
+        "epoch": 0,
+        "version": "2.7.7",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/ppc64-diag-2.7.7-1.el8.ppc64le.rpm",
+        "checksum": "sha256:2d77f4a2166122e3f7c5ace1bbfe5319ec6c2d24fff1c6f3e22ccb3e8b2327e0",
+        "check_gpg": true
+      },
+      {
+        "name": "ppc64-diag-rtas",
+        "epoch": 0,
+        "version": "2.7.7",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/ppc64-diag-rtas-2.7.7-1.el8.ppc64le.rpm",
+        "checksum": "sha256:0ad85fe7a6b42dae9248268706940b12c01e83141858df79e43223e173fe9840",
+        "check_gpg": true
+      },
+      {
+        "name": "prefixdevname",
+        "epoch": 0,
+        "version": "0.1.0",
+        "release": "6.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/prefixdevname-0.1.0-6.el8.ppc64le.rpm",
+        "checksum": "sha256:35983fb2e9104b81caaa9e6d40352ea8b2b987fb811f935602d04cc90fdee76a",
+        "check_gpg": true
+      },
+      {
+        "name": "procps-ng",
+        "epoch": 0,
+        "version": "3.3.15",
+        "release": "6.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/procps-ng-3.3.15-6.el8.ppc64le.rpm",
+        "checksum": "sha256:1cfa672c25cb5849bb2aa652e045e4a4a272c025befb1fe5e58cb32823faa30d",
+        "check_gpg": true
+      },
+      {
+        "name": "psmisc",
+        "epoch": 0,
+        "version": "23.1",
+        "release": "5.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/psmisc-23.1-5.el8.ppc64le.rpm",
+        "checksum": "sha256:2394d6a1ce4de90590e65111d870b172cb9d4e30e1e6f58a334b29e717fdd031",
+        "check_gpg": true
+      },
+      {
+        "name": "publicsuffix-list-dafsa",
+        "epoch": 0,
+        "version": "20180723",
+        "release": "1.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/publicsuffix-list-dafsa-20180723-1.el8.noarch.rpm",
+        "checksum": "sha256:65ecf1e479dc2b2f7f09c2e86d7457043b3470b3eab3c4ee8909b50b0a669fc2",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-audit",
+        "epoch": 0,
+        "version": "3.0",
+        "release": "0.17.20191104git1c2f876.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-audit-3.0-0.17.20191104git1c2f876.el8.ppc64le.rpm",
+        "checksum": "sha256:d816e850877d0fdbc5ee0951dbd78ca79613602aa5cccd1b324c10d700968d3b",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-cffi",
+        "epoch": 0,
+        "version": "1.11.5",
+        "release": "5.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-cffi-1.11.5-5.el8.ppc64le.rpm",
+        "checksum": "sha256:4c124ec5a10a5c32e390d848942a04baa8761f190a4a95d3ed7b5c626ca17fc8",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-chardet",
+        "epoch": 0,
+        "version": "3.0.4",
+        "release": "7.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-chardet-3.0.4-7.el8.noarch.rpm",
+        "checksum": "sha256:176ffcb2cf0fdcbdd2d8119cbd98eef60a30fdb0fb065a9382d2c95e90c79652",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-configobj",
+        "epoch": 0,
+        "version": "5.0.6",
+        "release": "11.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-configobj-5.0.6-11.el8.noarch.rpm",
+        "checksum": "sha256:1bd969e0521820374122f5132e5998d9bd2ab185be66565a7266096297419c8e",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-cryptography",
+        "epoch": 0,
+        "version": "3.2.1",
+        "release": "5.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-cryptography-3.2.1-5.el8.ppc64le.rpm",
+        "checksum": "sha256:49e68a65bf87ae9ba812ffce76589c09f6766a0eaa5001d7e4a1c782e91d71c0",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-dateutil",
+        "epoch": 1,
+        "version": "2.6.1",
+        "release": "6.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-dateutil-2.6.1-6.el8.noarch.rpm",
+        "checksum": "sha256:c5b5967a094ced90899052a82e2c245529b75ba3f46e0ce1a89cfc95edb935ea",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-dbus",
+        "epoch": 0,
+        "version": "1.2.4",
+        "release": "15.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-dbus-1.2.4-15.el8.ppc64le.rpm",
+        "checksum": "sha256:c59538d646715fdb1f94c6be3fa0949871b8c860d5c54db4640a1197663a130b",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-decorator",
+        "epoch": 0,
+        "version": "4.2.1",
+        "release": "2.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-decorator-4.2.1-2.el8.noarch.rpm",
+        "checksum": "sha256:0e9a8a0f823bf0ef948862f0ccb62353460bd07931e756c98f23908c1c526578",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-dnf",
+        "epoch": 0,
+        "version": "4.7.0",
+        "release": "2.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-dnf-4.7.0-2.el8.noarch.rpm",
+        "checksum": "sha256:ccfa1810aa19fae08aefd29cffe28b65d5123cd17bd7d2d4207f03cf9795594c",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-dnf-plugins-core",
+        "epoch": 0,
+        "version": "4.0.21",
+        "release": "2.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-dnf-plugins-core-4.0.21-2.el8.noarch.rpm",
+        "checksum": "sha256:28c0f457d67213319f0313d993a3b2f8a778a077b202cd75bf45eb2792949d32",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-gobject-base",
+        "epoch": 0,
+        "version": "3.28.3",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-gobject-base-3.28.3-2.el8.ppc64le.rpm",
+        "checksum": "sha256:8781993942f622945aefe59e449a5ff4608f969db79fbe893040890ff08fc1f9",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-gpg",
+        "epoch": 0,
+        "version": "1.13.1",
+        "release": "9.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-gpg-1.13.1-9.el8.ppc64le.rpm",
+        "checksum": "sha256:111d88db3a52121f04f2741cc72ce8dda6d6f6ef2cc36452c042e0141b316334",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-hawkey",
+        "epoch": 0,
+        "version": "0.63.0",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-hawkey-0.63.0-2.el8.ppc64le.rpm",
+        "checksum": "sha256:4715730da2b4a5bf6cc2ab85208071f00c7b279e4b2f75df0bd954446185e14c",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-idna",
+        "epoch": 0,
+        "version": "2.5",
+        "release": "5.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-idna-2.5-5.el8.noarch.rpm",
+        "checksum": "sha256:78c43d8a15ca018de1803e4baac5819e1baab1963fd31f1e44e54e8a573acbfc",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-jwt",
+        "epoch": 0,
+        "version": "1.6.1",
+        "release": "2.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-jwt-1.6.1-2.el8.noarch.rpm",
+        "checksum": "sha256:ebeb05a4a9cdd5d060859eabac1349029c0120615c98fc939e26664c030655c1",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libcomps",
+        "epoch": 0,
+        "version": "0.1.16",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-libcomps-0.1.16-2.el8.ppc64le.rpm",
+        "checksum": "sha256:594d8b368013caa4eaba4eade896fc1cec8ef569052bd491f493c193e07c6d80",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libdnf",
+        "epoch": 0,
+        "version": "0.63.0",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-libdnf-0.63.0-2.el8.ppc64le.rpm",
+        "checksum": "sha256:abc36bf7797a427b64c3c99b4f74714bfa66b906b62358be6fdafe493a66415e",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libs",
+        "epoch": 0,
+        "version": "3.6.8",
+        "release": "39.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-libs-3.6.8-39.el8.ppc64le.rpm",
+        "checksum": "sha256:405bda98fe97c1a5cf70511ae2d167256b25dd8721b88899465e9847525e2068",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libselinux",
+        "epoch": 0,
+        "version": "2.9",
+        "release": "5.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-libselinux-2.9-5.el8.ppc64le.rpm",
+        "checksum": "sha256:3b5d31b89683be71c72b77cfceb59238f4c76a796de6ae85525b3d5cfe2a8f23",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libsemanage",
+        "epoch": 0,
+        "version": "2.9",
+        "release": "6.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-libsemanage-2.9-6.el8.ppc64le.rpm",
+        "checksum": "sha256:882a327cb5e2d809bfe695e9622caced76e7d89c96dcb40203ad8b7d281630fa",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libxml2",
+        "epoch": 0,
+        "version": "2.9.7",
+        "release": "11.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-libxml2-2.9.7-11.el8.ppc64le.rpm",
+        "checksum": "sha256:d77a7b1602a9ab7543171091dcb37100552f4738d40389028cbf2992c3152f52",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-linux-procfs",
+        "epoch": 0,
+        "version": "0.6.3",
+        "release": "1.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-linux-procfs-0.6.3-1.el8.noarch.rpm",
+        "checksum": "sha256:dc835194ecfa6ebda81e0a764c953eff3422a61863e9a3e0dc74ea4cae7a4d94",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-oauthlib",
+        "epoch": 0,
+        "version": "2.1.0",
+        "release": "1.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-oauthlib-2.1.0-1.el8.noarch.rpm",
+        "checksum": "sha256:20874a9d40b12125c9e5b97fe4ccda3f94acbc03da1dec7299123901f5b56631",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-perf",
+        "epoch": 0,
+        "version": "4.18.0",
+        "release": "331.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-perf-4.18.0-331.el8.ppc64le.rpm",
+        "checksum": "sha256:cb21226326a5a695c993daba749f5d758658d58612b05280a04cca98cba3f83a",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-pip-wheel",
+        "epoch": 0,
+        "version": "9.0.3",
+        "release": "20.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-pip-wheel-9.0.3-20.el8.noarch.rpm",
+        "checksum": "sha256:6c9dfb73e199975275633f05d31388cd61c5a77dec5678db958b4e6624eb21ba",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-ply",
+        "epoch": 0,
+        "version": "3.9",
+        "release": "9.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-ply-3.9-9.el8.noarch.rpm",
+        "checksum": "sha256:d1e8c7a00924d1a6dee44ade189025853a501d4f77c73f3bfc006aa907d97daf",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-policycoreutils",
+        "epoch": 0,
+        "version": "2.9",
+        "release": "15.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-policycoreutils-2.9-15.el8.noarch.rpm",
+        "checksum": "sha256:3eca41ba67f8121586709b6fa2c57b20b4fab73bbb8a4c133269d0cc964f362c",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-pycparser",
+        "epoch": 0,
+        "version": "2.14",
+        "release": "14.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-pycparser-2.14-14.el8.noarch.rpm",
+        "checksum": "sha256:8891a9a4707611c13a5693b195201dd940254ffdb03cf5742952329282bb8cb7",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-pysocks",
+        "epoch": 0,
+        "version": "1.6.8",
+        "release": "3.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-pysocks-1.6.8-3.el8.noarch.rpm",
+        "checksum": "sha256:7f506879c64e0bb4d98782d025f46fb9a07517487ae4cbebbb3985a98f4e2154",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-pyudev",
+        "epoch": 0,
+        "version": "0.21.0",
+        "release": "7.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-pyudev-0.21.0-7.el8.noarch.rpm",
+        "checksum": "sha256:aa0007192287faeaecc72d9fa48efdb3108c764d450dc8fea65474476da32c45",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-pyyaml",
+        "epoch": 0,
+        "version": "3.12",
+        "release": "12.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-pyyaml-3.12-12.el8.ppc64le.rpm",
+        "checksum": "sha256:5b0f2f11c7d635630ced3cc6431b60d27a2c80f878420654df18a714b3df6c0e",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-requests",
+        "epoch": 0,
+        "version": "2.20.0",
+        "release": "2.1.el8_1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-requests-2.20.0-2.1.el8_1.noarch.rpm",
+        "checksum": "sha256:003ee19ec5b88de212c3246bdfdb3e97a9910a25a219fd7cf5030b7bc666fea9",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-rpm",
+        "epoch": 0,
+        "version": "4.14.3",
+        "release": "15.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-rpm-4.14.3-15.el8.ppc64le.rpm",
+        "checksum": "sha256:ccf848b42acc0f691b4cb6e2830dc4263c7ce4df89b3f4002c3d6b9cd99b362b",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-setools",
+        "epoch": 0,
+        "version": "4.3.0",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-setools-4.3.0-2.el8.ppc64le.rpm",
+        "checksum": "sha256:c2776b30c82ad5566fdbcce83fcf9c699ad83dae57c6499eb64f8b8a7bc00b60",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-setuptools-wheel",
+        "epoch": 0,
+        "version": "39.2.0",
+        "release": "6.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-setuptools-wheel-39.2.0-6.el8.noarch.rpm",
+        "checksum": "sha256:b19bd4f106ce301ee21c860183cc1c2ef9c09bdf495059bdf16e8d8ccc71bbe8",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-six",
+        "epoch": 0,
+        "version": "1.11.0",
+        "release": "8.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-six-1.11.0-8.el8.noarch.rpm",
+        "checksum": "sha256:a04cb3117395b962edc32bf45d8411f240632476b0706b2df7f4a1a87b2ce34b",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-slip",
+        "epoch": 0,
+        "version": "0.6.4",
+        "release": "11.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-slip-0.6.4-11.el8.noarch.rpm",
+        "checksum": "sha256:233e5f78027b684e5aaac1395cc574aea3039059bf86eb4494422bc74216a396",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-slip-dbus",
+        "epoch": 0,
+        "version": "0.6.4",
+        "release": "11.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-slip-dbus-0.6.4-11.el8.noarch.rpm",
+        "checksum": "sha256:563b3741d26b6af963fdb7b0634e0791445a707d0b6093ac71c3224299241639",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-syspurpose",
+        "epoch": 0,
+        "version": "1.28.20",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-syspurpose-1.28.20-1.el8.ppc64le.rpm",
+        "checksum": "sha256:07c65a3efc2bb32027206df4f117b893268d028cbb3741208d73615a63525158",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-urllib3",
+        "epoch": 0,
+        "version": "1.24.2",
+        "release": "5.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-urllib3-1.24.2-5.el8.noarch.rpm",
+        "checksum": "sha256:aa1835fd302a37b84ac256db5dd0de09bd9883a5a07775aedb491faf46b18ee0",
+        "check_gpg": true
+      },
+      {
+        "name": "quota",
+        "epoch": 1,
+        "version": "4.04",
+        "release": "14.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/quota-4.04-14.el8.ppc64le.rpm",
+        "checksum": "sha256:612c21ec8de299b7244b931b492f17e811ecde1450e359f112bc88d20b115d73",
+        "check_gpg": true
+      },
+      {
+        "name": "quota-nls",
+        "epoch": 1,
+        "version": "4.04",
+        "release": "14.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/quota-nls-4.04-14.el8.noarch.rpm",
+        "checksum": "sha256:bc7fc2028a29ac7a406719ed4f6740f6bf12c20961223c1e839a2a39069af38d",
+        "check_gpg": true
+      },
+      {
+        "name": "rdma-core",
+        "epoch": 0,
+        "version": "35.0",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/rdma-core-35.0-1.el8.ppc64le.rpm",
+        "checksum": "sha256:4cc53ff12e7b8fcfafdd32eaac7b13266876766f22b3262b653eaa7b06fbbaaf",
+        "check_gpg": true
+      },
+      {
+        "name": "readline",
+        "epoch": 0,
+        "version": "7.0",
+        "release": "10.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/readline-7.0-10.el8.ppc64le.rpm",
+        "checksum": "sha256:0320663709136d07690fe299903700cc1dcc526d574fe8b952a01e1d24024ae4",
+        "check_gpg": true
+      },
+      {
+        "name": "rootfiles",
+        "epoch": 0,
+        "version": "8.1",
+        "release": "22.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/rootfiles-8.1-22.el8.noarch.rpm",
+        "checksum": "sha256:d967d6bbb33bf7a295a64807f81875c84e82a8ecc59b6c72fe955141b1660d39",
+        "check_gpg": true
+      },
+      {
+        "name": "rpcbind",
+        "epoch": 0,
+        "version": "1.2.5",
+        "release": "8.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/rpcbind-1.2.5-8.el8.ppc64le.rpm",
+        "checksum": "sha256:a81afd94bec26037880bccdb97937c7662ecb6c1006a8bbf657d8ffafc7c4614",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm",
+        "epoch": 0,
+        "version": "4.14.3",
+        "release": "15.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/rpm-4.14.3-15.el8.ppc64le.rpm",
+        "checksum": "sha256:4fae16ca54207cb952e3904b8eb8cc424f3f056f400e5e802ab1a9ef3e575834",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-build-libs",
+        "epoch": 0,
+        "version": "4.14.3",
+        "release": "15.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/rpm-build-libs-4.14.3-15.el8.ppc64le.rpm",
+        "checksum": "sha256:03ba1e86a04d912fd2878b457b06a6a7abad0ce96cd9a6932bf58cb4641b8fb7",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-libs",
+        "epoch": 0,
+        "version": "4.14.3",
+        "release": "15.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/rpm-libs-4.14.3-15.el8.ppc64le.rpm",
+        "checksum": "sha256:4e22015880d16cb7148d70895a2361f4fa05804f0391386e0e50554e6fd868b0",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-plugin-selinux",
+        "epoch": 0,
+        "version": "4.14.3",
+        "release": "15.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/rpm-plugin-selinux-4.14.3-15.el8.ppc64le.rpm",
+        "checksum": "sha256:9b1018a43b1a9245cdc71a342b962aa32fb799bd0ce66ee59b496cdd75200de9",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-plugin-systemd-inhibit",
+        "epoch": 0,
+        "version": "4.14.3",
+        "release": "15.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/rpm-plugin-systemd-inhibit-4.14.3-15.el8.ppc64le.rpm",
+        "checksum": "sha256:8cb953ea9ea1bd262bef00112e2c433583929cd7aec86ae60f1a725c6dcf7c09",
+        "check_gpg": true
+      },
+      {
+        "name": "rsync",
+        "epoch": 0,
+        "version": "3.1.3",
+        "release": "12.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/rsync-3.1.3-12.el8.ppc64le.rpm",
+        "checksum": "sha256:88ff01f3d3812bc3fb3d18970ecefde7ac8f1a6a29409946ed85173cf8645a3a",
+        "check_gpg": true
+      },
+      {
+        "name": "sed",
+        "epoch": 0,
+        "version": "4.5",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/sed-4.5-2.el8.ppc64le.rpm",
+        "checksum": "sha256:dbde46224833f804d8b92212fa3618ea53d0e0cb84ff07132a5ba36c1bc0b9df",
+        "check_gpg": true
+      },
+      {
+        "name": "selinux-policy",
+        "epoch": 0,
+        "version": "3.14.3",
+        "release": "76.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/selinux-policy-3.14.3-76.el8.noarch.rpm",
+        "checksum": "sha256:561a61d2d81bccb14d22a53b32301e0b6b9e9b9d80ad75991ee6ff796cae0ef7",
+        "check_gpg": true
+      },
+      {
+        "name": "selinux-policy-targeted",
+        "epoch": 0,
+        "version": "3.14.3",
+        "release": "76.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/selinux-policy-targeted-3.14.3-76.el8.noarch.rpm",
+        "checksum": "sha256:76df9e0fc779fcd7d3ee836ae254ead30b5f9492022b55901d1f8bd914d38ef6",
+        "check_gpg": true
+      },
+      {
+        "name": "servicelog",
+        "epoch": 0,
+        "version": "1.1.15",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/servicelog-1.1.15-1.el8.ppc64le.rpm",
+        "checksum": "sha256:605033c50f750dad4c344495a0d6b18dcfb2a091bba072441a38cbf9001c0363",
+        "check_gpg": true
+      },
+      {
+        "name": "setup",
+        "epoch": 0,
+        "version": "2.12.2",
+        "release": "6.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/setup-2.12.2-6.el8.noarch.rpm",
+        "checksum": "sha256:9e540fe1fcf866ba1e738e012eef5459d34cca30385df73973e6fc7c6eadb55f",
+        "check_gpg": true
+      },
+      {
+        "name": "sg3_utils",
+        "epoch": 0,
+        "version": "1.44",
+        "release": "5.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/sg3_utils-1.44-5.el8.ppc64le.rpm",
+        "checksum": "sha256:7d4c363f4a746f3a0946d19f303fe9c60c5fe178892528ec4f34d8ddd2c4c359",
+        "check_gpg": true
+      },
+      {
+        "name": "sg3_utils-libs",
+        "epoch": 0,
+        "version": "1.44",
+        "release": "5.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/sg3_utils-libs-1.44-5.el8.ppc64le.rpm",
+        "checksum": "sha256:8540be85295735194e0053eb2ab6b2bda2e27119b9b030877eff43f9272a20cf",
+        "check_gpg": true
+      },
+      {
+        "name": "shadow-utils",
+        "epoch": 2,
+        "version": "4.6",
+        "release": "14.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/shadow-utils-4.6-14.el8.ppc64le.rpm",
+        "checksum": "sha256:e1153055b6ea57ee81e6fb41b03023279059513d0fec728517ae0805186a5118",
+        "check_gpg": true
+      },
+      {
+        "name": "shared-mime-info",
+        "epoch": 0,
+        "version": "1.9",
+        "release": "3.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/shared-mime-info-1.9-3.el8.ppc64le.rpm",
+        "checksum": "sha256:f97b5915b3f75d2878104c198f205841813712103f1b3657d71d2c8d079cc947",
+        "check_gpg": true
+      },
+      {
+        "name": "slang",
+        "epoch": 0,
+        "version": "2.3.2",
+        "release": "3.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/slang-2.3.2-3.el8.ppc64le.rpm",
+        "checksum": "sha256:dd8998fa42db6769700a41203f5ef0efe523ed24734636ef0dc0d2a4d4a94747",
+        "check_gpg": true
+      },
+      {
+        "name": "snappy",
+        "epoch": 0,
+        "version": "1.1.8",
+        "release": "3.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/snappy-1.1.8-3.el8.ppc64le.rpm",
+        "checksum": "sha256:17c615aa31cf2afa434d1d1d42e0db85b564fe416d346721bd38c0db75f73119",
+        "check_gpg": true
+      },
+      {
+        "name": "sos",
+        "epoch": 0,
+        "version": "4.1",
+        "release": "5.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/sos-4.1-5.el8.noarch.rpm",
+        "checksum": "sha256:48f31b2798e2ebbf1a7b83f43c6aa2d2eb438a1e053906623c3a7391065c00d9",
+        "check_gpg": true
+      },
+      {
+        "name": "sqlite-libs",
+        "epoch": 0,
+        "version": "3.26.0",
+        "release": "15.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/sqlite-libs-3.26.0-15.el8.ppc64le.rpm",
+        "checksum": "sha256:31277c01ac529cc1c6a55fd87d6ce4dbb20290575d4e1e89cd40600eac9f3405",
+        "check_gpg": true
+      },
+      {
+        "name": "squashfs-tools",
+        "epoch": 0,
+        "version": "4.3",
+        "release": "20.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/squashfs-tools-4.3-20.el8.ppc64le.rpm",
+        "checksum": "sha256:4b00562fa291e956d910bb056c6120f0079f30093ea107757758683a6d418206",
+        "check_gpg": true
+      },
+      {
+        "name": "sssd-client",
+        "epoch": 0,
+        "version": "2.5.2",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/sssd-client-2.5.2-2.el8.ppc64le.rpm",
+        "checksum": "sha256:5796882ac3059835583bc399e8522c19646b717713ef553a71b20ca0535a1718",
+        "check_gpg": true
+      },
+      {
+        "name": "sssd-common",
+        "epoch": 0,
+        "version": "2.5.2",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/sssd-common-2.5.2-2.el8.ppc64le.rpm",
+        "checksum": "sha256:697f5bf30fbe44dd4dcba8392b85680952b7a1be9a0221349f4fde011a8cdd3c",
+        "check_gpg": true
+      },
+      {
+        "name": "sssd-kcm",
+        "epoch": 0,
+        "version": "2.5.2",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/sssd-kcm-2.5.2-2.el8.ppc64le.rpm",
+        "checksum": "sha256:c477e45fe5f8f5bab1ec1711210dd357392ad19eab48cda18d89b60df5067970",
+        "check_gpg": true
+      },
+      {
+        "name": "sssd-nfs-idmap",
+        "epoch": 0,
+        "version": "2.5.2",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/sssd-nfs-idmap-2.5.2-2.el8.ppc64le.rpm",
+        "checksum": "sha256:61b1d3440b078f35a3fe2b35c51d6d38498fb3dc8d8f5fedf52c7f0f8f6d8ecf",
+        "check_gpg": true
+      },
+      {
+        "name": "sudo",
+        "epoch": 0,
+        "version": "1.8.29",
+        "release": "7.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/sudo-1.8.29-7.el8.ppc64le.rpm",
+        "checksum": "sha256:bba1cd75958b43df5e3ceb820449008c19ed5fa562d54c2d46c5c57e79aa6b2a",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd",
+        "epoch": 0,
+        "version": "239",
+        "release": "49.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/systemd-239-49.el8.ppc64le.rpm",
+        "checksum": "sha256:8a501b9d8016eee68ce62a93a65842b15c8a57192b9f8189ebc85a11f2f47f9e",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-libs",
+        "epoch": 0,
+        "version": "239",
+        "release": "49.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/systemd-libs-239-49.el8.ppc64le.rpm",
+        "checksum": "sha256:3d175382237a94330d72af67ad2c41535dee7eade3e42178b86d2dc87478d030",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-pam",
+        "epoch": 0,
+        "version": "239",
+        "release": "49.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/systemd-pam-239-49.el8.ppc64le.rpm",
+        "checksum": "sha256:e95bb05fa5defeb16dd0e0957de676374b22b9daaf405273e636d1ce91001574",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-udev",
+        "epoch": 0,
+        "version": "239",
+        "release": "49.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/systemd-udev-239-49.el8.ppc64le.rpm",
+        "checksum": "sha256:3898e2ac4e04e80373bc7fe4092b26d502d4705177719117e25c083d44a9a150",
+        "check_gpg": true
+      },
+      {
+        "name": "tar",
+        "epoch": 2,
+        "version": "1.30",
+        "release": "5.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/tar-1.30-5.el8.ppc64le.rpm",
+        "checksum": "sha256:8c26cce4231f781db7b37d51ded377f9cfa01a5e6833d967082795f1220e2860",
+        "check_gpg": true
+      },
+      {
+        "name": "teamd",
+        "epoch": 0,
+        "version": "1.31",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/teamd-1.31-2.el8.ppc64le.rpm",
+        "checksum": "sha256:de9a24cdb3260850b49086745ba6f724aecff0bf7993729ae063c116da6915a4",
+        "check_gpg": true
+      },
+      {
+        "name": "timedatex",
+        "epoch": 0,
+        "version": "0.5",
+        "release": "3.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/timedatex-0.5-3.el8.ppc64le.rpm",
+        "checksum": "sha256:9dc236a8124d1fcbb41b970b5a4c45d6f7f97430c933c775121cae27f5f352a7",
+        "check_gpg": true
+      },
+      {
+        "name": "tpm2-tss",
+        "epoch": 0,
+        "version": "2.3.2",
+        "release": "4.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/tpm2-tss-2.3.2-4.el8.ppc64le.rpm",
+        "checksum": "sha256:d46ef49f8ddba1ee8cce6c9764014851cce2dbfb5dcb2457a31495393e6566c1",
+        "check_gpg": true
+      },
+      {
+        "name": "trousers",
+        "epoch": 0,
+        "version": "0.3.15",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/trousers-0.3.15-1.el8.ppc64le.rpm",
+        "checksum": "sha256:4164089bf1754c0ef18ae051e047f11299907204839ad4b7978f146a543a2e91",
+        "check_gpg": true
+      },
+      {
+        "name": "trousers-lib",
+        "epoch": 0,
+        "version": "0.3.15",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/trousers-lib-0.3.15-1.el8.ppc64le.rpm",
+        "checksum": "sha256:09096bc32e37443417cd625364df32674f9d5ff4ddbeb175e6d60637ed3d573f",
+        "check_gpg": true
+      },
+      {
+        "name": "tuned",
+        "epoch": 0,
+        "version": "2.16.0",
+        "release": "1.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/tuned-2.16.0-1.el8.noarch.rpm",
+        "checksum": "sha256:654d9074dc8ebb93230fe258188a17ba3f7dbac2f360f9f79cc4fb1516953018",
+        "check_gpg": true
+      },
+      {
+        "name": "tzdata",
+        "epoch": 0,
+        "version": "2021a",
+        "release": "1.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/tzdata-2021a-1.el8.noarch.rpm",
+        "checksum": "sha256:44999c555a6e4bb6cf5e6f6a79819e76912d036732cb50efaeefc20a180dd839",
+        "check_gpg": true
+      },
+      {
+        "name": "util-linux",
+        "epoch": 0,
+        "version": "2.32.1",
+        "release": "28.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/util-linux-2.32.1-28.el8.ppc64le.rpm",
+        "checksum": "sha256:ce954d3900cb547aea14df6ad5f310ea96bb5e83a155b93e2e64b2c13b686193",
+        "check_gpg": true
+      },
+      {
+        "name": "vim-minimal",
+        "epoch": 2,
+        "version": "8.0.1763",
+        "release": "15.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/vim-minimal-8.0.1763-15.el8.ppc64le.rpm",
+        "checksum": "sha256:368779f00f427680d954899dd73ad3b6a59c42baafb91cb100ea177f51185198",
+        "check_gpg": true
+      },
+      {
+        "name": "virt-what",
+        "epoch": 0,
+        "version": "1.18",
+        "release": "12.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/virt-what-1.18-12.el8.ppc64le.rpm",
+        "checksum": "sha256:f0c20dff5211f9c133ad5703daedcbe148528c634b0a1eea7887b420da4dc00c",
+        "check_gpg": true
+      },
+      {
+        "name": "which",
+        "epoch": 0,
+        "version": "2.21",
+        "release": "16.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/which-2.21-16.el8.ppc64le.rpm",
+        "checksum": "sha256:15cd74b4ad9d82417072fe867f086d68667afd4291b710b6c7feef985c492990",
+        "check_gpg": true
+      },
+      {
+        "name": "xfsprogs",
+        "epoch": 0,
+        "version": "5.0.0",
+        "release": "9.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/xfsprogs-5.0.0-9.el8.ppc64le.rpm",
+        "checksum": "sha256:480e0f1a9dcce6ed0728e9aba709e33f5522273da1e4b0859cf9d3bbe2216532",
+        "check_gpg": true
+      },
+      {
+        "name": "xz",
+        "epoch": 0,
+        "version": "5.2.4",
+        "release": "3.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/xz-5.2.4-3.el8.ppc64le.rpm",
+        "checksum": "sha256:cd8b0adfc4d2467a61ab2aa2b3e617bbd2a2592176da249365eef014faef827c",
+        "check_gpg": true
+      },
+      {
+        "name": "xz-libs",
+        "epoch": 0,
+        "version": "5.2.4",
+        "release": "3.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/xz-libs-5.2.4-3.el8.ppc64le.rpm",
+        "checksum": "sha256:a4577841148e7e2bf481447ae141eff319007e70a24295a22787bbfaecf4c4fe",
+        "check_gpg": true
+      },
+      {
+        "name": "yum",
+        "epoch": 0,
+        "version": "4.7.0",
+        "release": "2.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/yum-4.7.0-2.el8.noarch.rpm",
+        "checksum": "sha256:bc3e4dd9194760500ce9731d792f46afa049667185487bae88c23a38fdb10c37",
+        "check_gpg": true
+      },
+      {
+        "name": "yum-utils",
+        "epoch": 0,
+        "version": "4.0.21",
+        "release": "2.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/yum-utils-4.0.21-2.el8.noarch.rpm",
+        "checksum": "sha256:3c89b334988c0d1399d25baebe298d9e8cc768f28aefd581aae893aa1e69de84",
+        "check_gpg": true
+      },
+      {
+        "name": "zlib",
+        "epoch": 0,
+        "version": "1.2.11",
+        "release": "17.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/zlib-1.2.11-17.el8.ppc64le.rpm",
+        "checksum": "sha256:33a92d88496e8aa410976f073e324f761b2ae02a94c20c0f291072df84f648be",
+        "check_gpg": true
+      },
+      {
+        "name": "PackageKit",
+        "epoch": 0,
+        "version": "1.1.12",
+        "release": "6.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/PackageKit-1.1.12-6.el8.ppc64le.rpm",
+        "checksum": "sha256:8b73e398f5a3cdc8a7ded303586ca7a50b26cc76213a3cebe36fdfdca769b316",
+        "check_gpg": true
+      },
+      {
+        "name": "PackageKit-glib",
+        "epoch": 0,
+        "version": "1.1.12",
+        "release": "6.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/PackageKit-glib-1.1.12-6.el8.ppc64le.rpm",
+        "checksum": "sha256:ff02d15997cec2391c7d49203e49f88068993252ac1f496a11e182c92d9d0e88",
+        "check_gpg": true
+      },
+      {
+        "name": "abattis-cantarell-fonts",
+        "epoch": 0,
+        "version": "0.0.25",
+        "release": "6.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/abattis-cantarell-fonts-0.0.25-6.el8.noarch.rpm",
+        "checksum": "sha256:11838afbfab4da7d5fa6e01046f76cce0b0a0c174a87c522eba440fce16e316f",
+        "check_gpg": true
+      },
+      {
+        "name": "authselect-compat",
+        "epoch": 0,
+        "version": "1.2.2",
+        "release": "3.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/authselect-compat-1.2.2-3.el8.ppc64le.rpm",
+        "checksum": "sha256:e526de1fefb832b3e6a025642c77ac2527595925933412a7921606eb072e5ca9",
+        "check_gpg": true
+      },
+      {
+        "name": "cairo",
+        "epoch": 0,
+        "version": "1.15.12",
+        "release": "3.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/cairo-1.15.12-3.el8.ppc64le.rpm",
+        "checksum": "sha256:3d4e54f6bb2f6ee5417613d5d9bef407343adc768a0841ea58f831ffa868cbd0",
+        "check_gpg": true
+      },
+      {
+        "name": "cairo-gobject",
+        "epoch": 0,
+        "version": "1.15.12",
+        "release": "3.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/cairo-gobject-1.15.12-3.el8.ppc64le.rpm",
+        "checksum": "sha256:8623975eac20e039a7ba14323490db10169cf205ec98f5df2f55f7d410202663",
+        "check_gpg": true
+      },
+      {
+        "name": "centos-logos",
+        "epoch": 0,
+        "version": "85.8",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/centos-logos-85.8-1.el8.ppc64le.rpm",
+        "checksum": "sha256:2b76d31dc0fdff399a5b1d396caff67b9eb2f5b8f6cfa8d7a430eeaf6a09104d",
+        "check_gpg": true
+      },
+      {
+        "name": "cloud-init",
+        "epoch": 0,
+        "version": "21.1",
+        "release": "3.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/cloud-init-21.1-3.el8.noarch.rpm",
+        "checksum": "sha256:43d4db89cf7aa96d57be2847577cf1dba8cba99d5d43118ee54d0b97a4ef8b7e",
+        "check_gpg": true
+      },
+      {
+        "name": "cloud-utils-growpart",
+        "epoch": 0,
+        "version": "0.31",
+        "release": "3.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/cloud-utils-growpart-0.31-3.el8.noarch.rpm",
+        "checksum": "sha256:80f3973c07c06dd095203553abbb95d6ce1c24ccc92f24f46659bf05416f4778",
+        "check_gpg": true
+      },
+      {
+        "name": "geolite2-city",
+        "epoch": 0,
+        "version": "20180605",
+        "release": "1.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/geolite2-city-20180605-1.el8.noarch.rpm",
+        "checksum": "sha256:cad86777bcb265db0da766952ff63e8d33f0fd4f3b90b22d0a1da587a785db44",
+        "check_gpg": true
+      },
+      {
+        "name": "geolite2-country",
+        "epoch": 0,
+        "version": "20180605",
+        "release": "1.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/geolite2-country-20180605-1.el8.noarch.rpm",
+        "checksum": "sha256:67419432fe7d373f8e5ddaa7b0dd1c25389608bf2f4ee76dbabcc2d96eb8c9d0",
+        "check_gpg": true
+      },
+      {
+        "name": "libX11",
+        "epoch": 0,
+        "version": "1.6.8",
+        "release": "4.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/libX11-1.6.8-4.el8.ppc64le.rpm",
+        "checksum": "sha256:4b81b6f8279b75714cbac2f77b2e006f65cd799c2ec3d1c9c40840b1ab60c885",
+        "check_gpg": true
+      },
+      {
+        "name": "libX11-common",
+        "epoch": 0,
+        "version": "1.6.8",
+        "release": "4.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/libX11-common-1.6.8-4.el8.noarch.rpm",
+        "checksum": "sha256:5f445b2b2a4bdeabd555e25dfa10119d9f4e4e500d1c4492219dd8647f119ce2",
+        "check_gpg": true
+      },
+      {
+        "name": "libXau",
+        "epoch": 0,
+        "version": "1.0.9",
+        "release": "3.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/libXau-1.0.9-3.el8.ppc64le.rpm",
+        "checksum": "sha256:8c893a8300f812ca179e1f8863eff109e1b8f1c70044bc5f08eb38a592ffdecd",
+        "check_gpg": true
+      },
+      {
+        "name": "libXext",
+        "epoch": 0,
+        "version": "1.3.4",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/libXext-1.3.4-1.el8.ppc64le.rpm",
+        "checksum": "sha256:fc8e4e96da6ee6201a5126473666831314938e98bf699677be296e7811f6b7dd",
+        "check_gpg": true
+      },
+      {
+        "name": "libXrender",
+        "epoch": 0,
+        "version": "0.9.10",
+        "release": "7.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/libXrender-0.9.10-7.el8.ppc64le.rpm",
+        "checksum": "sha256:32ecf5a37bacbeec9451c4ad39672ac2816f9241d5a92f038b45059da2f3ebae",
+        "check_gpg": true
+      },
+      {
+        "name": "libestr",
+        "epoch": 0,
+        "version": "0.1.10",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/libestr-0.1.10-1.el8.ppc64le.rpm",
+        "checksum": "sha256:e525544166da577edcd03c6596f1e8787a257caaa19eef98c3a481681d2d978a",
+        "check_gpg": true
+      },
+      {
+        "name": "libfastjson",
+        "epoch": 0,
+        "version": "0.99.9",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/libfastjson-0.99.9-1.el8.ppc64le.rpm",
+        "checksum": "sha256:b55df489f643b495984915a0671e74262192813e07cff5812d778c8cf4c0b9d1",
+        "check_gpg": true
+      },
+      {
+        "name": "libmaxminddb",
+        "epoch": 0,
+        "version": "1.2.0",
+        "release": "10.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/libmaxminddb-1.2.0-10.el8.ppc64le.rpm",
+        "checksum": "sha256:29214e4bf64efb65d82bd3f318d0ac3b7a6b03f6f6abfd469148bc2f894c6846",
+        "check_gpg": true
+      },
+      {
+        "name": "libxcb",
+        "epoch": 0,
+        "version": "1.13.1",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/libxcb-1.13.1-1.el8.ppc64le.rpm",
+        "checksum": "sha256:16b390c34ddb56c075fb6f4b77bf9a0fffab219fcb3f3588b9151215ab2b0ad4",
+        "check_gpg": true
+      },
+      {
+        "name": "libxkbcommon",
+        "epoch": 0,
+        "version": "0.9.1",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/libxkbcommon-0.9.1-1.el8.ppc64le.rpm",
+        "checksum": "sha256:b5bd11b47b5b690dc667dc486941331d7cd3aaa4f0e5c4d638ec7b294bcc5012",
+        "check_gpg": true
+      },
+      {
+        "name": "oddjob",
+        "epoch": 0,
+        "version": "0.34.7",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/oddjob-0.34.7-1.el8.ppc64le.rpm",
+        "checksum": "sha256:20c3abcc5556f09e557a398886684d1efe8ef59687bedbb78c130a7d1d55868a",
+        "check_gpg": true
+      },
+      {
+        "name": "oddjob-mkhomedir",
+        "epoch": 0,
+        "version": "0.34.7",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/oddjob-mkhomedir-0.34.7-1.el8.ppc64le.rpm",
+        "checksum": "sha256:1cdd6c2abf0132da0d956398eb1dc736c0b93fd8e8465e7f1111ad05b2c322d8",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Digest",
+        "epoch": 0,
+        "version": "1.17",
+        "release": "395.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/perl-Digest-1.17-395.el8.noarch.rpm",
+        "checksum": "sha256:7e67dba2509f90064325e62e49412d5284a55f09b7b6878b9c8222692c500dde",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Digest-MD5",
+        "epoch": 0,
+        "version": "2.55",
+        "release": "396.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/perl-Digest-MD5-2.55-396.el8.ppc64le.rpm",
+        "checksum": "sha256:9f1a745b208091d4b009ec321a6fdc72c8a5e89167effed81c50571a13f1c87d",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-IO-Socket-IP",
+        "epoch": 0,
+        "version": "0.39",
+        "release": "5.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/perl-IO-Socket-IP-0.39-5.el8.noarch.rpm",
+        "checksum": "sha256:c7dfa7d5a4917eed3b44af87ffb9c6e18242ecd847a8edd140bcdd178cc8946a",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-IO-Socket-SSL",
+        "epoch": 0,
+        "version": "2.066",
+        "release": "4.module_el8.4.0+517+be1595ff",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/perl-IO-Socket-SSL-2.066-4.module_el8.4.0+517+be1595ff.noarch.rpm",
+        "checksum": "sha256:46e371b6245113ebca446adcbd2db39f2887b67dc5a640f62f6d346ec9f6980f",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Mozilla-CA",
+        "epoch": 0,
+        "version": "20160104",
+        "release": "7.module_el8.3.0+416+dee7bcef",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/perl-Mozilla-CA-20160104-7.module_el8.3.0+416+dee7bcef.noarch.rpm",
+        "checksum": "sha256:cea5d052286c0a120f6cdd0f3e559f13b0eedf9f83d2538e4369b6e05526d43d",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Net-SSLeay",
+        "epoch": 0,
+        "version": "1.88",
+        "release": "1.module_el8.4.0+517+be1595ff",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/perl-Net-SSLeay-1.88-1.module_el8.4.0+517+be1595ff.ppc64le.rpm",
+        "checksum": "sha256:62da6a936871ab7b8c3efc0332fe41b4ac10ff96b357fb2bd67deecb312f9277",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-URI",
+        "epoch": 0,
+        "version": "1.73",
+        "release": "3.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/perl-URI-1.73-3.el8.noarch.rpm",
+        "checksum": "sha256:9feaf80c733951790bc3578db42ea2abef65643ebb36779e46dccdaf4c76b525",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-libnet",
+        "epoch": 0,
+        "version": "3.11",
+        "release": "3.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/perl-libnet-3.11-3.el8.noarch.rpm",
+        "checksum": "sha256:627d792d7cca1e97c121be5f0808c9da96f54d6c986622af246c60354b9c316e",
+        "check_gpg": true
+      },
+      {
+        "name": "pinentry",
+        "epoch": 0,
+        "version": "1.1.0",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/pinentry-1.1.0-2.el8.ppc64le.rpm",
+        "checksum": "sha256:12fda64dea45a7b085a35a816a7d8035be6600cae38f7df04a3bc22ced4d4502",
+        "check_gpg": true
+      },
+      {
+        "name": "pixman",
+        "epoch": 0,
+        "version": "0.38.4",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/pixman-0.38.4-1.el8.ppc64le.rpm",
+        "checksum": "sha256:685d8ca4ac9c909ac2daa8bf454d8ce1de993c8ae29a8c78417dfd5d1c3aa65e",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-babel",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "7.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/python3-babel-2.5.1-7.el8.noarch.rpm",
+        "checksum": "sha256:d2748115958b57c9c5125e23bad9462edbabb33c81197424a33d8060745ff646",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-cairo",
+        "epoch": 0,
+        "version": "1.16.3",
+        "release": "6.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/python3-cairo-1.16.3-6.el8.ppc64le.rpm",
+        "checksum": "sha256:5cf4db298bbda87532af2b2468a0692ec93d28393285ae157c1b4a18efbd1ba5",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-gobject",
+        "epoch": 0,
+        "version": "3.28.3",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/python3-gobject-3.28.3-2.el8.ppc64le.rpm",
+        "checksum": "sha256:7632176e2d324ee98701f5d79024361379d510590e477f560a264aa6e8db233d",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-jinja2",
+        "epoch": 0,
+        "version": "2.10.1",
+        "release": "3.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/python3-jinja2-2.10.1-3.el8.noarch.rpm",
+        "checksum": "sha256:95cb9c201ee3b54fe6331bd7e74f43485632e95448d31fd340ffaa84a32b41ab",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-jsonpatch",
+        "epoch": 0,
+        "version": "1.21",
+        "release": "2.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/python3-jsonpatch-1.21-2.el8.noarch.rpm",
+        "checksum": "sha256:85eb614fc608f3b3f4bbd08d4a3b0ff6af188677ea4e009be021680c521cedae",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-jsonpointer",
+        "epoch": 0,
+        "version": "1.10",
+        "release": "11.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/python3-jsonpointer-1.10-11.el8.noarch.rpm",
+        "checksum": "sha256:60b0cbc5e435be346bb06f45f3336f8936d7362022d8bceda80ff16bc3fb7dd2",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-jsonschema",
+        "epoch": 0,
+        "version": "2.6.0",
+        "release": "4.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/python3-jsonschema-2.6.0-4.el8.noarch.rpm",
+        "checksum": "sha256:0feac495306bbe6e3149a352025bea8d23cda512859a230cbd3f510cf48caaf7",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-markupsafe",
+        "epoch": 0,
+        "version": "0.23",
+        "release": "19.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/python3-markupsafe-0.23-19.el8.ppc64le.rpm",
+        "checksum": "sha256:0f54422e17766a9e7385a553d941d1849c9e7ca4caea085305ba9fb1e15ae607",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-pexpect",
+        "epoch": 0,
+        "version": "4.3.1",
+        "release": "3.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/python3-pexpect-4.3.1-3.el8.noarch.rpm",
+        "checksum": "sha256:0bc637f0d028043e8388b083cdd8d0a0acea7fdbc79c0bc9401dfb02c20fb817",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-prettytable",
+        "epoch": 0,
+        "version": "0.7.2",
+        "release": "14.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/python3-prettytable-0.7.2-14.el8.noarch.rpm",
+        "checksum": "sha256:1b53c868277dec628058b31b1a8a8a2ccd8efe832ce9694805b5f82564136eb3",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-ptyprocess",
+        "epoch": 0,
+        "version": "0.5.2",
+        "release": "4.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/python3-ptyprocess-0.5.2-4.el8.noarch.rpm",
+        "checksum": "sha256:499e48b35f3b5f5da45031fa78fba559fee6a480ecb106e6c300eb8344510958",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-pydbus",
+        "epoch": 0,
+        "version": "0.6.0",
+        "release": "5.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/python3-pydbus-0.6.0-5.el8.noarch.rpm",
+        "checksum": "sha256:bfa39369bd3c36833126b6f46b747de0736a66835d97196195c0810161c24549",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-pyserial",
+        "epoch": 0,
+        "version": "3.1.1",
+        "release": "8.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/python3-pyserial-3.1.1-8.el8.noarch.rpm",
+        "checksum": "sha256:82ce159a9e4e4b6b4fdce9ad954aa507f67108430bd261a4dcd826e44d0152a4",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-pytz",
+        "epoch": 0,
+        "version": "2017.2",
+        "release": "9.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/python3-pytz-2017.2-9.el8.noarch.rpm",
+        "checksum": "sha256:0edde19e0c027c8cff31b82e1f4b0b198c00bf924047fcf4dd610a7d4965ab52",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-systemd",
+        "epoch": 0,
+        "version": "234",
+        "release": "8.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/python3-systemd-234-8.el8.ppc64le.rpm",
+        "checksum": "sha256:6b096b1da49230942e736576396091530cecb3f9bd8cc70b8b8a9f72a5148a0d",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-unbound",
+        "epoch": 0,
+        "version": "1.7.3",
+        "release": "17.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/python3-unbound-1.7.3-17.el8.ppc64le.rpm",
+        "checksum": "sha256:8571a2aa115d42f8b5e87ef58d10e9c24e6fbe5470fc2612df96f8740f3d960f",
+        "check_gpg": true
+      },
+      {
+        "name": "qemu-guest-agent",
+        "epoch": 15,
+        "version": "4.2.0",
+        "release": "52.module_el8.5.0+853+a4d5519d",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/qemu-guest-agent-4.2.0-52.module_el8.5.0+853+a4d5519d.ppc64le.rpm",
+        "checksum": "sha256:2fcacd153d4aa4ddddee3357b717e8d3f411382b180add28328c9faa94dd2ae4",
+        "check_gpg": true
+      },
+      {
+        "name": "rsyslog",
+        "epoch": 0,
+        "version": "8.2102.0",
+        "release": "5.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/rsyslog-8.2102.0-5.el8.ppc64le.rpm",
+        "checksum": "sha256:8945279d57ad510e018f92571ba8e5d811cf8a3165adf930b0d4015c5a077a35",
+        "check_gpg": true
+      },
+      {
+        "name": "setroubleshoot-plugins",
+        "epoch": 0,
+        "version": "3.3.13",
+        "release": "1.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/setroubleshoot-plugins-3.3.13-1.el8.noarch.rpm",
+        "checksum": "sha256:30f37ca1fe1592e29d3e97c1dec0646015000d19bffc40f13dcfe73e15be66fc",
+        "check_gpg": true
+      },
+      {
+        "name": "setroubleshoot-server",
+        "epoch": 0,
+        "version": "3.3.24",
+        "release": "3.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/setroubleshoot-server-3.3.24-3.el8.ppc64le.rpm",
+        "checksum": "sha256:27f43a7a8d1b18f5ede27728ecded75e510195a78abd9f3d0c1965d341e5e45a",
+        "check_gpg": true
+      },
+      {
+        "name": "sscg",
+        "epoch": 0,
+        "version": "2.3.3",
+        "release": "14.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/sscg-2.3.3-14.el8.ppc64le.rpm",
+        "checksum": "sha256:ab2988acbe3a2580703de6070646324e95efe982598a386e69ed9857ab123855",
+        "check_gpg": true
+      },
+      {
+        "name": "tcpdump",
+        "epoch": 14,
+        "version": "4.9.3",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/tcpdump-4.9.3-2.el8.ppc64le.rpm",
+        "checksum": "sha256:71f54759238edb9ae63dfc6ed893183a809e88321d8117dc40e0d403fc533585",
+        "check_gpg": true
+      },
+      {
+        "name": "unbound-libs",
+        "epoch": 0,
+        "version": "1.7.3",
+        "release": "17.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/unbound-libs-1.7.3-17.el8.ppc64le.rpm",
+        "checksum": "sha256:ebd64ac5cc7b9f58a40072fe9afefa2fd835e0eb18cdeaf085395c7e84affac3",
+        "check_gpg": true
+      },
+      {
+        "name": "xkeyboard-config",
+        "epoch": 0,
+        "version": "2.28",
+        "release": "1.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/xkeyboard-config-2.28-1.el8.noarch.rpm",
+        "checksum": "sha256:a2aeabb3962859069a78acc288bc3bffb35485428e162caafec8134f5ce6ca67",
+        "check_gpg": true
+      }
+    ]
+  },
+  "image-info": {
+    "/etc/resolv.conf": [],
+    "/etc/udev/rules.d": {
+      "70-persistent-ipoib.rules": [],
+      "90-vpdupdate.rules": [
+        "DEVPATH!=\"/devices/*\", GOTO=\"vpd_end\"",
+        "DEVPATH==\"/devices/virtual/*\", GOTO=\"vpd_end\"",
+        "DEVPATH==\"/devices/system/*\", GOTO=\"vpd_end\"",
+        "DEVPATH==\"/devices/cpu/*\", GOTO=\"vpd_end\"",
+        "DEVPATH==\"/devices/breakpoint/*\", GOTO=\"vpd_end\"",
+        "DEVPATH==\"/devices/tracepoint/*\", GOTO=\"vpd_end\"",
+        "DEVPATH==\"/devices/software/*\", GOTO=\"vpd_end\"",
+        "ENV{DEVTYPE}==\"scsi_target\", GOTO=\"vpd_end\"",
+        "SUBSYSTEM==\"enclosure\", GOTO=\"vpd_end\"",
+        "ENV{DEVTYPE}==\"partition\", GOTO=\"vpd_end\"",
+        "DEVPATH==\"/devices/uprobe/*\", GOTO=\"vpd_end\"",
+        "DEVPATH==\"/devices/kprobe/*\", GOTO=\"vpd_end\"",
+        "DEVPATH==\"/devices/rbd/*\", GOTO=\"vpd_end\"",
+        "SUBSYSTEM==\"scsi_device\", GOTO=\"vpd_update\"",
+        "SUBSYSTEM==\"scsi_host\", GOTO=\"vpd_update\"",
+        "SUBSYSTEMS==\"scsi*\", GOTO=\"vpd_end\"",
+        "SUBSYSTEM==\"nvme\", GOTO=\"vpd_update\"",
+        "SUBSYSTEM==\"nvme-subsystem\", GOTO=\"vpd_update\"",
+        "SUBSYSTEMS==\"nvme*\", GOTO=\"vpd_end\"",
+        "LABEL=\"vpd_update\"",
+        "RUN+=\"/bin/touch /run/run.vpdupdate\"",
+        "LABEL=\"vpd_end\""
+      ]
+    },
+    "boot-environment": {
+      "kernelopts": "root=UUID=0194fdc2-fa2f-4cc0-81d3-ff12045b73c8 console=tty0 console=ttyS0,115200n8 no_timer_check net.ifnames=0 crashkernel=auto",
+      "saved_entry": "ffffffffffffffffffffffffffffffff-4.18.0-331.el8.ppc64le"
+    },
+    "bootloader": "unknown",
+    "bootmenu": [
+      {
+        "grub_arg": "--unrestricted",
+        "grub_class": "kernel",
+        "grub_users": "$grub_users",
+        "id": "centos-20210819165143-4.18.0-331.el8.ppc64le",
+        "initrd": "/boot/initramfs-4.18.0-331.el8.ppc64le.img $tuned_initrd",
+        "linux": "/boot/vmlinuz-4.18.0-331.el8.ppc64le",
+        "options": "$kernelopts $tuned_params",
+        "title": "CentOS (4.18.0-331.el8.ppc64le) 8",
+        "version": "4.18.0-331.el8.ppc64le"
+      }
+    ],
+    "chrony": {
+      "leapsectz": [
+        "right/UTC"
+      ],
+      "pool": [
+        "2.centos.pool.ntp.org iburst"
+      ]
+    },
+    "cloud-init": {
+      "/etc/cloud": {
+        "cloud.cfg": {
+          "cloud_config_modules": [
+            "mounts",
+            "locale",
+            "set-passwords",
+            "rh_subscription",
+            "yum-add-repo",
+            "package-update-upgrade-install",
+            "timezone",
+            "puppet",
+            "chef",
+            "salt-minion",
+            "mcollective",
+            "disable-ec2-metadata",
+            "runcmd"
+          ],
+          "cloud_final_modules": [
+            "rightscale_userdata",
+            "scripts-per-once",
+            "scripts-per-boot",
+            "scripts-per-instance",
+            "scripts-user",
+            "ssh-authkey-fingerprints",
+            "keys-to-console",
+            "phone-home",
+            "final-message",
+            "power-state-change"
+          ],
+          "cloud_init_modules": [
+            "disk_setup",
+            "migrator",
+            "bootcmd",
+            "write-files",
+            "growpart",
+            "resizefs",
+            "set_hostname",
+            "update_hostname",
+            "update_etc_hosts",
+            "rsyslog",
+            "users-groups",
+            "ssh"
+          ],
+          "disable_root": 1,
+          "disable_vmware_customization": false,
+          "mount_default_fields": [
+            null,
+            null,
+            "auto",
+            "defaults,nofail,x-systemd.requires=cloud-init.service",
+            "0",
+            "2"
+          ],
+          "resize_rootfs_tmp": "/dev",
+          "ssh_deletekeys": 1,
+          "ssh_genkeytypes": [
+            "rsa",
+            "ecdsa",
+            "ed25519"
+          ],
+          "ssh_pwauth": 0,
+          "syslog_fix_perms": null,
+          "system_info": {
+            "default_user": {
+              "gecos": "Cloud User",
+              "groups": [
+                "adm",
+                "systemd-journal"
+              ],
+              "lock_passwd": true,
+              "name": "cloud-user",
+              "shell": "/bin/bash",
+              "sudo": [
+                "ALL=(ALL) NOPASSWD:ALL"
+              ]
+            },
+            "distro": "rhel",
+            "paths": {
+              "cloud_dir": "/var/lib/cloud",
+              "templates_dir": "/etc/cloud/templates"
+            },
+            "ssh_svcname": "sshd"
+          },
+          "users": [
+            "default"
+          ]
+        }
+      },
+      "/etc/cloud/cloud.cfg.d": {
+        "05_logging.cfg": {
+          "_log": [
+            "[loggers]\nkeys=root,cloudinit\n\n[handlers]\nkeys=consoleHandler,cloudLogHandler\n\n[formatters]\nkeys=simpleFormatter,arg0Formatter\n\n[logger_root]\nlevel=DEBUG\nhandlers=consoleHandler,cloudLogHandler\n\n[logger_cloudinit]\nlevel=DEBUG\nqualname=cloudinit\nhandlers=\npropagate=1\n\n[handler_consoleHandler]\nclass=StreamHandler\nlevel=WARNING\nformatter=arg0Formatter\nargs=(sys.stderr,)\n\n[formatter_arg0Formatter]\nformat=%(asctime)s - %(filename)s[%(levelname)s]: %(message)s\n\n[formatter_simpleFormatter]\nformat=[CLOUDINIT] %(filename)s[%(levelname)s]: %(message)s\n",
+            "[handler_cloudLogHandler]\nclass=FileHandler\nlevel=DEBUG\nformatter=arg0Formatter\nargs=('/var/log/cloud-init.log', 'a', 'UTF-8')\n",
+            "[handler_cloudLogHandler]\nclass=handlers.SysLogHandler\nlevel=DEBUG\nformatter=simpleFormatter\nargs=(\"/dev/log\", handlers.SysLogHandler.LOG_USER)\n"
+          ],
+          "log_cfgs": [
+            [
+              "[loggers]\nkeys=root,cloudinit\n\n[handlers]\nkeys=consoleHandler,cloudLogHandler\n\n[formatters]\nkeys=simpleFormatter,arg0Formatter\n\n[logger_root]\nlevel=DEBUG\nhandlers=consoleHandler,cloudLogHandler\n\n[logger_cloudinit]\nlevel=DEBUG\nqualname=cloudinit\nhandlers=\npropagate=1\n\n[handler_consoleHandler]\nclass=StreamHandler\nlevel=WARNING\nformatter=arg0Formatter\nargs=(sys.stderr,)\n\n[formatter_arg0Formatter]\nformat=%(asctime)s - %(filename)s[%(levelname)s]: %(message)s\n\n[formatter_simpleFormatter]\nformat=[CLOUDINIT] %(filename)s[%(levelname)s]: %(message)s\n",
+              "[handler_cloudLogHandler]\nclass=FileHandler\nlevel=DEBUG\nformatter=arg0Formatter\nargs=('/var/log/cloud-init.log', 'a', 'UTF-8')\n"
+            ]
+          ],
+          "output": {
+            "all": "| tee -a /var/log/cloud-init-output.log"
+          }
+        }
+      }
+    },
+    "default-target": "multi-user.target",
+    "dnf": {
+      "vars": {
+        "contentdir": "centos",
+        "infra": "stock",
+        "stream": "8-stream"
+      }
+    },
+    "dracut": {
+      "/usr/lib/dracut/dracut.conf.d": {
+        "01-dist.conf": {
+          "early_microcode": "yes",
+          "hostonly": "yes",
+          "hostonly_cmdline": "no",
+          "i18n_default_font": "eurlatgr",
+          "i18n_install_all": "yes",
+          "i18n_vars": "/etc/sysconfig/keyboard:KEYTABLE-KEYMAP /etc/sysconfig/i18n:SYSFONT-FONT,FONTACM-FONT_MAP,FONT_UNIMAP",
+          "install_optional_items": " vi /etc/virc ps grep cat rm ",
+          "prefix": "/",
+          "reproducible": "yes",
+          "stdloglvl": "3",
+          "sysloglvl": "5",
+          "systemdsystemconfdir": "/etc/systemd/system",
+          "systemdsystemunitdir": "/usr/lib/systemd/system",
+          "systemdutildir": "/usr/lib/systemd",
+          "udevdir": "/usr/lib/udev"
+        },
+        "02-generic-image.conf": {
+          "hostonly": "no"
+        }
+      }
+    },
+    "fstab": [
+      [
+        "UUID=0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+        "/",
+        "xfs",
+        "defaults",
+        "0",
+        "0"
+      ]
+    ],
+    "groups": [
+      "adm:x:4:",
+      "audio:x:63:",
+      "bin:x:1:",
+      "cdrom:x:11:",
+      "chrony:x:988:",
+      "cockpit-ws:x:990:",
+      "cockpit-wsinstance:x:989:",
+      "daemon:x:2:",
+      "dbus:x:81:",
+      "dialout:x:18:",
+      "disk:x:6:",
+      "floppy:x:19:",
+      "ftp:x:50:",
+      "games:x:20:",
+      "input:x:999:",
+      "kmem:x:9:",
+      "kvm:x:36:",
+      "lock:x:54:",
+      "lp:x:7:",
+      "mail:x:12:",
+      "man:x:15:",
+      "mem:x:8:",
+      "nobody:x:65534:",
+      "polkitd:x:996:",
+      "redhat:x:1000:",
+      "render:x:998:",
+      "root:x:0:",
+      "rpc:x:32:",
+      "rpcuser:x:29:",
+      "service:x:995:",
+      "setroubleshoot:x:991:",
+      "ssh_keys:x:994:",
+      "sshd:x:74:",
+      "sssd:x:992:",
+      "sys:x:3:",
+      "systemd-coredump:x:997:",
+      "systemd-journal:x:190:",
+      "systemd-resolve:x:193:",
+      "tape:x:33:",
+      "tcpdump:x:72:",
+      "tss:x:59:",
+      "tty:x:5:",
+      "unbound:x:993:",
+      "users:x:100:",
+      "utempter:x:35:",
+      "utmp:x:22:",
+      "video:x:39:",
+      "wheel:x:10:"
+    ],
+    "hosts": [
+      "127.0.0.1   localhost localhost.localdomain localhost4 localhost4.localdomain4",
+      "::1         localhost localhost.localdomain localhost6 localhost6.localdomain6"
+    ],
+    "image-format": {
+      "compat": "0.10",
+      "type": "qcow2"
+    },
+    "locale": {
+      "LANG": "en_US.UTF-8"
+    },
+    "machine-id": "",
+    "modprobe": {
+      "/usr/lib/modprobe.d": {
+        "dist-blacklist.conf": {
+          "blacklist": [
+            "chsc_sch"
+          ]
+        }
+      }
+    },
+    "os-release": {
+      "ANSI_COLOR": "0;31",
+      "BUG_REPORT_URL": "https://bugzilla.redhat.com/",
+      "CPE_NAME": "cpe:/o:centos:centos:8",
+      "HOME_URL": "https://centos.org/",
+      "ID": "centos",
+      "ID_LIKE": "rhel fedora",
+      "NAME": "CentOS Stream",
+      "PLATFORM_ID": "platform:el8",
+      "PRETTY_NAME": "CentOS Stream 8",
+      "REDHAT_SUPPORT_PRODUCT": "Red Hat Enterprise Linux 8",
+      "REDHAT_SUPPORT_PRODUCT_VERSION": "CentOS Stream",
+      "VERSION": "8",
+      "VERSION_ID": "8"
+    },
+    "packages": [
+      "NetworkManager-1.32.8-1.el8.ppc64le",
+      "NetworkManager-libnm-1.32.8-1.el8.ppc64le",
+      "NetworkManager-team-1.32.8-1.el8.ppc64le",
+      "NetworkManager-tui-1.32.8-1.el8.ppc64le",
+      "PackageKit-1.1.12-6.el8.ppc64le",
+      "PackageKit-glib-1.1.12-6.el8.ppc64le",
+      "abattis-cantarell-fonts-0.0.25-6.el8.noarch",
+      "acl-2.2.53-1.el8.ppc64le",
+      "audit-3.0-0.17.20191104git1c2f876.el8.ppc64le",
+      "audit-libs-3.0-0.17.20191104git1c2f876.el8.ppc64le",
+      "authselect-1.2.2-3.el8.ppc64le",
+      "authselect-compat-1.2.2-3.el8.ppc64le",
+      "authselect-libs-1.2.2-3.el8.ppc64le",
+      "basesystem-11-5.el8.noarch",
+      "bash-4.4.20-2.el8.ppc64le",
+      "bc-1.07.1-5.el8.ppc64le",
+      "bind-export-libs-9.11.26-4.el8_4.ppc64le",
+      "brotli-1.0.6-3.el8.ppc64le",
+      "bzip2-1.0.6-26.el8.ppc64le",
+      "bzip2-libs-1.0.6-26.el8.ppc64le",
+      "c-ares-1.13.0-5.el8.ppc64le",
+      "ca-certificates-2021.2.50-82.el8.noarch",
+      "cairo-1.15.12-3.el8.ppc64le",
+      "cairo-gobject-1.15.12-3.el8.ppc64le",
+      "centos-gpg-keys-8-2.el8.noarch",
+      "centos-logos-85.8-1.el8.ppc64le",
+      "centos-stream-release-8.5-3.el8.noarch",
+      "centos-stream-repos-8-2.el8.noarch",
+      "checkpolicy-2.9-1.el8.ppc64le",
+      "chkconfig-1.19.1-1.el8.ppc64le",
+      "chrony-4.1-1.el8.ppc64le",
+      "cloud-init-21.1-3.el8.noarch",
+      "cloud-utils-growpart-0.31-3.el8.noarch",
+      "cockpit-bridge-250-1.el8.ppc64le",
+      "cockpit-system-250-1.el8.noarch",
+      "cockpit-ws-250-1.el8.ppc64le",
+      "coreutils-8.30-12.el8.ppc64le",
+      "coreutils-common-8.30-12.el8.ppc64le",
+      "cpio-2.12-10.el8.ppc64le",
+      "cracklib-2.9.6-15.el8.ppc64le",
+      "cracklib-dicts-2.9.6-15.el8.ppc64le",
+      "cronie-1.5.2-4.el8.ppc64le",
+      "cronie-anacron-1.5.2-4.el8.ppc64le",
+      "crontabs-1.11-17.20190603git.el8.noarch",
+      "crypto-policies-20210617-1.gitc776d3e.el8.noarch",
+      "crypto-policies-scripts-20210617-1.gitc776d3e.el8.noarch",
+      "cryptsetup-libs-2.3.3-4.el8.ppc64le",
+      "curl-7.61.1-18.el8_4.1.ppc64le",
+      "cyrus-sasl-lib-2.1.27-5.el8.ppc64le",
+      "dbus-1.12.8-14.el8.ppc64le",
+      "dbus-common-1.12.8-14.el8.noarch",
+      "dbus-daemon-1.12.8-14.el8.ppc64le",
+      "dbus-glib-0.110-2.el8.ppc64le",
+      "dbus-libs-1.12.8-14.el8.ppc64le",
+      "dbus-tools-1.12.8-14.el8.ppc64le",
+      "dejavu-fonts-common-2.35-7.el8.noarch",
+      "dejavu-sans-mono-fonts-2.35-7.el8.noarch",
+      "device-mapper-1.02.177-6.el8.ppc64le",
+      "device-mapper-libs-1.02.177-6.el8.ppc64le",
+      "dhcp-client-4.3.6-45.el8.ppc64le",
+      "dhcp-common-4.3.6-45.el8.noarch",
+      "dhcp-libs-4.3.6-45.el8.ppc64le",
+      "diffutils-3.6-6.el8.ppc64le",
+      "dnf-4.7.0-2.el8.noarch",
+      "dnf-data-4.7.0-2.el8.noarch",
+      "dnf-plugins-core-4.0.21-2.el8.noarch",
+      "dosfstools-4.1-6.el8.ppc64le",
+      "dracut-049-188.git20210802.el8.ppc64le",
+      "dracut-config-generic-049-188.git20210802.el8.ppc64le",
+      "dracut-network-049-188.git20210802.el8.ppc64le",
+      "dracut-squash-049-188.git20210802.el8.ppc64le",
+      "e2fsprogs-1.45.6-2.el8.ppc64le",
+      "e2fsprogs-libs-1.45.6-2.el8.ppc64le",
+      "elfutils-debuginfod-client-0.185-1.el8.ppc64le",
+      "elfutils-default-yama-scope-0.185-1.el8.noarch",
+      "elfutils-libelf-0.185-1.el8.ppc64le",
+      "elfutils-libs-0.185-1.el8.ppc64le",
+      "ethtool-5.8-6.el8.ppc64le",
+      "expat-2.2.5-4.el8.ppc64le",
+      "file-5.33-20.el8.ppc64le",
+      "file-libs-5.33-20.el8.ppc64le",
+      "filesystem-3.8-6.el8.ppc64le",
+      "findutils-4.6.0-20.el8.ppc64le",
+      "fontconfig-2.13.1-3.el8.ppc64le",
+      "fontpackages-filesystem-1.44-22.el8.noarch",
+      "freetype-2.9.1-4.el8_3.1.ppc64le",
+      "fuse-libs-2.9.7-12.el8.ppc64le",
+      "gawk-4.2.1-2.el8.ppc64le",
+      "gdbm-1.18-1.el8.ppc64le",
+      "gdbm-libs-1.18-1.el8.ppc64le",
+      "gdk-pixbuf2-2.36.12-5.el8.ppc64le",
+      "geolite2-city-20180605-1.el8.noarch",
+      "geolite2-country-20180605-1.el8.noarch",
+      "gettext-0.19.8.1-17.el8.ppc64le",
+      "gettext-libs-0.19.8.1-17.el8.ppc64le",
+      "glib-networking-2.56.1-1.1.el8.ppc64le",
+      "glib2-2.56.4-156.el8.ppc64le",
+      "glibc-2.28-162.el8.ppc64le",
+      "glibc-all-langpacks-2.28-162.el8.ppc64le",
+      "glibc-common-2.28-162.el8.ppc64le",
+      "gmp-6.1.2-10.el8.ppc64le",
+      "gnupg2-2.2.20-2.el8.ppc64le",
+      "gnupg2-smime-2.2.20-2.el8.ppc64le",
+      "gnutls-3.6.16-4.el8.ppc64le",
+      "gobject-introspection-1.56.1-1.el8.ppc64le",
+      "gpg-pubkey-8483c65d-5ccc5b19",
+      "gpgme-1.13.1-9.el8.ppc64le",
+      "grep-3.1-6.el8.ppc64le",
+      "groff-base-1.22.3-18.el8.ppc64le",
+      "grub2-common-2.02-99.el8.noarch",
+      "grub2-ppc64le-2.02-99.el8.ppc64le",
+      "grub2-ppc64le-modules-2.02-99.el8.noarch",
+      "grub2-tools-2.02-99.el8.ppc64le",
+      "grub2-tools-extra-2.02-99.el8.ppc64le",
+      "grub2-tools-minimal-2.02-99.el8.ppc64le",
+      "grubby-8.40-41.el8.ppc64le",
+      "gsettings-desktop-schemas-3.32.0-6.el8.ppc64le",
+      "gssproxy-0.8.0-19.el8.ppc64le",
+      "gzip-1.9-12.el8.ppc64le",
+      "hardlink-1.3-6.el8.ppc64le",
+      "hdparm-9.54-4.el8.ppc64le",
+      "hostname-3.20-7.el8.0.1.ppc64le",
+      "hwdata-0.314-8.9.el8.noarch",
+      "ima-evm-utils-1.3.2-12.el8.ppc64le",
+      "info-6.5-6.el8.ppc64le",
+      "initscripts-10.00.15-1.el8.ppc64le",
+      "ipcalc-0.2.4-4.el8.ppc64le",
+      "iproute-5.12.0-2.el8.ppc64le",
+      "iputils-20180629-7.el8.ppc64le",
+      "irqbalance-1.4.0-6.el8.ppc64le",
+      "jansson-2.11-3.el8.ppc64le",
+      "json-c-0.13.1-2.el8.ppc64le",
+      "json-glib-1.4.4-1.el8.ppc64le",
+      "kbd-2.0.4-10.el8.ppc64le",
+      "kbd-legacy-2.0.4-10.el8.noarch",
+      "kbd-misc-2.0.4-10.el8.noarch",
+      "kernel-4.18.0-331.el8.ppc64le",
+      "kernel-core-4.18.0-331.el8.ppc64le",
+      "kernel-modules-4.18.0-331.el8.ppc64le",
+      "kernel-tools-4.18.0-331.el8.ppc64le",
+      "kernel-tools-libs-4.18.0-331.el8.ppc64le",
+      "kexec-tools-2.0.20-56.el8.ppc64le",
+      "keyutils-1.5.10-9.el8.ppc64le",
+      "keyutils-libs-1.5.10-9.el8.ppc64le",
+      "kmod-25-18.el8.ppc64le",
+      "kmod-libs-25-18.el8.ppc64le",
+      "kpartx-0.8.4-17.el8.ppc64le",
+      "krb5-libs-1.18.2-13.el8.ppc64le",
+      "less-530-1.el8.ppc64le",
+      "libX11-1.6.8-4.el8.ppc64le",
+      "libX11-common-1.6.8-4.el8.noarch",
+      "libXau-1.0.9-3.el8.ppc64le",
+      "libXext-1.3.4-1.el8.ppc64le",
+      "libXrender-0.9.10-7.el8.ppc64le",
+      "libacl-2.2.53-1.el8.ppc64le",
+      "libappstream-glib-0.7.14-3.el8.ppc64le",
+      "libarchive-3.3.3-1.el8.ppc64le",
+      "libassuan-2.5.1-3.el8.ppc64le",
+      "libattr-2.4.48-3.el8.ppc64le",
+      "libbasicobjects-0.1.1-39.el8.ppc64le",
+      "libblkid-2.32.1-28.el8.ppc64le",
+      "libbpf-0.3.0-1.el8.ppc64le",
+      "libcap-2.26-4.el8.ppc64le",
+      "libcap-ng-0.7.11-1.el8.ppc64le",
+      "libcollection-0.7.0-39.el8.ppc64le",
+      "libcom_err-1.45.6-2.el8.ppc64le",
+      "libcomps-0.1.16-2.el8.ppc64le",
+      "libcroco-0.6.12-4.el8_2.1.ppc64le",
+      "libcurl-7.61.1-18.el8_4.1.ppc64le",
+      "libdaemon-0.14-15.el8.ppc64le",
+      "libdb-5.3.28-40.el8.ppc64le",
+      "libdb-utils-5.3.28-40.el8.ppc64le",
+      "libdhash-0.5.0-39.el8.ppc64le",
+      "libdnf-0.63.0-2.el8.ppc64le",
+      "libedit-3.1-23.20170329cvs.el8.ppc64le",
+      "libestr-0.1.10-1.el8.ppc64le",
+      "libevent-2.1.8-5.el8.ppc64le",
+      "libfastjson-0.99.9-1.el8.ppc64le",
+      "libfdisk-2.32.1-28.el8.ppc64le",
+      "libffi-3.1-22.el8.ppc64le",
+      "libgcc-8.5.0-3.el8.ppc64le",
+      "libgcrypt-1.8.5-6.el8.ppc64le",
+      "libgomp-8.5.0-3.el8.ppc64le",
+      "libgpg-error-1.31-1.el8.ppc64le",
+      "libibverbs-35.0-1.el8.ppc64le",
+      "libidn2-2.2.0-1.el8.ppc64le",
+      "libini_config-1.3.1-39.el8.ppc64le",
+      "libkcapi-1.2.0-2.el8.ppc64le",
+      "libkcapi-hmaccalc-1.2.0-2.el8.ppc64le",
+      "libksba-1.3.5-7.el8.ppc64le",
+      "libldb-2.3.0-2.el8.ppc64le",
+      "libmaxminddb-1.2.0-10.el8.ppc64le",
+      "libmnl-1.0.4-6.el8.ppc64le",
+      "libmodman-2.0.1-17.el8.ppc64le",
+      "libmodulemd-2.12.1-1.el8.ppc64le",
+      "libmount-2.32.1-28.el8.ppc64le",
+      "libndp-1.7-6.el8.ppc64le",
+      "libnfsidmap-2.3.3-46.el8.ppc64le",
+      "libnghttp2-1.33.0-3.el8_2.1.ppc64le",
+      "libnl3-3.5.0-1.el8.ppc64le",
+      "libnl3-cli-3.5.0-1.el8.ppc64le",
+      "libnsl2-1.2.0-2.20180605git4a062cf.el8.ppc64le",
+      "libpath_utils-0.2.1-39.el8.ppc64le",
+      "libpcap-1.9.1-5.el8.ppc64le",
+      "libpipeline-1.5.0-2.el8.ppc64le",
+      "libpng-1.6.34-5.el8.ppc64le",
+      "libproxy-0.4.15-5.2.el8.ppc64le",
+      "libpsl-0.20.2-6.el8.ppc64le",
+      "libpwquality-1.4.4-3.el8.ppc64le",
+      "libref_array-0.1.5-39.el8.ppc64le",
+      "librepo-1.14.0-2.el8.ppc64le",
+      "libreport-filesystem-2.9.5-15.el8.ppc64le",
+      "librtas-2.0.2-1.el8.ppc64le",
+      "libseccomp-2.5.1-1.el8.ppc64le",
+      "libsecret-0.18.6-1.el8.ppc64le",
+      "libselinux-2.9-5.el8.ppc64le",
+      "libselinux-utils-2.9-5.el8.ppc64le",
+      "libsemanage-2.9-6.el8.ppc64le",
+      "libsepol-2.9-2.el8.ppc64le",
+      "libservicelog-1.1.19-2.el8.ppc64le",
+      "libsigsegv-2.11-5.el8.ppc64le",
+      "libsmartcols-2.32.1-28.el8.ppc64le",
+      "libsolv-0.7.19-1.el8.ppc64le",
+      "libsoup-2.62.3-2.el8.ppc64le",
+      "libss-1.45.6-2.el8.ppc64le",
+      "libssh-0.9.4-3.el8.ppc64le",
+      "libssh-config-0.9.4-3.el8.noarch",
+      "libsss_autofs-2.5.2-2.el8.ppc64le",
+      "libsss_certmap-2.5.2-2.el8.ppc64le",
+      "libsss_idmap-2.5.2-2.el8.ppc64le",
+      "libsss_nss_idmap-2.5.2-2.el8.ppc64le",
+      "libsss_sudo-2.5.2-2.el8.ppc64le",
+      "libstdc++-8.5.0-3.el8.ppc64le",
+      "libstemmer-0-10.585svn.el8.ppc64le",
+      "libsysfs-2.1.0-24.el8.ppc64le",
+      "libtalloc-2.3.2-1.el8.ppc64le",
+      "libtasn1-4.13-3.el8.ppc64le",
+      "libtdb-1.4.3-1.el8.ppc64le",
+      "libteam-1.31-2.el8.ppc64le",
+      "libtevent-0.11.0-0.el8.ppc64le",
+      "libtirpc-1.1.4-5.el8.ppc64le",
+      "libunistring-0.9.9-3.el8.ppc64le",
+      "libusbx-1.0.23-4.el8.ppc64le",
+      "libuser-0.62-23.el8.ppc64le",
+      "libutempter-1.1.6-14.el8.ppc64le",
+      "libuuid-2.32.1-28.el8.ppc64le",
+      "libverto-0.3.0-5.el8.ppc64le",
+      "libverto-libevent-0.3.0-5.el8.ppc64le",
+      "libvpd-2.2.8-1.el8.ppc64le",
+      "libxcb-1.13.1-1.el8.ppc64le",
+      "libxcrypt-4.1.1-6.el8.ppc64le",
+      "libxkbcommon-0.9.1-1.el8.ppc64le",
+      "libxml2-2.9.7-11.el8.ppc64le",
+      "libyaml-0.1.7-5.el8.ppc64le",
+      "libzstd-1.4.4-1.el8.ppc64le",
+      "linux-firmware-20210702-103.gitd79c2677.el8.noarch",
+      "lmdb-libs-0.9.24-1.el8.ppc64le",
+      "logrotate-3.14.0-4.el8.ppc64le",
+      "lshw-B.02.19.2-6.el8.ppc64le",
+      "lsscsi-0.32-2.el8.ppc64le",
+      "lsvpd-1.7.12-1.el8.ppc64le",
+      "lua-libs-5.3.4-11.el8.ppc64le",
+      "lz4-libs-1.8.3-3.el8_4.ppc64le",
+      "lzo-2.08-14.el8.ppc64le",
+      "man-db-2.7.6.1-18.el8.ppc64le",
+      "memstrack-0.1.11-1.el8.ppc64le",
+      "mozjs60-60.9.0-4.el8.ppc64le",
+      "mpfr-3.1.6-1.el8.ppc64le",
+      "ncurses-6.1-9.20180224.el8.ppc64le",
+      "ncurses-base-6.1-9.20180224.el8.noarch",
+      "ncurses-libs-6.1-9.20180224.el8.ppc64le",
+      "net-tools-2.0-0.52.20160912git.el8.ppc64le",
+      "nettle-3.4.1-7.el8.ppc64le",
+      "newt-0.52.20-11.el8.ppc64le",
+      "nfs-utils-2.3.3-46.el8.ppc64le",
+      "npth-1.5-4.el8.ppc64le",
+      "numactl-libs-2.0.12-13.el8.ppc64le",
+      "oddjob-0.34.7-1.el8.ppc64le",
+      "oddjob-mkhomedir-0.34.7-1.el8.ppc64le",
+      "opal-prd-6.7.1-1.el8.ppc64le",
+      "openldap-2.4.46-18.el8.ppc64le",
+      "openssh-8.0p1-9.el8.ppc64le",
+      "openssh-clients-8.0p1-9.el8.ppc64le",
+      "openssh-server-8.0p1-9.el8.ppc64le",
+      "openssl-1.1.1k-4.el8.ppc64le",
+      "openssl-libs-1.1.1k-4.el8.ppc64le",
+      "openssl-pkcs11-0.4.10-2.el8.ppc64le",
+      "os-prober-1.74-6.el8.ppc64le",
+      "p11-kit-0.23.22-1.el8.ppc64le",
+      "p11-kit-trust-0.23.22-1.el8.ppc64le",
+      "pam-1.3.1-15.el8.ppc64le",
+      "parted-3.2-39.el8.ppc64le",
+      "passwd-0.80-3.el8.ppc64le",
+      "pciutils-3.7.0-1.el8.ppc64le",
+      "pciutils-libs-3.7.0-1.el8.ppc64le",
+      "pcre-8.42-6.el8.ppc64le",
+      "pcre2-10.32-2.el8.ppc64le",
+      "perl-Carp-1.42-396.el8.noarch",
+      "perl-Data-Dumper-2.167-399.el8.ppc64le",
+      "perl-Digest-1.17-395.el8.noarch",
+      "perl-Digest-MD5-2.55-396.el8.ppc64le",
+      "perl-Encode-2.97-3.el8.ppc64le",
+      "perl-Errno-1.28-420.el8.ppc64le",
+      "perl-Exporter-5.72-396.el8.noarch",
+      "perl-File-Path-2.15-2.el8.noarch",
+      "perl-File-Temp-0.230.600-1.el8.noarch",
+      "perl-Getopt-Long-2.50-4.el8.noarch",
+      "perl-HTTP-Tiny-0.074-1.el8.noarch",
+      "perl-IO-1.38-420.el8.ppc64le",
+      "perl-IO-Socket-IP-0.39-5.el8.noarch",
+      "perl-IO-Socket-SSL-2.066-4.module_el8.4.0+517+be1595ff.noarch",
+      "perl-MIME-Base64-3.15-396.el8.ppc64le",
+      "perl-Mozilla-CA-20160104-7.module_el8.3.0+416+dee7bcef.noarch",
+      "perl-Net-SSLeay-1.88-1.module_el8.4.0+517+be1595ff.ppc64le",
+      "perl-PathTools-3.74-1.el8.ppc64le",
+      "perl-Pod-Escapes-1.07-395.el8.noarch",
+      "perl-Pod-Perldoc-3.28-396.el8.noarch",
+      "perl-Pod-Simple-3.35-395.el8.noarch",
+      "perl-Pod-Usage-1.69-395.el8.noarch",
+      "perl-Scalar-List-Utils-1.49-2.el8.ppc64le",
+      "perl-Socket-2.027-3.el8.ppc64le",
+      "perl-Storable-3.11-3.el8.ppc64le",
+      "perl-Term-ANSIColor-4.06-396.el8.noarch",
+      "perl-Term-Cap-1.17-395.el8.noarch",
+      "perl-Text-ParseWords-3.30-395.el8.noarch",
+      "perl-Text-Tabs+Wrap-2013.0523-395.el8.noarch",
+      "perl-Time-Local-1.280-1.el8.noarch",
+      "perl-URI-1.73-3.el8.noarch",
+      "perl-Unicode-Normalize-1.25-396.el8.ppc64le",
+      "perl-constant-1.33-396.el8.noarch",
+      "perl-interpreter-5.26.3-420.el8.ppc64le",
+      "perl-libnet-3.11-3.el8.noarch",
+      "perl-libs-5.26.3-420.el8.ppc64le",
+      "perl-macros-5.26.3-420.el8.ppc64le",
+      "perl-parent-0.237-1.el8.noarch",
+      "perl-podlators-4.11-1.el8.noarch",
+      "perl-threads-2.21-2.el8.ppc64le",
+      "perl-threads-shared-1.58-2.el8.ppc64le",
+      "pigz-2.4-4.el8.ppc64le",
+      "pinentry-1.1.0-2.el8.ppc64le",
+      "pixman-0.38.4-1.el8.ppc64le",
+      "platform-python-3.6.8-39.el8.ppc64le",
+      "platform-python-pip-9.0.3-20.el8.noarch",
+      "platform-python-setuptools-39.2.0-6.el8.noarch",
+      "policycoreutils-2.9-15.el8.ppc64le",
+      "policycoreutils-python-utils-2.9-15.el8.noarch",
+      "polkit-0.115-12.el8.ppc64le",
+      "polkit-libs-0.115-12.el8.ppc64le",
+      "polkit-pkla-compat-0.1-12.el8.ppc64le",
+      "popt-1.18-1.el8.ppc64le",
+      "powerpc-utils-1.3.8-7.el8.ppc64le",
+      "powerpc-utils-core-1.3.8-7.el8.ppc64le",
+      "ppc64-diag-2.7.7-1.el8.ppc64le",
+      "ppc64-diag-rtas-2.7.7-1.el8.ppc64le",
+      "prefixdevname-0.1.0-6.el8.ppc64le",
+      "procps-ng-3.3.15-6.el8.ppc64le",
+      "psmisc-23.1-5.el8.ppc64le",
+      "publicsuffix-list-dafsa-20180723-1.el8.noarch",
+      "python3-audit-3.0-0.17.20191104git1c2f876.el8.ppc64le",
+      "python3-babel-2.5.1-7.el8.noarch",
+      "python3-cairo-1.16.3-6.el8.ppc64le",
+      "python3-cffi-1.11.5-5.el8.ppc64le",
+      "python3-chardet-3.0.4-7.el8.noarch",
+      "python3-configobj-5.0.6-11.el8.noarch",
+      "python3-cryptography-3.2.1-5.el8.ppc64le",
+      "python3-dateutil-2.6.1-6.el8.noarch",
+      "python3-dbus-1.2.4-15.el8.ppc64le",
+      "python3-decorator-4.2.1-2.el8.noarch",
+      "python3-dnf-4.7.0-2.el8.noarch",
+      "python3-dnf-plugins-core-4.0.21-2.el8.noarch",
+      "python3-gobject-3.28.3-2.el8.ppc64le",
+      "python3-gobject-base-3.28.3-2.el8.ppc64le",
+      "python3-gpg-1.13.1-9.el8.ppc64le",
+      "python3-hawkey-0.63.0-2.el8.ppc64le",
+      "python3-idna-2.5-5.el8.noarch",
+      "python3-jinja2-2.10.1-3.el8.noarch",
+      "python3-jsonpatch-1.21-2.el8.noarch",
+      "python3-jsonpointer-1.10-11.el8.noarch",
+      "python3-jsonschema-2.6.0-4.el8.noarch",
+      "python3-jwt-1.6.1-2.el8.noarch",
+      "python3-libcomps-0.1.16-2.el8.ppc64le",
+      "python3-libdnf-0.63.0-2.el8.ppc64le",
+      "python3-libs-3.6.8-39.el8.ppc64le",
+      "python3-libselinux-2.9-5.el8.ppc64le",
+      "python3-libsemanage-2.9-6.el8.ppc64le",
+      "python3-libxml2-2.9.7-11.el8.ppc64le",
+      "python3-linux-procfs-0.6.3-1.el8.noarch",
+      "python3-markupsafe-0.23-19.el8.ppc64le",
+      "python3-oauthlib-2.1.0-1.el8.noarch",
+      "python3-perf-4.18.0-331.el8.ppc64le",
+      "python3-pexpect-4.3.1-3.el8.noarch",
+      "python3-pip-wheel-9.0.3-20.el8.noarch",
+      "python3-ply-3.9-9.el8.noarch",
+      "python3-policycoreutils-2.9-15.el8.noarch",
+      "python3-prettytable-0.7.2-14.el8.noarch",
+      "python3-ptyprocess-0.5.2-4.el8.noarch",
+      "python3-pycparser-2.14-14.el8.noarch",
+      "python3-pydbus-0.6.0-5.el8.noarch",
+      "python3-pyserial-3.1.1-8.el8.noarch",
+      "python3-pysocks-1.6.8-3.el8.noarch",
+      "python3-pytz-2017.2-9.el8.noarch",
+      "python3-pyudev-0.21.0-7.el8.noarch",
+      "python3-pyyaml-3.12-12.el8.ppc64le",
+      "python3-requests-2.20.0-2.1.el8_1.noarch",
+      "python3-rpm-4.14.3-15.el8.ppc64le",
+      "python3-setools-4.3.0-2.el8.ppc64le",
+      "python3-setuptools-wheel-39.2.0-6.el8.noarch",
+      "python3-six-1.11.0-8.el8.noarch",
+      "python3-slip-0.6.4-11.el8.noarch",
+      "python3-slip-dbus-0.6.4-11.el8.noarch",
+      "python3-syspurpose-1.28.20-1.el8.ppc64le",
+      "python3-systemd-234-8.el8.ppc64le",
+      "python3-unbound-1.7.3-17.el8.ppc64le",
+      "python3-urllib3-1.24.2-5.el8.noarch",
+      "qemu-guest-agent-4.2.0-52.module_el8.5.0+853+a4d5519d.ppc64le",
+      "quota-4.04-14.el8.ppc64le",
+      "quota-nls-4.04-14.el8.noarch",
+      "rdma-core-35.0-1.el8.ppc64le",
+      "readline-7.0-10.el8.ppc64le",
+      "rootfiles-8.1-22.el8.noarch",
+      "rpcbind-1.2.5-8.el8.ppc64le",
+      "rpm-4.14.3-15.el8.ppc64le",
+      "rpm-build-libs-4.14.3-15.el8.ppc64le",
+      "rpm-libs-4.14.3-15.el8.ppc64le",
+      "rpm-plugin-selinux-4.14.3-15.el8.ppc64le",
+      "rpm-plugin-systemd-inhibit-4.14.3-15.el8.ppc64le",
+      "rsync-3.1.3-12.el8.ppc64le",
+      "rsyslog-8.2102.0-5.el8.ppc64le",
+      "sed-4.5-2.el8.ppc64le",
+      "selinux-policy-3.14.3-76.el8.noarch",
+      "selinux-policy-targeted-3.14.3-76.el8.noarch",
+      "servicelog-1.1.15-1.el8.ppc64le",
+      "setroubleshoot-plugins-3.3.13-1.el8.noarch",
+      "setroubleshoot-server-3.3.24-3.el8.ppc64le",
+      "setup-2.12.2-6.el8.noarch",
+      "sg3_utils-1.44-5.el8.ppc64le",
+      "sg3_utils-libs-1.44-5.el8.ppc64le",
+      "shadow-utils-4.6-14.el8.ppc64le",
+      "shared-mime-info-1.9-3.el8.ppc64le",
+      "slang-2.3.2-3.el8.ppc64le",
+      "snappy-1.1.8-3.el8.ppc64le",
+      "sos-4.1-5.el8.noarch",
+      "sqlite-libs-3.26.0-15.el8.ppc64le",
+      "squashfs-tools-4.3-20.el8.ppc64le",
+      "sscg-2.3.3-14.el8.ppc64le",
+      "sssd-client-2.5.2-2.el8.ppc64le",
+      "sssd-common-2.5.2-2.el8.ppc64le",
+      "sssd-kcm-2.5.2-2.el8.ppc64le",
+      "sssd-nfs-idmap-2.5.2-2.el8.ppc64le",
+      "sudo-1.8.29-7.el8.ppc64le",
+      "systemd-239-49.el8.ppc64le",
+      "systemd-libs-239-49.el8.ppc64le",
+      "systemd-pam-239-49.el8.ppc64le",
+      "systemd-udev-239-49.el8.ppc64le",
+      "tar-1.30-5.el8.ppc64le",
+      "tcpdump-4.9.3-2.el8.ppc64le",
+      "teamd-1.31-2.el8.ppc64le",
+      "timedatex-0.5-3.el8.ppc64le",
+      "tpm2-tss-2.3.2-4.el8.ppc64le",
+      "trousers-0.3.15-1.el8.ppc64le",
+      "trousers-lib-0.3.15-1.el8.ppc64le",
+      "tuned-2.16.0-1.el8.noarch",
+      "tzdata-2021a-1.el8.noarch",
+      "unbound-libs-1.7.3-17.el8.ppc64le",
+      "util-linux-2.32.1-28.el8.ppc64le",
+      "vim-minimal-8.0.1763-15.el8.ppc64le",
+      "virt-what-1.18-12.el8.ppc64le",
+      "which-2.21-16.el8.ppc64le",
+      "xfsprogs-5.0.0-9.el8.ppc64le",
+      "xkeyboard-config-2.28-1.el8.noarch",
+      "xz-5.2.4-3.el8.ppc64le",
+      "xz-libs-5.2.4-3.el8.ppc64le",
+      "yum-4.7.0-2.el8.noarch",
+      "yum-utils-4.0.21-2.el8.noarch",
+      "zlib-1.2.11-17.el8.ppc64le"
+    ],
+    "partition-table": "dos",
+    "partition-table-id": "0x14fc63d2",
+    "partitions": [
+      {
+        "bootable": true,
+        "fstype": null,
+        "label": null,
+        "partuuid": "14fc63d2-01",
+        "size": 4194304,
+        "start": 1048576,
+        "type": "41",
+        "uuid": null
+      },
+      {
+        "bootable": false,
+        "fstype": "xfs",
+        "label": null,
+        "partuuid": "14fc63d2-02",
+        "size": 10732124160,
+        "start": 5242880,
+        "type": "83",
+        "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8"
+      }
+    ],
+    "passwd": [
+      "adm:x:3:4:adm:/var/adm:/sbin/nologin",
+      "bin:x:1:1:bin:/bin:/sbin/nologin",
+      "chrony:x:992:988::/var/lib/chrony:/sbin/nologin",
+      "cockpit-ws:x:994:990:User for cockpit web service:/nonexisting:/sbin/nologin",
+      "cockpit-wsinstance:x:993:989:User for cockpit-ws instances:/nonexisting:/sbin/nologin",
+      "daemon:x:2:2:daemon:/sbin:/sbin/nologin",
+      "dbus:x:81:81:System message bus:/:/sbin/nologin",
+      "ftp:x:14:50:FTP User:/var/ftp:/sbin/nologin",
+      "games:x:12:100:games:/usr/games:/sbin/nologin",
+      "halt:x:7:0:halt:/sbin:/sbin/halt",
+      "lp:x:4:7:lp:/var/spool/lpd:/sbin/nologin",
+      "mail:x:8:12:mail:/var/spool/mail:/sbin/nologin",
+      "nobody:x:65534:65534:Kernel Overflow User:/:/sbin/nologin",
+      "operator:x:11:0:operator:/root:/sbin/nologin",
+      "polkitd:x:998:996:User for polkitd:/:/sbin/nologin",
+      "redhat:x:1000:1000::/home/redhat:/bin/bash",
+      "root:x:0:0:root:/root:/bin/bash",
+      "rpc:x:32:32:Rpcbind Daemon:/var/lib/rpcbind:/sbin/nologin",
+      "rpcuser:x:29:29:RPC Service User:/var/lib/nfs:/sbin/nologin",
+      "setroubleshoot:x:995:991::/var/lib/setroubleshoot:/sbin/nologin",
+      "shutdown:x:6:0:shutdown:/sbin:/sbin/shutdown",
+      "sshd:x:74:74:Privilege-separated SSH:/var/empty/sshd:/sbin/nologin",
+      "sssd:x:996:992:User for sssd:/:/sbin/nologin",
+      "sync:x:5:0:sync:/sbin:/bin/sync",
+      "systemd-coredump:x:999:997:systemd Core Dumper:/:/sbin/nologin",
+      "systemd-resolve:x:193:193:systemd Resolver:/:/sbin/nologin",
+      "tcpdump:x:72:72::/:/sbin/nologin",
+      "tss:x:59:59:Account used for TPM access:/dev/null:/sbin/nologin",
+      "unbound:x:997:993:Unbound DNS resolver:/etc/unbound:/sbin/nologin"
+    ],
+    "rpm-verify": {
+      "changed": {
+        "/etc/machine-id": ".M.......",
+        "/proc": ".M.......",
+        "/sys": ".M.......",
+        "/var/lib/powerpc-utils/smt.state": "..5....T.",
+        "/var/log/lastlog": ".M....G..",
+        "/var/spool/anacron/cron.daily": ".M.......",
+        "/var/spool/anacron/cron.monthly": ".M.......",
+        "/var/spool/anacron/cron.weekly": ".M......."
+      },
+      "missing": []
+    },
+    "selinux": {
+      "policy": {
+        "SELINUX": "enforcing",
+        "SELINUXTYPE": "targeted"
+      }
+    },
+    "services-disabled": [
+      "arp-ethers.service",
+      "chrony-dnssrv@.timer",
+      "chrony-wait.service",
+      "cockpit.socket",
+      "console-getty.service",
+      "cpupower.service",
+      "debug-shell.service",
+      "exit.target",
+      "fstrim.timer",
+      "gssproxy.service",
+      "halt.target",
+      "kexec.target",
+      "kvm_stat.service",
+      "man-db-restart-cache-update.service",
+      "nfs-blkmap.service",
+      "nfs-convert.service",
+      "nfs-server.service",
+      "oddjobd.service",
+      "poweroff.target",
+      "rdisc.service",
+      "remote-cryptsetup.target",
+      "runlevel0.target",
+      "serial-getty@.service",
+      "smt_off.service",
+      "smtstate.service",
+      "sshd-keygen@.service",
+      "sshd.socket",
+      "sssd-autofs.socket",
+      "sssd-nss.socket",
+      "sssd-pac.socket",
+      "sssd-pam-priv.socket",
+      "sssd-pam.socket",
+      "sssd-ssh.socket",
+      "sssd-sudo.socket",
+      "systemd-resolved.service",
+      "tcsd.service",
+      "tmp.mount"
+    ],
+    "services-enabled": [
+      "NetworkManager-dispatcher.service",
+      "NetworkManager-wait-online.service",
+      "NetworkManager.service",
+      "auditd.service",
+      "autovt@.service",
+      "chronyd.service",
+      "cloud-config.service",
+      "cloud-final.service",
+      "cloud-init-local.service",
+      "cloud-init.service",
+      "crond.service",
+      "ctrl-alt-del.target",
+      "dbus-org.freedesktop.nm-dispatcher.service",
+      "dbus-org.freedesktop.timedate1.service",
+      "dnf-makecache.timer",
+      "getty@.service",
+      "hcn-init.service",
+      "import-state.service",
+      "irqbalance.service",
+      "kdump.service",
+      "loadmodules.service",
+      "nfs-client.target",
+      "nis-domainname.service",
+      "opal-prd.service",
+      "opal_errd.service",
+      "qemu-guest-agent.service",
+      "reboot.target",
+      "remote-fs.target",
+      "rpcbind.service",
+      "rpcbind.socket",
+      "rsyslog.service",
+      "rtas_errd.service",
+      "runlevel6.target",
+      "selinux-autorelabel-mark.service",
+      "sshd.service",
+      "sssd-kcm.socket",
+      "sssd.service",
+      "syslog.service",
+      "timedatex.service",
+      "tuned.service",
+      "unbound-anchor.timer"
+    ],
+    "sudoers": {
+      "/etc/sudoers": [
+        "Defaults   !visiblepw",
+        "Defaults    always_set_home",
+        "Defaults    match_group_by_gid",
+        "Defaults    always_query_group_plugin",
+        "Defaults    env_reset",
+        "Defaults    env_keep =  \"COLORS DISPLAY HOSTNAME HISTSIZE KDEDIR LS_COLORS\"",
+        "Defaults    env_keep += \"MAIL PS1 PS2 QTDIR USERNAME LANG LC_ADDRESS LC_CTYPE\"",
+        "Defaults    env_keep += \"LC_COLLATE LC_IDENTIFICATION LC_MEASUREMENT LC_MESSAGES\"",
+        "Defaults    env_keep += \"LC_MONETARY LC_NAME LC_NUMERIC LC_PAPER LC_TELEPHONE\"",
+        "Defaults    env_keep += \"LC_TIME LC_ALL LANGUAGE LINGUAS _XKB_CHARSET XAUTHORITY\"",
+        "Defaults    secure_path = /sbin:/bin:/usr/sbin:/usr/bin",
+        "root\tALL=(ALL) \tALL",
+        "%wheel\tALL=(ALL)\tALL"
+      ]
+    },
+    "sysconfig": {
+      "kernel": {
+        "DEFAULTKERNEL": "kernel",
+        "UPDATEDEFAULT": "yes"
+      },
+      "network": {
+        "NETWORKING": "yes",
+        "NOZEROCONF": "yes"
+      }
+    },
+    "sysctl.d": {
+      "/usr/lib/sysctl.d": {
+        "10-default-yama-scope.conf": [
+          "kernel.yama.ptrace_scope = 0"
+        ],
+        "50-coredump.conf": [
+          "kernel.core_pattern=|/usr/lib/systemd/systemd-coredump %P %u %g %s %t %c %h %e",
+          "kernel.core_pipe_limit=16"
+        ],
+        "50-default.conf": [
+          "kernel.sysrq = 16",
+          "kernel.core_uses_pid = 1",
+          "kernel.kptr_restrict = 1",
+          "net.ipv4.conf.all.rp_filter = 1",
+          "net.ipv4.conf.all.accept_source_route = 0",
+          "net.ipv4.conf.all.promote_secondaries = 1",
+          "net.core.default_qdisc = fq_codel",
+          "fs.protected_hardlinks = 1",
+          "fs.protected_symlinks = 1"
+        ],
+        "50-libkcapi-optmem_max.conf": [
+          "net.core.optmem_max = 81920"
+        ],
+        "50-pid-max.conf": [
+          "kernel.pid_max = 4194304"
+        ]
+      }
+    },
+    "systemd-service-dropins": {
+      "/usr/lib/systemd/system": {
+        "systemd-udev-trigger.service.d": {
+          "Unit": {
+            "RefuseManualStop": "true"
+          }
+        }
+      }
+    },
+    "timezone": "New_York",
+    "tmpfiles.d": {
+      "/usr/lib/tmpfiles.d": {
+        "cloud-init.conf": [
+          "d /run/cloud-init 0700 root root - -"
+        ],
+        "cockpit-tempfiles.conf": [
+          "C /run/cockpit/inactive.motd 0640 root wheel - /usr/share/cockpit/motd/inactive.motd",
+          "f /run/cockpit/active.motd   0640 root wheel -",
+          "L+ /run/cockpit/motd - - - - inactive.motd"
+        ],
+        "cryptsetup.conf": [
+          "d /run/cryptsetup 0700 root root -"
+        ],
+        "dbus.conf": [
+          "d /var/lib/dbus 0755 - - -",
+          "L /var/lib/dbus/machine-id - - - - /etc/machine-id"
+        ],
+        "dnf.conf": [
+          "R /var/tmp/dnf*/locks/*",
+          "r /var/cache/dnf/download_lock.pid",
+          "r /var/cache/dnf/metadata_lock.pid",
+          "r /var/lib/dnf/rpmdb_lock.pid",
+          "r /var/log/log_lock.pid"
+        ],
+        "etc.conf": [
+          "L /etc/os-release - - - - ../usr/lib/os-release",
+          "L /etc/localtime - - - - ../usr/share/zoneinfo/UTC",
+          "L+ /etc/mtab - - - - ../proc/self/mounts",
+          "C /etc/nsswitch.conf - - - -",
+          "C /etc/pam.d - - - -"
+        ],
+        "home.conf": [
+          "Q /home 0755 - - -",
+          "q /srv 0755 - - -"
+        ],
+        "journal-nocow.conf": [
+          "h /var/log/journal - - - - +C",
+          "h /var/log/journal/%m - - - - +C",
+          "h /var/log/journal/remote - - - - +C"
+        ],
+        "legacy.conf": [
+          "d /run/lock 0755 root root -",
+          "L /var/lock - - - - ../run/lock",
+          "d /run/lock/subsys 0755 root root -",
+          "r! /forcefsck",
+          "r! /fastboot",
+          "r! /forcequotacheck"
+        ],
+        "libselinux.conf": [
+          "d /run/setrans 0755 root root"
+        ],
+        "man-db.conf": [
+          "d /var/cache/man 0755 root root 1w"
+        ],
+        "openssh.conf": [
+          "d /var/empty/sshd 711 root root -"
+        ],
+        "pam.conf": [
+          "d /run/console 0755 root root -",
+          "d /run/faillock 0755 root root -",
+          "d /run/sepermit 0755 root root -"
+        ],
+        "portables.conf": [
+          "Q /var/lib/portables 0700"
+        ],
+        "rpcbind.conf": [
+          "D     /run/rpcbind 0700  rpc  rpc  -  -"
+        ],
+        "rpm.conf": [
+          "r /var/lib/rpm/__db.*"
+        ],
+        "selinux-policy.conf": [
+          "z /sys/devices/system/cpu/online - - -",
+          "Z /sys/class/net - - -",
+          "z /sys/kernel/uevent_helper - - -",
+          "w /sys/fs/selinux/checkreqprot - - - - 0"
+        ],
+        "setroubleshoot.conf": [
+          "d /run/setroubleshoot 711 setroubleshoot setroubleshoot -"
+        ],
+        "sudo.conf": [
+          "d /run/sudo 0711 root root",
+          "D /run/sudo/ts 0700 root root"
+        ],
+        "systemd-nologin.conf": [
+          "F! /run/nologin 0644 - - - \"System is booting up. Unprivileged users are not permitted to log in yet. Please come back later. For technical details, see pam_nologin(8).\""
+        ],
+        "systemd.conf": [
+          "d /run/user 0755 root root -",
+          "F! /run/utmp 0664 root utmp -",
+          "d /run/systemd/ask-password 0755 root root -",
+          "d /run/systemd/seats 0755 root root -",
+          "d /run/systemd/sessions 0755 root root -",
+          "d /run/systemd/users 0755 root root -",
+          "d /run/systemd/machines 0755 root root -",
+          "d /run/systemd/shutdown 0755 root root -",
+          "d /run/log 0755 root root -",
+          "z /run/log/journal 2755 root systemd-journal - -",
+          "Z /run/log/journal/%m ~2750 root systemd-journal - -",
+          "a+ /run/log/journal/%m - - - - d:group:adm:r-x,d:group:wheel:r-x",
+          "a+ /run/log/journal/%m - - - - group:adm:r-x,group:wheel:r-x",
+          "a+ /run/log/journal/%m/*.journal* - - - - group:adm:r--,group:wheel:r--",
+          "z /var/log/journal 2755 root systemd-journal - -",
+          "z /var/log/journal/%m 2755 root systemd-journal - -",
+          "z /var/log/journal/%m/system.journal 0640 root systemd-journal - -",
+          "a+ /var/log/journal    - - - - d:group::r-x,d:group:adm:r-x,d:group:wheel:r-x",
+          "a+ /var/log/journal    - - - - group::r-x,group:adm:r-x,group:wheel:r-x",
+          "a+ /var/log/journal/%m - - - - d:group:adm:r-x,d:group:wheel:r-x",
+          "a+ /var/log/journal/%m - - - - group:adm:r-x,group:wheel:r-x",
+          "a+ /var/log/journal/%m/system.journal - - - - group:adm:r--,group:wheel:r--",
+          "d /var/lib/systemd 0755 root root -",
+          "d /var/lib/systemd/coredump 0755 root root 3d",
+          "d /var/lib/private 0700 root root -",
+          "d /var/log/private 0700 root root -",
+          "d /var/cache/private 0700 root root -"
+        ],
+        "tmp.conf": [
+          "q /tmp 1777 root root 10d",
+          "q /var/tmp 1777 root root 30d",
+          "x /tmp/systemd-private-%b-*",
+          "X /tmp/systemd-private-%b-*/tmp",
+          "x /var/tmp/systemd-private-%b-*",
+          "X /var/tmp/systemd-private-%b-*/tmp",
+          "R! /tmp/systemd-private-*",
+          "R! /var/tmp/systemd-private-*"
+        ],
+        "tuned.conf": [
+          "d /run/tuned 0755 root root -"
+        ],
+        "var.conf": [
+          "q /var 0755 - - -",
+          "L /var/run - - - - ../run",
+          "d /var/log 0755 - - -",
+          "f /var/log/wtmp 0664 root utmp -",
+          "f /var/log/btmp 0660 root utmp -",
+          "f /var/log/lastlog 0664 root utmp -",
+          "d /var/cache 0755 - - -",
+          "d /var/lib 0755 - - -",
+          "d /var/spool 0755 - - -"
+        ],
+        "x11.conf": [
+          "D! /tmp/.X11-unix 1777 root root 10d",
+          "D! /tmp/.ICE-unix 1777 root root 10d",
+          "D! /tmp/.XIM-unix 1777 root root 10d",
+          "D! /tmp/.font-unix 1777 root root 10d",
+          "D! /tmp/.Test-unix 1777 root root 10d",
+          "r! /tmp/.X[0-9]*-lock"
+        ]
+      }
+    }
+  }
+}

--- a/test/data/manifests/centos_8-ppc64le-qcow2_customize-boot.json
+++ b/test/data/manifests/centos_8-ppc64le-qcow2_customize-boot.json
@@ -1,0 +1,15497 @@
+{
+  "compose-request": {
+    "distro": "centos-8",
+    "arch": "ppc64le",
+    "image-type": "qcow2",
+    "repositories": [
+      {
+        "name": "baseos",
+        "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/",
+        "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\nVersion: GnuPG v2.0.22 (GNU/Linux)\n\nmQINBFzMWxkBEADHrskpBgN9OphmhRkc7P/YrsAGSvvl7kfu+e9KAaU6f5MeAVyn\nrIoM43syyGkgFyWgjZM8/rur7EMPY2yt+2q/1ZfLVCRn9856JqTIq0XRpDUe4nKQ\n8BlA7wDVZoSDxUZkSuTIyExbDf0cpw89Tcf62Mxmi8jh74vRlPy1PgjWL5494b3X\n5fxDidH4bqPZyxTBqPrUFuo+EfUVEqiGF94Ppq6ZUvrBGOVo1V1+Ifm9CGEK597c\naevcGc1RFlgxIgN84UpuDjPR9/zSndwJ7XsXYvZ6HXcKGagRKsfYDWGPkA5cOL/e\nf+yObOnC43yPUvpggQ4KaNJ6+SMTZOKikM8yciyBwLqwrjo8FlJgkv8Vfag/2UR7\nJINbyqHHoLUhQ2m6HXSwK4YjtwidF9EUkaBZWrrskYR3IRZLXlWqeOi/+ezYOW0m\nvufrkcvsh+TKlVVnuwmEPjJ8mwUSpsLdfPJo1DHsd8FS03SCKPaXFdD7ePfEjiYk\nnHpQaKE01aWVSLUiygn7F7rYemGqV9Vt7tBw5pz0vqSC72a5E3zFzIIuHx6aANry\nGat3aqU3qtBXOrA/dPkX9cWE+UR5wo/A2UdKJZLlGhM2WRJ3ltmGT48V9CeS6N9Y\nm4CKdzvg7EWjlTlFrd/8WJ2KoqOE9leDPeXRPncubJfJ6LLIHyG09h9kKQARAQAB\ntDpDZW50T1MgKENlbnRPUyBPZmZpY2lhbCBTaWduaW5nIEtleSkgPHNlY3VyaXR5\nQGNlbnRvcy5vcmc+iQI3BBMBAgAhBQJczFsZAhsDBgsJCAcDAgYVCAIJCgsDFgIB\nAh4BAheAAAoJEAW1VbOEg8ZdjOsP/2ygSxH9jqffOU9SKyJDlraL2gIutqZ3B8pl\nGy/Qnb9QD1EJVb4ZxOEhcY2W9VJfIpnf3yBuAto7zvKe/G1nxH4Bt6WTJQCkUjcs\nN3qPWsx1VslsAEz7bXGiHym6Ay4xF28bQ9XYIokIQXd0T2rD3/lNGxNtORZ2bKjD\nvOzYzvh2idUIY1DgGWJ11gtHFIA9CvHcW+SMPEhkcKZJAO51ayFBqTSSpiorVwTq\na0cB+cgmCQOI4/MY+kIvzoexfG7xhkUqe0wxmph9RQQxlTbNQDCdaxSgwbF2T+gw\nbyaDvkS4xtR6Soj7BKjKAmcnf5fn4C5Or0KLUqMzBtDMbfQQihn62iZJN6ZZ/4dg\nq4HTqyVpyuzMXsFpJ9L/FqH2DJ4exGGpBv00ba/Zauy7GsqOc5PnNBsYaHCply0X\n407DRx51t9YwYI/ttValuehq9+gRJpOTTKp6AjZn/a5Yt3h6jDgpNfM/EyLFIY9z\nV6CXqQQ/8JRvaik/JsGCf+eeLZOw4koIjZGEAg04iuyNTjhx0e/QHEVcYAqNLhXG\nrCTTbCn3NSUO9qxEXC+K/1m1kaXoCGA0UWlVGZ1JSifbbMx0yxq/brpEZPUYm+32\no8XfbocBWljFUJ+6aljTvZ3LQLKTSPW7TFO+GXycAOmCGhlXh2tlc6iTc41PACqy\nyy+mHmSv\n=kkH7\n-----END PGP PUBLIC KEY BLOCK-----\n",
+        "check_gpg": true
+      },
+      {
+        "name": "appstream",
+        "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/",
+        "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\nVersion: GnuPG v2.0.22 (GNU/Linux)\n\nmQINBFzMWxkBEADHrskpBgN9OphmhRkc7P/YrsAGSvvl7kfu+e9KAaU6f5MeAVyn\nrIoM43syyGkgFyWgjZM8/rur7EMPY2yt+2q/1ZfLVCRn9856JqTIq0XRpDUe4nKQ\n8BlA7wDVZoSDxUZkSuTIyExbDf0cpw89Tcf62Mxmi8jh74vRlPy1PgjWL5494b3X\n5fxDidH4bqPZyxTBqPrUFuo+EfUVEqiGF94Ppq6ZUvrBGOVo1V1+Ifm9CGEK597c\naevcGc1RFlgxIgN84UpuDjPR9/zSndwJ7XsXYvZ6HXcKGagRKsfYDWGPkA5cOL/e\nf+yObOnC43yPUvpggQ4KaNJ6+SMTZOKikM8yciyBwLqwrjo8FlJgkv8Vfag/2UR7\nJINbyqHHoLUhQ2m6HXSwK4YjtwidF9EUkaBZWrrskYR3IRZLXlWqeOi/+ezYOW0m\nvufrkcvsh+TKlVVnuwmEPjJ8mwUSpsLdfPJo1DHsd8FS03SCKPaXFdD7ePfEjiYk\nnHpQaKE01aWVSLUiygn7F7rYemGqV9Vt7tBw5pz0vqSC72a5E3zFzIIuHx6aANry\nGat3aqU3qtBXOrA/dPkX9cWE+UR5wo/A2UdKJZLlGhM2WRJ3ltmGT48V9CeS6N9Y\nm4CKdzvg7EWjlTlFrd/8WJ2KoqOE9leDPeXRPncubJfJ6LLIHyG09h9kKQARAQAB\ntDpDZW50T1MgKENlbnRPUyBPZmZpY2lhbCBTaWduaW5nIEtleSkgPHNlY3VyaXR5\nQGNlbnRvcy5vcmc+iQI3BBMBAgAhBQJczFsZAhsDBgsJCAcDAgYVCAIJCgsDFgIB\nAh4BAheAAAoJEAW1VbOEg8ZdjOsP/2ygSxH9jqffOU9SKyJDlraL2gIutqZ3B8pl\nGy/Qnb9QD1EJVb4ZxOEhcY2W9VJfIpnf3yBuAto7zvKe/G1nxH4Bt6WTJQCkUjcs\nN3qPWsx1VslsAEz7bXGiHym6Ay4xF28bQ9XYIokIQXd0T2rD3/lNGxNtORZ2bKjD\nvOzYzvh2idUIY1DgGWJ11gtHFIA9CvHcW+SMPEhkcKZJAO51ayFBqTSSpiorVwTq\na0cB+cgmCQOI4/MY+kIvzoexfG7xhkUqe0wxmph9RQQxlTbNQDCdaxSgwbF2T+gw\nbyaDvkS4xtR6Soj7BKjKAmcnf5fn4C5Or0KLUqMzBtDMbfQQihn62iZJN6ZZ/4dg\nq4HTqyVpyuzMXsFpJ9L/FqH2DJ4exGGpBv00ba/Zauy7GsqOc5PnNBsYaHCply0X\n407DRx51t9YwYI/ttValuehq9+gRJpOTTKp6AjZn/a5Yt3h6jDgpNfM/EyLFIY9z\nV6CXqQQ/8JRvaik/JsGCf+eeLZOw4koIjZGEAg04iuyNTjhx0e/QHEVcYAqNLhXG\nrCTTbCn3NSUO9qxEXC+K/1m1kaXoCGA0UWlVGZ1JSifbbMx0yxq/brpEZPUYm+32\no8XfbocBWljFUJ+6aljTvZ3LQLKTSPW7TFO+GXycAOmCGhlXh2tlc6iTc41PACqy\nyy+mHmSv\n=kkH7\n-----END PGP PUBLIC KEY BLOCK-----\n",
+        "check_gpg": true
+      }
+    ],
+    "filename": "disk.qcow2",
+    "blueprint": {
+      "name": "qcow2-customize-boot-test",
+      "description": "Image for boot test",
+      "packages": [
+        {
+          "name": "bash",
+          "version": "*"
+        }
+      ],
+      "modules": [],
+      "groups": [
+        {
+          "name": "core"
+        }
+      ],
+      "customizations": {
+        "hostname": "my-host",
+        "kernel": {
+          "append": "debug"
+        },
+        "sshkey": [
+          {
+            "user": "user1",
+            "key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC61wMCjOSHwbVb4VfVyl5sn497qW4PsdQ7Ty7aD6wDNZ/QjjULkDV/yW5WjDlDQ7UqFH0Sr7vywjqDizUAqK7zM5FsUKsUXWHWwg/ehKg8j9xKcMv11AkFoUoujtfAujnKODkk58XSA9whPr7qcw3vPrmog680pnMSzf9LC7J6kXfs6lkoKfBh9VnlxusCrw2yg0qI1fHAZBLPx7mW6+me71QZsS6sVz8v8KXyrXsKTdnF50FjzHcK9HXDBtSJS5wA3fkcRYymJe0o6WMWNdgSRVpoSiWaHHmFgdMUJaYoCfhXzyl7LtNb3Q+Sveg+tJK7JaRXBLMUllOlJ6ll5Hod root@localhost"
+          }
+        ],
+        "user": [
+          {
+            "name": "user2",
+            "description": "description 2",
+            "password": "$6$BhyxFBgrEFh0VrPJ$MllG8auiU26x2pmzL4.1maHzPHrA.4gTdCvlATFp8HJU9UPee4zCS9BVl2HOzKaUYD/zEm8r/OF05F2icWB0K/",
+            "key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC61wMCjOSHwbVb4VfVyl5sn497qW4PsdQ7Ty7aD6wDNZ/QjjULkDV/yW5WjDlDQ7UqFH0Sr7vywjqDizUAqK7zM5FsUKsUXWHWwg/ehKg8j9xKcMv11AkFoUoujtfAujnKODkk58XSA9whPr7qcw3vPrmog680pnMSzf9LC7J6kXfs6lkoKfBh9VnlxusCrw2yg0qI1fHAZBLPx7mW6+me71QZsS6sVz8v8KXyrXsKTdnF50FjzHcK9HXDBtSJS5wA3fkcRYymJe0o6WMWNdgSRVpoSiWaHHmFgdMUJaYoCfhXzyl7LtNb3Q+Sveg+tJK7JaRXBLMUllOlJ6ll5Hod root@localhost",
+            "home": "/home/home2",
+            "shell": "/bin/sh",
+            "groups": [
+              "group1"
+            ],
+            "uid": 1020,
+            "gid": 1050
+          }
+        ],
+        "group": [
+          {
+            "name": "group1",
+            "gid": 1030
+          },
+          {
+            "name": "group2",
+            "gid": 1050
+          }
+        ],
+        "timezone": {
+          "timezone": "Europe/London",
+          "ntpservers": [
+            "time.example.com"
+          ]
+        },
+        "locale": {
+          "languages": [
+            "el_CY.UTF-8"
+          ],
+          "keyboard": "dvorak"
+        },
+        "services": {
+          "enabled": [
+            "sshd.socket"
+          ],
+          "disabled": [
+            "bluetooth.service"
+          ]
+        }
+      }
+    }
+  },
+  "manifest": {
+    "version": "2",
+    "pipelines": [
+      {
+        "name": "build",
+        "runner": "org.osbuild.centos8",
+        "stages": [
+          {
+            "type": "org.osbuild.rpm",
+            "inputs": {
+              "packages": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  "sha256:2c1baefd0f802507d9741da8da54f6eae42b04967f9d433d7f9e0f124434c70d",
+                  "sha256:be49b69bc5de947ee2151f397993a691a57bc53952058c32cde0fca674da7d8c",
+                  "sha256:48226934763e4c412c1eb65df314e6879720b4b1ebcb3d07c126c9526639cb68",
+                  "sha256:3a438b53e8377eccf90cac0fd42ed2b513fc869bfb7b96e3d2a4f6984a287f90",
+                  "sha256:8729b157f0925feccdaef8aacd91c6aebe0109e621675bcc15e1830673b0e19d",
+                  "sha256:56c3d429ea949467dc0bca882646cf40a58fb6f27750f5664ff2919f5d38ada5",
+                  "sha256:1fad1d1f8b56e6967863aeb60f5fa3615e6a35b0f6532d8a23066e6823b50860",
+                  "sha256:842ff55b80ac9a5c3357bf52646a5761a4c4786bb3e64b56d8fa5d8fe34ef8bb",
+                  "sha256:15b17b95cf9cb9fb64e0c8e56110836bdcaf70de81b8cbdb60e181fc90456e06",
+                  "sha256:a82958266d292f4725fc1981ea57a861b7fc7feeb7a9551d0b61b98ca51a5662",
+                  "sha256:eee92733e8989029929d5cb1f673b15fdb814dac32e148d5bc02378b44c8699a",
+                  "sha256:ff8b51c6a8bacc5ef6b5da0f049d170ab1c1ecebad50ded3c04ed384eca9a2c0",
+                  "sha256:383a5e6bb9e94de53baaf5c7493cd50a68c893c6a30acfbe28407d33bb133efc",
+                  "sha256:19061d12407c0c4bca6abcaef01695b70dcd3967ff102dd07178a2193a280e29",
+                  "sha256:4e3e93a3d2039c2a8305030b7960bd1100d7d20705a1afb1325a4ee79478a74a",
+                  "sha256:084d79ed3d7127e6d46e9ac6e654d8ef181a156435808dc8eb32968b6c1b4946",
+                  "sha256:2a8f9e5119a034801904185dcbf1bc29db67e9e9b0cf5893615722d7bb33099c",
+                  "sha256:67f37cee02ba744dfc7957725f5ef9df229778f6a2f7afc659625b458da6167e",
+                  "sha256:b10d8521963a2494fdb2b5f8fb0de837dc86d4016c3b10019fb8970a09582451",
+                  "sha256:47ad43730c8bc72c90f2fb3dbd3526d716ada2fad94e62cb443658e94c6503c5",
+                  "sha256:5c1940e1f173e22b053f3a89022903cea34a6af20dff81c65548c4e2ba3a8293",
+                  "sha256:1a4e44583a767289bb0d354db93c6a9132420e13376d4fcae866d69620bb11bb",
+                  "sha256:7baac88adafdc5958fb818c7685d3c6548f6e2e585e4435ceee4a168edc3597e",
+                  "sha256:090563f18409c228274bb61dcf1001f63a55c1246fb2838a998cb3c5fd8c3874",
+                  "sha256:c58b0b900a7ffc778980461d74dc236bf2c790d2e5e8c04e28876e221b48a1c8",
+                  "sha256:cc5f8dd4e061da3a73aa67112e24f2cc5c0ad0cd4334dc798b8834cf6259a779",
+                  "sha256:698e8ecaf71719dafacae79de05080d567b69fad3511e8b8d42b9af96a7c41db",
+                  "sha256:441b3862f5a0fd504bbbba18d96d1b2b920fb95a79dc45a753a6a664ad285b07",
+                  "sha256:a42de8ce71380b1f4e8ac5b4ce720bf565c99a0b09ef983c0550a91a467bc155",
+                  "sha256:4f92835a6e4ee4276df49019e068d1871b75821f52b405c699bd9f199df58b80",
+                  "sha256:42464424b9fa731f8122fe748aad0005519fc87b770dbbdb71f29f514ea0e889",
+                  "sha256:45c48d32120739734ae97479cc0f3ca19796ea47e360ba39d52b77ce3ada61d7",
+                  "sha256:04eee0a9c079186aa58b5536ac8bcbd2a360700b83fa7b9f6eb127c1386b7ef4",
+                  "sha256:881b28a3a37d114bc3f046605b24663560009b13a507217e007643f5682efdd5",
+                  "sha256:9e67ac5948125dd165c9a74ec848d48b313ef4264bbbb89630a782dbd972d72c",
+                  "sha256:9fb07c2324cccbbc19e3ffade50ee7da41909b2f6c24f49ffd9978ba375de193",
+                  "sha256:f4eca686b314edb06d3fe1c526f573c7248c811af70cba76132cdc9c541cadc1",
+                  "sha256:30ceeb5a6cadaeccdbde088bfb52ba88190fa530c11f4a2aafd62b4b4ad6b404",
+                  "sha256:e87acf226a9511b3a5f83e7fed9c5c20addbbdae47ab67c614404a9392b77e50",
+                  "sha256:d150e53fa73c3786da9e4f6e23d374100b0dd2923485d4a08e9a56ac2786cf83",
+                  "sha256:88be5116908aa5013f540c767f6811774342780bb72d3ec197b3429bfb2f9862",
+                  "sha256:e156e6fa9ef6a483f8505ce0eeadbcab12b887c4996233ce5d6258076f6bce50",
+                  "sha256:e65f7d7c8def6b168e013914bc0d1137aed65c3010e9796df3b823854472f3e1",
+                  "sha256:a49b922f117b9bfb0b07e9848151f8a2948345328ebc534cd28ac187d7ed3f94",
+                  "sha256:caa0bd6617a8d5e535faedec5f6f3ea7c5e6da1898751f6c9c34a89a95c286ff",
+                  "sha256:d1cf2d973db2f1af46f124776b9ab4bd782e7065c8c8428a4ddef60989e4225d",
+                  "sha256:4992eb036c0797daf9b984af1a34fe27a30287ee5d2bd5e2f5a0df3a09bdbb59",
+                  "sha256:d807e7fb8bf24be50642a6dced954c6ea208199daab2d27c9f73d789ba82fa37",
+                  "sha256:8cd6ef9902851f07cfd9682e2d6873648690f0c2ec65345276b557ede042d8b9",
+                  "sha256:d1d362fd4f8022ad05171efe40e84d15ec6c5e5f419d6099ebc8e46e7da632c1",
+                  "sha256:78fd472a1c7f49b8a432788ea2dfc1119f155a394f41585b4e715d2585fc92ab",
+                  "sha256:e392a6b41381ffad04626d092fd2af9477c72e197a74efddf987832c3bfa521f",
+                  "sha256:ad338b7a3f3bed96300d9ce7f0307e09d758962b8496c10fb3554bf62405d153",
+                  "sha256:bfb45644212cfbbe48b05149f8d53e77d7bd02ca9fc9045cc37115101175a3a0",
+                  "sha256:fa7bef727ba8657208bb3df95916f0bc912332cb8534c695facef32ffbd72f20",
+                  "sha256:257e086bb52086254fa8cc95a5c4998668b4fcb5203ad3c2275c1150816acc9b",
+                  "sha256:af0a4287e302baa7c85655ddfe5a7049b8eaf31aff03886f4fc57c920d26d491",
+                  "sha256:11ff811a72c82084c7c14700b23d29643e153442a34b3b486e270e5b40e38d0a",
+                  "sha256:a2d96efed83ab31d21481af044835a940673ee4ade2763af78c06d2df87b94f7",
+                  "sha256:51760acfb6ca87db5be7a9296d6a3d1220767956c576a26c6d46784e25db85bb",
+                  "sha256:24f5cd46a7395cd046b10d6ddc4de435ec6595d0dcdb2d179c94cc9082a12f14",
+                  "sha256:2451a475f248a4c66e64d149fefa8bfc195fcd7b3f369bae221a94f8ce4c2d67",
+                  "sha256:4a08d5264e865548e65d31886c91b659b33a2c2ba39fd115b00af3ea0bc91a83",
+                  "sha256:7cccedcc359f2a2542858088704bf3d0ec3e46cb7b72f602408fbab937a522d3",
+                  "sha256:d8dad22276baffe9496d5e05ef35d21dd6f9d8f910339daced2c3ff42d7a28c5",
+                  "sha256:78b2b9cbf041d4461daf7ac11a24d1e79a9c57f47aa265dba4d09067efe3d96b",
+                  "sha256:ac3b306c193bd20658950da402ae0cbdd8337110117de5e5d7eba970822671fd",
+                  "sha256:fb276cc0ebc6bd27d344f7e0811f26cb3f0e59da09182489095724bdf2a075f8",
+                  "sha256:5a0927d231fbafa8b865591922fc07d39d9b4b263a1e9c0bbef691282f706cd0",
+                  "sha256:e1e28504928648404a3b652440091eba010cd99221183ef78601cbd152261d91",
+                  "sha256:42bb566be1936bdb40937f9c0a96c4acc93057379385f1807cba18f60443d3e4",
+                  "sha256:8119d276749b35cd9c283c1a8d970b3528bea58427eb37eafc22b6093a978f08",
+                  "sha256:6d1ac29b3a38408f6d238d6718384e05be7346789c6200b354335b0e0c9c77df",
+                  "sha256:331b91a0928c05618c7fed3e12bbe9ecb9e4619d08c7e85d3de344a08d2f0f1a",
+                  "sha256:49c7c718cb4e2b6f0effd0dec4f4cb4e109d260c192b2b329a58a1da9a24ad1d",
+                  "sha256:a3ef96219165bfc64d4f5d50f51fbd43e803c500619240ffe4db1f9f8e337f83",
+                  "sha256:ef86061338fa321c959cadc75ecbdfd405eebaa1042eec9d9c737d4d9d92568f",
+                  "sha256:6fe1188081e441595ce29ebed4d1985e5890815158244f69f092ee930656f755",
+                  "sha256:a80c1d6d32db7ce8fdd58bb4f3f488b74e94261a38512dc8a15179ae33697e63",
+                  "sha256:b437a08d4670ef440ba6dbaae4ccb39f989f0c2a3d280ea66d6fd9532a313286",
+                  "sha256:230731b577f8d29e7e8e8fd6d1ea02702fb4364fcc7034d838ccddc4d66da8c3",
+                  "sha256:54f59ddb56e89a5330373e07ea05934fc58360eb7480615ede2a3ed6982e1eef",
+                  "sha256:ff1580bd4ec5841d4937b383917fa30f318b4f419b8067a77468eb4a9630ba10",
+                  "sha256:3303f41952491bad2b31ee507eaabaf13dabe5ec9624c4b58a4a8301c4cd89dd",
+                  "sha256:df40cada982b04336fe8b250b4fdd576ddd03a014bb519a69b34640369bef661",
+                  "sha256:9c4cd61b98253904436180f58c564bda61be1fa1b5523e4ecbbdc174d0c2a9aa",
+                  "sha256:43bfc890caf7855f2fb55c24474b58cd5c8c7b51e4db4f40d1f302fffd31985b",
+                  "sha256:30ae4489980021a727f247d48b4d74d4c6c7667d00bd1a670f045ea24a885541",
+                  "sha256:77e4cfbc823e3764308822ccf03b257861f9360f3b948829f1d73148b321b00e",
+                  "sha256:9b69a221cf9395a110849bb428bb1cfe9fb489322df0fa6017f5978a827ee0e9",
+                  "sha256:e0a7b9f3b56b4737f5711dc6b03f256fbf2488656b8874acabb494b58ba0c1c1",
+                  "sha256:5c74a0e3005ea3cb90dff80cfa1e7d64c97f5c01612d253cf4e65aca962b7be4",
+                  "sha256:194dbe332ccdb33d58f040da07667257e176975f6b2f17343bbf33fb99deb097",
+                  "sha256:e21a84107568047432e474e08da24aea2340409d57ea8cf170182927dc76de12",
+                  "sha256:b83a0199c3d471151f07f6de626a1a4a362dd6aa29d84cf1c0ada2c966ce29c9",
+                  "sha256:709ea71f36495ac2ac89d72d2eb603b6aa55b2c1a70633f23514dd897936f02b",
+                  "sha256:aea253461d1a34a239b445ee07cb34398a9cbb6ed40e252182a91cddcf59004b",
+                  "sha256:a0b8a6b2c8dad75290228086dd0af342979604bbf4b9500029e25d766835c0f4",
+                  "sha256:0afac6f4f9ed1c59510675d87da45c7966c0f7aae6e8dd056961aceed8c4fe0a",
+                  "sha256:12696f5638ad2068c5c8940495d15c3bb1c57990000dbda7428b008e9e63ab5b",
+                  "sha256:f3d9ccb762146dc97f2d201d979fbb0e9171d1203fb985f3ef48b5c2a176c2a9",
+                  "sha256:c5a60ffb80cd1f9b90c797f1d1ac80e5536eb32a5b276871445e7279ac701c5f",
+                  "sha256:0515afdac097ad54cf4b24e0644f0789cab5535a54107aa44940ffd991a6cef3",
+                  "sha256:020abac486839c7be29fae37a686dc7749398c333cb8ba94b3390b386ffcbff7",
+                  "sha256:31d924d1540dd4e927a4c3aa936cec4bfb54ed302d3e8acc1be8b52dd5deb10c",
+                  "sha256:fd6e1803ff367036da5b52b2183e1408691b379cc1320971bb664737507f89a4",
+                  "sha256:6b312faed4a0508da2f15d3f31a6daccfc0ec6621e5fb7b20956027dce5fa395",
+                  "sha256:a5f9f2c4f39f393971f268aebb1b55d18d0d96693d08a9ed70403e8565807bb6",
+                  "sha256:d6eb27d158b6397e52ab6a952fec4e3c414638a08750a6c011d32eb117accd82",
+                  "sha256:4e497225fe36781735cc92c0886f6858b19d4557ed9ecafe1247b8233c206075",
+                  "sha256:d3a4f367a9c5ba936b1bb5480db390889a303e5ec8ff34bb4274c1d840a1784d",
+                  "sha256:8d7777da3f54f965cf3058cabf987c01b93a1dd041e8359eb7822eba57d8c8df",
+                  "sha256:b58be8f7685340b35e61945b1ab499bc1030b0b021b2ac5576897cf079ff7812",
+                  "sha256:9b8a8a843fe9a972f6433e11b95b5a8d1d2971ed40fe1acda6807e34f0773c62",
+                  "sha256:1aa321c66a3661e78d938b805e5c311d519f04bf3496545ffdacc7c152bc9b21",
+                  "sha256:3dfffdadfb10def9a3671a255e4fa71d8b22231ccf2c929e96689101dda8ce2c",
+                  "sha256:c5c61536e768553067cee488830c64866d109cade24917dbe23f82c861af07c5",
+                  "sha256:98c28a91d41f634edb8c1f001dbc45c0de534332d059a2e8feff448fb7235c49",
+                  "sha256:b4a1ac1ff5cd22a5dab6c96dfc2dbd7cd6ba750691ad5c53a97a1f088fc42abc",
+                  "sha256:01b0562b890a80c202fff9175dc845500660c7f1655292d4ee13ca667acab081",
+                  "sha256:56c866bcff69fd60b630841ff990296b26c2f45d8c6054311b5c476bc67466ac",
+                  "sha256:4fe264ed1cfd0c074f4601354b0128a9e5068f0fcde7382fd5429585f0d4cd2c",
+                  "sha256:95103f7c339aec4b485b7f569aa8a5e1a54286b3d2acde427328c49e4d8d80d1",
+                  "sha256:adc56041458e556df5663e7da264e151c24aaf1c2a94e49df9790ba191ea1b37",
+                  "sha256:0f57b051654b6d75789b437dafd7040b6c90daee17827be24352c0f11a74bba7",
+                  "sha256:1b5136570cefb8273dd5affc73c1456cf239cc8b18be72d6c4d09794af7f3352",
+                  "sha256:679724b45157b4d4c9ebe2eb32e188b9a65d47c23be886498d7a178caaf113bb",
+                  "sha256:767dd64d91c23adda537c7759ae3b4f720d3c76e03b52bc9231e52e0113db3ab",
+                  "sha256:2dbfe3cb37c18b39393870baa77f3bbd42be53517abffdd990b13ed70ee3dd3e",
+                  "sha256:f5bcb82a732c02d6f31bbf156887049883c76cedc9c6a11b049358a74f4d45d0",
+                  "sha256:32ebba6472cdc331bd3366ca996ad3039b3a1b41c61a849b88074e1b722cad2c",
+                  "sha256:75e9ed16ace51ba04a62505aaed215bf9c722d6f4b1c33cc3e3962076c300ee8",
+                  "sha256:d539404dafd8ad5d785ab3da6f8bd5a2bf5dff9e01be0ff1bc1d251786dda25c",
+                  "sha256:bff39fef1fc01564156123fcade75b4bc50402a2971a031d9a426c7014b1e681",
+                  "sha256:6b9875495111bcd2d3c5e9e380b3be17fb0a730891468fb45bdba3b3692b00ea",
+                  "sha256:e217c2687212d931ad9a6a02afb20cc34f6d051786d136e337f91079c9f73d22",
+                  "sha256:c1291b69a65a860069195a33cf6640df8667e960f9f030ceeea4497c47858b94",
+                  "sha256:d8c00baf46e33f9e5f1b9e139bbea9fe0f27badb432c992b9cf8c4f7017094bf",
+                  "sha256:1a968f65db066243cbd0a6e12d193ef674637f044299a15b5d6b910e91411812",
+                  "sha256:4a167fa4a7238bd94b3134173f6267b19cdebc2fde98b583344749e1f4c9bf09",
+                  "sha256:8904fdb492f34e5242ba483fb6b7b158342662575b3d5ac9abbc380568840d4a",
+                  "sha256:6bfc201a12dc7bba21069a663aa692a96c5e8920b0d94a4e355c332d7ead15ba",
+                  "sha256:393e7bb9f93ffb3cbba620fbfeb229f2b8345454bc60ac0508f76735544ed289",
+                  "sha256:f24bce642ec88622490b2f09a45fa3985da7f6511a1aae131853c4ea4c309e6b",
+                  "sha256:4c5aabda0cd9edb40e141066d400d2e4b232bc22ab60e806a6399691c391cabc",
+                  "sha256:9936485ac7111967d6962bc539de7b08807e310117adb78b11c21a5db0f0f890",
+                  "sha256:0230acdbc9da4b36da812f0e585a7602eda4982c899b3b3a4c2bc9b4546d8e74",
+                  "sha256:7abf49cabbaf996afc0c2604f10ea18f8f22a903fc4ba3728a18f5892353c5c9",
+                  "sha256:41716536ea16798238ac89fbc3041b3f9dc80f9a64ea4b19d6e67ad2c909269a",
+                  "sha256:17ffe1d683dbff48f9b2ef903401e471e5e51a992bf0890632bceb94561893de",
+                  "sha256:8403cfc97e0e72e37639b8c54d92f1ee427e48a70d52d5260a37fa104f2df20d",
+                  "sha256:7a66928044c3478964aeaf6f9e981fdbcfa6b2ff7fad9f2ad57a8c09387cbbf2",
+                  "sha256:c24b21415b737f18fad7aeb192e60f7d323f7ba69434ecc1e78b3af0003be8dc",
+                  "sha256:c2479eb811f4d9b8624ef20119e1abdc109f639c2cf576eb945b340362d87b05",
+                  "sha256:46606c1ed76a4da2a9d18016aeb50f4dddf58e1b45d665c983c58f8e605bf73e",
+                  "sha256:d87f7fa5e637442eb638bcaafdc44ca3895d91a153015ff9af6a87219f0dc372",
+                  "sha256:71c88f04921ae61a7009f9443f95c70ec3424a798429fc01e6c1432c1077aacb",
+                  "sha256:bf994cb2e5c367d78483662c7de6e69950aaf04bc6cfdbbef4d1ef7ce153717c",
+                  "sha256:b7330d40f75b8ec786e41c45a202e44f0e49ec29ddf8944120fbdb373a6c6617",
+                  "sha256:bb82b10a91493d745dc533b5de5335db650adb0c8a90548fdf5dad13569a16f4",
+                  "sha256:9e2ef90cb484b37232e829ec400dcddd3f9f0d189eb6f0074b3b5874d4553d1c",
+                  "sha256:3ed319e31a9c38e5f4e336195b5cbd253b3f8b17f93f185829f078c5ef420305",
+                  "sha256:5c46bef8c0e95e05716e9a53b77970c1378d93bcb9a800018a24f7e1763b45b9",
+                  "sha256:3edfdbc82f97ec12e59c80c67897fc1eeb44c3d16820f761a8f15272965ea3a1",
+                  "sha256:cdd6594a3bca71d32a5061b85457cc8148611e7f042ba6e812a1c0a2faebac92",
+                  "sha256:56650f8b8f2b01c1090d184d7d6d396f0109f8a02f915c97b081be73ea12df08",
+                  "sha256:946ba273a3a3b6fdf140f3c03112918c0a556a5871c477f5dbbb98600e6ca557",
+                  "sha256:c64632c85c3a49dc82222cdb3d0ee87eafa64f3096ffeba5bcc16c49ee2d260e",
+                  "sha256:15554476d03595246aec194e63ec9db7469d5b3ed81a27a8a2720e82df1f8bf4",
+                  "sha256:3b00ac82c31b447e306fcb47b4469fdc4e6d87385b42358c2e76badb51b074a3",
+                  "sha256:1cfa672c25cb5849bb2aa652e045e4a4a272c025befb1fe5e58cb32823faa30d",
+                  "sha256:2394d6a1ce4de90590e65111d870b172cb9d4e30e1e6f58a334b29e717fdd031",
+                  "sha256:65ecf1e479dc2b2f7f09c2e86d7457043b3470b3eab3c4ee8909b50b0a669fc2",
+                  "sha256:176ffcb2cf0fdcbdd2d8119cbd98eef60a30fdb0fb065a9382d2c95e90c79652",
+                  "sha256:ccfa1810aa19fae08aefd29cffe28b65d5123cd17bd7d2d4207f03cf9795594c",
+                  "sha256:111d88db3a52121f04f2741cc72ce8dda6d6f6ef2cc36452c042e0141b316334",
+                  "sha256:4715730da2b4a5bf6cc2ab85208071f00c7b279e4b2f75df0bd954446185e14c",
+                  "sha256:78c43d8a15ca018de1803e4baac5819e1baab1963fd31f1e44e54e8a573acbfc",
+                  "sha256:5c0957decce3babef9864904be13190b0072aef720e9f4ca820bab6c02a20178",
+                  "sha256:594d8b368013caa4eaba4eade896fc1cec8ef569052bd491f493c193e07c6d80",
+                  "sha256:abc36bf7797a427b64c3c99b4f74714bfa66b906b62358be6fdafe493a66415e",
+                  "sha256:35eb77080d99941b137da8c6cb25305ad4ff64cf2a7ba1f8adbf8d0998b5fe45",
+                  "sha256:405bda98fe97c1a5cf70511ae2d167256b25dd8721b88899465e9847525e2068",
+                  "sha256:3b5d31b89683be71c72b77cfceb59238f4c76a796de6ae85525b3d5cfe2a8f23",
+                  "sha256:6c9dfb73e199975275633f05d31388cd61c5a77dec5678db958b4e6624eb21ba",
+                  "sha256:7f506879c64e0bb4d98782d025f46fb9a07517487ae4cbebbb3985a98f4e2154",
+                  "sha256:003ee19ec5b88de212c3246bdfdb3e97a9910a25a219fd7cf5030b7bc666fea9",
+                  "sha256:ccf848b42acc0f691b4cb6e2830dc4263c7ce4df89b3f4002c3d6b9cd99b362b",
+                  "sha256:c6f27b6e01d80e756408e3c1451e4af00e7d02da0aa24402644c0785118753fe",
+                  "sha256:b19bd4f106ce301ee21c860183cc1c2ef9c09bdf495059bdf16e8d8ccc71bbe8",
+                  "sha256:a04cb3117395b962edc32bf45d8411f240632476b0706b2df7f4a1a87b2ce34b",
+                  "sha256:aa1835fd302a37b84ac256db5dd0de09bd9883a5a07775aedb491faf46b18ee0",
+                  "sha256:0320663709136d07690fe299903700cc1dcc526d574fe8b952a01e1d24024ae4",
+                  "sha256:4fae16ca54207cb952e3904b8eb8cc424f3f056f400e5e802ab1a9ef3e575834",
+                  "sha256:03ba1e86a04d912fd2878b457b06a6a7abad0ce96cd9a6932bf58cb4641b8fb7",
+                  "sha256:4e22015880d16cb7148d70895a2361f4fa05804f0391386e0e50554e6fd868b0",
+                  "sha256:9b1018a43b1a9245cdc71a342b962aa32fb799bd0ce66ee59b496cdd75200de9",
+                  "sha256:8cb953ea9ea1bd262bef00112e2c433583929cd7aec86ae60f1a725c6dcf7c09",
+                  "sha256:dbde46224833f804d8b92212fa3618ea53d0e0cb84ff07132a5ba36c1bc0b9df",
+                  "sha256:561a61d2d81bccb14d22a53b32301e0b6b9e9b9d80ad75991ee6ff796cae0ef7",
+                  "sha256:76df9e0fc779fcd7d3ee836ae254ead30b5f9492022b55901d1f8bd914d38ef6",
+                  "sha256:9e540fe1fcf866ba1e738e012eef5459d34cca30385df73973e6fc7c6eadb55f",
+                  "sha256:e1153055b6ea57ee81e6fb41b03023279059513d0fec728517ae0805186a5118",
+                  "sha256:f97b5915b3f75d2878104c198f205841813712103f1b3657d71d2c8d079cc947",
+                  "sha256:31277c01ac529cc1c6a55fd87d6ce4dbb20290575d4e1e89cd40600eac9f3405",
+                  "sha256:4b00562fa291e956d910bb056c6120f0079f30093ea107757758683a6d418206",
+                  "sha256:8a501b9d8016eee68ce62a93a65842b15c8a57192b9f8189ebc85a11f2f47f9e",
+                  "sha256:3d175382237a94330d72af67ad2c41535dee7eade3e42178b86d2dc87478d030",
+                  "sha256:e95bb05fa5defeb16dd0e0957de676374b22b9daaf405273e636d1ce91001574",
+                  "sha256:3898e2ac4e04e80373bc7fe4092b26d502d4705177719117e25c083d44a9a150",
+                  "sha256:8c26cce4231f781db7b37d51ded377f9cfa01a5e6833d967082795f1220e2860",
+                  "sha256:d46ef49f8ddba1ee8cce6c9764014851cce2dbfb5dcb2457a31495393e6566c1",
+                  "sha256:4164089bf1754c0ef18ae051e047f11299907204839ad4b7978f146a543a2e91",
+                  "sha256:09096bc32e37443417cd625364df32674f9d5ff4ddbeb175e6d60637ed3d573f",
+                  "sha256:44999c555a6e4bb6cf5e6f6a79819e76912d036732cb50efaeefc20a180dd839",
+                  "sha256:ce954d3900cb547aea14df6ad5f310ea96bb5e83a155b93e2e64b2c13b686193",
+                  "sha256:15cd74b4ad9d82417072fe867f086d68667afd4291b710b6c7feef985c492990",
+                  "sha256:480e0f1a9dcce6ed0728e9aba709e33f5522273da1e4b0859cf9d3bbe2216532",
+                  "sha256:cd8b0adfc4d2467a61ab2aa2b3e617bbd2a2592176da249365eef014faef827c",
+                  "sha256:a4577841148e7e2bf481447ae141eff319007e70a24295a22787bbfaecf4c4fe",
+                  "sha256:33a92d88496e8aa410976f073e324f761b2ae02a94c20c0f291072df84f648be",
+                  "sha256:a388c955ace01f09f522c0ccf3afd47e682b22a87756e185f9134bdff72fb2ff",
+                  "sha256:5374ef6981f9a29d08c3400488b010f477fe7722367fcd6d29244ba8bd29b89c",
+                  "sha256:864f5bf99bf805c3e1143f78a78012d2f910f0d5627519b1f263a4d5cc6fa45e",
+                  "sha256:e14ef6f934d9a20645b9eb781902d6a03b7c8123985c88536e06205b240ba509",
+                  "sha256:b5bd11b47b5b690dc667dc486941331d7cd3aaa4f0e5c4d638ec7b294bcc5012",
+                  "sha256:0bad67cd4773d94db37a39c77f44b6eb380febc0de33fa51cacc2140c9c699b9",
+                  "sha256:94e73ee7b1a5e6791a7cdce615f8a7e23fe1e6359b22ee366b71f45a5ef13483",
+                  "sha256:41512b492c3020571b4d8c671160758ec0e4b78212d75808291a5c56224b644b",
+                  "sha256:12fda64dea45a7b085a35a816a7d8035be6600cae38f7df04a3bc22ced4d4502",
+                  "sha256:3c9de6673cb840c3c6925bd1df87da0ef3b118d35dbe8f30bbafd0dfc67a939c",
+                  "sha256:9dc5c484c7821cc737f872973764203376106d643b9adc4ef66bece1b0cc8fdc",
+                  "sha256:0f54422e17766a9e7385a553d941d1849c9e7ca4caea085305ba9fb1e15ae607",
+                  "sha256:b01c567dbd2b9bf82301b254a8962a8fb8f30d12a8f566145eee0f3936f47b5d",
+                  "sha256:b615599db3ac6249e7b18e0c66474e080dc71ee72612bfa0268ea36b1a74e8da",
+                  "sha256:8571a2aa115d42f8b5e87ef58d10e9c24e6fbe5470fc2612df96f8740f3d960f",
+                  "sha256:3973aa7ac4416f1d33ffa8f4e9a5b126e7e2f77ed1ec63a70312b509b4934a9d",
+                  "sha256:9ea4e52636b010504bfff1662c57988feb81cdfe97ba7c092f6efe3abdbe2dd7",
+                  "sha256:ebd64ac5cc7b9f58a40072fe9afefa2fd835e0eb18cdeaf085395c7e84affac3",
+                  "sha256:a2aeabb3962859069a78acc288bc3bffb35485428e162caafec8134f5ce6ca67"
+                ]
+              }
+            },
+            "options": {
+              "gpgkeys": [
+                "-----BEGIN PGP PUBLIC KEY BLOCK-----\nVersion: GnuPG v2.0.22 (GNU/Linux)\n\nmQINBFzMWxkBEADHrskpBgN9OphmhRkc7P/YrsAGSvvl7kfu+e9KAaU6f5MeAVyn\nrIoM43syyGkgFyWgjZM8/rur7EMPY2yt+2q/1ZfLVCRn9856JqTIq0XRpDUe4nKQ\n8BlA7wDVZoSDxUZkSuTIyExbDf0cpw89Tcf62Mxmi8jh74vRlPy1PgjWL5494b3X\n5fxDidH4bqPZyxTBqPrUFuo+EfUVEqiGF94Ppq6ZUvrBGOVo1V1+Ifm9CGEK597c\naevcGc1RFlgxIgN84UpuDjPR9/zSndwJ7XsXYvZ6HXcKGagRKsfYDWGPkA5cOL/e\nf+yObOnC43yPUvpggQ4KaNJ6+SMTZOKikM8yciyBwLqwrjo8FlJgkv8Vfag/2UR7\nJINbyqHHoLUhQ2m6HXSwK4YjtwidF9EUkaBZWrrskYR3IRZLXlWqeOi/+ezYOW0m\nvufrkcvsh+TKlVVnuwmEPjJ8mwUSpsLdfPJo1DHsd8FS03SCKPaXFdD7ePfEjiYk\nnHpQaKE01aWVSLUiygn7F7rYemGqV9Vt7tBw5pz0vqSC72a5E3zFzIIuHx6aANry\nGat3aqU3qtBXOrA/dPkX9cWE+UR5wo/A2UdKJZLlGhM2WRJ3ltmGT48V9CeS6N9Y\nm4CKdzvg7EWjlTlFrd/8WJ2KoqOE9leDPeXRPncubJfJ6LLIHyG09h9kKQARAQAB\ntDpDZW50T1MgKENlbnRPUyBPZmZpY2lhbCBTaWduaW5nIEtleSkgPHNlY3VyaXR5\nQGNlbnRvcy5vcmc+iQI3BBMBAgAhBQJczFsZAhsDBgsJCAcDAgYVCAIJCgsDFgIB\nAh4BAheAAAoJEAW1VbOEg8ZdjOsP/2ygSxH9jqffOU9SKyJDlraL2gIutqZ3B8pl\nGy/Qnb9QD1EJVb4ZxOEhcY2W9VJfIpnf3yBuAto7zvKe/G1nxH4Bt6WTJQCkUjcs\nN3qPWsx1VslsAEz7bXGiHym6Ay4xF28bQ9XYIokIQXd0T2rD3/lNGxNtORZ2bKjD\nvOzYzvh2idUIY1DgGWJ11gtHFIA9CvHcW+SMPEhkcKZJAO51ayFBqTSSpiorVwTq\na0cB+cgmCQOI4/MY+kIvzoexfG7xhkUqe0wxmph9RQQxlTbNQDCdaxSgwbF2T+gw\nbyaDvkS4xtR6Soj7BKjKAmcnf5fn4C5Or0KLUqMzBtDMbfQQihn62iZJN6ZZ/4dg\nq4HTqyVpyuzMXsFpJ9L/FqH2DJ4exGGpBv00ba/Zauy7GsqOc5PnNBsYaHCply0X\n407DRx51t9YwYI/ttValuehq9+gRJpOTTKp6AjZn/a5Yt3h6jDgpNfM/EyLFIY9z\nV6CXqQQ/8JRvaik/JsGCf+eeLZOw4koIjZGEAg04iuyNTjhx0e/QHEVcYAqNLhXG\nrCTTbCn3NSUO9qxEXC+K/1m1kaXoCGA0UWlVGZ1JSifbbMx0yxq/brpEZPUYm+32\no8XfbocBWljFUJ+6aljTvZ3LQLKTSPW7TFO+GXycAOmCGhlXh2tlc6iTc41PACqy\nyy+mHmSv\n=kkH7\n-----END PGP PUBLIC KEY BLOCK-----\n",
+                "-----BEGIN PGP PUBLIC KEY BLOCK-----\nVersion: GnuPG v2.0.22 (GNU/Linux)\n\nmQINBFzMWxkBEADHrskpBgN9OphmhRkc7P/YrsAGSvvl7kfu+e9KAaU6f5MeAVyn\nrIoM43syyGkgFyWgjZM8/rur7EMPY2yt+2q/1ZfLVCRn9856JqTIq0XRpDUe4nKQ\n8BlA7wDVZoSDxUZkSuTIyExbDf0cpw89Tcf62Mxmi8jh74vRlPy1PgjWL5494b3X\n5fxDidH4bqPZyxTBqPrUFuo+EfUVEqiGF94Ppq6ZUvrBGOVo1V1+Ifm9CGEK597c\naevcGc1RFlgxIgN84UpuDjPR9/zSndwJ7XsXYvZ6HXcKGagRKsfYDWGPkA5cOL/e\nf+yObOnC43yPUvpggQ4KaNJ6+SMTZOKikM8yciyBwLqwrjo8FlJgkv8Vfag/2UR7\nJINbyqHHoLUhQ2m6HXSwK4YjtwidF9EUkaBZWrrskYR3IRZLXlWqeOi/+ezYOW0m\nvufrkcvsh+TKlVVnuwmEPjJ8mwUSpsLdfPJo1DHsd8FS03SCKPaXFdD7ePfEjiYk\nnHpQaKE01aWVSLUiygn7F7rYemGqV9Vt7tBw5pz0vqSC72a5E3zFzIIuHx6aANry\nGat3aqU3qtBXOrA/dPkX9cWE+UR5wo/A2UdKJZLlGhM2WRJ3ltmGT48V9CeS6N9Y\nm4CKdzvg7EWjlTlFrd/8WJ2KoqOE9leDPeXRPncubJfJ6LLIHyG09h9kKQARAQAB\ntDpDZW50T1MgKENlbnRPUyBPZmZpY2lhbCBTaWduaW5nIEtleSkgPHNlY3VyaXR5\nQGNlbnRvcy5vcmc+iQI3BBMBAgAhBQJczFsZAhsDBgsJCAcDAgYVCAIJCgsDFgIB\nAh4BAheAAAoJEAW1VbOEg8ZdjOsP/2ygSxH9jqffOU9SKyJDlraL2gIutqZ3B8pl\nGy/Qnb9QD1EJVb4ZxOEhcY2W9VJfIpnf3yBuAto7zvKe/G1nxH4Bt6WTJQCkUjcs\nN3qPWsx1VslsAEz7bXGiHym6Ay4xF28bQ9XYIokIQXd0T2rD3/lNGxNtORZ2bKjD\nvOzYzvh2idUIY1DgGWJ11gtHFIA9CvHcW+SMPEhkcKZJAO51ayFBqTSSpiorVwTq\na0cB+cgmCQOI4/MY+kIvzoexfG7xhkUqe0wxmph9RQQxlTbNQDCdaxSgwbF2T+gw\nbyaDvkS4xtR6Soj7BKjKAmcnf5fn4C5Or0KLUqMzBtDMbfQQihn62iZJN6ZZ/4dg\nq4HTqyVpyuzMXsFpJ9L/FqH2DJ4exGGpBv00ba/Zauy7GsqOc5PnNBsYaHCply0X\n407DRx51t9YwYI/ttValuehq9+gRJpOTTKp6AjZn/a5Yt3h6jDgpNfM/EyLFIY9z\nV6CXqQQ/8JRvaik/JsGCf+eeLZOw4koIjZGEAg04iuyNTjhx0e/QHEVcYAqNLhXG\nrCTTbCn3NSUO9qxEXC+K/1m1kaXoCGA0UWlVGZ1JSifbbMx0yxq/brpEZPUYm+32\no8XfbocBWljFUJ+6aljTvZ3LQLKTSPW7TFO+GXycAOmCGhlXh2tlc6iTc41PACqy\nyy+mHmSv\n=kkH7\n-----END PGP PUBLIC KEY BLOCK-----\n"
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.selinux",
+            "options": {
+              "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts",
+              "labels": {
+                "/usr/bin/cp": "system_u:object_r:install_exec_t:s0",
+                "/usr/bin/tar": "system_u:object_r:install_exec_t:s0"
+              }
+            }
+          }
+        ]
+      },
+      {
+        "name": "os",
+        "build": "name:build",
+        "stages": [
+          {
+            "type": "org.osbuild.rpm",
+            "inputs": {
+              "packages": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  "sha256:a6ef8e56d53c29e92b46a7ad62c22380056153b2d5810c39c0cc1658a4250d5b",
+                  "sha256:d3ad718b08b44e1fca355abd46a6c315a9d73ab38f9f3c3d551642b55866e182",
+                  "sha256:3ed20aba45a8c175e818de998d906fb2759387c607bd9b15dbbefee8c73097ba",
+                  "sha256:5f068787bd9a0190b03e64cd770e44ace593c5aa09e3f4c470c44d8d484b4674",
+                  "sha256:2c1baefd0f802507d9741da8da54f6eae42b04967f9d433d7f9e0f124434c70d",
+                  "sha256:42829311fe40b7487530ee432aeb8e1df86e5168373f038cccb60d0db94601d3",
+                  "sha256:be49b69bc5de947ee2151f397993a691a57bc53952058c32cde0fca674da7d8c",
+                  "sha256:f14cc62cf70a187384adff6bedf8b09858b8f441a9be87ebf3ae975c4e6b0d73",
+                  "sha256:4966b1832e9eccd8f83ecc20143fb6f18215107bdecd7267b4605cdae4a6562a",
+                  "sha256:48226934763e4c412c1eb65df314e6879720b4b1ebcb3d07c126c9526639cb68",
+                  "sha256:3a438b53e8377eccf90cac0fd42ed2b513fc869bfb7b96e3d2a4f6984a287f90",
+                  "sha256:c12c7dc6676c6ccc5ca08ceddfb1b4e46c9f1ed49cbc241292ae6d1fdb0d9d62",
+                  "sha256:297b8a7b336dfc298d86d76d400459d2fa63af8628f5e19e35314a33a6478234",
+                  "sha256:8729b157f0925feccdaef8aacd91c6aebe0109e621675bcc15e1830673b0e19d",
+                  "sha256:06c8c530fb914e07375c183f13b8431456377cec33376423f6589d1047277587",
+                  "sha256:56c3d429ea949467dc0bca882646cf40a58fb6f27750f5664ff2919f5d38ada5",
+                  "sha256:1f2a096d6a75662a86a06ff2859e6ba916bbc8c6d8cb7b73810ffbb9fef4b089",
+                  "sha256:1fad1d1f8b56e6967863aeb60f5fa3615e6a35b0f6532d8a23066e6823b50860",
+                  "sha256:842ff55b80ac9a5c3357bf52646a5761a4c4786bb3e64b56d8fa5d8fe34ef8bb",
+                  "sha256:15b17b95cf9cb9fb64e0c8e56110836bdcaf70de81b8cbdb60e181fc90456e06",
+                  "sha256:a82958266d292f4725fc1981ea57a861b7fc7feeb7a9551d0b61b98ca51a5662",
+                  "sha256:38fe7db64baf2d4804a14466a6244f3c1de3bd5deca0ad4044e96d0d3f3751c7",
+                  "sha256:eee92733e8989029929d5cb1f673b15fdb814dac32e148d5bc02378b44c8699a",
+                  "sha256:24fcc5bc49b059b221075989f25875fb821079088dca694aec262446cde50cb7",
+                  "sha256:dbc730cf810cc886667a7a9b17883ba15bc40e933a38dd820f2f026cf8007805",
+                  "sha256:3818fe6ec4996402b718827ba40ca01cc3c8276646d80030b652a26153aea2b7",
+                  "sha256:ec85355744a8b37aa7fbe48d6f8afd8d0538129b70e82d238c3b57ae08559430",
+                  "sha256:ff8b51c6a8bacc5ef6b5da0f049d170ab1c1ecebad50ded3c04ed384eca9a2c0",
+                  "sha256:383a5e6bb9e94de53baaf5c7493cd50a68c893c6a30acfbe28407d33bb133efc",
+                  "sha256:19061d12407c0c4bca6abcaef01695b70dcd3967ff102dd07178a2193a280e29",
+                  "sha256:4e3e93a3d2039c2a8305030b7960bd1100d7d20705a1afb1325a4ee79478a74a",
+                  "sha256:084d79ed3d7127e6d46e9ac6e654d8ef181a156435808dc8eb32968b6c1b4946",
+                  "sha256:edf00207b603cbfe86b07f8be5c4ee14ff1dd85ec4b7d82d760483ffcea43891",
+                  "sha256:6faee589c5a7454502e5ec07586a4856e7f1376bd551741af2acf03afb9716e6",
+                  "sha256:bcf25aae89f7368b16346bc1ec92850175bcc2312bf7a5e74bc3c512bcd345b0",
+                  "sha256:2a8f9e5119a034801904185dcbf1bc29db67e9e9b0cf5893615722d7bb33099c",
+                  "sha256:67f37cee02ba744dfc7957725f5ef9df229778f6a2f7afc659625b458da6167e",
+                  "sha256:b10d8521963a2494fdb2b5f8fb0de837dc86d4016c3b10019fb8970a09582451",
+                  "sha256:47ad43730c8bc72c90f2fb3dbd3526d716ada2fad94e62cb443658e94c6503c5",
+                  "sha256:5c1940e1f173e22b053f3a89022903cea34a6af20dff81c65548c4e2ba3a8293",
+                  "sha256:1a4e44583a767289bb0d354db93c6a9132420e13376d4fcae866d69620bb11bb",
+                  "sha256:7baac88adafdc5958fb818c7685d3c6548f6e2e585e4435ceee4a168edc3597e",
+                  "sha256:090563f18409c228274bb61dcf1001f63a55c1246fb2838a998cb3c5fd8c3874",
+                  "sha256:c58b0b900a7ffc778980461d74dc236bf2c790d2e5e8c04e28876e221b48a1c8",
+                  "sha256:cc5f8dd4e061da3a73aa67112e24f2cc5c0ad0cd4334dc798b8834cf6259a779",
+                  "sha256:698e8ecaf71719dafacae79de05080d567b69fad3511e8b8d42b9af96a7c41db",
+                  "sha256:dd80a8169e27959a27651616e998be8b49ffdca141744177cb42126ff0ae12b5",
+                  "sha256:a8a27e1ffbb92356d6376334687b9eaa0cb5f2eece2670128f3a01e391e9f3bb",
+                  "sha256:441b3862f5a0fd504bbbba18d96d1b2b920fb95a79dc45a753a6a664ad285b07",
+                  "sha256:a42de8ce71380b1f4e8ac5b4ce720bf565c99a0b09ef983c0550a91a467bc155",
+                  "sha256:ca5d70414653e1b769124582699bc2400f05b5382a9a8dc6bb4ab4f28dac9c20",
+                  "sha256:d64da85b0e013679fb06eeadad74465d9556d7ad21e97beb1b5f61fb0658cd10",
+                  "sha256:ed40678aa26d63b71a122bd394b46b362df083c8f4ae3267f205a7d77ff69fdf",
+                  "sha256:4f92835a6e4ee4276df49019e068d1871b75821f52b405c699bd9f199df58b80",
+                  "sha256:42464424b9fa731f8122fe748aad0005519fc87b770dbbdb71f29f514ea0e889",
+                  "sha256:45c48d32120739734ae97479cc0f3ca19796ea47e360ba39d52b77ce3ada61d7",
+                  "sha256:47b61754a278c4ca378871c874ccf6a0a07bffaef38505315cfa94f262887845",
+                  "sha256:04eee0a9c079186aa58b5536ac8bcbd2a360700b83fa7b9f6eb127c1386b7ef4",
+                  "sha256:881b28a3a37d114bc3f046605b24663560009b13a507217e007643f5682efdd5",
+                  "sha256:71d45853b0a8673e6354892df7a420ad77200a018ee5334b30b893862d030fa9",
+                  "sha256:2588ff56ab340c06ce8b5be22cbe23de89d4f336b38ae930daf11db1c6a24391",
+                  "sha256:412f3eaa5f7e226fdc4678a3266edab76d8998f7d76763075f690a01362ef89c",
+                  "sha256:9e67ac5948125dd165c9a74ec848d48b313ef4264bbbb89630a782dbd972d72c",
+                  "sha256:9fb07c2324cccbbc19e3ffade50ee7da41909b2f6c24f49ffd9978ba375de193",
+                  "sha256:f4eca686b314edb06d3fe1c526f573c7248c811af70cba76132cdc9c541cadc1",
+                  "sha256:30ceeb5a6cadaeccdbde088bfb52ba88190fa530c11f4a2aafd62b4b4ad6b404",
+                  "sha256:e87acf226a9511b3a5f83e7fed9c5c20addbbdae47ab67c614404a9392b77e50",
+                  "sha256:d150e53fa73c3786da9e4f6e23d374100b0dd2923485d4a08e9a56ac2786cf83",
+                  "sha256:e8b7968fe6613c4cd6324436089cc9c1558cd63fb7da87fd46cc7c15c4ab7f66",
+                  "sha256:88be5116908aa5013f540c767f6811774342780bb72d3ec197b3429bfb2f9862",
+                  "sha256:e156e6fa9ef6a483f8505ce0eeadbcab12b887c4996233ce5d6258076f6bce50",
+                  "sha256:e65f7d7c8def6b168e013914bc0d1137aed65c3010e9796df3b823854472f3e1",
+                  "sha256:a49b922f117b9bfb0b07e9848151f8a2948345328ebc534cd28ac187d7ed3f94",
+                  "sha256:caa0bd6617a8d5e535faedec5f6f3ea7c5e6da1898751f6c9c34a89a95c286ff",
+                  "sha256:e403c9839742c4b13e715541237f79ffe52870d59867bebd39e19e7080948db1",
+                  "sha256:700b9050aa490b5eca6d1f8630cbebceb122fce11c370689b5ccb37f5a43ee2f",
+                  "sha256:d1cf2d973db2f1af46f124776b9ab4bd782e7065c8c8428a4ddef60989e4225d",
+                  "sha256:4992eb036c0797daf9b984af1a34fe27a30287ee5d2bd5e2f5a0df3a09bdbb59",
+                  "sha256:d807e7fb8bf24be50642a6dced954c6ea208199daab2d27c9f73d789ba82fa37",
+                  "sha256:8cd6ef9902851f07cfd9682e2d6873648690f0c2ec65345276b557ede042d8b9",
+                  "sha256:d1d362fd4f8022ad05171efe40e84d15ec6c5e5f419d6099ebc8e46e7da632c1",
+                  "sha256:4fc1c84b4434df8a5ccd960d906896e4094236f43ad4aea083a12fb5b8a824f9",
+                  "sha256:78fd472a1c7f49b8a432788ea2dfc1119f155a394f41585b4e715d2585fc92ab",
+                  "sha256:e392a6b41381ffad04626d092fd2af9477c72e197a74efddf987832c3bfa521f",
+                  "sha256:4942002f6e3a471b8d51801047ea2584d5cd1dad5d4c4e44bce7af50c5b7cb14",
+                  "sha256:ad338b7a3f3bed96300d9ce7f0307e09d758962b8496c10fb3554bf62405d153",
+                  "sha256:bfb45644212cfbbe48b05149f8d53e77d7bd02ca9fc9045cc37115101175a3a0",
+                  "sha256:fa7bef727ba8657208bb3df95916f0bc912332cb8534c695facef32ffbd72f20",
+                  "sha256:257e086bb52086254fa8cc95a5c4998668b4fcb5203ad3c2275c1150816acc9b",
+                  "sha256:af0a4287e302baa7c85655ddfe5a7049b8eaf31aff03886f4fc57c920d26d491",
+                  "sha256:11ff811a72c82084c7c14700b23d29643e153442a34b3b486e270e5b40e38d0a",
+                  "sha256:a2d96efed83ab31d21481af044835a940673ee4ade2763af78c06d2df87b94f7",
+                  "sha256:51760acfb6ca87db5be7a9296d6a3d1220767956c576a26c6d46784e25db85bb",
+                  "sha256:754bf53a39cea727d9d89d59df32e020842dc71f6a0561ea36f8203aff2d5d69",
+                  "sha256:24f5cd46a7395cd046b10d6ddc4de435ec6595d0dcdb2d179c94cc9082a12f14",
+                  "sha256:2451a475f248a4c66e64d149fefa8bfc195fcd7b3f369bae221a94f8ce4c2d67",
+                  "sha256:cff4b4ac50fed2ceab6add52a66513ed9ca04b024f07a25c53df49f762eea2d2",
+                  "sha256:4a08d5264e865548e65d31886c91b659b33a2c2ba39fd115b00af3ea0bc91a83",
+                  "sha256:7cccedcc359f2a2542858088704bf3d0ec3e46cb7b72f602408fbab937a522d3",
+                  "sha256:d8dad22276baffe9496d5e05ef35d21dd6f9d8f910339daced2c3ff42d7a28c5",
+                  "sha256:78b2b9cbf041d4461daf7ac11a24d1e79a9c57f47aa265dba4d09067efe3d96b",
+                  "sha256:ac3b306c193bd20658950da402ae0cbdd8337110117de5e5d7eba970822671fd",
+                  "sha256:fb276cc0ebc6bd27d344f7e0811f26cb3f0e59da09182489095724bdf2a075f8",
+                  "sha256:5a0927d231fbafa8b865591922fc07d39d9b4b263a1e9c0bbef691282f706cd0",
+                  "sha256:7cced5f47c4035e01fffce0989b62113a75016e5220e7b207c4b96be7ed90403",
+                  "sha256:ffb6d471f5c82b0407cc41a25aea25bf83d6779b3ef20f0557c4fd0da6111bb7",
+                  "sha256:e1e28504928648404a3b652440091eba010cd99221183ef78601cbd152261d91",
+                  "sha256:42bb566be1936bdb40937f9c0a96c4acc93057379385f1807cba18f60443d3e4",
+                  "sha256:8c05fe038c7792203afa47f4534318f6c674672999b444909706ce0826bf1b8f",
+                  "sha256:a571c94456b9a1743e94f4f72159de52bb13fe93437b81da675351553a881a17",
+                  "sha256:dfecfa1299d11d6a77503e626a2e9a14e1a75666bc8ea2abaf7ff515d2c86332",
+                  "sha256:8119d276749b35cd9c283c1a8d970b3528bea58427eb37eafc22b6093a978f08",
+                  "sha256:6d1ac29b3a38408f6d238d6718384e05be7346789c6200b354335b0e0c9c77df",
+                  "sha256:d751a4fdecc0dc3c5ff897e3ff4c25e7addc698d590e2bfc4c893e693be7d558",
+                  "sha256:5418cf17fad308fe9a8d3acdf4ae10f433da50c32f10ae4089be2f8423dea4cf",
+                  "sha256:12b0565d080311c7804d8fb1d697ecdef8807563ebeee4443e2fa6d35b1d958f",
+                  "sha256:6d02615212a88eb204b8f6d2a7cfbf6183a12f29d72ca5dbfbe5c45c63068ef8",
+                  "sha256:cbe98d6dcf93449d9c2fbf95de75f065f8da67a23f13401c672d78b28c6b7f6a",
+                  "sha256:965ec1b760513e1ae539747624bd241d6575675e8a04c5caa572faadb54007c7",
+                  "sha256:331b91a0928c05618c7fed3e12bbe9ecb9e4619d08c7e85d3de344a08d2f0f1a",
+                  "sha256:36c05d62567b455f2722c6e5cf431071174adf4c1d3b7450f0c1aaa903210bc3",
+                  "sha256:49c7c718cb4e2b6f0effd0dec4f4cb4e109d260c192b2b329a58a1da9a24ad1d",
+                  "sha256:a3ef96219165bfc64d4f5d50f51fbd43e803c500619240ffe4db1f9f8e337f83",
+                  "sha256:ef86061338fa321c959cadc75ecbdfd405eebaa1042eec9d9c737d4d9d92568f",
+                  "sha256:7bb5051dee5f6633a02cf5a3285dd86890cc6521e497526a8149dc5c5ebad062",
+                  "sha256:4aca3cee9de1a4cd7ac56a12550f286894a215cac593c18857278f7b0e48f328",
+                  "sha256:1d6551bce8f8a1e53682fafe4f67fa830c333f0b37db7acbeaca0095b5ce870b",
+                  "sha256:e45848a3fbfa1d46709448593fa7929fee4c5a83d2168c0d41d498251e4b5dae",
+                  "sha256:83cb349e65d5b783518b735d8fb477264f0a6bd7cdd6f4096f8493dbd45f2ff7",
+                  "sha256:30dd1d58b7b963d052341f4583a7417823cf4dbbe7ac4b536f3a5250c4d34582",
+                  "sha256:588874c2fc18a927a479aac7affef52f52d09e5b20102dfab70836d420ae553e",
+                  "sha256:6fe1188081e441595ce29ebed4d1985e5890815158244f69f092ee930656f755",
+                  "sha256:a80c1d6d32db7ce8fdd58bb4f3f488b74e94261a38512dc8a15179ae33697e63",
+                  "sha256:b437a08d4670ef440ba6dbaae4ccb39f989f0c2a3d280ea66d6fd9532a313286",
+                  "sha256:230731b577f8d29e7e8e8fd6d1ea02702fb4364fcc7034d838ccddc4d66da8c3",
+                  "sha256:54f59ddb56e89a5330373e07ea05934fc58360eb7480615ede2a3ed6982e1eef",
+                  "sha256:427eba707b42761a0ef57107ba5a22f80fc6379d1537c757fe1929d6d066b05c",
+                  "sha256:ff1580bd4ec5841d4937b383917fa30f318b4f419b8067a77468eb4a9630ba10",
+                  "sha256:e778fc7e5d62fe488e250a1916cdb7f692e98e23d0c2b4264672b2574ff416e5",
+                  "sha256:df40cada982b04336fe8b250b4fdd576ddd03a014bb519a69b34640369bef661",
+                  "sha256:9c4cd61b98253904436180f58c564bda61be1fa1b5523e4ecbbdc174d0c2a9aa",
+                  "sha256:43bfc890caf7855f2fb55c24474b58cd5c8c7b51e4db4f40d1f302fffd31985b",
+                  "sha256:2f6c73fdcd5c5e5b6d8b58663e498a0099db8029386869a4aca670471f6c298e",
+                  "sha256:30ae4489980021a727f247d48b4d74d4c6c7667d00bd1a670f045ea24a885541",
+                  "sha256:4a8899d3b91a0f847ce793480700b26dc8336c5ee20d9b66067c76fe0dab2f17",
+                  "sha256:77e4cfbc823e3764308822ccf03b257861f9360f3b948829f1d73148b321b00e",
+                  "sha256:9b69a221cf9395a110849bb428bb1cfe9fb489322df0fa6017f5978a827ee0e9",
+                  "sha256:360be5b93e106d77a8f4e84b318ee8dc14349f223540e0e200e0dfce2676ec04",
+                  "sha256:e0a7b9f3b56b4737f5711dc6b03f256fbf2488656b8874acabb494b58ba0c1c1",
+                  "sha256:5c74a0e3005ea3cb90dff80cfa1e7d64c97f5c01612d253cf4e65aca962b7be4",
+                  "sha256:194dbe332ccdb33d58f040da07667257e176975f6b2f17343bbf33fb99deb097",
+                  "sha256:e21a84107568047432e474e08da24aea2340409d57ea8cf170182927dc76de12",
+                  "sha256:f7a2eddcda47cb75108add34c0ce919ceb847605830ad33aeb4bd64d6bed24f3",
+                  "sha256:b83a0199c3d471151f07f6de626a1a4a362dd6aa29d84cf1c0ada2c966ce29c9",
+                  "sha256:709ea71f36495ac2ac89d72d2eb603b6aa55b2c1a70633f23514dd897936f02b",
+                  "sha256:6ac918d2bc175b3f356926ca96a998c29bffe256f7d802e8ef654b1226da3ef6",
+                  "sha256:aea253461d1a34a239b445ee07cb34398a9cbb6ed40e252182a91cddcf59004b",
+                  "sha256:cc662127a17d4e08e90f75703f376067eed48f5d6b5b8d106fa3824397f1978e",
+                  "sha256:a0b8a6b2c8dad75290228086dd0af342979604bbf4b9500029e25d766835c0f4",
+                  "sha256:0afac6f4f9ed1c59510675d87da45c7966c0f7aae6e8dd056961aceed8c4fe0a",
+                  "sha256:12696f5638ad2068c5c8940495d15c3bb1c57990000dbda7428b008e9e63ab5b",
+                  "sha256:f3d9ccb762146dc97f2d201d979fbb0e9171d1203fb985f3ef48b5c2a176c2a9",
+                  "sha256:c5a60ffb80cd1f9b90c797f1d1ac80e5536eb32a5b276871445e7279ac701c5f",
+                  "sha256:0515afdac097ad54cf4b24e0644f0789cab5535a54107aa44940ffd991a6cef3",
+                  "sha256:020abac486839c7be29fae37a686dc7749398c333cb8ba94b3390b386ffcbff7",
+                  "sha256:8ab06f608f45445bdef489cedb40d419aa7282e127ee26dbfcf417350a3f1630",
+                  "sha256:31d924d1540dd4e927a4c3aa936cec4bfb54ed302d3e8acc1be8b52dd5deb10c",
+                  "sha256:1b95698d64dd299827f62cbe43d373e985da2d8900c4489a49475f53fa04f414",
+                  "sha256:fd6e1803ff367036da5b52b2183e1408691b379cc1320971bb664737507f89a4",
+                  "sha256:6b312faed4a0508da2f15d3f31a6daccfc0ec6621e5fb7b20956027dce5fa395",
+                  "sha256:a5f9f2c4f39f393971f268aebb1b55d18d0d96693d08a9ed70403e8565807bb6",
+                  "sha256:a0a8e31422da7d695a3788a7cae3f929d42cb4982889422588904ecc6879182e",
+                  "sha256:59008e3619cae0f40e183b7003e722cb312b00bdba775ec9f06cdd833b53c26a",
+                  "sha256:d7bacff8f9be89871c6ec98c3356de11008ae574da852bdc15cee7ebb9ac39be",
+                  "sha256:d6eb27d158b6397e52ab6a952fec4e3c414638a08750a6c011d32eb117accd82",
+                  "sha256:4e497225fe36781735cc92c0886f6858b19d4557ed9ecafe1247b8233c206075",
+                  "sha256:2812ae39c665069f4b27e9bd26dde9141d4f4e7802befb1b14ac4e27a8225b4b",
+                  "sha256:07fb48b313f6d4c1c8b1ffd9c5226c68f99616e46bbd04b325527d817b500577",
+                  "sha256:d3a4f367a9c5ba936b1bb5480db390889a303e5ec8ff34bb4274c1d840a1784d",
+                  "sha256:caabc61e9aa83275f9d2fefcfda56fddf19e7031bcf9f9b84f858bb1f040e24c",
+                  "sha256:35bd989d63522f9699b1a90dd453f866818cc3d247096a910a27fd7e49b09ac2",
+                  "sha256:8d7777da3f54f965cf3058cabf987c01b93a1dd041e8359eb7822eba57d8c8df",
+                  "sha256:fb6e437a24450106c03f25dc1c3f6b78549b82c2d0bd4387dce1350ca3c5f1f5",
+                  "sha256:61ba252d7ee5d955b929f6d7d39d65d25c62e3d3cfc65ee6cf55c764b1c64a90",
+                  "sha256:7adc584a7d43968d22706da5ffa127020536375f82beea5ef677cab39c5f64c5",
+                  "sha256:b58be8f7685340b35e61945b1ab499bc1030b0b021b2ac5576897cf079ff7812",
+                  "sha256:6051967b12b097d0027dc1a1aac68448c1bea901fd76c6ea0d43450f24605252",
+                  "sha256:9b8a8a843fe9a972f6433e11b95b5a8d1d2971ed40fe1acda6807e34f0773c62",
+                  "sha256:1aa321c66a3661e78d938b805e5c311d519f04bf3496545ffdacc7c152bc9b21",
+                  "sha256:419f9c08de110eee9b2ff0a61e9aa1bbb56939f9239739c17a753a0d9210d10f",
+                  "sha256:3dfffdadfb10def9a3671a255e4fa71d8b22231ccf2c929e96689101dda8ce2c",
+                  "sha256:c5c61536e768553067cee488830c64866d109cade24917dbe23f82c861af07c5",
+                  "sha256:98c28a91d41f634edb8c1f001dbc45c0de534332d059a2e8feff448fb7235c49",
+                  "sha256:b4a1ac1ff5cd22a5dab6c96dfc2dbd7cd6ba750691ad5c53a97a1f088fc42abc",
+                  "sha256:01b0562b890a80c202fff9175dc845500660c7f1655292d4ee13ca667acab081",
+                  "sha256:56c866bcff69fd60b630841ff990296b26c2f45d8c6054311b5c476bc67466ac",
+                  "sha256:4fe264ed1cfd0c074f4601354b0128a9e5068f0fcde7382fd5429585f0d4cd2c",
+                  "sha256:95103f7c339aec4b485b7f569aa8a5e1a54286b3d2acde427328c49e4d8d80d1",
+                  "sha256:adc56041458e556df5663e7da264e151c24aaf1c2a94e49df9790ba191ea1b37",
+                  "sha256:2669ab8439093418c6c437c1f2e931d4152f5ac371e5a0f2d20b18455483c3a1",
+                  "sha256:0f57b051654b6d75789b437dafd7040b6c90daee17827be24352c0f11a74bba7",
+                  "sha256:1b5136570cefb8273dd5affc73c1456cf239cc8b18be72d6c4d09794af7f3352",
+                  "sha256:679724b45157b4d4c9ebe2eb32e188b9a65d47c23be886498d7a178caaf113bb",
+                  "sha256:1649f9d356cda961dd08dafa92475557ac398da9a657ee019de0c1f2c0593c8a",
+                  "sha256:767dd64d91c23adda537c7759ae3b4f720d3c76e03b52bc9231e52e0113db3ab",
+                  "sha256:2dbfe3cb37c18b39393870baa77f3bbd42be53517abffdd990b13ed70ee3dd3e",
+                  "sha256:f5bcb82a732c02d6f31bbf156887049883c76cedc9c6a11b049358a74f4d45d0",
+                  "sha256:2d1655f040141384ec8760e4a47e0455ce518989f7bb1a830ab9534bfb38a78a",
+                  "sha256:d3e95ed161acd1ba957b1864e7ca2102d9c39380bbdd56eddebf11d5219b3a04",
+                  "sha256:572bec3deb2f8ae7a6ad46976738c2630023eec1d9bd13ab1ccca7b54256daee",
+                  "sha256:466601cf2b7bebf49a6a8e936b32dffc844c9ed4cd82961d008d17cfccc596e8",
+                  "sha256:70fe40ffb2fb3eb2c3626afbfdb200a2429e000c2fbb172886c23b1908000501",
+                  "sha256:32ebba6472cdc331bd3366ca996ad3039b3a1b41c61a849b88074e1b722cad2c",
+                  "sha256:cd603035aa26b9d12e6b23680e3f1a908341fd9f2086eb540834aee45b4c8604",
+                  "sha256:4fb1b85fe3712a292f8dd8f1d65805607485dbf97307cf146bbc6e0293a7c725",
+                  "sha256:5f76a72e58cd374ec83e26f42778adb3b90aacd091527a34c8a347089034d398",
+                  "sha256:75e9ed16ace51ba04a62505aaed215bf9c722d6f4b1c33cc3e3962076c300ee8",
+                  "sha256:c3c1c42a41ab18dc09214bcd3a567bb7ba9b9c2191a6e1079b9770dfe2d3a338",
+                  "sha256:60eb345663d2f6ec4b5c304cd21685dc7148d34739477136d96ab6bc131d9c4d",
+                  "sha256:7962bed04e961194d64769b4b7d5c85836808361c606e943b013098fe53df782",
+                  "sha256:d539404dafd8ad5d785ab3da6f8bd5a2bf5dff9e01be0ff1bc1d251786dda25c",
+                  "sha256:bff39fef1fc01564156123fcade75b4bc50402a2971a031d9a426c7014b1e681",
+                  "sha256:6b9875495111bcd2d3c5e9e380b3be17fb0a730891468fb45bdba3b3692b00ea",
+                  "sha256:b29c8cb61ef138fdf00a458f0646cf9390e0f39783f02f6b81a956585dc6b302",
+                  "sha256:e217c2687212d931ad9a6a02afb20cc34f6d051786d136e337f91079c9f73d22",
+                  "sha256:c1291b69a65a860069195a33cf6640df8667e960f9f030ceeea4497c47858b94",
+                  "sha256:d8c00baf46e33f9e5f1b9e139bbea9fe0f27badb432c992b9cf8c4f7017094bf",
+                  "sha256:d909f0e1b6ddb29ad2d3da21208077e3c976212e07471114745859f70be9738d",
+                  "sha256:62ac185c4d6d242b187022c8376469073c211e8deca2a7b2badf1d775e2fd5a3",
+                  "sha256:1a968f65db066243cbd0a6e12d193ef674637f044299a15b5d6b910e91411812",
+                  "sha256:4a167fa4a7238bd94b3134173f6267b19cdebc2fde98b583344749e1f4c9bf09",
+                  "sha256:8904fdb492f34e5242ba483fb6b7b158342662575b3d5ac9abbc380568840d4a",
+                  "sha256:6bfc201a12dc7bba21069a663aa692a96c5e8920b0d94a4e355c332d7ead15ba",
+                  "sha256:7aeb44195a1c984aff87cf8429d2aa40f6947b0a47d3603e1ca5c3cf8d284459",
+                  "sha256:f6cd5ed6305952c1cd842fbca0e5d9613f736646cfac2082a2db37f5d065468c",
+                  "sha256:791acd72bc40be9ba5fa6b77d78def5da623544408b72baa4c81181c03a205cb",
+                  "sha256:906bffa419bdb1a6d3094d7a6f2308527f5ece250bfcb962df79e9867f28236d",
+                  "sha256:deeeab9fcf6b9cb47235974158561967e299344e040c408e6b5d7464af2f3882",
+                  "sha256:0eb36aba0f471119ccb001ea4f1819002ae535882df63e871be80e01f4f776bb",
+                  "sha256:393e7bb9f93ffb3cbba620fbfeb229f2b8345454bc60ac0508f76735544ed289",
+                  "sha256:f24bce642ec88622490b2f09a45fa3985da7f6511a1aae131853c4ea4c309e6b",
+                  "sha256:4c5aabda0cd9edb40e141066d400d2e4b232bc22ab60e806a6399691c391cabc",
+                  "sha256:4079a1edf72a60c97ee48f0a98820b3b014575b402ea05a64cbc5f2b8af674de",
+                  "sha256:9936485ac7111967d6962bc539de7b08807e310117adb78b11c21a5db0f0f890",
+                  "sha256:c62991989974533b86a29586b799623a908add501287f2c890be4fc8a6af2c7d",
+                  "sha256:0230acdbc9da4b36da812f0e585a7602eda4982c899b3b3a4c2bc9b4546d8e74",
+                  "sha256:7abf49cabbaf996afc0c2604f10ea18f8f22a903fc4ba3728a18f5892353c5c9",
+                  "sha256:41716536ea16798238ac89fbc3041b3f9dc80f9a64ea4b19d6e67ad2c909269a",
+                  "sha256:17ffe1d683dbff48f9b2ef903401e471e5e51a992bf0890632bceb94561893de",
+                  "sha256:d2e9ef1d33330a14155d5bd6a8cf122f9390cceb8a7a12c0364ae8e44410fb8d",
+                  "sha256:8403cfc97e0e72e37639b8c54d92f1ee427e48a70d52d5260a37fa104f2df20d",
+                  "sha256:b64219f2278bf3f032b71593da63f563920778230946b66f1037bef2f2a7358b",
+                  "sha256:bd9a6c7fe7405aaeeeb7d351ca1def52737b8ec2344021263aed64c6dc363d56",
+                  "sha256:7a66928044c3478964aeaf6f9e981fdbcfa6b2ff7fad9f2ad57a8c09387cbbf2",
+                  "sha256:5bcb506bd5559870631aa838711e683a5a2a07c6c0171be6bbeda9ba92dcdf5e",
+                  "sha256:6495f3b729a1ceecd7cfdf318cfaa8ecf776ffa16293aad9f97cc542b6901ef7",
+                  "sha256:c24b21415b737f18fad7aeb192e60f7d323f7ba69434ecc1e78b3af0003be8dc",
+                  "sha256:965dca9dc74ed26f4204debe15b8e4dd1b8e41a80b8608287a9ef22f0b6f507e",
+                  "sha256:bb4b6716669e27c7619f63751770cb87e7cfecd4e302e2ce6588035509168352",
+                  "sha256:f8130aecd446f997d0e2011481275db0552bf57bd7af0d7a655eded5f52ca94e",
+                  "sha256:c2479eb811f4d9b8624ef20119e1abdc109f639c2cf576eb945b340362d87b05",
+                  "sha256:46606c1ed76a4da2a9d18016aeb50f4dddf58e1b45d665c983c58f8e605bf73e",
+                  "sha256:d87f7fa5e637442eb638bcaafdc44ca3895d91a153015ff9af6a87219f0dc372",
+                  "sha256:71c88f04921ae61a7009f9443f95c70ec3424a798429fc01e6c1432c1077aacb",
+                  "sha256:bf994cb2e5c367d78483662c7de6e69950aaf04bc6cfdbbef4d1ef7ce153717c",
+                  "sha256:b7330d40f75b8ec786e41c45a202e44f0e49ec29ddf8944120fbdb373a6c6617",
+                  "sha256:bb82b10a91493d745dc533b5de5335db650adb0c8a90548fdf5dad13569a16f4",
+                  "sha256:9e2ef90cb484b37232e829ec400dcddd3f9f0d189eb6f0074b3b5874d4553d1c",
+                  "sha256:dfb7add4926f9a350755294af3c20f114ac59f32e00cadc9ec625b2a51703ad0",
+                  "sha256:7b334d84bf03876c5738efa3857faaa35ede5c8eab30a5621ecfd4efa7ce39a5",
+                  "sha256:dd96950b4282e64ce3e37f0bd1a51834beb286037184f3796f9889bfa1ed0d72",
+                  "sha256:3ed319e31a9c38e5f4e336195b5cbd253b3f8b17f93f185829f078c5ef420305",
+                  "sha256:5c46bef8c0e95e05716e9a53b77970c1378d93bcb9a800018a24f7e1763b45b9",
+                  "sha256:d03b9f4b9848e3a88d62bcf6e536d659c325b2dc03b2136be7342b5fe5e2b6a9",
+                  "sha256:a34e0c5859e5e8757afafba47d83396226b646f32954ef7ecda4ad3be464bed6",
+                  "sha256:fc9d3ee3946b87efcd9531f876d23a9e8d5769aab3e0ad6007ac2cdb4068499c",
+                  "sha256:cffc31e10891c58edc89cebd211bc0be69d99f54f67682c91f97dc53e6381f0f",
+                  "sha256:7edc503f5a919c489b651757095d8031982d530cc88088fdaeb743188364e9b0",
+                  "sha256:e83928bd4552ecdf8e71d283e2358c7eccd006d284ba31fbc9c89e407989fd60",
+                  "sha256:e269f7d33abbb790311ffa95fa7df9766cac8bf31ace24fce6ed732ba0db19ae",
+                  "sha256:da4c6daa0d5406bc967cc89b02a69689491f42c543aceea1a31136f0f1a8d991",
+                  "sha256:a1af93a1b62e8ca05b7597d5749a2b3d28735a86928f0432064fec61db1ff844",
+                  "sha256:74e11b9013f81bd30ec7934ea695d267d164967fec27a02652aa48602b94bc51",
+                  "sha256:dc1d4f59ba0728e65433bc7f903b3799d61545ed3eed7427ad0fe36dcd0f831b",
+                  "sha256:6b588ff47d46d33b02bc296e6e5cc263d6c8ff51ee97b59ca8b34d5c45d57912",
+                  "sha256:545cd23ad8e4f71a5109551093668fd4b5e1a50d6a60364ce0f04f64eecd99d1",
+                  "sha256:0225dc3999e3d7b1bb57186a2fc93c98bd1e4e08e062fb51c966e1f2a2c91bb4",
+                  "sha256:51c3ee5d824bdde0a8faa10c99841c2590c0c26edfb17125aa97945a688c83ed",
+                  "sha256:794f970f498af07b37f914c19ad5dedc6b6c2f89d343af9dd1768d17232555de",
+                  "sha256:61ee52dfdcbcd98acc765b45781ea5de94831f55675c0faaf615872f92268757",
+                  "sha256:8d19cdf57ba61fecd9e07f24fe88768f58196543f7c032adada8a0cc48eee6b3",
+                  "sha256:c238e0a5472c59c54093ffa23af6a963b4ae437eedfb6b9ebbcb482752c6d16b",
+                  "sha256:f4e3607f242bbca7ec2379822ca961860e6d9c276da51c6e2dfd17a29469ec78",
+                  "sha256:6bbb721dd2c411c85c75f7477b14c54c776d78ee9b93557615e919ef47577440",
+                  "sha256:2975de6545b4ca7907ae368a1716c531764e4afccbf27fb0a694d90e983c38e2",
+                  "sha256:7e50a5d0f2fbd8c95375f72f5772c7731186e999a447121b8247f448b065a4ef",
+                  "sha256:1edcf2b441ddf21417ef2b33e1ab2a30900758819335d7fabafe3b16bb3eab62",
+                  "sha256:04ee771fad226ade609b0e879d15c32898379360db27ef1bc6d9f5a77127d5a8",
+                  "sha256:7559c097998db5e5d14dab1a7a1637a5749e9dab234ca68d17c9c21f8cfbf8d6",
+                  "sha256:d5ee453757bd1b479881f0a57b968427404b81d9fed07d04afebcbcfcbf536ab",
+                  "sha256:4b40402374fc4a9202a67d3ede77dedbe5ed1bab57479a5b5cb5cd6c45283bf4",
+                  "sha256:926ce547a03e1bd2aac94b1792d7ccea16d1e6bd91903458e63a095268e1b02f",
+                  "sha256:f5e73bbd776a2426a796971d8d38664f2e94898479fb76947dccdd28cf9fe1d0",
+                  "sha256:78d17ed089151e7fa3d1a3cdbbac8ca3b1b5c484fae5ba025642cc9107991037",
+                  "sha256:47f414f515a2c3103d0e7dae67c47a3b2bc76ea2413d666052012b11dbdd0feb",
+                  "sha256:b566154cc9b2b1996716def297d58101f3015a1b868187f1f9e4cd3074ae9988",
+                  "sha256:3edfdbc82f97ec12e59c80c67897fc1eeb44c3d16820f761a8f15272965ea3a1",
+                  "sha256:cdd6594a3bca71d32a5061b85457cc8148611e7f042ba6e812a1c0a2faebac92",
+                  "sha256:56650f8b8f2b01c1090d184d7d6d396f0109f8a02f915c97b081be73ea12df08",
+                  "sha256:946ba273a3a3b6fdf140f3c03112918c0a556a5871c477f5dbbb98600e6ca557",
+                  "sha256:c64632c85c3a49dc82222cdb3d0ee87eafa64f3096ffeba5bcc16c49ee2d260e",
+                  "sha256:a9d4dd71786b3147d53da1aa44f134e61b1e5527b6c7ece6c2b19474b6ca9270",
+                  "sha256:e716fd0130980916f4b1aeac8f98dbcd8ced81e2c119b7877204cc6b1a058418",
+                  "sha256:15554476d03595246aec194e63ec9db7469d5b3ed81a27a8a2720e82df1f8bf4",
+                  "sha256:0727078eff2abaf1e5770b331ed8162d8e95cf2cf1de06de7540d034999d72ef",
+                  "sha256:3b00ac82c31b447e306fcb47b4469fdc4e6d87385b42358c2e76badb51b074a3",
+                  "sha256:401a2690658194fdd92994c29aa57c18cc5e3100fe7bbdba33d0fa26f2213eb3",
+                  "sha256:720088f184124166386634a523f3566a7fc56f802dbd6e6f816e959236542770",
+                  "sha256:2d77f4a2166122e3f7c5ace1bbfe5319ec6c2d24fff1c6f3e22ccb3e8b2327e0",
+                  "sha256:0ad85fe7a6b42dae9248268706940b12c01e83141858df79e43223e173fe9840",
+                  "sha256:35983fb2e9104b81caaa9e6d40352ea8b2b987fb811f935602d04cc90fdee76a",
+                  "sha256:1cfa672c25cb5849bb2aa652e045e4a4a272c025befb1fe5e58cb32823faa30d",
+                  "sha256:2394d6a1ce4de90590e65111d870b172cb9d4e30e1e6f58a334b29e717fdd031",
+                  "sha256:65ecf1e479dc2b2f7f09c2e86d7457043b3470b3eab3c4ee8909b50b0a669fc2",
+                  "sha256:d816e850877d0fdbc5ee0951dbd78ca79613602aa5cccd1b324c10d700968d3b",
+                  "sha256:4c124ec5a10a5c32e390d848942a04baa8761f190a4a95d3ed7b5c626ca17fc8",
+                  "sha256:176ffcb2cf0fdcbdd2d8119cbd98eef60a30fdb0fb065a9382d2c95e90c79652",
+                  "sha256:1bd969e0521820374122f5132e5998d9bd2ab185be66565a7266096297419c8e",
+                  "sha256:49e68a65bf87ae9ba812ffce76589c09f6766a0eaa5001d7e4a1c782e91d71c0",
+                  "sha256:c5b5967a094ced90899052a82e2c245529b75ba3f46e0ce1a89cfc95edb935ea",
+                  "sha256:c59538d646715fdb1f94c6be3fa0949871b8c860d5c54db4640a1197663a130b",
+                  "sha256:0e9a8a0f823bf0ef948862f0ccb62353460bd07931e756c98f23908c1c526578",
+                  "sha256:ccfa1810aa19fae08aefd29cffe28b65d5123cd17bd7d2d4207f03cf9795594c",
+                  "sha256:28c0f457d67213319f0313d993a3b2f8a778a077b202cd75bf45eb2792949d32",
+                  "sha256:8781993942f622945aefe59e449a5ff4608f969db79fbe893040890ff08fc1f9",
+                  "sha256:111d88db3a52121f04f2741cc72ce8dda6d6f6ef2cc36452c042e0141b316334",
+                  "sha256:4715730da2b4a5bf6cc2ab85208071f00c7b279e4b2f75df0bd954446185e14c",
+                  "sha256:78c43d8a15ca018de1803e4baac5819e1baab1963fd31f1e44e54e8a573acbfc",
+                  "sha256:ebeb05a4a9cdd5d060859eabac1349029c0120615c98fc939e26664c030655c1",
+                  "sha256:594d8b368013caa4eaba4eade896fc1cec8ef569052bd491f493c193e07c6d80",
+                  "sha256:abc36bf7797a427b64c3c99b4f74714bfa66b906b62358be6fdafe493a66415e",
+                  "sha256:405bda98fe97c1a5cf70511ae2d167256b25dd8721b88899465e9847525e2068",
+                  "sha256:3b5d31b89683be71c72b77cfceb59238f4c76a796de6ae85525b3d5cfe2a8f23",
+                  "sha256:882a327cb5e2d809bfe695e9622caced76e7d89c96dcb40203ad8b7d281630fa",
+                  "sha256:d77a7b1602a9ab7543171091dcb37100552f4738d40389028cbf2992c3152f52",
+                  "sha256:dc835194ecfa6ebda81e0a764c953eff3422a61863e9a3e0dc74ea4cae7a4d94",
+                  "sha256:20874a9d40b12125c9e5b97fe4ccda3f94acbc03da1dec7299123901f5b56631",
+                  "sha256:cb21226326a5a695c993daba749f5d758658d58612b05280a04cca98cba3f83a",
+                  "sha256:6c9dfb73e199975275633f05d31388cd61c5a77dec5678db958b4e6624eb21ba",
+                  "sha256:d1e8c7a00924d1a6dee44ade189025853a501d4f77c73f3bfc006aa907d97daf",
+                  "sha256:3eca41ba67f8121586709b6fa2c57b20b4fab73bbb8a4c133269d0cc964f362c",
+                  "sha256:8891a9a4707611c13a5693b195201dd940254ffdb03cf5742952329282bb8cb7",
+                  "sha256:7f506879c64e0bb4d98782d025f46fb9a07517487ae4cbebbb3985a98f4e2154",
+                  "sha256:aa0007192287faeaecc72d9fa48efdb3108c764d450dc8fea65474476da32c45",
+                  "sha256:5b0f2f11c7d635630ced3cc6431b60d27a2c80f878420654df18a714b3df6c0e",
+                  "sha256:003ee19ec5b88de212c3246bdfdb3e97a9910a25a219fd7cf5030b7bc666fea9",
+                  "sha256:ccf848b42acc0f691b4cb6e2830dc4263c7ce4df89b3f4002c3d6b9cd99b362b",
+                  "sha256:c2776b30c82ad5566fdbcce83fcf9c699ad83dae57c6499eb64f8b8a7bc00b60",
+                  "sha256:b19bd4f106ce301ee21c860183cc1c2ef9c09bdf495059bdf16e8d8ccc71bbe8",
+                  "sha256:a04cb3117395b962edc32bf45d8411f240632476b0706b2df7f4a1a87b2ce34b",
+                  "sha256:233e5f78027b684e5aaac1395cc574aea3039059bf86eb4494422bc74216a396",
+                  "sha256:563b3741d26b6af963fdb7b0634e0791445a707d0b6093ac71c3224299241639",
+                  "sha256:07c65a3efc2bb32027206df4f117b893268d028cbb3741208d73615a63525158",
+                  "sha256:aa1835fd302a37b84ac256db5dd0de09bd9883a5a07775aedb491faf46b18ee0",
+                  "sha256:612c21ec8de299b7244b931b492f17e811ecde1450e359f112bc88d20b115d73",
+                  "sha256:bc7fc2028a29ac7a406719ed4f6740f6bf12c20961223c1e839a2a39069af38d",
+                  "sha256:4cc53ff12e7b8fcfafdd32eaac7b13266876766f22b3262b653eaa7b06fbbaaf",
+                  "sha256:0320663709136d07690fe299903700cc1dcc526d574fe8b952a01e1d24024ae4",
+                  "sha256:d967d6bbb33bf7a295a64807f81875c84e82a8ecc59b6c72fe955141b1660d39",
+                  "sha256:a81afd94bec26037880bccdb97937c7662ecb6c1006a8bbf657d8ffafc7c4614",
+                  "sha256:4fae16ca54207cb952e3904b8eb8cc424f3f056f400e5e802ab1a9ef3e575834",
+                  "sha256:03ba1e86a04d912fd2878b457b06a6a7abad0ce96cd9a6932bf58cb4641b8fb7",
+                  "sha256:4e22015880d16cb7148d70895a2361f4fa05804f0391386e0e50554e6fd868b0",
+                  "sha256:9b1018a43b1a9245cdc71a342b962aa32fb799bd0ce66ee59b496cdd75200de9",
+                  "sha256:8cb953ea9ea1bd262bef00112e2c433583929cd7aec86ae60f1a725c6dcf7c09",
+                  "sha256:88ff01f3d3812bc3fb3d18970ecefde7ac8f1a6a29409946ed85173cf8645a3a",
+                  "sha256:dbde46224833f804d8b92212fa3618ea53d0e0cb84ff07132a5ba36c1bc0b9df",
+                  "sha256:561a61d2d81bccb14d22a53b32301e0b6b9e9b9d80ad75991ee6ff796cae0ef7",
+                  "sha256:76df9e0fc779fcd7d3ee836ae254ead30b5f9492022b55901d1f8bd914d38ef6",
+                  "sha256:605033c50f750dad4c344495a0d6b18dcfb2a091bba072441a38cbf9001c0363",
+                  "sha256:9e540fe1fcf866ba1e738e012eef5459d34cca30385df73973e6fc7c6eadb55f",
+                  "sha256:7d4c363f4a746f3a0946d19f303fe9c60c5fe178892528ec4f34d8ddd2c4c359",
+                  "sha256:8540be85295735194e0053eb2ab6b2bda2e27119b9b030877eff43f9272a20cf",
+                  "sha256:e1153055b6ea57ee81e6fb41b03023279059513d0fec728517ae0805186a5118",
+                  "sha256:f97b5915b3f75d2878104c198f205841813712103f1b3657d71d2c8d079cc947",
+                  "sha256:dd8998fa42db6769700a41203f5ef0efe523ed24734636ef0dc0d2a4d4a94747",
+                  "sha256:17c615aa31cf2afa434d1d1d42e0db85b564fe416d346721bd38c0db75f73119",
+                  "sha256:48f31b2798e2ebbf1a7b83f43c6aa2d2eb438a1e053906623c3a7391065c00d9",
+                  "sha256:31277c01ac529cc1c6a55fd87d6ce4dbb20290575d4e1e89cd40600eac9f3405",
+                  "sha256:4b00562fa291e956d910bb056c6120f0079f30093ea107757758683a6d418206",
+                  "sha256:5796882ac3059835583bc399e8522c19646b717713ef553a71b20ca0535a1718",
+                  "sha256:697f5bf30fbe44dd4dcba8392b85680952b7a1be9a0221349f4fde011a8cdd3c",
+                  "sha256:c477e45fe5f8f5bab1ec1711210dd357392ad19eab48cda18d89b60df5067970",
+                  "sha256:61b1d3440b078f35a3fe2b35c51d6d38498fb3dc8d8f5fedf52c7f0f8f6d8ecf",
+                  "sha256:bba1cd75958b43df5e3ceb820449008c19ed5fa562d54c2d46c5c57e79aa6b2a",
+                  "sha256:8a501b9d8016eee68ce62a93a65842b15c8a57192b9f8189ebc85a11f2f47f9e",
+                  "sha256:3d175382237a94330d72af67ad2c41535dee7eade3e42178b86d2dc87478d030",
+                  "sha256:e95bb05fa5defeb16dd0e0957de676374b22b9daaf405273e636d1ce91001574",
+                  "sha256:3898e2ac4e04e80373bc7fe4092b26d502d4705177719117e25c083d44a9a150",
+                  "sha256:8c26cce4231f781db7b37d51ded377f9cfa01a5e6833d967082795f1220e2860",
+                  "sha256:de9a24cdb3260850b49086745ba6f724aecff0bf7993729ae063c116da6915a4",
+                  "sha256:9dc236a8124d1fcbb41b970b5a4c45d6f7f97430c933c775121cae27f5f352a7",
+                  "sha256:d46ef49f8ddba1ee8cce6c9764014851cce2dbfb5dcb2457a31495393e6566c1",
+                  "sha256:4164089bf1754c0ef18ae051e047f11299907204839ad4b7978f146a543a2e91",
+                  "sha256:09096bc32e37443417cd625364df32674f9d5ff4ddbeb175e6d60637ed3d573f",
+                  "sha256:654d9074dc8ebb93230fe258188a17ba3f7dbac2f360f9f79cc4fb1516953018",
+                  "sha256:44999c555a6e4bb6cf5e6f6a79819e76912d036732cb50efaeefc20a180dd839",
+                  "sha256:ce954d3900cb547aea14df6ad5f310ea96bb5e83a155b93e2e64b2c13b686193",
+                  "sha256:368779f00f427680d954899dd73ad3b6a59c42baafb91cb100ea177f51185198",
+                  "sha256:f0c20dff5211f9c133ad5703daedcbe148528c634b0a1eea7887b420da4dc00c",
+                  "sha256:15cd74b4ad9d82417072fe867f086d68667afd4291b710b6c7feef985c492990",
+                  "sha256:480e0f1a9dcce6ed0728e9aba709e33f5522273da1e4b0859cf9d3bbe2216532",
+                  "sha256:cd8b0adfc4d2467a61ab2aa2b3e617bbd2a2592176da249365eef014faef827c",
+                  "sha256:a4577841148e7e2bf481447ae141eff319007e70a24295a22787bbfaecf4c4fe",
+                  "sha256:bc3e4dd9194760500ce9731d792f46afa049667185487bae88c23a38fdb10c37",
+                  "sha256:3c89b334988c0d1399d25baebe298d9e8cc768f28aefd581aae893aa1e69de84",
+                  "sha256:33a92d88496e8aa410976f073e324f761b2ae02a94c20c0f291072df84f648be",
+                  "sha256:8b73e398f5a3cdc8a7ded303586ca7a50b26cc76213a3cebe36fdfdca769b316",
+                  "sha256:ff02d15997cec2391c7d49203e49f88068993252ac1f496a11e182c92d9d0e88",
+                  "sha256:11838afbfab4da7d5fa6e01046f76cce0b0a0c174a87c522eba440fce16e316f",
+                  "sha256:e526de1fefb832b3e6a025642c77ac2527595925933412a7921606eb072e5ca9",
+                  "sha256:3d4e54f6bb2f6ee5417613d5d9bef407343adc768a0841ea58f831ffa868cbd0",
+                  "sha256:8623975eac20e039a7ba14323490db10169cf205ec98f5df2f55f7d410202663",
+                  "sha256:2b76d31dc0fdff399a5b1d396caff67b9eb2f5b8f6cfa8d7a430eeaf6a09104d",
+                  "sha256:43d4db89cf7aa96d57be2847577cf1dba8cba99d5d43118ee54d0b97a4ef8b7e",
+                  "sha256:80f3973c07c06dd095203553abbb95d6ce1c24ccc92f24f46659bf05416f4778",
+                  "sha256:cad86777bcb265db0da766952ff63e8d33f0fd4f3b90b22d0a1da587a785db44",
+                  "sha256:67419432fe7d373f8e5ddaa7b0dd1c25389608bf2f4ee76dbabcc2d96eb8c9d0",
+                  "sha256:4b81b6f8279b75714cbac2f77b2e006f65cd799c2ec3d1c9c40840b1ab60c885",
+                  "sha256:5f445b2b2a4bdeabd555e25dfa10119d9f4e4e500d1c4492219dd8647f119ce2",
+                  "sha256:8c893a8300f812ca179e1f8863eff109e1b8f1c70044bc5f08eb38a592ffdecd",
+                  "sha256:fc8e4e96da6ee6201a5126473666831314938e98bf699677be296e7811f6b7dd",
+                  "sha256:32ecf5a37bacbeec9451c4ad39672ac2816f9241d5a92f038b45059da2f3ebae",
+                  "sha256:e525544166da577edcd03c6596f1e8787a257caaa19eef98c3a481681d2d978a",
+                  "sha256:b55df489f643b495984915a0671e74262192813e07cff5812d778c8cf4c0b9d1",
+                  "sha256:29214e4bf64efb65d82bd3f318d0ac3b7a6b03f6f6abfd469148bc2f894c6846",
+                  "sha256:16b390c34ddb56c075fb6f4b77bf9a0fffab219fcb3f3588b9151215ab2b0ad4",
+                  "sha256:b5bd11b47b5b690dc667dc486941331d7cd3aaa4f0e5c4d638ec7b294bcc5012",
+                  "sha256:20c3abcc5556f09e557a398886684d1efe8ef59687bedbb78c130a7d1d55868a",
+                  "sha256:1cdd6c2abf0132da0d956398eb1dc736c0b93fd8e8465e7f1111ad05b2c322d8",
+                  "sha256:7e67dba2509f90064325e62e49412d5284a55f09b7b6878b9c8222692c500dde",
+                  "sha256:9f1a745b208091d4b009ec321a6fdc72c8a5e89167effed81c50571a13f1c87d",
+                  "sha256:c7dfa7d5a4917eed3b44af87ffb9c6e18242ecd847a8edd140bcdd178cc8946a",
+                  "sha256:46e371b6245113ebca446adcbd2db39f2887b67dc5a640f62f6d346ec9f6980f",
+                  "sha256:cea5d052286c0a120f6cdd0f3e559f13b0eedf9f83d2538e4369b6e05526d43d",
+                  "sha256:62da6a936871ab7b8c3efc0332fe41b4ac10ff96b357fb2bd67deecb312f9277",
+                  "sha256:9feaf80c733951790bc3578db42ea2abef65643ebb36779e46dccdaf4c76b525",
+                  "sha256:627d792d7cca1e97c121be5f0808c9da96f54d6c986622af246c60354b9c316e",
+                  "sha256:12fda64dea45a7b085a35a816a7d8035be6600cae38f7df04a3bc22ced4d4502",
+                  "sha256:685d8ca4ac9c909ac2daa8bf454d8ce1de993c8ae29a8c78417dfd5d1c3aa65e",
+                  "sha256:d2748115958b57c9c5125e23bad9462edbabb33c81197424a33d8060745ff646",
+                  "sha256:5cf4db298bbda87532af2b2468a0692ec93d28393285ae157c1b4a18efbd1ba5",
+                  "sha256:7632176e2d324ee98701f5d79024361379d510590e477f560a264aa6e8db233d",
+                  "sha256:95cb9c201ee3b54fe6331bd7e74f43485632e95448d31fd340ffaa84a32b41ab",
+                  "sha256:85eb614fc608f3b3f4bbd08d4a3b0ff6af188677ea4e009be021680c521cedae",
+                  "sha256:60b0cbc5e435be346bb06f45f3336f8936d7362022d8bceda80ff16bc3fb7dd2",
+                  "sha256:0feac495306bbe6e3149a352025bea8d23cda512859a230cbd3f510cf48caaf7",
+                  "sha256:0f54422e17766a9e7385a553d941d1849c9e7ca4caea085305ba9fb1e15ae607",
+                  "sha256:0bc637f0d028043e8388b083cdd8d0a0acea7fdbc79c0bc9401dfb02c20fb817",
+                  "sha256:1b53c868277dec628058b31b1a8a8a2ccd8efe832ce9694805b5f82564136eb3",
+                  "sha256:499e48b35f3b5f5da45031fa78fba559fee6a480ecb106e6c300eb8344510958",
+                  "sha256:bfa39369bd3c36833126b6f46b747de0736a66835d97196195c0810161c24549",
+                  "sha256:82ce159a9e4e4b6b4fdce9ad954aa507f67108430bd261a4dcd826e44d0152a4",
+                  "sha256:0edde19e0c027c8cff31b82e1f4b0b198c00bf924047fcf4dd610a7d4965ab52",
+                  "sha256:6b096b1da49230942e736576396091530cecb3f9bd8cc70b8b8a9f72a5148a0d",
+                  "sha256:8571a2aa115d42f8b5e87ef58d10e9c24e6fbe5470fc2612df96f8740f3d960f",
+                  "sha256:2fcacd153d4aa4ddddee3357b717e8d3f411382b180add28328c9faa94dd2ae4",
+                  "sha256:8945279d57ad510e018f92571ba8e5d811cf8a3165adf930b0d4015c5a077a35",
+                  "sha256:30f37ca1fe1592e29d3e97c1dec0646015000d19bffc40f13dcfe73e15be66fc",
+                  "sha256:27f43a7a8d1b18f5ede27728ecded75e510195a78abd9f3d0c1965d341e5e45a",
+                  "sha256:ab2988acbe3a2580703de6070646324e95efe982598a386e69ed9857ab123855",
+                  "sha256:71f54759238edb9ae63dfc6ed893183a809e88321d8117dc40e0d403fc533585",
+                  "sha256:ebd64ac5cc7b9f58a40072fe9afefa2fd835e0eb18cdeaf085395c7e84affac3",
+                  "sha256:a2aeabb3962859069a78acc288bc3bffb35485428e162caafec8134f5ce6ca67",
+                  "sha256:a6ef8e56d53c29e92b46a7ad62c22380056153b2d5810c39c0cc1658a4250d5b",
+                  "sha256:d3ad718b08b44e1fca355abd46a6c315a9d73ab38f9f3c3d551642b55866e182",
+                  "sha256:3ed20aba45a8c175e818de998d906fb2759387c607bd9b15dbbefee8c73097ba",
+                  "sha256:5f068787bd9a0190b03e64cd770e44ace593c5aa09e3f4c470c44d8d484b4674",
+                  "sha256:2c1baefd0f802507d9741da8da54f6eae42b04967f9d433d7f9e0f124434c70d",
+                  "sha256:42829311fe40b7487530ee432aeb8e1df86e5168373f038cccb60d0db94601d3",
+                  "sha256:be49b69bc5de947ee2151f397993a691a57bc53952058c32cde0fca674da7d8c",
+                  "sha256:f14cc62cf70a187384adff6bedf8b09858b8f441a9be87ebf3ae975c4e6b0d73",
+                  "sha256:4966b1832e9eccd8f83ecc20143fb6f18215107bdecd7267b4605cdae4a6562a",
+                  "sha256:48226934763e4c412c1eb65df314e6879720b4b1ebcb3d07c126c9526639cb68",
+                  "sha256:3a438b53e8377eccf90cac0fd42ed2b513fc869bfb7b96e3d2a4f6984a287f90",
+                  "sha256:c12c7dc6676c6ccc5ca08ceddfb1b4e46c9f1ed49cbc241292ae6d1fdb0d9d62",
+                  "sha256:8729b157f0925feccdaef8aacd91c6aebe0109e621675bcc15e1830673b0e19d",
+                  "sha256:56c3d429ea949467dc0bca882646cf40a58fb6f27750f5664ff2919f5d38ada5",
+                  "sha256:1f2a096d6a75662a86a06ff2859e6ba916bbc8c6d8cb7b73810ffbb9fef4b089",
+                  "sha256:1fad1d1f8b56e6967863aeb60f5fa3615e6a35b0f6532d8a23066e6823b50860",
+                  "sha256:842ff55b80ac9a5c3357bf52646a5761a4c4786bb3e64b56d8fa5d8fe34ef8bb",
+                  "sha256:15b17b95cf9cb9fb64e0c8e56110836bdcaf70de81b8cbdb60e181fc90456e06",
+                  "sha256:a82958266d292f4725fc1981ea57a861b7fc7feeb7a9551d0b61b98ca51a5662",
+                  "sha256:eee92733e8989029929d5cb1f673b15fdb814dac32e148d5bc02378b44c8699a",
+                  "sha256:24fcc5bc49b059b221075989f25875fb821079088dca694aec262446cde50cb7",
+                  "sha256:ff8b51c6a8bacc5ef6b5da0f049d170ab1c1ecebad50ded3c04ed384eca9a2c0",
+                  "sha256:383a5e6bb9e94de53baaf5c7493cd50a68c893c6a30acfbe28407d33bb133efc",
+                  "sha256:19061d12407c0c4bca6abcaef01695b70dcd3967ff102dd07178a2193a280e29",
+                  "sha256:4e3e93a3d2039c2a8305030b7960bd1100d7d20705a1afb1325a4ee79478a74a",
+                  "sha256:084d79ed3d7127e6d46e9ac6e654d8ef181a156435808dc8eb32968b6c1b4946",
+                  "sha256:edf00207b603cbfe86b07f8be5c4ee14ff1dd85ec4b7d82d760483ffcea43891",
+                  "sha256:6faee589c5a7454502e5ec07586a4856e7f1376bd551741af2acf03afb9716e6",
+                  "sha256:bcf25aae89f7368b16346bc1ec92850175bcc2312bf7a5e74bc3c512bcd345b0",
+                  "sha256:2a8f9e5119a034801904185dcbf1bc29db67e9e9b0cf5893615722d7bb33099c",
+                  "sha256:67f37cee02ba744dfc7957725f5ef9df229778f6a2f7afc659625b458da6167e",
+                  "sha256:b10d8521963a2494fdb2b5f8fb0de837dc86d4016c3b10019fb8970a09582451",
+                  "sha256:47ad43730c8bc72c90f2fb3dbd3526d716ada2fad94e62cb443658e94c6503c5",
+                  "sha256:5c1940e1f173e22b053f3a89022903cea34a6af20dff81c65548c4e2ba3a8293",
+                  "sha256:1a4e44583a767289bb0d354db93c6a9132420e13376d4fcae866d69620bb11bb",
+                  "sha256:7baac88adafdc5958fb818c7685d3c6548f6e2e585e4435ceee4a168edc3597e",
+                  "sha256:090563f18409c228274bb61dcf1001f63a55c1246fb2838a998cb3c5fd8c3874",
+                  "sha256:c58b0b900a7ffc778980461d74dc236bf2c790d2e5e8c04e28876e221b48a1c8",
+                  "sha256:cc5f8dd4e061da3a73aa67112e24f2cc5c0ad0cd4334dc798b8834cf6259a779",
+                  "sha256:698e8ecaf71719dafacae79de05080d567b69fad3511e8b8d42b9af96a7c41db",
+                  "sha256:441b3862f5a0fd504bbbba18d96d1b2b920fb95a79dc45a753a6a664ad285b07",
+                  "sha256:a42de8ce71380b1f4e8ac5b4ce720bf565c99a0b09ef983c0550a91a467bc155",
+                  "sha256:4f92835a6e4ee4276df49019e068d1871b75821f52b405c699bd9f199df58b80",
+                  "sha256:42464424b9fa731f8122fe748aad0005519fc87b770dbbdb71f29f514ea0e889",
+                  "sha256:45c48d32120739734ae97479cc0f3ca19796ea47e360ba39d52b77ce3ada61d7",
+                  "sha256:47b61754a278c4ca378871c874ccf6a0a07bffaef38505315cfa94f262887845",
+                  "sha256:881b28a3a37d114bc3f046605b24663560009b13a507217e007643f5682efdd5",
+                  "sha256:37a5d2adbe9e34309731885445decdf722ed7bc18d971c5a7f6a536f8876fd90",
+                  "sha256:2588ff56ab340c06ce8b5be22cbe23de89d4f336b38ae930daf11db1c6a24391",
+                  "sha256:412f3eaa5f7e226fdc4678a3266edab76d8998f7d76763075f690a01362ef89c",
+                  "sha256:9e67ac5948125dd165c9a74ec848d48b313ef4264bbbb89630a782dbd972d72c",
+                  "sha256:9fb07c2324cccbbc19e3ffade50ee7da41909b2f6c24f49ffd9978ba375de193",
+                  "sha256:f4eca686b314edb06d3fe1c526f573c7248c811af70cba76132cdc9c541cadc1",
+                  "sha256:30ceeb5a6cadaeccdbde088bfb52ba88190fa530c11f4a2aafd62b4b4ad6b404",
+                  "sha256:e87acf226a9511b3a5f83e7fed9c5c20addbbdae47ab67c614404a9392b77e50",
+                  "sha256:d150e53fa73c3786da9e4f6e23d374100b0dd2923485d4a08e9a56ac2786cf83",
+                  "sha256:e8b7968fe6613c4cd6324436089cc9c1558cd63fb7da87fd46cc7c15c4ab7f66",
+                  "sha256:88be5116908aa5013f540c767f6811774342780bb72d3ec197b3429bfb2f9862",
+                  "sha256:e156e6fa9ef6a483f8505ce0eeadbcab12b887c4996233ce5d6258076f6bce50",
+                  "sha256:e65f7d7c8def6b168e013914bc0d1137aed65c3010e9796df3b823854472f3e1",
+                  "sha256:a49b922f117b9bfb0b07e9848151f8a2948345328ebc534cd28ac187d7ed3f94",
+                  "sha256:caa0bd6617a8d5e535faedec5f6f3ea7c5e6da1898751f6c9c34a89a95c286ff",
+                  "sha256:5e34865a724e4e08cda721b66f24d4806d4b0b5ce059c340759d0a1a861a907d",
+                  "sha256:56cd753773415b5f3cafa693992e158d98dacdd1053d5018118b7685e1f8fb45",
+                  "sha256:4992eb036c0797daf9b984af1a34fe27a30287ee5d2bd5e2f5a0df3a09bdbb59",
+                  "sha256:d807e7fb8bf24be50642a6dced954c6ea208199daab2d27c9f73d789ba82fa37",
+                  "sha256:8cd6ef9902851f07cfd9682e2d6873648690f0c2ec65345276b557ede042d8b9",
+                  "sha256:d1d362fd4f8022ad05171efe40e84d15ec6c5e5f419d6099ebc8e46e7da632c1",
+                  "sha256:78fd472a1c7f49b8a432788ea2dfc1119f155a394f41585b4e715d2585fc92ab",
+                  "sha256:e392a6b41381ffad04626d092fd2af9477c72e197a74efddf987832c3bfa521f",
+                  "sha256:ad338b7a3f3bed96300d9ce7f0307e09d758962b8496c10fb3554bf62405d153",
+                  "sha256:bfb45644212cfbbe48b05149f8d53e77d7bd02ca9fc9045cc37115101175a3a0",
+                  "sha256:fa7bef727ba8657208bb3df95916f0bc912332cb8534c695facef32ffbd72f20",
+                  "sha256:257e086bb52086254fa8cc95a5c4998668b4fcb5203ad3c2275c1150816acc9b",
+                  "sha256:af0a4287e302baa7c85655ddfe5a7049b8eaf31aff03886f4fc57c920d26d491",
+                  "sha256:11ff811a72c82084c7c14700b23d29643e153442a34b3b486e270e5b40e38d0a",
+                  "sha256:a2d96efed83ab31d21481af044835a940673ee4ade2763af78c06d2df87b94f7",
+                  "sha256:51760acfb6ca87db5be7a9296d6a3d1220767956c576a26c6d46784e25db85bb",
+                  "sha256:754bf53a39cea727d9d89d59df32e020842dc71f6a0561ea36f8203aff2d5d69",
+                  "sha256:24f5cd46a7395cd046b10d6ddc4de435ec6595d0dcdb2d179c94cc9082a12f14",
+                  "sha256:2451a475f248a4c66e64d149fefa8bfc195fcd7b3f369bae221a94f8ce4c2d67",
+                  "sha256:cff4b4ac50fed2ceab6add52a66513ed9ca04b024f07a25c53df49f762eea2d2",
+                  "sha256:4a08d5264e865548e65d31886c91b659b33a2c2ba39fd115b00af3ea0bc91a83",
+                  "sha256:78b2b9cbf041d4461daf7ac11a24d1e79a9c57f47aa265dba4d09067efe3d96b",
+                  "sha256:fb276cc0ebc6bd27d344f7e0811f26cb3f0e59da09182489095724bdf2a075f8",
+                  "sha256:5a0927d231fbafa8b865591922fc07d39d9b4b263a1e9c0bbef691282f706cd0",
+                  "sha256:e1e28504928648404a3b652440091eba010cd99221183ef78601cbd152261d91",
+                  "sha256:42bb566be1936bdb40937f9c0a96c4acc93057379385f1807cba18f60443d3e4",
+                  "sha256:8c05fe038c7792203afa47f4534318f6c674672999b444909706ce0826bf1b8f",
+                  "sha256:a571c94456b9a1743e94f4f72159de52bb13fe93437b81da675351553a881a17",
+                  "sha256:dfecfa1299d11d6a77503e626a2e9a14e1a75666bc8ea2abaf7ff515d2c86332",
+                  "sha256:8119d276749b35cd9c283c1a8d970b3528bea58427eb37eafc22b6093a978f08",
+                  "sha256:6d1ac29b3a38408f6d238d6718384e05be7346789c6200b354335b0e0c9c77df",
+                  "sha256:d751a4fdecc0dc3c5ff897e3ff4c25e7addc698d590e2bfc4c893e693be7d558",
+                  "sha256:12b0565d080311c7804d8fb1d697ecdef8807563ebeee4443e2fa6d35b1d958f",
+                  "sha256:ccc815d5d4e9ff62f2b666c285ebf27060218ff480c171cc541ccbf1005f05b3",
+                  "sha256:dc71fa093b472bf0d59ab44f6f824592bb0e8fcceb88035e980d91aa2626f826",
+                  "sha256:7a550ec0bb8be2920abc6198faac70132027bc672c7bc3897ba0331727b94aa7",
+                  "sha256:cbf4b003c37cd3e44ba6586f02d9f869ef4df49902d409cae6005becb3b93d51",
+                  "sha256:8ced8726c50d2809362c78ddefb876b208a9099e81e2be1c22fd8227190ba063",
+                  "sha256:3bbc114c65c8ecada03b8c4e0fd4a53b7cf3059177e927011f64bf2d87a38a35",
+                  "sha256:6d02615212a88eb204b8f6d2a7cfbf6183a12f29d72ca5dbfbe5c45c63068ef8",
+                  "sha256:cbe98d6dcf93449d9c2fbf95de75f065f8da67a23f13401c672d78b28c6b7f6a",
+                  "sha256:4c0deab7bf49d21c6dd0ab568880a2da8180df52f15d9388aed61e169d63f8dd",
+                  "sha256:07ce52eb60e4fbe4906e160a8e166002a4b8edb66b6813f68c08d67c4d644b82",
+                  "sha256:c23f55b72b4e09c456c2837321dd626cadb9785dec89d31b2e30ca3c752e6d4d",
+                  "sha256:067c25522b7ae516b4df454a01d4798126b8d6004812d5476272f8159fe66c02",
+                  "sha256:a14a6628db9ed048511cabda7ba62dc019c2aa0d32c13fee0778d88e112b70e2",
+                  "sha256:59ec15255141f3d0d2e0907c9e48ba9a3a93694da1b5414fddb5868ecdf76377",
+                  "sha256:10814d88ff647e12aeceae4c3815f9eeb66ce7327099c642f934a391fd915f2c",
+                  "sha256:686e82956e8f875e0dc8b4bac509813a2b63bd39226baea5a3b79e4fd7483a97",
+                  "sha256:3b777b51480977dd90050524eec747d73b635a17775228037617fe1d145a6fcf",
+                  "sha256:7a67a83093c0a23619de1e2b489166940a0195a9ddb84e44bb523e5c93306331",
+                  "sha256:9853341ea14daa32558a3787c318396f5c05e947949848bad4bba16e9ac0d1f6",
+                  "sha256:b7d265ac19947ea2a73e9735b63c407dcad881fa8c0d8b2e35dce948efab3d83",
+                  "sha256:9c3cc9ed1b5dc277a39403d0aadd4dd8b843d05fe478d40f60249cad2039aae8",
+                  "sha256:965ec1b760513e1ae539747624bd241d6575675e8a04c5caa572faadb54007c7",
+                  "sha256:331b91a0928c05618c7fed3e12bbe9ecb9e4619d08c7e85d3de344a08d2f0f1a",
+                  "sha256:49c7c718cb4e2b6f0effd0dec4f4cb4e109d260c192b2b329a58a1da9a24ad1d",
+                  "sha256:a3ef96219165bfc64d4f5d50f51fbd43e803c500619240ffe4db1f9f8e337f83",
+                  "sha256:ef86061338fa321c959cadc75ecbdfd405eebaa1042eec9d9c737d4d9d92568f",
+                  "sha256:7bb5051dee5f6633a02cf5a3285dd86890cc6521e497526a8149dc5c5ebad062",
+                  "sha256:4aca3cee9de1a4cd7ac56a12550f286894a215cac593c18857278f7b0e48f328",
+                  "sha256:1d6551bce8f8a1e53682fafe4f67fa830c333f0b37db7acbeaca0095b5ce870b",
+                  "sha256:e45848a3fbfa1d46709448593fa7929fee4c5a83d2168c0d41d498251e4b5dae",
+                  "sha256:83cb349e65d5b783518b735d8fb477264f0a6bd7cdd6f4096f8493dbd45f2ff7",
+                  "sha256:30dd1d58b7b963d052341f4583a7417823cf4dbbe7ac4b536f3a5250c4d34582",
+                  "sha256:6fe1188081e441595ce29ebed4d1985e5890815158244f69f092ee930656f755",
+                  "sha256:a80c1d6d32db7ce8fdd58bb4f3f488b74e94261a38512dc8a15179ae33697e63",
+                  "sha256:b437a08d4670ef440ba6dbaae4ccb39f989f0c2a3d280ea66d6fd9532a313286",
+                  "sha256:230731b577f8d29e7e8e8fd6d1ea02702fb4364fcc7034d838ccddc4d66da8c3",
+                  "sha256:54f59ddb56e89a5330373e07ea05934fc58360eb7480615ede2a3ed6982e1eef",
+                  "sha256:427eba707b42761a0ef57107ba5a22f80fc6379d1537c757fe1929d6d066b05c",
+                  "sha256:ff1580bd4ec5841d4937b383917fa30f318b4f419b8067a77468eb4a9630ba10",
+                  "sha256:df40cada982b04336fe8b250b4fdd576ddd03a014bb519a69b34640369bef661",
+                  "sha256:9c4cd61b98253904436180f58c564bda61be1fa1b5523e4ecbbdc174d0c2a9aa",
+                  "sha256:43bfc890caf7855f2fb55c24474b58cd5c8c7b51e4db4f40d1f302fffd31985b",
+                  "sha256:2f6c73fdcd5c5e5b6d8b58663e498a0099db8029386869a4aca670471f6c298e",
+                  "sha256:30ae4489980021a727f247d48b4d74d4c6c7667d00bd1a670f045ea24a885541",
+                  "sha256:4a8899d3b91a0f847ce793480700b26dc8336c5ee20d9b66067c76fe0dab2f17",
+                  "sha256:77e4cfbc823e3764308822ccf03b257861f9360f3b948829f1d73148b321b00e",
+                  "sha256:9b69a221cf9395a110849bb428bb1cfe9fb489322df0fa6017f5978a827ee0e9",
+                  "sha256:360be5b93e106d77a8f4e84b318ee8dc14349f223540e0e200e0dfce2676ec04",
+                  "sha256:e0a7b9f3b56b4737f5711dc6b03f256fbf2488656b8874acabb494b58ba0c1c1",
+                  "sha256:5c74a0e3005ea3cb90dff80cfa1e7d64c97f5c01612d253cf4e65aca962b7be4",
+                  "sha256:194dbe332ccdb33d58f040da07667257e176975f6b2f17343bbf33fb99deb097",
+                  "sha256:e21a84107568047432e474e08da24aea2340409d57ea8cf170182927dc76de12",
+                  "sha256:f7a2eddcda47cb75108add34c0ce919ceb847605830ad33aeb4bd64d6bed24f3",
+                  "sha256:b83a0199c3d471151f07f6de626a1a4a362dd6aa29d84cf1c0ada2c966ce29c9",
+                  "sha256:709ea71f36495ac2ac89d72d2eb603b6aa55b2c1a70633f23514dd897936f02b",
+                  "sha256:6ac918d2bc175b3f356926ca96a998c29bffe256f7d802e8ef654b1226da3ef6",
+                  "sha256:aea253461d1a34a239b445ee07cb34398a9cbb6ed40e252182a91cddcf59004b",
+                  "sha256:cc662127a17d4e08e90f75703f376067eed48f5d6b5b8d106fa3824397f1978e",
+                  "sha256:a0b8a6b2c8dad75290228086dd0af342979604bbf4b9500029e25d766835c0f4",
+                  "sha256:0afac6f4f9ed1c59510675d87da45c7966c0f7aae6e8dd056961aceed8c4fe0a",
+                  "sha256:12696f5638ad2068c5c8940495d15c3bb1c57990000dbda7428b008e9e63ab5b",
+                  "sha256:f3d9ccb762146dc97f2d201d979fbb0e9171d1203fb985f3ef48b5c2a176c2a9",
+                  "sha256:c5a60ffb80cd1f9b90c797f1d1ac80e5536eb32a5b276871445e7279ac701c5f",
+                  "sha256:0515afdac097ad54cf4b24e0644f0789cab5535a54107aa44940ffd991a6cef3",
+                  "sha256:020abac486839c7be29fae37a686dc7749398c333cb8ba94b3390b386ffcbff7",
+                  "sha256:8ab06f608f45445bdef489cedb40d419aa7282e127ee26dbfcf417350a3f1630",
+                  "sha256:31d924d1540dd4e927a4c3aa936cec4bfb54ed302d3e8acc1be8b52dd5deb10c",
+                  "sha256:1b95698d64dd299827f62cbe43d373e985da2d8900c4489a49475f53fa04f414",
+                  "sha256:fd6e1803ff367036da5b52b2183e1408691b379cc1320971bb664737507f89a4",
+                  "sha256:6b312faed4a0508da2f15d3f31a6daccfc0ec6621e5fb7b20956027dce5fa395",
+                  "sha256:a5f9f2c4f39f393971f268aebb1b55d18d0d96693d08a9ed70403e8565807bb6",
+                  "sha256:a0a8e31422da7d695a3788a7cae3f929d42cb4982889422588904ecc6879182e",
+                  "sha256:59008e3619cae0f40e183b7003e722cb312b00bdba775ec9f06cdd833b53c26a",
+                  "sha256:d6eb27d158b6397e52ab6a952fec4e3c414638a08750a6c011d32eb117accd82",
+                  "sha256:4e497225fe36781735cc92c0886f6858b19d4557ed9ecafe1247b8233c206075",
+                  "sha256:2812ae39c665069f4b27e9bd26dde9141d4f4e7802befb1b14ac4e27a8225b4b",
+                  "sha256:b57141234c3c1d1b2d46dfec037dcae8ba3ebdc534660c661771aab46e38b44b",
+                  "sha256:6d9b770c5d34ee0fb93e78b6ce44c3e0e99ecaa9d57265e32256e14a3bba8190",
+                  "sha256:07fb48b313f6d4c1c8b1ffd9c5226c68f99616e46bbd04b325527d817b500577",
+                  "sha256:037b950664c45aadf7476e208cca5908c2415c7a7da15071fea51cd1bcae4795",
+                  "sha256:d3a4f367a9c5ba936b1bb5480db390889a303e5ec8ff34bb4274c1d840a1784d",
+                  "sha256:caabc61e9aa83275f9d2fefcfda56fddf19e7031bcf9f9b84f858bb1f040e24c",
+                  "sha256:35bd989d63522f9699b1a90dd453f866818cc3d247096a910a27fd7e49b09ac2",
+                  "sha256:8d7777da3f54f965cf3058cabf987c01b93a1dd041e8359eb7822eba57d8c8df",
+                  "sha256:fb6e437a24450106c03f25dc1c3f6b78549b82c2d0bd4387dce1350ca3c5f1f5",
+                  "sha256:61ba252d7ee5d955b929f6d7d39d65d25c62e3d3cfc65ee6cf55c764b1c64a90",
+                  "sha256:7adc584a7d43968d22706da5ffa127020536375f82beea5ef677cab39c5f64c5",
+                  "sha256:9b8a8a843fe9a972f6433e11b95b5a8d1d2971ed40fe1acda6807e34f0773c62",
+                  "sha256:1aa321c66a3661e78d938b805e5c311d519f04bf3496545ffdacc7c152bc9b21",
+                  "sha256:419f9c08de110eee9b2ff0a61e9aa1bbb56939f9239739c17a753a0d9210d10f",
+                  "sha256:3dfffdadfb10def9a3671a255e4fa71d8b22231ccf2c929e96689101dda8ce2c",
+                  "sha256:c5c61536e768553067cee488830c64866d109cade24917dbe23f82c861af07c5",
+                  "sha256:98c28a91d41f634edb8c1f001dbc45c0de534332d059a2e8feff448fb7235c49",
+                  "sha256:b4a1ac1ff5cd22a5dab6c96dfc2dbd7cd6ba750691ad5c53a97a1f088fc42abc",
+                  "sha256:01b0562b890a80c202fff9175dc845500660c7f1655292d4ee13ca667acab081",
+                  "sha256:56c866bcff69fd60b630841ff990296b26c2f45d8c6054311b5c476bc67466ac",
+                  "sha256:4fe264ed1cfd0c074f4601354b0128a9e5068f0fcde7382fd5429585f0d4cd2c",
+                  "sha256:95103f7c339aec4b485b7f569aa8a5e1a54286b3d2acde427328c49e4d8d80d1",
+                  "sha256:adc56041458e556df5663e7da264e151c24aaf1c2a94e49df9790ba191ea1b37",
+                  "sha256:2669ab8439093418c6c437c1f2e931d4152f5ac371e5a0f2d20b18455483c3a1",
+                  "sha256:0f57b051654b6d75789b437dafd7040b6c90daee17827be24352c0f11a74bba7",
+                  "sha256:1b5136570cefb8273dd5affc73c1456cf239cc8b18be72d6c4d09794af7f3352",
+                  "sha256:679724b45157b4d4c9ebe2eb32e188b9a65d47c23be886498d7a178caaf113bb",
+                  "sha256:767dd64d91c23adda537c7759ae3b4f720d3c76e03b52bc9231e52e0113db3ab",
+                  "sha256:2dbfe3cb37c18b39393870baa77f3bbd42be53517abffdd990b13ed70ee3dd3e",
+                  "sha256:f5bcb82a732c02d6f31bbf156887049883c76cedc9c6a11b049358a74f4d45d0",
+                  "sha256:2d1655f040141384ec8760e4a47e0455ce518989f7bb1a830ab9534bfb38a78a",
+                  "sha256:d3e95ed161acd1ba957b1864e7ca2102d9c39380bbdd56eddebf11d5219b3a04",
+                  "sha256:572bec3deb2f8ae7a6ad46976738c2630023eec1d9bd13ab1ccca7b54256daee",
+                  "sha256:466601cf2b7bebf49a6a8e936b32dffc844c9ed4cd82961d008d17cfccc596e8",
+                  "sha256:70fe40ffb2fb3eb2c3626afbfdb200a2429e000c2fbb172886c23b1908000501",
+                  "sha256:32ebba6472cdc331bd3366ca996ad3039b3a1b41c61a849b88074e1b722cad2c",
+                  "sha256:4fb1b85fe3712a292f8dd8f1d65805607485dbf97307cf146bbc6e0293a7c725",
+                  "sha256:5f76a72e58cd374ec83e26f42778adb3b90aacd091527a34c8a347089034d398",
+                  "sha256:75e9ed16ace51ba04a62505aaed215bf9c722d6f4b1c33cc3e3962076c300ee8",
+                  "sha256:c3c1c42a41ab18dc09214bcd3a567bb7ba9b9c2191a6e1079b9770dfe2d3a338",
+                  "sha256:60eb345663d2f6ec4b5c304cd21685dc7148d34739477136d96ab6bc131d9c4d",
+                  "sha256:7962bed04e961194d64769b4b7d5c85836808361c606e943b013098fe53df782",
+                  "sha256:d539404dafd8ad5d785ab3da6f8bd5a2bf5dff9e01be0ff1bc1d251786dda25c",
+                  "sha256:bff39fef1fc01564156123fcade75b4bc50402a2971a031d9a426c7014b1e681",
+                  "sha256:6b9875495111bcd2d3c5e9e380b3be17fb0a730891468fb45bdba3b3692b00ea",
+                  "sha256:b29c8cb61ef138fdf00a458f0646cf9390e0f39783f02f6b81a956585dc6b302",
+                  "sha256:e217c2687212d931ad9a6a02afb20cc34f6d051786d136e337f91079c9f73d22",
+                  "sha256:c1291b69a65a860069195a33cf6640df8667e960f9f030ceeea4497c47858b94",
+                  "sha256:d8c00baf46e33f9e5f1b9e139bbea9fe0f27badb432c992b9cf8c4f7017094bf",
+                  "sha256:62ac185c4d6d242b187022c8376469073c211e8deca2a7b2badf1d775e2fd5a3",
+                  "sha256:1a968f65db066243cbd0a6e12d193ef674637f044299a15b5d6b910e91411812",
+                  "sha256:4a167fa4a7238bd94b3134173f6267b19cdebc2fde98b583344749e1f4c9bf09",
+                  "sha256:8904fdb492f34e5242ba483fb6b7b158342662575b3d5ac9abbc380568840d4a",
+                  "sha256:6bfc201a12dc7bba21069a663aa692a96c5e8920b0d94a4e355c332d7ead15ba",
+                  "sha256:7aeb44195a1c984aff87cf8429d2aa40f6947b0a47d3603e1ca5c3cf8d284459",
+                  "sha256:f6cd5ed6305952c1cd842fbca0e5d9613f736646cfac2082a2db37f5d065468c",
+                  "sha256:791acd72bc40be9ba5fa6b77d78def5da623544408b72baa4c81181c03a205cb",
+                  "sha256:906bffa419bdb1a6d3094d7a6f2308527f5ece250bfcb962df79e9867f28236d",
+                  "sha256:deeeab9fcf6b9cb47235974158561967e299344e040c408e6b5d7464af2f3882",
+                  "sha256:0eb36aba0f471119ccb001ea4f1819002ae535882df63e871be80e01f4f776bb",
+                  "sha256:393e7bb9f93ffb3cbba620fbfeb229f2b8345454bc60ac0508f76735544ed289",
+                  "sha256:f24bce642ec88622490b2f09a45fa3985da7f6511a1aae131853c4ea4c309e6b",
+                  "sha256:4c5aabda0cd9edb40e141066d400d2e4b232bc22ab60e806a6399691c391cabc",
+                  "sha256:4079a1edf72a60c97ee48f0a98820b3b014575b402ea05a64cbc5f2b8af674de",
+                  "sha256:9936485ac7111967d6962bc539de7b08807e310117adb78b11c21a5db0f0f890",
+                  "sha256:c62991989974533b86a29586b799623a908add501287f2c890be4fc8a6af2c7d",
+                  "sha256:0230acdbc9da4b36da812f0e585a7602eda4982c899b3b3a4c2bc9b4546d8e74",
+                  "sha256:7abf49cabbaf996afc0c2604f10ea18f8f22a903fc4ba3728a18f5892353c5c9",
+                  "sha256:41716536ea16798238ac89fbc3041b3f9dc80f9a64ea4b19d6e67ad2c909269a",
+                  "sha256:17ffe1d683dbff48f9b2ef903401e471e5e51a992bf0890632bceb94561893de",
+                  "sha256:8403cfc97e0e72e37639b8c54d92f1ee427e48a70d52d5260a37fa104f2df20d",
+                  "sha256:b64219f2278bf3f032b71593da63f563920778230946b66f1037bef2f2a7358b",
+                  "sha256:fb1aa2fc7bbe75deca5b66f2151742b4afeb5c75a668b11b9875c81894bb2a3f",
+                  "sha256:7a66928044c3478964aeaf6f9e981fdbcfa6b2ff7fad9f2ad57a8c09387cbbf2",
+                  "sha256:5bcb506bd5559870631aa838711e683a5a2a07c6c0171be6bbeda9ba92dcdf5e",
+                  "sha256:6495f3b729a1ceecd7cfdf318cfaa8ecf776ffa16293aad9f97cc542b6901ef7",
+                  "sha256:c24b21415b737f18fad7aeb192e60f7d323f7ba69434ecc1e78b3af0003be8dc",
+                  "sha256:965dca9dc74ed26f4204debe15b8e4dd1b8e41a80b8608287a9ef22f0b6f507e",
+                  "sha256:bb4b6716669e27c7619f63751770cb87e7cfecd4e302e2ce6588035509168352",
+                  "sha256:f8130aecd446f997d0e2011481275db0552bf57bd7af0d7a655eded5f52ca94e",
+                  "sha256:c2479eb811f4d9b8624ef20119e1abdc109f639c2cf576eb945b340362d87b05",
+                  "sha256:46606c1ed76a4da2a9d18016aeb50f4dddf58e1b45d665c983c58f8e605bf73e",
+                  "sha256:d87f7fa5e637442eb638bcaafdc44ca3895d91a153015ff9af6a87219f0dc372",
+                  "sha256:71c88f04921ae61a7009f9443f95c70ec3424a798429fc01e6c1432c1077aacb",
+                  "sha256:bf994cb2e5c367d78483662c7de6e69950aaf04bc6cfdbbef4d1ef7ce153717c",
+                  "sha256:b7330d40f75b8ec786e41c45a202e44f0e49ec29ddf8944120fbdb373a6c6617",
+                  "sha256:bb82b10a91493d745dc533b5de5335db650adb0c8a90548fdf5dad13569a16f4",
+                  "sha256:9e2ef90cb484b37232e829ec400dcddd3f9f0d189eb6f0074b3b5874d4553d1c",
+                  "sha256:dfb7add4926f9a350755294af3c20f114ac59f32e00cadc9ec625b2a51703ad0",
+                  "sha256:7b334d84bf03876c5738efa3857faaa35ede5c8eab30a5621ecfd4efa7ce39a5",
+                  "sha256:dd96950b4282e64ce3e37f0bd1a51834beb286037184f3796f9889bfa1ed0d72",
+                  "sha256:3ed319e31a9c38e5f4e336195b5cbd253b3f8b17f93f185829f078c5ef420305",
+                  "sha256:5c46bef8c0e95e05716e9a53b77970c1378d93bcb9a800018a24f7e1763b45b9",
+                  "sha256:d03b9f4b9848e3a88d62bcf6e536d659c325b2dc03b2136be7342b5fe5e2b6a9",
+                  "sha256:a34e0c5859e5e8757afafba47d83396226b646f32954ef7ecda4ad3be464bed6",
+                  "sha256:fc9d3ee3946b87efcd9531f876d23a9e8d5769aab3e0ad6007ac2cdb4068499c",
+                  "sha256:cffc31e10891c58edc89cebd211bc0be69d99f54f67682c91f97dc53e6381f0f",
+                  "sha256:7edc503f5a919c489b651757095d8031982d530cc88088fdaeb743188364e9b0",
+                  "sha256:e83928bd4552ecdf8e71d283e2358c7eccd006d284ba31fbc9c89e407989fd60",
+                  "sha256:e269f7d33abbb790311ffa95fa7df9766cac8bf31ace24fce6ed732ba0db19ae",
+                  "sha256:da4c6daa0d5406bc967cc89b02a69689491f42c543aceea1a31136f0f1a8d991",
+                  "sha256:a1af93a1b62e8ca05b7597d5749a2b3d28735a86928f0432064fec61db1ff844",
+                  "sha256:74e11b9013f81bd30ec7934ea695d267d164967fec27a02652aa48602b94bc51",
+                  "sha256:dc1d4f59ba0728e65433bc7f903b3799d61545ed3eed7427ad0fe36dcd0f831b",
+                  "sha256:6b588ff47d46d33b02bc296e6e5cc263d6c8ff51ee97b59ca8b34d5c45d57912",
+                  "sha256:545cd23ad8e4f71a5109551093668fd4b5e1a50d6a60364ce0f04f64eecd99d1",
+                  "sha256:0225dc3999e3d7b1bb57186a2fc93c98bd1e4e08e062fb51c966e1f2a2c91bb4",
+                  "sha256:51c3ee5d824bdde0a8faa10c99841c2590c0c26edfb17125aa97945a688c83ed",
+                  "sha256:794f970f498af07b37f914c19ad5dedc6b6c2f89d343af9dd1768d17232555de",
+                  "sha256:61ee52dfdcbcd98acc765b45781ea5de94831f55675c0faaf615872f92268757",
+                  "sha256:8d19cdf57ba61fecd9e07f24fe88768f58196543f7c032adada8a0cc48eee6b3",
+                  "sha256:c238e0a5472c59c54093ffa23af6a963b4ae437eedfb6b9ebbcb482752c6d16b",
+                  "sha256:f4e3607f242bbca7ec2379822ca961860e6d9c276da51c6e2dfd17a29469ec78",
+                  "sha256:6bbb721dd2c411c85c75f7477b14c54c776d78ee9b93557615e919ef47577440",
+                  "sha256:2975de6545b4ca7907ae368a1716c531764e4afccbf27fb0a694d90e983c38e2",
+                  "sha256:7e50a5d0f2fbd8c95375f72f5772c7731186e999a447121b8247f448b065a4ef",
+                  "sha256:1edcf2b441ddf21417ef2b33e1ab2a30900758819335d7fabafe3b16bb3eab62",
+                  "sha256:04ee771fad226ade609b0e879d15c32898379360db27ef1bc6d9f5a77127d5a8",
+                  "sha256:7559c097998db5e5d14dab1a7a1637a5749e9dab234ca68d17c9c21f8cfbf8d6",
+                  "sha256:d5ee453757bd1b479881f0a57b968427404b81d9fed07d04afebcbcfcbf536ab",
+                  "sha256:4b40402374fc4a9202a67d3ede77dedbe5ed1bab57479a5b5cb5cd6c45283bf4",
+                  "sha256:926ce547a03e1bd2aac94b1792d7ccea16d1e6bd91903458e63a095268e1b02f",
+                  "sha256:f5e73bbd776a2426a796971d8d38664f2e94898479fb76947dccdd28cf9fe1d0",
+                  "sha256:78d17ed089151e7fa3d1a3cdbbac8ca3b1b5c484fae5ba025642cc9107991037",
+                  "sha256:47f414f515a2c3103d0e7dae67c47a3b2bc76ea2413d666052012b11dbdd0feb",
+                  "sha256:b566154cc9b2b1996716def297d58101f3015a1b868187f1f9e4cd3074ae9988",
+                  "sha256:3edfdbc82f97ec12e59c80c67897fc1eeb44c3d16820f761a8f15272965ea3a1",
+                  "sha256:cdd6594a3bca71d32a5061b85457cc8148611e7f042ba6e812a1c0a2faebac92",
+                  "sha256:56650f8b8f2b01c1090d184d7d6d396f0109f8a02f915c97b081be73ea12df08",
+                  "sha256:946ba273a3a3b6fdf140f3c03112918c0a556a5871c477f5dbbb98600e6ca557",
+                  "sha256:c64632c85c3a49dc82222cdb3d0ee87eafa64f3096ffeba5bcc16c49ee2d260e",
+                  "sha256:e716fd0130980916f4b1aeac8f98dbcd8ced81e2c119b7877204cc6b1a058418",
+                  "sha256:15554476d03595246aec194e63ec9db7469d5b3ed81a27a8a2720e82df1f8bf4",
+                  "sha256:0727078eff2abaf1e5770b331ed8162d8e95cf2cf1de06de7540d034999d72ef",
+                  "sha256:3b00ac82c31b447e306fcb47b4469fdc4e6d87385b42358c2e76badb51b074a3",
+                  "sha256:401a2690658194fdd92994c29aa57c18cc5e3100fe7bbdba33d0fa26f2213eb3",
+                  "sha256:720088f184124166386634a523f3566a7fc56f802dbd6e6f816e959236542770",
+                  "sha256:2d77f4a2166122e3f7c5ace1bbfe5319ec6c2d24fff1c6f3e22ccb3e8b2327e0",
+                  "sha256:0ad85fe7a6b42dae9248268706940b12c01e83141858df79e43223e173fe9840",
+                  "sha256:35983fb2e9104b81caaa9e6d40352ea8b2b987fb811f935602d04cc90fdee76a",
+                  "sha256:1cfa672c25cb5849bb2aa652e045e4a4a272c025befb1fe5e58cb32823faa30d",
+                  "sha256:65ecf1e479dc2b2f7f09c2e86d7457043b3470b3eab3c4ee8909b50b0a669fc2",
+                  "sha256:1bd969e0521820374122f5132e5998d9bd2ab185be66565a7266096297419c8e",
+                  "sha256:c5b5967a094ced90899052a82e2c245529b75ba3f46e0ce1a89cfc95edb935ea",
+                  "sha256:c59538d646715fdb1f94c6be3fa0949871b8c860d5c54db4640a1197663a130b",
+                  "sha256:0e9a8a0f823bf0ef948862f0ccb62353460bd07931e756c98f23908c1c526578",
+                  "sha256:ccfa1810aa19fae08aefd29cffe28b65d5123cd17bd7d2d4207f03cf9795594c",
+                  "sha256:28c0f457d67213319f0313d993a3b2f8a778a077b202cd75bf45eb2792949d32",
+                  "sha256:acfee60459ffe722b9362696f58a26b606b637094d9439bf5f898310daf8ba24",
+                  "sha256:8781993942f622945aefe59e449a5ff4608f969db79fbe893040890ff08fc1f9",
+                  "sha256:111d88db3a52121f04f2741cc72ce8dda6d6f6ef2cc36452c042e0141b316334",
+                  "sha256:4715730da2b4a5bf6cc2ab85208071f00c7b279e4b2f75df0bd954446185e14c",
+                  "sha256:594d8b368013caa4eaba4eade896fc1cec8ef569052bd491f493c193e07c6d80",
+                  "sha256:abc36bf7797a427b64c3c99b4f74714bfa66b906b62358be6fdafe493a66415e",
+                  "sha256:405bda98fe97c1a5cf70511ae2d167256b25dd8721b88899465e9847525e2068",
+                  "sha256:3b5d31b89683be71c72b77cfceb59238f4c76a796de6ae85525b3d5cfe2a8f23",
+                  "sha256:dc835194ecfa6ebda81e0a764c953eff3422a61863e9a3e0dc74ea4cae7a4d94",
+                  "sha256:73ff0ee3bef442e48df0f95d26fee18606cfb1aee81617c3202a6b35bb0fca0c",
+                  "sha256:cb21226326a5a695c993daba749f5d758658d58612b05280a04cca98cba3f83a",
+                  "sha256:6c9dfb73e199975275633f05d31388cd61c5a77dec5678db958b4e6624eb21ba",
+                  "sha256:aa0007192287faeaecc72d9fa48efdb3108c764d450dc8fea65474476da32c45",
+                  "sha256:ccf848b42acc0f691b4cb6e2830dc4263c7ce4df89b3f4002c3d6b9cd99b362b",
+                  "sha256:b19bd4f106ce301ee21c860183cc1c2ef9c09bdf495059bdf16e8d8ccc71bbe8",
+                  "sha256:a04cb3117395b962edc32bf45d8411f240632476b0706b2df7f4a1a87b2ce34b",
+                  "sha256:233e5f78027b684e5aaac1395cc574aea3039059bf86eb4494422bc74216a396",
+                  "sha256:563b3741d26b6af963fdb7b0634e0791445a707d0b6093ac71c3224299241639",
+                  "sha256:07c65a3efc2bb32027206df4f117b893268d028cbb3741208d73615a63525158",
+                  "sha256:4cc53ff12e7b8fcfafdd32eaac7b13266876766f22b3262b653eaa7b06fbbaaf",
+                  "sha256:0320663709136d07690fe299903700cc1dcc526d574fe8b952a01e1d24024ae4",
+                  "sha256:d967d6bbb33bf7a295a64807f81875c84e82a8ecc59b6c72fe955141b1660d39",
+                  "sha256:4fae16ca54207cb952e3904b8eb8cc424f3f056f400e5e802ab1a9ef3e575834",
+                  "sha256:03ba1e86a04d912fd2878b457b06a6a7abad0ce96cd9a6932bf58cb4641b8fb7",
+                  "sha256:4e22015880d16cb7148d70895a2361f4fa05804f0391386e0e50554e6fd868b0",
+                  "sha256:9b1018a43b1a9245cdc71a342b962aa32fb799bd0ce66ee59b496cdd75200de9",
+                  "sha256:8cb953ea9ea1bd262bef00112e2c433583929cd7aec86ae60f1a725c6dcf7c09",
+                  "sha256:dbde46224833f804d8b92212fa3618ea53d0e0cb84ff07132a5ba36c1bc0b9df",
+                  "sha256:561a61d2d81bccb14d22a53b32301e0b6b9e9b9d80ad75991ee6ff796cae0ef7",
+                  "sha256:76df9e0fc779fcd7d3ee836ae254ead30b5f9492022b55901d1f8bd914d38ef6",
+                  "sha256:605033c50f750dad4c344495a0d6b18dcfb2a091bba072441a38cbf9001c0363",
+                  "sha256:9e540fe1fcf866ba1e738e012eef5459d34cca30385df73973e6fc7c6eadb55f",
+                  "sha256:7d4c363f4a746f3a0946d19f303fe9c60c5fe178892528ec4f34d8ddd2c4c359",
+                  "sha256:8540be85295735194e0053eb2ab6b2bda2e27119b9b030877eff43f9272a20cf",
+                  "sha256:e1153055b6ea57ee81e6fb41b03023279059513d0fec728517ae0805186a5118",
+                  "sha256:f97b5915b3f75d2878104c198f205841813712103f1b3657d71d2c8d079cc947",
+                  "sha256:dd8998fa42db6769700a41203f5ef0efe523ed24734636ef0dc0d2a4d4a94747",
+                  "sha256:17c615aa31cf2afa434d1d1d42e0db85b564fe416d346721bd38c0db75f73119",
+                  "sha256:31277c01ac529cc1c6a55fd87d6ce4dbb20290575d4e1e89cd40600eac9f3405",
+                  "sha256:4b00562fa291e956d910bb056c6120f0079f30093ea107757758683a6d418206",
+                  "sha256:5796882ac3059835583bc399e8522c19646b717713ef553a71b20ca0535a1718",
+                  "sha256:697f5bf30fbe44dd4dcba8392b85680952b7a1be9a0221349f4fde011a8cdd3c",
+                  "sha256:c477e45fe5f8f5bab1ec1711210dd357392ad19eab48cda18d89b60df5067970",
+                  "sha256:61b1d3440b078f35a3fe2b35c51d6d38498fb3dc8d8f5fedf52c7f0f8f6d8ecf",
+                  "sha256:bba1cd75958b43df5e3ceb820449008c19ed5fa562d54c2d46c5c57e79aa6b2a",
+                  "sha256:8a501b9d8016eee68ce62a93a65842b15c8a57192b9f8189ebc85a11f2f47f9e",
+                  "sha256:3d175382237a94330d72af67ad2c41535dee7eade3e42178b86d2dc87478d030",
+                  "sha256:e95bb05fa5defeb16dd0e0957de676374b22b9daaf405273e636d1ce91001574",
+                  "sha256:3898e2ac4e04e80373bc7fe4092b26d502d4705177719117e25c083d44a9a150",
+                  "sha256:de9a24cdb3260850b49086745ba6f724aecff0bf7993729ae063c116da6915a4",
+                  "sha256:9dc236a8124d1fcbb41b970b5a4c45d6f7f97430c933c775121cae27f5f352a7",
+                  "sha256:d46ef49f8ddba1ee8cce6c9764014851cce2dbfb5dcb2457a31495393e6566c1",
+                  "sha256:4164089bf1754c0ef18ae051e047f11299907204839ad4b7978f146a543a2e91",
+                  "sha256:09096bc32e37443417cd625364df32674f9d5ff4ddbeb175e6d60637ed3d573f",
+                  "sha256:654d9074dc8ebb93230fe258188a17ba3f7dbac2f360f9f79cc4fb1516953018",
+                  "sha256:44999c555a6e4bb6cf5e6f6a79819e76912d036732cb50efaeefc20a180dd839",
+                  "sha256:ce954d3900cb547aea14df6ad5f310ea96bb5e83a155b93e2e64b2c13b686193",
+                  "sha256:368779f00f427680d954899dd73ad3b6a59c42baafb91cb100ea177f51185198",
+                  "sha256:f0c20dff5211f9c133ad5703daedcbe148528c634b0a1eea7887b420da4dc00c",
+                  "sha256:15cd74b4ad9d82417072fe867f086d68667afd4291b710b6c7feef985c492990",
+                  "sha256:480e0f1a9dcce6ed0728e9aba709e33f5522273da1e4b0859cf9d3bbe2216532",
+                  "sha256:cd8b0adfc4d2467a61ab2aa2b3e617bbd2a2592176da249365eef014faef827c",
+                  "sha256:a4577841148e7e2bf481447ae141eff319007e70a24295a22787bbfaecf4c4fe",
+                  "sha256:bc3e4dd9194760500ce9731d792f46afa049667185487bae88c23a38fdb10c37",
+                  "sha256:33a92d88496e8aa410976f073e324f761b2ae02a94c20c0f291072df84f648be",
+                  "sha256:e525544166da577edcd03c6596f1e8787a257caaa19eef98c3a481681d2d978a",
+                  "sha256:b55df489f643b495984915a0671e74262192813e07cff5812d778c8cf4c0b9d1",
+                  "sha256:b5bd11b47b5b690dc667dc486941331d7cd3aaa4f0e5c4d638ec7b294bcc5012",
+                  "sha256:7e67dba2509f90064325e62e49412d5284a55f09b7b6878b9c8222692c500dde",
+                  "sha256:9f1a745b208091d4b009ec321a6fdc72c8a5e89167effed81c50571a13f1c87d",
+                  "sha256:c7dfa7d5a4917eed3b44af87ffb9c6e18242ecd847a8edd140bcdd178cc8946a",
+                  "sha256:46e371b6245113ebca446adcbd2db39f2887b67dc5a640f62f6d346ec9f6980f",
+                  "sha256:cea5d052286c0a120f6cdd0f3e559f13b0eedf9f83d2538e4369b6e05526d43d",
+                  "sha256:62da6a936871ab7b8c3efc0332fe41b4ac10ff96b357fb2bd67deecb312f9277",
+                  "sha256:9feaf80c733951790bc3578db42ea2abef65643ebb36779e46dccdaf4c76b525",
+                  "sha256:627d792d7cca1e97c121be5f0808c9da96f54d6c986622af246c60354b9c316e",
+                  "sha256:12fda64dea45a7b085a35a816a7d8035be6600cae38f7df04a3bc22ced4d4502",
+                  "sha256:24a37dea79558196e493bfdf202f5e29503e266d9e944457d3fd212b41264466",
+                  "sha256:a3430017f322fd147130a5572e4f1d357950d304aeef07c8c640be0dfe63b627",
+                  "sha256:f342cdc282518eab3c87bc964306092b77eeeed8ca1d815272f6d4e3431c9037",
+                  "sha256:8571a2aa115d42f8b5e87ef58d10e9c24e6fbe5470fc2612df96f8740f3d960f",
+                  "sha256:8945279d57ad510e018f92571ba8e5d811cf8a3165adf930b0d4015c5a077a35",
+                  "sha256:ebd64ac5cc7b9f58a40072fe9afefa2fd835e0eb18cdeaf085395c7e84affac3",
+                  "sha256:a2aeabb3962859069a78acc288bc3bffb35485428e162caafec8134f5ce6ca67"
+                ]
+              }
+            },
+            "options": {
+              "gpgkeys": [
+                "-----BEGIN PGP PUBLIC KEY BLOCK-----\nVersion: GnuPG v2.0.22 (GNU/Linux)\n\nmQINBFzMWxkBEADHrskpBgN9OphmhRkc7P/YrsAGSvvl7kfu+e9KAaU6f5MeAVyn\nrIoM43syyGkgFyWgjZM8/rur7EMPY2yt+2q/1ZfLVCRn9856JqTIq0XRpDUe4nKQ\n8BlA7wDVZoSDxUZkSuTIyExbDf0cpw89Tcf62Mxmi8jh74vRlPy1PgjWL5494b3X\n5fxDidH4bqPZyxTBqPrUFuo+EfUVEqiGF94Ppq6ZUvrBGOVo1V1+Ifm9CGEK597c\naevcGc1RFlgxIgN84UpuDjPR9/zSndwJ7XsXYvZ6HXcKGagRKsfYDWGPkA5cOL/e\nf+yObOnC43yPUvpggQ4KaNJ6+SMTZOKikM8yciyBwLqwrjo8FlJgkv8Vfag/2UR7\nJINbyqHHoLUhQ2m6HXSwK4YjtwidF9EUkaBZWrrskYR3IRZLXlWqeOi/+ezYOW0m\nvufrkcvsh+TKlVVnuwmEPjJ8mwUSpsLdfPJo1DHsd8FS03SCKPaXFdD7ePfEjiYk\nnHpQaKE01aWVSLUiygn7F7rYemGqV9Vt7tBw5pz0vqSC72a5E3zFzIIuHx6aANry\nGat3aqU3qtBXOrA/dPkX9cWE+UR5wo/A2UdKJZLlGhM2WRJ3ltmGT48V9CeS6N9Y\nm4CKdzvg7EWjlTlFrd/8WJ2KoqOE9leDPeXRPncubJfJ6LLIHyG09h9kKQARAQAB\ntDpDZW50T1MgKENlbnRPUyBPZmZpY2lhbCBTaWduaW5nIEtleSkgPHNlY3VyaXR5\nQGNlbnRvcy5vcmc+iQI3BBMBAgAhBQJczFsZAhsDBgsJCAcDAgYVCAIJCgsDFgIB\nAh4BAheAAAoJEAW1VbOEg8ZdjOsP/2ygSxH9jqffOU9SKyJDlraL2gIutqZ3B8pl\nGy/Qnb9QD1EJVb4ZxOEhcY2W9VJfIpnf3yBuAto7zvKe/G1nxH4Bt6WTJQCkUjcs\nN3qPWsx1VslsAEz7bXGiHym6Ay4xF28bQ9XYIokIQXd0T2rD3/lNGxNtORZ2bKjD\nvOzYzvh2idUIY1DgGWJ11gtHFIA9CvHcW+SMPEhkcKZJAO51ayFBqTSSpiorVwTq\na0cB+cgmCQOI4/MY+kIvzoexfG7xhkUqe0wxmph9RQQxlTbNQDCdaxSgwbF2T+gw\nbyaDvkS4xtR6Soj7BKjKAmcnf5fn4C5Or0KLUqMzBtDMbfQQihn62iZJN6ZZ/4dg\nq4HTqyVpyuzMXsFpJ9L/FqH2DJ4exGGpBv00ba/Zauy7GsqOc5PnNBsYaHCply0X\n407DRx51t9YwYI/ttValuehq9+gRJpOTTKp6AjZn/a5Yt3h6jDgpNfM/EyLFIY9z\nV6CXqQQ/8JRvaik/JsGCf+eeLZOw4koIjZGEAg04iuyNTjhx0e/QHEVcYAqNLhXG\nrCTTbCn3NSUO9qxEXC+K/1m1kaXoCGA0UWlVGZ1JSifbbMx0yxq/brpEZPUYm+32\no8XfbocBWljFUJ+6aljTvZ3LQLKTSPW7TFO+GXycAOmCGhlXh2tlc6iTc41PACqy\nyy+mHmSv\n=kkH7\n-----END PGP PUBLIC KEY BLOCK-----\n",
+                "-----BEGIN PGP PUBLIC KEY BLOCK-----\nVersion: GnuPG v2.0.22 (GNU/Linux)\n\nmQINBFzMWxkBEADHrskpBgN9OphmhRkc7P/YrsAGSvvl7kfu+e9KAaU6f5MeAVyn\nrIoM43syyGkgFyWgjZM8/rur7EMPY2yt+2q/1ZfLVCRn9856JqTIq0XRpDUe4nKQ\n8BlA7wDVZoSDxUZkSuTIyExbDf0cpw89Tcf62Mxmi8jh74vRlPy1PgjWL5494b3X\n5fxDidH4bqPZyxTBqPrUFuo+EfUVEqiGF94Ppq6ZUvrBGOVo1V1+Ifm9CGEK597c\naevcGc1RFlgxIgN84UpuDjPR9/zSndwJ7XsXYvZ6HXcKGagRKsfYDWGPkA5cOL/e\nf+yObOnC43yPUvpggQ4KaNJ6+SMTZOKikM8yciyBwLqwrjo8FlJgkv8Vfag/2UR7\nJINbyqHHoLUhQ2m6HXSwK4YjtwidF9EUkaBZWrrskYR3IRZLXlWqeOi/+ezYOW0m\nvufrkcvsh+TKlVVnuwmEPjJ8mwUSpsLdfPJo1DHsd8FS03SCKPaXFdD7ePfEjiYk\nnHpQaKE01aWVSLUiygn7F7rYemGqV9Vt7tBw5pz0vqSC72a5E3zFzIIuHx6aANry\nGat3aqU3qtBXOrA/dPkX9cWE+UR5wo/A2UdKJZLlGhM2WRJ3ltmGT48V9CeS6N9Y\nm4CKdzvg7EWjlTlFrd/8WJ2KoqOE9leDPeXRPncubJfJ6LLIHyG09h9kKQARAQAB\ntDpDZW50T1MgKENlbnRPUyBPZmZpY2lhbCBTaWduaW5nIEtleSkgPHNlY3VyaXR5\nQGNlbnRvcy5vcmc+iQI3BBMBAgAhBQJczFsZAhsDBgsJCAcDAgYVCAIJCgsDFgIB\nAh4BAheAAAoJEAW1VbOEg8ZdjOsP/2ygSxH9jqffOU9SKyJDlraL2gIutqZ3B8pl\nGy/Qnb9QD1EJVb4ZxOEhcY2W9VJfIpnf3yBuAto7zvKe/G1nxH4Bt6WTJQCkUjcs\nN3qPWsx1VslsAEz7bXGiHym6Ay4xF28bQ9XYIokIQXd0T2rD3/lNGxNtORZ2bKjD\nvOzYzvh2idUIY1DgGWJ11gtHFIA9CvHcW+SMPEhkcKZJAO51ayFBqTSSpiorVwTq\na0cB+cgmCQOI4/MY+kIvzoexfG7xhkUqe0wxmph9RQQxlTbNQDCdaxSgwbF2T+gw\nbyaDvkS4xtR6Soj7BKjKAmcnf5fn4C5Or0KLUqMzBtDMbfQQihn62iZJN6ZZ/4dg\nq4HTqyVpyuzMXsFpJ9L/FqH2DJ4exGGpBv00ba/Zauy7GsqOc5PnNBsYaHCply0X\n407DRx51t9YwYI/ttValuehq9+gRJpOTTKp6AjZn/a5Yt3h6jDgpNfM/EyLFIY9z\nV6CXqQQ/8JRvaik/JsGCf+eeLZOw4koIjZGEAg04iuyNTjhx0e/QHEVcYAqNLhXG\nrCTTbCn3NSUO9qxEXC+K/1m1kaXoCGA0UWlVGZ1JSifbbMx0yxq/brpEZPUYm+32\no8XfbocBWljFUJ+6aljTvZ3LQLKTSPW7TFO+GXycAOmCGhlXh2tlc6iTc41PACqy\nyy+mHmSv\n=kkH7\n-----END PGP PUBLIC KEY BLOCK-----\n"
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.fix-bls",
+            "options": {}
+          },
+          {
+            "type": "org.osbuild.locale",
+            "options": {
+              "language": "el_CY.UTF-8"
+            }
+          },
+          {
+            "type": "org.osbuild.keymap",
+            "options": {
+              "keymap": "dvorak"
+            }
+          },
+          {
+            "type": "org.osbuild.hostname",
+            "options": {
+              "hostname": "my-host"
+            }
+          },
+          {
+            "type": "org.osbuild.timezone",
+            "options": {
+              "zone": "Europe/London"
+            }
+          },
+          {
+            "type": "org.osbuild.chrony",
+            "options": {
+              "timeservers": [
+                "time.example.com"
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.groups",
+            "options": {
+              "groups": {
+                "group1": {
+                  "name": "group1",
+                  "gid": 1030
+                },
+                "group2": {
+                  "name": "group2",
+                  "gid": 1050
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.users",
+            "options": {
+              "users": {
+                "user1": {
+                  "key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC61wMCjOSHwbVb4VfVyl5sn497qW4PsdQ7Ty7aD6wDNZ/QjjULkDV/yW5WjDlDQ7UqFH0Sr7vywjqDizUAqK7zM5FsUKsUXWHWwg/ehKg8j9xKcMv11AkFoUoujtfAujnKODkk58XSA9whPr7qcw3vPrmog680pnMSzf9LC7J6kXfs6lkoKfBh9VnlxusCrw2yg0qI1fHAZBLPx7mW6+me71QZsS6sVz8v8KXyrXsKTdnF50FjzHcK9HXDBtSJS5wA3fkcRYymJe0o6WMWNdgSRVpoSiWaHHmFgdMUJaYoCfhXzyl7LtNb3Q+Sveg+tJK7JaRXBLMUllOlJ6ll5Hod root@localhost"
+                },
+                "user2": {
+                  "uid": 1020,
+                  "gid": 1050,
+                  "groups": [
+                    "group1"
+                  ],
+                  "description": "description 2",
+                  "home": "/home/home2",
+                  "shell": "/bin/sh",
+                  "password": "$6$BhyxFBgrEFh0VrPJ$MllG8auiU26x2pmzL4.1maHzPHrA.4gTdCvlATFp8HJU9UPee4zCS9BVl2HOzKaUYD/zEm8r/OF05F2icWB0K/",
+                  "key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC61wMCjOSHwbVb4VfVyl5sn497qW4PsdQ7Ty7aD6wDNZ/QjjULkDV/yW5WjDlDQ7UqFH0Sr7vywjqDizUAqK7zM5FsUKsUXWHWwg/ehKg8j9xKcMv11AkFoUoujtfAujnKODkk58XSA9whPr7qcw3vPrmog680pnMSzf9LC7J6kXfs6lkoKfBh9VnlxusCrw2yg0qI1fHAZBLPx7mW6+me71QZsS6sVz8v8KXyrXsKTdnF50FjzHcK9HXDBtSJS5wA3fkcRYymJe0o6WMWNdgSRVpoSiWaHHmFgdMUJaYoCfhXzyl7LtNb3Q+Sveg+tJK7JaRXBLMUllOlJ6ll5Hod root@localhost"
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.systemd",
+            "options": {
+              "enabled_services": [
+                "sshd.socket"
+              ],
+              "disabled_services": [
+                "bluetooth.service"
+              ],
+              "default_target": "multi-user.target"
+            }
+          },
+          {
+            "type": "org.osbuild.sysconfig",
+            "options": {
+              "kernel": {
+                "update_default": true,
+                "default_kernel": "kernel"
+              },
+              "network": {
+                "networking": true,
+                "no_zero_conf": true
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.fstab",
+            "options": {
+              "filesystems": [
+                {
+                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+                  "vfs_type": "xfs",
+                  "path": "/",
+                  "options": "defaults"
+                }
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.grub2",
+            "options": {
+              "root_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "kernel_opts": "console=tty0 console=ttyS0,115200n8 no_timer_check net.ifnames=0 crashkernel=auto debug",
+              "legacy": "powerpc-ieee1275",
+              "saved_entry": "ffffffffffffffffffffffffffffffff-4.18.0-331.el8.ppc64le"
+            }
+          },
+          {
+            "type": "org.osbuild.selinux",
+            "options": {
+              "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
+            }
+          }
+        ]
+      },
+      {
+        "name": "image",
+        "build": "name:build",
+        "stages": [
+          {
+            "type": "org.osbuild.truncate",
+            "options": {
+              "filename": "disk.img",
+              "size": "10737418240"
+            }
+          },
+          {
+            "type": "org.osbuild.sfdisk",
+            "options": {
+              "label": "dos",
+              "uuid": "0x14fc63d2",
+              "partitions": [
+                {
+                  "bootable": true,
+                  "size": 8192,
+                  "start": 2048,
+                  "type": "41"
+                },
+                {
+                  "size": 20961180,
+                  "start": 10240
+                }
+              ]
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "disk.img"
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.mkfs.xfs",
+            "options": {
+              "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8"
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "disk.img",
+                  "start": 10240,
+                  "size": 20961180
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.copy",
+            "inputs": {
+              "root-tree": {
+                "type": "org.osbuild.tree",
+                "origin": "org.osbuild.pipeline",
+                "references": [
+                  "name:os"
+                ]
+              }
+            },
+            "options": {
+              "paths": [
+                {
+                  "from": "input://root-tree/",
+                  "to": "mount://root/"
+                }
+              ]
+            },
+            "devices": {
+              "root": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "disk.img",
+                  "start": 10240,
+                  "size": 20961180
+                }
+              }
+            },
+            "mounts": [
+              {
+                "name": "root",
+                "type": "org.osbuild.xfs",
+                "source": "root",
+                "target": "/"
+              }
+            ]
+          },
+          {
+            "type": "org.osbuild.grub2.inst",
+            "options": {
+              "filename": "disk.img",
+              "platform": "powerpc-ieee1275",
+              "location": 2048,
+              "core": {
+                "type": "mkimage",
+                "partlabel": "dos",
+                "filesystem": "xfs"
+              },
+              "prefix": {
+                "type": "partition",
+                "partlabel": "dos",
+                "number": 1,
+                "path": "/boot/grub2"
+              }
+            }
+          }
+        ]
+      },
+      {
+        "name": "qcow2",
+        "build": "name:build",
+        "stages": [
+          {
+            "type": "org.osbuild.qemu",
+            "inputs": {
+              "image": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.pipeline",
+                "references": {
+                  "name:image": {
+                    "file": "disk.img"
+                  }
+                }
+              }
+            },
+            "options": {
+              "filename": "disk.qcow2",
+              "format": {
+                "type": "qcow2",
+                "compat": "0.10"
+              }
+            }
+          }
+        ]
+      }
+    ],
+    "sources": {
+      "org.osbuild.curl": {
+        "items": {
+          "sha256:003ee19ec5b88de212c3246bdfdb3e97a9910a25a219fd7cf5030b7bc666fea9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-requests-2.20.0-2.1.el8_1.noarch.rpm"
+          },
+          "sha256:01b0562b890a80c202fff9175dc845500660c7f1655292d4ee13ca667acab081": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libsecret-0.18.6-1.el8.ppc64le.rpm"
+          },
+          "sha256:020abac486839c7be29fae37a686dc7749398c333cb8ba94b3390b386ffcbff7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libgpg-error-1.31-1.el8.ppc64le.rpm"
+          },
+          "sha256:0225dc3999e3d7b1bb57186a2fc93c98bd1e4e08e062fb51c966e1f2a2c91bb4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/perl-Pod-Perldoc-3.28-396.el8.noarch.rpm"
+          },
+          "sha256:0230acdbc9da4b36da812f0e585a7602eda4982c899b3b3a4c2bc9b4546d8e74": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/mpfr-3.1.6-1.el8.ppc64le.rpm"
+          },
+          "sha256:0320663709136d07690fe299903700cc1dcc526d574fe8b952a01e1d24024ae4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/readline-7.0-10.el8.ppc64le.rpm"
+          },
+          "sha256:037b950664c45aadf7476e208cca5908c2415c7a7da15071fea51cd1bcae4795": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libnftnl-1.1.5-4.el8.ppc64le.rpm"
+          },
+          "sha256:03ba1e86a04d912fd2878b457b06a6a7abad0ce96cd9a6932bf58cb4641b8fb7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/rpm-build-libs-4.14.3-15.el8.ppc64le.rpm"
+          },
+          "sha256:04ee771fad226ade609b0e879d15c32898379360db27ef1bc6d9f5a77127d5a8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/perl-Unicode-Normalize-1.25-396.el8.ppc64le.rpm"
+          },
+          "sha256:04eee0a9c079186aa58b5536ac8bcbd2a360700b83fa7b9f6eb127c1386b7ef4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/dosfstools-4.1-6.el8.ppc64le.rpm"
+          },
+          "sha256:0515afdac097ad54cf4b24e0644f0789cab5535a54107aa44940ffd991a6cef3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libgomp-8.5.0-3.el8.ppc64le.rpm"
+          },
+          "sha256:067c25522b7ae516b4df454a01d4798126b8d6004812d5476272f8159fe66c02": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/iwl135-firmware-18.168.6.1-103.el8.1.noarch.rpm"
+          },
+          "sha256:06c8c530fb914e07375c183f13b8431456377cec33376423f6589d1047277587": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/bzip2-1.0.6-26.el8.ppc64le.rpm"
+          },
+          "sha256:0727078eff2abaf1e5770b331ed8162d8e95cf2cf1de06de7540d034999d72ef": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/polkit-pkla-compat-0.1-12.el8.ppc64le.rpm"
+          },
+          "sha256:07c65a3efc2bb32027206df4f117b893268d028cbb3741208d73615a63525158": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-syspurpose-1.28.20-1.el8.ppc64le.rpm"
+          },
+          "sha256:07ce52eb60e4fbe4906e160a8e166002a4b8edb66b6813f68c08d67c4d644b82": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/iwl1000-firmware-39.31.5.1-103.el8.1.noarch.rpm"
+          },
+          "sha256:07fb48b313f6d4c1c8b1ffd9c5226c68f99616e46bbd04b325527d817b500577": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libnfsidmap-2.3.3-46.el8.ppc64le.rpm"
+          },
+          "sha256:084d79ed3d7127e6d46e9ac6e654d8ef181a156435808dc8eb32968b6c1b4946": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/cracklib-dicts-2.9.6-15.el8.ppc64le.rpm"
+          },
+          "sha256:090563f18409c228274bb61dcf1001f63a55c1246fb2838a998cb3c5fd8c3874": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/dbus-daemon-1.12.8-14.el8.ppc64le.rpm"
+          },
+          "sha256:09096bc32e37443417cd625364df32674f9d5ff4ddbeb175e6d60637ed3d573f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/trousers-lib-0.3.15-1.el8.ppc64le.rpm"
+          },
+          "sha256:0ad85fe7a6b42dae9248268706940b12c01e83141858df79e43223e173fe9840": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/ppc64-diag-rtas-2.7.7-1.el8.ppc64le.rpm"
+          },
+          "sha256:0afac6f4f9ed1c59510675d87da45c7966c0f7aae6e8dd056961aceed8c4fe0a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libfdisk-2.32.1-28.el8.ppc64le.rpm"
+          },
+          "sha256:0bad67cd4773d94db37a39c77f44b6eb380febc0de33fa51cacc2140c9c699b9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/lorax-28.14.61-2.el8.ppc64le.rpm"
+          },
+          "sha256:0bc637f0d028043e8388b083cdd8d0a0acea7fdbc79c0bc9401dfb02c20fb817": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/python3-pexpect-4.3.1-3.el8.noarch.rpm"
+          },
+          "sha256:0e9a8a0f823bf0ef948862f0ccb62353460bd07931e756c98f23908c1c526578": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-decorator-4.2.1-2.el8.noarch.rpm"
+          },
+          "sha256:0eb36aba0f471119ccb001ea4f1819002ae535882df63e871be80e01f4f776bb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/lsvpd-1.7.12-1.el8.ppc64le.rpm"
+          },
+          "sha256:0edde19e0c027c8cff31b82e1f4b0b198c00bf924047fcf4dd610a7d4965ab52": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/python3-pytz-2017.2-9.el8.noarch.rpm"
+          },
+          "sha256:0f54422e17766a9e7385a553d941d1849c9e7ca4caea085305ba9fb1e15ae607": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/python3-markupsafe-0.23-19.el8.ppc64le.rpm"
+          },
+          "sha256:0f57b051654b6d75789b437dafd7040b6c90daee17827be24352c0f11a74bba7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libsigsegv-2.11-5.el8.ppc64le.rpm"
+          },
+          "sha256:0feac495306bbe6e3149a352025bea8d23cda512859a230cbd3f510cf48caaf7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/python3-jsonschema-2.6.0-4.el8.noarch.rpm"
+          },
+          "sha256:10814d88ff647e12aeceae4c3815f9eeb66ce7327099c642f934a391fd915f2c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/iwl3160-firmware-25.30.13.0-103.el8.1.noarch.rpm"
+          },
+          "sha256:111d88db3a52121f04f2741cc72ce8dda6d6f6ef2cc36452c042e0141b316334": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-gpg-1.13.1-9.el8.ppc64le.rpm"
+          },
+          "sha256:11838afbfab4da7d5fa6e01046f76cce0b0a0c174a87c522eba440fce16e316f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/abattis-cantarell-fonts-0.0.25-6.el8.noarch.rpm"
+          },
+          "sha256:11ff811a72c82084c7c14700b23d29643e153442a34b3b486e270e5b40e38d0a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/gnupg2-2.2.20-2.el8.ppc64le.rpm"
+          },
+          "sha256:12696f5638ad2068c5c8940495d15c3bb1c57990000dbda7428b008e9e63ab5b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libffi-3.1-22.el8.ppc64le.rpm"
+          },
+          "sha256:12b0565d080311c7804d8fb1d697ecdef8807563ebeee4443e2fa6d35b1d958f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/iproute-5.12.0-2.el8.ppc64le.rpm"
+          },
+          "sha256:12fda64dea45a7b085a35a816a7d8035be6600cae38f7df04a3bc22ced4d4502": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/pinentry-1.1.0-2.el8.ppc64le.rpm"
+          },
+          "sha256:15554476d03595246aec194e63ec9db7469d5b3ed81a27a8a2720e82df1f8bf4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/polkit-libs-0.115-12.el8.ppc64le.rpm"
+          },
+          "sha256:15b17b95cf9cb9fb64e0c8e56110836bdcaf70de81b8cbdb60e181fc90456e06": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/centos-stream-release-8.5-3.el8.noarch.rpm"
+          },
+          "sha256:15cd74b4ad9d82417072fe867f086d68667afd4291b710b6c7feef985c492990": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/which-2.21-16.el8.ppc64le.rpm"
+          },
+          "sha256:1649f9d356cda961dd08dafa92475557ac398da9a657ee019de0c1f2c0593c8a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libsoup-2.62.3-2.el8.ppc64le.rpm"
+          },
+          "sha256:16b390c34ddb56c075fb6f4b77bf9a0fffab219fcb3f3588b9151215ab2b0ad4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/libxcb-1.13.1-1.el8.ppc64le.rpm"
+          },
+          "sha256:176ffcb2cf0fdcbdd2d8119cbd98eef60a30fdb0fb065a9382d2c95e90c79652": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-chardet-3.0.4-7.el8.noarch.rpm"
+          },
+          "sha256:17c615aa31cf2afa434d1d1d42e0db85b564fe416d346721bd38c0db75f73119": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/snappy-1.1.8-3.el8.ppc64le.rpm"
+          },
+          "sha256:17ffe1d683dbff48f9b2ef903401e471e5e51a992bf0890632bceb94561893de": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/ncurses-libs-6.1-9.20180224.el8.ppc64le.rpm"
+          },
+          "sha256:19061d12407c0c4bca6abcaef01695b70dcd3967ff102dd07178a2193a280e29": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/cpio-2.12-10.el8.ppc64le.rpm"
+          },
+          "sha256:194dbe332ccdb33d58f040da07667257e176975f6b2f17343bbf33fb99deb097": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libcroco-0.6.12-4.el8_2.1.ppc64le.rpm"
+          },
+          "sha256:1a4e44583a767289bb0d354db93c6a9132420e13376d4fcae866d69620bb11bb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/dbus-1.12.8-14.el8.ppc64le.rpm"
+          },
+          "sha256:1a968f65db066243cbd0a6e12d193ef674637f044299a15b5d6b910e91411812": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libxcrypt-4.1.1-6.el8.ppc64le.rpm"
+          },
+          "sha256:1aa321c66a3661e78d938b805e5c311d519f04bf3496545ffdacc7c152bc9b21": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libpwquality-1.4.4-3.el8.ppc64le.rpm"
+          },
+          "sha256:1b5136570cefb8273dd5affc73c1456cf239cc8b18be72d6c4d09794af7f3352": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libsmartcols-2.32.1-28.el8.ppc64le.rpm"
+          },
+          "sha256:1b53c868277dec628058b31b1a8a8a2ccd8efe832ce9694805b5f82564136eb3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/python3-prettytable-0.7.2-14.el8.noarch.rpm"
+          },
+          "sha256:1b95698d64dd299827f62cbe43d373e985da2d8900c4489a49475f53fa04f414": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libini_config-1.3.1-39.el8.ppc64le.rpm"
+          },
+          "sha256:1bd969e0521820374122f5132e5998d9bd2ab185be66565a7266096297419c8e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-configobj-5.0.6-11.el8.noarch.rpm"
+          },
+          "sha256:1cdd6c2abf0132da0d956398eb1dc736c0b93fd8e8465e7f1111ad05b2c322d8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/oddjob-mkhomedir-0.34.7-1.el8.ppc64le.rpm"
+          },
+          "sha256:1cfa672c25cb5849bb2aa652e045e4a4a272c025befb1fe5e58cb32823faa30d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/procps-ng-3.3.15-6.el8.ppc64le.rpm"
+          },
+          "sha256:1d6551bce8f8a1e53682fafe4f67fa830c333f0b37db7acbeaca0095b5ce870b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/kernel-modules-4.18.0-331.el8.ppc64le.rpm"
+          },
+          "sha256:1edcf2b441ddf21417ef2b33e1ab2a30900758819335d7fabafe3b16bb3eab62": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/perl-Time-Local-1.280-1.el8.noarch.rpm"
+          },
+          "sha256:1f2a096d6a75662a86a06ff2859e6ba916bbc8c6d8cb7b73810ffbb9fef4b089": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/c-ares-1.13.0-5.el8.ppc64le.rpm"
+          },
+          "sha256:1fad1d1f8b56e6967863aeb60f5fa3615e6a35b0f6532d8a23066e6823b50860": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/ca-certificates-2021.2.50-82.el8.noarch.rpm"
+          },
+          "sha256:20874a9d40b12125c9e5b97fe4ccda3f94acbc03da1dec7299123901f5b56631": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-oauthlib-2.1.0-1.el8.noarch.rpm"
+          },
+          "sha256:20c3abcc5556f09e557a398886684d1efe8ef59687bedbb78c130a7d1d55868a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/oddjob-0.34.7-1.el8.ppc64le.rpm"
+          },
+          "sha256:230731b577f8d29e7e8e8fd6d1ea02702fb4364fcc7034d838ccddc4d66da8c3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/kpartx-0.8.4-17.el8.ppc64le.rpm"
+          },
+          "sha256:233e5f78027b684e5aaac1395cc574aea3039059bf86eb4494422bc74216a396": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-slip-0.6.4-11.el8.noarch.rpm"
+          },
+          "sha256:2394d6a1ce4de90590e65111d870b172cb9d4e30e1e6f58a334b29e717fdd031": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/psmisc-23.1-5.el8.ppc64le.rpm"
+          },
+          "sha256:2451a475f248a4c66e64d149fefa8bfc195fcd7b3f369bae221a94f8ce4c2d67": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/grep-3.1-6.el8.ppc64le.rpm"
+          },
+          "sha256:24a37dea79558196e493bfdf202f5e29503e266d9e944457d3fd212b41264466": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/plymouth-0.9.4-9.20200615git1e36e30.el8.ppc64le.rpm"
+          },
+          "sha256:24f5cd46a7395cd046b10d6ddc4de435ec6595d0dcdb2d179c94cc9082a12f14": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/gpgme-1.13.1-9.el8.ppc64le.rpm"
+          },
+          "sha256:24fcc5bc49b059b221075989f25875fb821079088dca694aec262446cde50cb7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/chrony-4.1-1.el8.ppc64le.rpm"
+          },
+          "sha256:257e086bb52086254fa8cc95a5c4998668b4fcb5203ad3c2275c1150816acc9b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/glibc-common-2.28-162.el8.ppc64le.rpm"
+          },
+          "sha256:2588ff56ab340c06ce8b5be22cbe23de89d4f336b38ae930daf11db1c6a24391": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/dracut-network-049-188.git20210802.el8.ppc64le.rpm"
+          },
+          "sha256:2669ab8439093418c6c437c1f2e931d4152f5ac371e5a0f2d20b18455483c3a1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libservicelog-1.1.19-2.el8.ppc64le.rpm"
+          },
+          "sha256:27f43a7a8d1b18f5ede27728ecded75e510195a78abd9f3d0c1965d341e5e45a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/setroubleshoot-server-3.3.24-3.el8.ppc64le.rpm"
+          },
+          "sha256:2812ae39c665069f4b27e9bd26dde9141d4f4e7802befb1b14ac4e27a8225b4b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libndp-1.7-6.el8.ppc64le.rpm"
+          },
+          "sha256:28c0f457d67213319f0313d993a3b2f8a778a077b202cd75bf45eb2792949d32": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-dnf-plugins-core-4.0.21-2.el8.noarch.rpm"
+          },
+          "sha256:29214e4bf64efb65d82bd3f318d0ac3b7a6b03f6f6abfd469148bc2f894c6846": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/libmaxminddb-1.2.0-10.el8.ppc64le.rpm"
+          },
+          "sha256:2975de6545b4ca7907ae368a1716c531764e4afccbf27fb0a694d90e983c38e2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/perl-Text-ParseWords-3.30-395.el8.noarch.rpm"
+          },
+          "sha256:297b8a7b336dfc298d86d76d400459d2fa63af8628f5e19e35314a33a6478234": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/bind-export-libs-9.11.26-4.el8_4.ppc64le.rpm"
+          },
+          "sha256:2a8f9e5119a034801904185dcbf1bc29db67e9e9b0cf5893615722d7bb33099c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/crypto-policies-20210617-1.gitc776d3e.el8.noarch.rpm"
+          },
+          "sha256:2b76d31dc0fdff399a5b1d396caff67b9eb2f5b8f6cfa8d7a430eeaf6a09104d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/centos-logos-85.8-1.el8.ppc64le.rpm"
+          },
+          "sha256:2c1baefd0f802507d9741da8da54f6eae42b04967f9d433d7f9e0f124434c70d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/acl-2.2.53-1.el8.ppc64le.rpm"
+          },
+          "sha256:2d1655f040141384ec8760e4a47e0455ce518989f7bb1a830ab9534bfb38a78a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libsss_autofs-2.5.2-2.el8.ppc64le.rpm"
+          },
+          "sha256:2d77f4a2166122e3f7c5ace1bbfe5319ec6c2d24fff1c6f3e22ccb3e8b2327e0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/ppc64-diag-2.7.7-1.el8.ppc64le.rpm"
+          },
+          "sha256:2dbfe3cb37c18b39393870baa77f3bbd42be53517abffdd990b13ed70ee3dd3e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libssh-0.9.4-3.el8.ppc64le.rpm"
+          },
+          "sha256:2f6c73fdcd5c5e5b6d8b58663e498a0099db8029386869a4aca670471f6c298e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libbasicobjects-0.1.1-39.el8.ppc64le.rpm"
+          },
+          "sha256:2fcacd153d4aa4ddddee3357b717e8d3f411382b180add28328c9faa94dd2ae4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/qemu-guest-agent-4.2.0-52.module_el8.5.0+853+a4d5519d.ppc64le.rpm"
+          },
+          "sha256:30ae4489980021a727f247d48b4d74d4c6c7667d00bd1a670f045ea24a885541": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libblkid-2.32.1-28.el8.ppc64le.rpm"
+          },
+          "sha256:30ceeb5a6cadaeccdbde088bfb52ba88190fa530c11f4a2aafd62b4b4ad6b404": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/elfutils-default-yama-scope-0.185-1.el8.noarch.rpm"
+          },
+          "sha256:30dd1d58b7b963d052341f4583a7417823cf4dbbe7ac4b536f3a5250c4d34582": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/kexec-tools-2.0.20-56.el8.ppc64le.rpm"
+          },
+          "sha256:30f37ca1fe1592e29d3e97c1dec0646015000d19bffc40f13dcfe73e15be66fc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/setroubleshoot-plugins-3.3.13-1.el8.noarch.rpm"
+          },
+          "sha256:31277c01ac529cc1c6a55fd87d6ce4dbb20290575d4e1e89cd40600eac9f3405": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/sqlite-libs-3.26.0-15.el8.ppc64le.rpm"
+          },
+          "sha256:31d924d1540dd4e927a4c3aa936cec4bfb54ed302d3e8acc1be8b52dd5deb10c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libidn2-2.2.0-1.el8.ppc64le.rpm"
+          },
+          "sha256:32ebba6472cdc331bd3366ca996ad3039b3a1b41c61a849b88074e1b722cad2c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libstdc++-8.5.0-3.el8.ppc64le.rpm"
+          },
+          "sha256:32ecf5a37bacbeec9451c4ad39672ac2816f9241d5a92f038b45059da2f3ebae": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/libXrender-0.9.10-7.el8.ppc64le.rpm"
+          },
+          "sha256:3303f41952491bad2b31ee507eaabaf13dabe5ec9624c4b58a4a8301c4cd89dd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libaio-0.3.112-1.el8.ppc64le.rpm"
+          },
+          "sha256:331b91a0928c05618c7fed3e12bbe9ecb9e4619d08c7e85d3de344a08d2f0f1a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/json-c-0.13.1-2.el8.ppc64le.rpm"
+          },
+          "sha256:33a92d88496e8aa410976f073e324f761b2ae02a94c20c0f291072df84f648be": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/zlib-1.2.11-17.el8.ppc64le.rpm"
+          },
+          "sha256:35983fb2e9104b81caaa9e6d40352ea8b2b987fb811f935602d04cc90fdee76a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/prefixdevname-0.1.0-6.el8.ppc64le.rpm"
+          },
+          "sha256:35bd989d63522f9699b1a90dd453f866818cc3d247096a910a27fd7e49b09ac2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libnl3-cli-3.5.0-1.el8.ppc64le.rpm"
+          },
+          "sha256:35eb77080d99941b137da8c6cb25305ad4ff64cf2a7ba1f8adbf8d0998b5fe45": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-librepo-1.14.0-2.el8.ppc64le.rpm"
+          },
+          "sha256:360be5b93e106d77a8f4e84b318ee8dc14349f223540e0e200e0dfce2676ec04": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libcollection-0.7.0-39.el8.ppc64le.rpm"
+          },
+          "sha256:368779f00f427680d954899dd73ad3b6a59c42baafb91cb100ea177f51185198": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/vim-minimal-8.0.1763-15.el8.ppc64le.rpm"
+          },
+          "sha256:36c05d62567b455f2722c6e5cf431071174adf4c1d3b7450f0c1aaa903210bc3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/json-glib-1.4.4-1.el8.ppc64le.rpm"
+          },
+          "sha256:37a5d2adbe9e34309731885445decdf722ed7bc18d971c5a7f6a536f8876fd90": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/dracut-config-rescue-049-188.git20210802.el8.ppc64le.rpm"
+          },
+          "sha256:3818fe6ec4996402b718827ba40ca01cc3c8276646d80030b652a26153aea2b7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/cockpit-system-250-1.el8.noarch.rpm"
+          },
+          "sha256:383a5e6bb9e94de53baaf5c7493cd50a68c893c6a30acfbe28407d33bb133efc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/coreutils-common-8.30-12.el8.ppc64le.rpm"
+          },
+          "sha256:3898e2ac4e04e80373bc7fe4092b26d502d4705177719117e25c083d44a9a150": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/systemd-udev-239-49.el8.ppc64le.rpm"
+          },
+          "sha256:38fe7db64baf2d4804a14466a6244f3c1de3bd5deca0ad4044e96d0d3f3751c7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/checkpolicy-2.9-1.el8.ppc64le.rpm"
+          },
+          "sha256:393e7bb9f93ffb3cbba620fbfeb229f2b8345454bc60ac0508f76735544ed289": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/lua-libs-5.3.4-11.el8.ppc64le.rpm"
+          },
+          "sha256:3973aa7ac4416f1d33ffa8f4e9a5b126e7e2f77ed1ec63a70312b509b4934a9d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/python36-3.6.8-37.module_el8.5.0+771+e5d9a225.ppc64le.rpm"
+          },
+          "sha256:3a438b53e8377eccf90cac0fd42ed2b513fc869bfb7b96e3d2a4f6984a287f90": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/bash-4.4.20-2.el8.ppc64le.rpm"
+          },
+          "sha256:3b00ac82c31b447e306fcb47b4469fdc4e6d87385b42358c2e76badb51b074a3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/popt-1.18-1.el8.ppc64le.rpm"
+          },
+          "sha256:3b5d31b89683be71c72b77cfceb59238f4c76a796de6ae85525b3d5cfe2a8f23": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-libselinux-2.9-5.el8.ppc64le.rpm"
+          },
+          "sha256:3b777b51480977dd90050524eec747d73b635a17775228037617fe1d145a6fcf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/iwl5150-firmware-8.24.2.2-103.el8.1.noarch.rpm"
+          },
+          "sha256:3bbc114c65c8ecada03b8c4e0fd4a53b7cf3059177e927011f64bf2d87a38a35": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/iptables-libs-1.8.4-19.el8.ppc64le.rpm"
+          },
+          "sha256:3c89b334988c0d1399d25baebe298d9e8cc768f28aefd581aae893aa1e69de84": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/yum-utils-4.0.21-2.el8.noarch.rpm"
+          },
+          "sha256:3c9de6673cb840c3c6925bd1df87da0ef3b118d35dbe8f30bbafd0dfc67a939c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/python3-kickstart-3.16.13-1.el8.noarch.rpm"
+          },
+          "sha256:3d175382237a94330d72af67ad2c41535dee7eade3e42178b86d2dc87478d030": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/systemd-libs-239-49.el8.ppc64le.rpm"
+          },
+          "sha256:3d4e54f6bb2f6ee5417613d5d9bef407343adc768a0841ea58f831ffa868cbd0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/cairo-1.15.12-3.el8.ppc64le.rpm"
+          },
+          "sha256:3dfffdadfb10def9a3671a255e4fa71d8b22231ccf2c929e96689101dda8ce2c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/librepo-1.14.0-2.el8.ppc64le.rpm"
+          },
+          "sha256:3eca41ba67f8121586709b6fa2c57b20b4fab73bbb8a4c133269d0cc964f362c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-policycoreutils-2.9-15.el8.noarch.rpm"
+          },
+          "sha256:3ed20aba45a8c175e818de998d906fb2759387c607bd9b15dbbefee8c73097ba": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/NetworkManager-team-1.32.8-1.el8.ppc64le.rpm"
+          },
+          "sha256:3ed319e31a9c38e5f4e336195b5cbd253b3f8b17f93f185829f078c5ef420305": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/pcre-8.42-6.el8.ppc64le.rpm"
+          },
+          "sha256:3edfdbc82f97ec12e59c80c67897fc1eeb44c3d16820f761a8f15272965ea3a1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/pigz-2.4-4.el8.ppc64le.rpm"
+          },
+          "sha256:401a2690658194fdd92994c29aa57c18cc5e3100fe7bbdba33d0fa26f2213eb3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/powerpc-utils-1.3.8-7.el8.ppc64le.rpm"
+          },
+          "sha256:405bda98fe97c1a5cf70511ae2d167256b25dd8721b88899465e9847525e2068": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-libs-3.6.8-39.el8.ppc64le.rpm"
+          },
+          "sha256:4079a1edf72a60c97ee48f0a98820b3b014575b402ea05a64cbc5f2b8af674de": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/man-db-2.7.6.1-18.el8.ppc64le.rpm"
+          },
+          "sha256:412f3eaa5f7e226fdc4678a3266edab76d8998f7d76763075f690a01362ef89c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/dracut-squash-049-188.git20210802.el8.ppc64le.rpm"
+          },
+          "sha256:41512b492c3020571b4d8c671160758ec0e4b78212d75808291a5c56224b644b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/lorax-templates-rhel-8.5-2.el8.noarch.rpm"
+          },
+          "sha256:4164089bf1754c0ef18ae051e047f11299907204839ad4b7978f146a543a2e91": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/trousers-0.3.15-1.el8.ppc64le.rpm"
+          },
+          "sha256:41716536ea16798238ac89fbc3041b3f9dc80f9a64ea4b19d6e67ad2c909269a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/ncurses-base-6.1-9.20180224.el8.noarch.rpm"
+          },
+          "sha256:419f9c08de110eee9b2ff0a61e9aa1bbb56939f9239739c17a753a0d9210d10f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libref_array-0.1.5-39.el8.ppc64le.rpm"
+          },
+          "sha256:42464424b9fa731f8122fe748aad0005519fc87b770dbbdb71f29f514ea0e889": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/dnf-4.7.0-2.el8.noarch.rpm"
+          },
+          "sha256:427eba707b42761a0ef57107ba5a22f80fc6379d1537c757fe1929d6d066b05c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/less-530-1.el8.ppc64le.rpm"
+          },
+          "sha256:42829311fe40b7487530ee432aeb8e1df86e5168373f038cccb60d0db94601d3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/audit-3.0-0.17.20191104git1c2f876.el8.ppc64le.rpm"
+          },
+          "sha256:42bb566be1936bdb40937f9c0a96c4acc93057379385f1807cba18f60443d3e4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/hardlink-1.3-6.el8.ppc64le.rpm"
+          },
+          "sha256:43bfc890caf7855f2fb55c24474b58cd5c8c7b51e4db4f40d1f302fffd31985b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libattr-2.4.48-3.el8.ppc64le.rpm"
+          },
+          "sha256:43d4db89cf7aa96d57be2847577cf1dba8cba99d5d43118ee54d0b97a4ef8b7e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/cloud-init-21.1-3.el8.noarch.rpm"
+          },
+          "sha256:441b3862f5a0fd504bbbba18d96d1b2b920fb95a79dc45a753a6a664ad285b07": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/device-mapper-1.02.177-6.el8.ppc64le.rpm"
+          },
+          "sha256:44999c555a6e4bb6cf5e6f6a79819e76912d036732cb50efaeefc20a180dd839": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/tzdata-2021a-1.el8.noarch.rpm"
+          },
+          "sha256:45c48d32120739734ae97479cc0f3ca19796ea47e360ba39d52b77ce3ada61d7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/dnf-data-4.7.0-2.el8.noarch.rpm"
+          },
+          "sha256:46606c1ed76a4da2a9d18016aeb50f4dddf58e1b45d665c983c58f8e605bf73e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/openssl-libs-1.1.1k-4.el8.ppc64le.rpm"
+          },
+          "sha256:466601cf2b7bebf49a6a8e936b32dffc844c9ed4cd82961d008d17cfccc596e8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libsss_nss_idmap-2.5.2-2.el8.ppc64le.rpm"
+          },
+          "sha256:46e371b6245113ebca446adcbd2db39f2887b67dc5a640f62f6d346ec9f6980f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/perl-IO-Socket-SSL-2.066-4.module_el8.4.0+517+be1595ff.noarch.rpm"
+          },
+          "sha256:4715730da2b4a5bf6cc2ab85208071f00c7b279e4b2f75df0bd954446185e14c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-hawkey-0.63.0-2.el8.ppc64le.rpm"
+          },
+          "sha256:47ad43730c8bc72c90f2fb3dbd3526d716ada2fad94e62cb443658e94c6503c5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/curl-7.61.1-18.el8_4.1.ppc64le.rpm"
+          },
+          "sha256:47b61754a278c4ca378871c874ccf6a0a07bffaef38505315cfa94f262887845": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/dnf-plugins-core-4.0.21-2.el8.noarch.rpm"
+          },
+          "sha256:47f414f515a2c3103d0e7dae67c47a3b2bc76ea2413d666052012b11dbdd0feb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/perl-threads-2.21-2.el8.ppc64le.rpm"
+          },
+          "sha256:480e0f1a9dcce6ed0728e9aba709e33f5522273da1e4b0859cf9d3bbe2216532": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/xfsprogs-5.0.0-9.el8.ppc64le.rpm"
+          },
+          "sha256:48226934763e4c412c1eb65df314e6879720b4b1ebcb3d07c126c9526639cb68": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/basesystem-11-5.el8.noarch.rpm"
+          },
+          "sha256:48f31b2798e2ebbf1a7b83f43c6aa2d2eb438a1e053906623c3a7391065c00d9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/sos-4.1-5.el8.noarch.rpm"
+          },
+          "sha256:4942002f6e3a471b8d51801047ea2584d5cd1dad5d4c4e44bce7af50c5b7cb14": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/glib-networking-2.56.1-1.1.el8.ppc64le.rpm"
+          },
+          "sha256:4966b1832e9eccd8f83ecc20143fb6f18215107bdecd7267b4605cdae4a6562a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/authselect-libs-1.2.2-3.el8.ppc64le.rpm"
+          },
+          "sha256:4992eb036c0797daf9b984af1a34fe27a30287ee5d2bd5e2f5a0df3a09bdbb59": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/fuse-libs-2.9.7-12.el8.ppc64le.rpm"
+          },
+          "sha256:499e48b35f3b5f5da45031fa78fba559fee6a480ecb106e6c300eb8344510958": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/python3-ptyprocess-0.5.2-4.el8.noarch.rpm"
+          },
+          "sha256:49c7c718cb4e2b6f0effd0dec4f4cb4e109d260c192b2b329a58a1da9a24ad1d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/kbd-2.0.4-10.el8.ppc64le.rpm"
+          },
+          "sha256:49e68a65bf87ae9ba812ffce76589c09f6766a0eaa5001d7e4a1c782e91d71c0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-cryptography-3.2.1-5.el8.ppc64le.rpm"
+          },
+          "sha256:4a08d5264e865548e65d31886c91b659b33a2c2ba39fd115b00af3ea0bc91a83": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/grub2-common-2.02-99.el8.noarch.rpm"
+          },
+          "sha256:4a167fa4a7238bd94b3134173f6267b19cdebc2fde98b583344749e1f4c9bf09": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libxml2-2.9.7-11.el8.ppc64le.rpm"
+          },
+          "sha256:4a8899d3b91a0f847ce793480700b26dc8336c5ee20d9b66067c76fe0dab2f17": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libbpf-0.3.0-1.el8.ppc64le.rpm"
+          },
+          "sha256:4aca3cee9de1a4cd7ac56a12550f286894a215cac593c18857278f7b0e48f328": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/kernel-core-4.18.0-331.el8.ppc64le.rpm"
+          },
+          "sha256:4b00562fa291e956d910bb056c6120f0079f30093ea107757758683a6d418206": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/squashfs-tools-4.3-20.el8.ppc64le.rpm"
+          },
+          "sha256:4b40402374fc4a9202a67d3ede77dedbe5ed1bab57479a5b5cb5cd6c45283bf4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/perl-libs-5.26.3-420.el8.ppc64le.rpm"
+          },
+          "sha256:4b81b6f8279b75714cbac2f77b2e006f65cd799c2ec3d1c9c40840b1ab60c885": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/libX11-1.6.8-4.el8.ppc64le.rpm"
+          },
+          "sha256:4c0deab7bf49d21c6dd0ab568880a2da8180df52f15d9388aed61e169d63f8dd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/iwl100-firmware-39.31.5.1-103.el8.1.noarch.rpm"
+          },
+          "sha256:4c124ec5a10a5c32e390d848942a04baa8761f190a4a95d3ed7b5c626ca17fc8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-cffi-1.11.5-5.el8.ppc64le.rpm"
+          },
+          "sha256:4c5aabda0cd9edb40e141066d400d2e4b232bc22ab60e806a6399691c391cabc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/lzo-2.08-14.el8.ppc64le.rpm"
+          },
+          "sha256:4cc53ff12e7b8fcfafdd32eaac7b13266876766f22b3262b653eaa7b06fbbaaf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/rdma-core-35.0-1.el8.ppc64le.rpm"
+          },
+          "sha256:4e22015880d16cb7148d70895a2361f4fa05804f0391386e0e50554e6fd868b0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/rpm-libs-4.14.3-15.el8.ppc64le.rpm"
+          },
+          "sha256:4e3e93a3d2039c2a8305030b7960bd1100d7d20705a1afb1325a4ee79478a74a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/cracklib-2.9.6-15.el8.ppc64le.rpm"
+          },
+          "sha256:4e497225fe36781735cc92c0886f6858b19d4557ed9ecafe1247b8233c206075": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libmount-2.32.1-28.el8.ppc64le.rpm"
+          },
+          "sha256:4f92835a6e4ee4276df49019e068d1871b75821f52b405c699bd9f199df58b80": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/diffutils-3.6-6.el8.ppc64le.rpm"
+          },
+          "sha256:4fae16ca54207cb952e3904b8eb8cc424f3f056f400e5e802ab1a9ef3e575834": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/rpm-4.14.3-15.el8.ppc64le.rpm"
+          },
+          "sha256:4fb1b85fe3712a292f8dd8f1d65805607485dbf97307cf146bbc6e0293a7c725": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libsysfs-2.1.0-24.el8.ppc64le.rpm"
+          },
+          "sha256:4fc1c84b4434df8a5ccd960d906896e4094236f43ad4aea083a12fb5b8a824f9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/gdk-pixbuf2-2.36.12-5.el8.ppc64le.rpm"
+          },
+          "sha256:4fe264ed1cfd0c074f4601354b0128a9e5068f0fcde7382fd5429585f0d4cd2c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libselinux-utils-2.9-5.el8.ppc64le.rpm"
+          },
+          "sha256:51760acfb6ca87db5be7a9296d6a3d1220767956c576a26c6d46784e25db85bb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/gnutls-3.6.16-4.el8.ppc64le.rpm"
+          },
+          "sha256:51c3ee5d824bdde0a8faa10c99841c2590c0c26edfb17125aa97945a688c83ed": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/perl-Pod-Simple-3.35-395.el8.noarch.rpm"
+          },
+          "sha256:5374ef6981f9a29d08c3400488b010f477fe7722367fcd6d29244ba8bd29b89c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/genisoimage-1.1.11-39.el8.ppc64le.rpm"
+          },
+          "sha256:5418cf17fad308fe9a8d3acdf4ae10f433da50c32f10ae4089be2f8423dea4cf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/ipcalc-0.2.4-4.el8.ppc64le.rpm"
+          },
+          "sha256:545cd23ad8e4f71a5109551093668fd4b5e1a50d6a60364ce0f04f64eecd99d1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/perl-Pod-Escapes-1.07-395.el8.noarch.rpm"
+          },
+          "sha256:54f59ddb56e89a5330373e07ea05934fc58360eb7480615ede2a3ed6982e1eef": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/krb5-libs-1.18.2-13.el8.ppc64le.rpm"
+          },
+          "sha256:561a61d2d81bccb14d22a53b32301e0b6b9e9b9d80ad75991ee6ff796cae0ef7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/selinux-policy-3.14.3-76.el8.noarch.rpm"
+          },
+          "sha256:563b3741d26b6af963fdb7b0634e0791445a707d0b6093ac71c3224299241639": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-slip-dbus-0.6.4-11.el8.noarch.rpm"
+          },
+          "sha256:56650f8b8f2b01c1090d184d7d6d396f0109f8a02f915c97b081be73ea12df08": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/platform-python-pip-9.0.3-20.el8.noarch.rpm"
+          },
+          "sha256:56c3d429ea949467dc0bca882646cf40a58fb6f27750f5664ff2919f5d38ada5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/bzip2-libs-1.0.6-26.el8.ppc64le.rpm"
+          },
+          "sha256:56c866bcff69fd60b630841ff990296b26c2f45d8c6054311b5c476bc67466ac": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libselinux-2.9-5.el8.ppc64le.rpm"
+          },
+          "sha256:56cd753773415b5f3cafa693992e158d98dacdd1053d5018118b7685e1f8fb45": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/firewalld-filesystem-0.9.3-7.el8.noarch.rpm"
+          },
+          "sha256:572bec3deb2f8ae7a6ad46976738c2630023eec1d9bd13ab1ccca7b54256daee": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libsss_idmap-2.5.2-2.el8.ppc64le.rpm"
+          },
+          "sha256:5796882ac3059835583bc399e8522c19646b717713ef553a71b20ca0535a1718": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/sssd-client-2.5.2-2.el8.ppc64le.rpm"
+          },
+          "sha256:588874c2fc18a927a479aac7affef52f52d09e5b20102dfab70836d420ae553e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/keyutils-1.5.10-9.el8.ppc64le.rpm"
+          },
+          "sha256:59008e3619cae0f40e183b7003e722cb312b00bdba775ec9f06cdd833b53c26a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libmnl-1.0.4-6.el8.ppc64le.rpm"
+          },
+          "sha256:594d8b368013caa4eaba4eade896fc1cec8ef569052bd491f493c193e07c6d80": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-libcomps-0.1.16-2.el8.ppc64le.rpm"
+          },
+          "sha256:59ec15255141f3d0d2e0907c9e48ba9a3a93694da1b5414fddb5868ecdf76377": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/iwl2030-firmware-18.168.6.1-103.el8.1.noarch.rpm"
+          },
+          "sha256:5a0927d231fbafa8b865591922fc07d39d9b4b263a1e9c0bbef691282f706cd0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/grubby-8.40-41.el8.ppc64le.rpm"
+          },
+          "sha256:5b0f2f11c7d635630ced3cc6431b60d27a2c80f878420654df18a714b3df6c0e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-pyyaml-3.12-12.el8.ppc64le.rpm"
+          },
+          "sha256:5bcb506bd5559870631aa838711e683a5a2a07c6c0171be6bbeda9ba92dcdf5e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/numactl-libs-2.0.12-13.el8.ppc64le.rpm"
+          },
+          "sha256:5c0957decce3babef9864904be13190b0072aef720e9f4ca820bab6c02a20178": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-iniparse-0.4-31.el8.noarch.rpm"
+          },
+          "sha256:5c1940e1f173e22b053f3a89022903cea34a6af20dff81c65548c4e2ba3a8293": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/cyrus-sasl-lib-2.1.27-5.el8.ppc64le.rpm"
+          },
+          "sha256:5c46bef8c0e95e05716e9a53b77970c1378d93bcb9a800018a24f7e1763b45b9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/pcre2-10.32-2.el8.ppc64le.rpm"
+          },
+          "sha256:5c74a0e3005ea3cb90dff80cfa1e7d64c97f5c01612d253cf4e65aca962b7be4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libcomps-0.1.16-2.el8.ppc64le.rpm"
+          },
+          "sha256:5cf4db298bbda87532af2b2468a0692ec93d28393285ae157c1b4a18efbd1ba5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/python3-cairo-1.16.3-6.el8.ppc64le.rpm"
+          },
+          "sha256:5e34865a724e4e08cda721b66f24d4806d4b0b5ce059c340759d0a1a861a907d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/firewalld-0.9.3-7.el8.noarch.rpm"
+          },
+          "sha256:5f068787bd9a0190b03e64cd770e44ace593c5aa09e3f4c470c44d8d484b4674": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/NetworkManager-tui-1.32.8-1.el8.ppc64le.rpm"
+          },
+          "sha256:5f445b2b2a4bdeabd555e25dfa10119d9f4e4e500d1c4492219dd8647f119ce2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/libX11-common-1.6.8-4.el8.noarch.rpm"
+          },
+          "sha256:5f76a72e58cd374ec83e26f42778adb3b90aacd091527a34c8a347089034d398": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libtalloc-2.3.2-1.el8.ppc64le.rpm"
+          },
+          "sha256:605033c50f750dad4c344495a0d6b18dcfb2a091bba072441a38cbf9001c0363": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/servicelog-1.1.15-1.el8.ppc64le.rpm"
+          },
+          "sha256:6051967b12b097d0027dc1a1aac68448c1bea901fd76c6ea0d43450f24605252": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libproxy-0.4.15-5.2.el8.ppc64le.rpm"
+          },
+          "sha256:60b0cbc5e435be346bb06f45f3336f8936d7362022d8bceda80ff16bc3fb7dd2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/python3-jsonpointer-1.10-11.el8.noarch.rpm"
+          },
+          "sha256:60eb345663d2f6ec4b5c304cd21685dc7148d34739477136d96ab6bc131d9c4d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libteam-1.31-2.el8.ppc64le.rpm"
+          },
+          "sha256:612c21ec8de299b7244b931b492f17e811ecde1450e359f112bc88d20b115d73": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/quota-4.04-14.el8.ppc64le.rpm"
+          },
+          "sha256:61b1d3440b078f35a3fe2b35c51d6d38498fb3dc8d8f5fedf52c7f0f8f6d8ecf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/sssd-nfs-idmap-2.5.2-2.el8.ppc64le.rpm"
+          },
+          "sha256:61ba252d7ee5d955b929f6d7d39d65d25c62e3d3cfc65ee6cf55c764b1c64a90": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libpcap-1.9.1-5.el8.ppc64le.rpm"
+          },
+          "sha256:61ee52dfdcbcd98acc765b45781ea5de94831f55675c0faaf615872f92268757": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/perl-Scalar-List-Utils-1.49-2.el8.ppc64le.rpm"
+          },
+          "sha256:627d792d7cca1e97c121be5f0808c9da96f54d6c986622af246c60354b9c316e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/perl-libnet-3.11-3.el8.noarch.rpm"
+          },
+          "sha256:62ac185c4d6d242b187022c8376469073c211e8deca2a7b2badf1d775e2fd5a3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libvpd-2.2.8-1.el8.ppc64le.rpm"
+          },
+          "sha256:62da6a936871ab7b8c3efc0332fe41b4ac10ff96b357fb2bd67deecb312f9277": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/perl-Net-SSLeay-1.88-1.module_el8.4.0+517+be1595ff.ppc64le.rpm"
+          },
+          "sha256:6495f3b729a1ceecd7cfdf318cfaa8ecf776ffa16293aad9f97cc542b6901ef7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/opal-prd-6.7.1-1.el8.ppc64le.rpm"
+          },
+          "sha256:654d9074dc8ebb93230fe258188a17ba3f7dbac2f360f9f79cc4fb1516953018": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/tuned-2.16.0-1.el8.noarch.rpm"
+          },
+          "sha256:65ecf1e479dc2b2f7f09c2e86d7457043b3470b3eab3c4ee8909b50b0a669fc2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/publicsuffix-list-dafsa-20180723-1.el8.noarch.rpm"
+          },
+          "sha256:67419432fe7d373f8e5ddaa7b0dd1c25389608bf2f4ee76dbabcc2d96eb8c9d0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/geolite2-country-20180605-1.el8.noarch.rpm"
+          },
+          "sha256:679724b45157b4d4c9ebe2eb32e188b9a65d47c23be886498d7a178caaf113bb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libsolv-0.7.19-1.el8.ppc64le.rpm"
+          },
+          "sha256:67f37cee02ba744dfc7957725f5ef9df229778f6a2f7afc659625b458da6167e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/crypto-policies-scripts-20210617-1.gitc776d3e.el8.noarch.rpm"
+          },
+          "sha256:685d8ca4ac9c909ac2daa8bf454d8ce1de993c8ae29a8c78417dfd5d1c3aa65e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/pixman-0.38.4-1.el8.ppc64le.rpm"
+          },
+          "sha256:686e82956e8f875e0dc8b4bac509813a2b63bd39226baea5a3b79e4fd7483a97": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/iwl5000-firmware-8.83.5.1_1-103.el8.1.noarch.rpm"
+          },
+          "sha256:697f5bf30fbe44dd4dcba8392b85680952b7a1be9a0221349f4fde011a8cdd3c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/sssd-common-2.5.2-2.el8.ppc64le.rpm"
+          },
+          "sha256:698e8ecaf71719dafacae79de05080d567b69fad3511e8b8d42b9af96a7c41db": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/dbus-tools-1.12.8-14.el8.ppc64le.rpm"
+          },
+          "sha256:6ac918d2bc175b3f356926ca96a998c29bffe256f7d802e8ef654b1226da3ef6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libdhash-0.5.0-39.el8.ppc64le.rpm"
+          },
+          "sha256:6b096b1da49230942e736576396091530cecb3f9bd8cc70b8b8a9f72a5148a0d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/python3-systemd-234-8.el8.ppc64le.rpm"
+          },
+          "sha256:6b312faed4a0508da2f15d3f31a6daccfc0ec6621e5fb7b20956027dce5fa395": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libkcapi-hmaccalc-1.2.0-2.el8.ppc64le.rpm"
+          },
+          "sha256:6b588ff47d46d33b02bc296e6e5cc263d6c8ff51ee97b59ca8b34d5c45d57912": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/perl-PathTools-3.74-1.el8.ppc64le.rpm"
+          },
+          "sha256:6b9875495111bcd2d3c5e9e380b3be17fb0a730891468fb45bdba3b3692b00ea": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libusbx-1.0.23-4.el8.ppc64le.rpm"
+          },
+          "sha256:6bbb721dd2c411c85c75f7477b14c54c776d78ee9b93557615e919ef47577440": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/perl-Term-Cap-1.17-395.el8.noarch.rpm"
+          },
+          "sha256:6bfc201a12dc7bba21069a663aa692a96c5e8920b0d94a4e355c332d7ead15ba": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libzstd-1.4.4-1.el8.ppc64le.rpm"
+          },
+          "sha256:6c9dfb73e199975275633f05d31388cd61c5a77dec5678db958b4e6624eb21ba": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-pip-wheel-9.0.3-20.el8.noarch.rpm"
+          },
+          "sha256:6d02615212a88eb204b8f6d2a7cfbf6183a12f29d72ca5dbfbe5c45c63068ef8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/iputils-20180629-7.el8.ppc64le.rpm"
+          },
+          "sha256:6d1ac29b3a38408f6d238d6718384e05be7346789c6200b354335b0e0c9c77df": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/info-6.5-6.el8.ppc64le.rpm"
+          },
+          "sha256:6d9b770c5d34ee0fb93e78b6ce44c3e0e99ecaa9d57265e32256e14a3bba8190": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libnfnetlink-1.0.1-13.el8.ppc64le.rpm"
+          },
+          "sha256:6faee589c5a7454502e5ec07586a4856e7f1376bd551741af2acf03afb9716e6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/cronie-anacron-1.5.2-4.el8.ppc64le.rpm"
+          },
+          "sha256:6fe1188081e441595ce29ebed4d1985e5890815158244f69f092ee930656f755": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/keyutils-libs-1.5.10-9.el8.ppc64le.rpm"
+          },
+          "sha256:700b9050aa490b5eca6d1f8630cbebceb122fce11c370689b5ccb37f5a43ee2f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/fontpackages-filesystem-1.44-22.el8.noarch.rpm"
+          },
+          "sha256:709ea71f36495ac2ac89d72d2eb603b6aa55b2c1a70633f23514dd897936f02b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libdb-utils-5.3.28-40.el8.ppc64le.rpm"
+          },
+          "sha256:70fe40ffb2fb3eb2c3626afbfdb200a2429e000c2fbb172886c23b1908000501": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libsss_sudo-2.5.2-2.el8.ppc64le.rpm"
+          },
+          "sha256:71c88f04921ae61a7009f9443f95c70ec3424a798429fc01e6c1432c1077aacb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/os-prober-1.74-6.el8.ppc64le.rpm"
+          },
+          "sha256:71d45853b0a8673e6354892df7a420ad77200a018ee5334b30b893862d030fa9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/dracut-config-generic-049-188.git20210802.el8.ppc64le.rpm"
+          },
+          "sha256:71f54759238edb9ae63dfc6ed893183a809e88321d8117dc40e0d403fc533585": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/tcpdump-4.9.3-2.el8.ppc64le.rpm"
+          },
+          "sha256:720088f184124166386634a523f3566a7fc56f802dbd6e6f816e959236542770": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/powerpc-utils-core-1.3.8-7.el8.ppc64le.rpm"
+          },
+          "sha256:73ff0ee3bef442e48df0f95d26fee18606cfb1aee81617c3202a6b35bb0fca0c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-nftables-0.9.3-20.el8.ppc64le.rpm"
+          },
+          "sha256:74e11b9013f81bd30ec7934ea695d267d164967fec27a02652aa48602b94bc51": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/perl-IO-1.38-420.el8.ppc64le.rpm"
+          },
+          "sha256:754bf53a39cea727d9d89d59df32e020842dc71f6a0561ea36f8203aff2d5d69": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/gobject-introspection-1.56.1-1.el8.ppc64le.rpm"
+          },
+          "sha256:7559c097998db5e5d14dab1a7a1637a5749e9dab234ca68d17c9c21f8cfbf8d6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/perl-constant-1.33-396.el8.noarch.rpm"
+          },
+          "sha256:75e9ed16ace51ba04a62505aaed215bf9c722d6f4b1c33cc3e3962076c300ee8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libtasn1-4.13-3.el8.ppc64le.rpm"
+          },
+          "sha256:7632176e2d324ee98701f5d79024361379d510590e477f560a264aa6e8db233d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/python3-gobject-3.28.3-2.el8.ppc64le.rpm"
+          },
+          "sha256:767dd64d91c23adda537c7759ae3b4f720d3c76e03b52bc9231e52e0113db3ab": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libss-1.45.6-2.el8.ppc64le.rpm"
+          },
+          "sha256:76df9e0fc779fcd7d3ee836ae254ead30b5f9492022b55901d1f8bd914d38ef6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/selinux-policy-targeted-3.14.3-76.el8.noarch.rpm"
+          },
+          "sha256:77e4cfbc823e3764308822ccf03b257861f9360f3b948829f1d73148b321b00e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libcap-2.26-4.el8.ppc64le.rpm"
+          },
+          "sha256:78b2b9cbf041d4461daf7ac11a24d1e79a9c57f47aa265dba4d09067efe3d96b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/grub2-tools-2.02-99.el8.ppc64le.rpm"
+          },
+          "sha256:78c43d8a15ca018de1803e4baac5819e1baab1963fd31f1e44e54e8a573acbfc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-idna-2.5-5.el8.noarch.rpm"
+          },
+          "sha256:78d17ed089151e7fa3d1a3cdbbac8ca3b1b5c484fae5ba025642cc9107991037": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/perl-podlators-4.11-1.el8.noarch.rpm"
+          },
+          "sha256:78fd472a1c7f49b8a432788ea2dfc1119f155a394f41585b4e715d2585fc92ab": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/gettext-0.19.8.1-17.el8.ppc64le.rpm"
+          },
+          "sha256:791acd72bc40be9ba5fa6b77d78def5da623544408b72baa4c81181c03a205cb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/logrotate-3.14.0-4.el8.ppc64le.rpm"
+          },
+          "sha256:794f970f498af07b37f914c19ad5dedc6b6c2f89d343af9dd1768d17232555de": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/perl-Pod-Usage-1.69-395.el8.noarch.rpm"
+          },
+          "sha256:7962bed04e961194d64769b4b7d5c85836808361c606e943b013098fe53df782": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libtevent-0.11.0-0.el8.ppc64le.rpm"
+          },
+          "sha256:7a550ec0bb8be2920abc6198faac70132027bc672c7bc3897ba0331727b94aa7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/ipset-libs-7.1-1.el8.ppc64le.rpm"
+          },
+          "sha256:7a66928044c3478964aeaf6f9e981fdbcfa6b2ff7fad9f2ad57a8c09387cbbf2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/npth-1.5-4.el8.ppc64le.rpm"
+          },
+          "sha256:7a67a83093c0a23619de1e2b489166940a0195a9ddb84e44bb523e5c93306331": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/iwl6000-firmware-9.221.4.1-103.el8.1.noarch.rpm"
+          },
+          "sha256:7abf49cabbaf996afc0c2604f10ea18f8f22a903fc4ba3728a18f5892353c5c9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/ncurses-6.1-9.20180224.el8.ppc64le.rpm"
+          },
+          "sha256:7adc584a7d43968d22706da5ffa127020536375f82beea5ef677cab39c5f64c5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libpipeline-1.5.0-2.el8.ppc64le.rpm"
+          },
+          "sha256:7aeb44195a1c984aff87cf8429d2aa40f6947b0a47d3603e1ca5c3cf8d284459": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/linux-firmware-20210702-103.gitd79c2677.el8.noarch.rpm"
+          },
+          "sha256:7b334d84bf03876c5738efa3857faaa35ede5c8eab30a5621ecfd4efa7ce39a5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/pciutils-3.7.0-1.el8.ppc64le.rpm"
+          },
+          "sha256:7baac88adafdc5958fb818c7685d3c6548f6e2e585e4435ceee4a168edc3597e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/dbus-common-1.12.8-14.el8.noarch.rpm"
+          },
+          "sha256:7bb5051dee5f6633a02cf5a3285dd86890cc6521e497526a8149dc5c5ebad062": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/kernel-4.18.0-331.el8.ppc64le.rpm"
+          },
+          "sha256:7cccedcc359f2a2542858088704bf3d0ec3e46cb7b72f602408fbab937a522d3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/grub2-ppc64le-2.02-99.el8.ppc64le.rpm"
+          },
+          "sha256:7cced5f47c4035e01fffce0989b62113a75016e5220e7b207c4b96be7ed90403": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/gsettings-desktop-schemas-3.32.0-6.el8.ppc64le.rpm"
+          },
+          "sha256:7d4c363f4a746f3a0946d19f303fe9c60c5fe178892528ec4f34d8ddd2c4c359": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/sg3_utils-1.44-5.el8.ppc64le.rpm"
+          },
+          "sha256:7e50a5d0f2fbd8c95375f72f5772c7731186e999a447121b8247f448b065a4ef": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/perl-Text-Tabs+Wrap-2013.0523-395.el8.noarch.rpm"
+          },
+          "sha256:7e67dba2509f90064325e62e49412d5284a55f09b7b6878b9c8222692c500dde": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/perl-Digest-1.17-395.el8.noarch.rpm"
+          },
+          "sha256:7edc503f5a919c489b651757095d8031982d530cc88088fdaeb743188364e9b0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/perl-Exporter-5.72-396.el8.noarch.rpm"
+          },
+          "sha256:7f506879c64e0bb4d98782d025f46fb9a07517487ae4cbebbb3985a98f4e2154": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-pysocks-1.6.8-3.el8.noarch.rpm"
+          },
+          "sha256:80f3973c07c06dd095203553abbb95d6ce1c24ccc92f24f46659bf05416f4778": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/cloud-utils-growpart-0.31-3.el8.noarch.rpm"
+          },
+          "sha256:8119d276749b35cd9c283c1a8d970b3528bea58427eb37eafc22b6093a978f08": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/ima-evm-utils-1.3.2-12.el8.ppc64le.rpm"
+          },
+          "sha256:82ce159a9e4e4b6b4fdce9ad954aa507f67108430bd261a4dcd826e44d0152a4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/python3-pyserial-3.1.1-8.el8.noarch.rpm"
+          },
+          "sha256:83cb349e65d5b783518b735d8fb477264f0a6bd7cdd6f4096f8493dbd45f2ff7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/kernel-tools-libs-4.18.0-331.el8.ppc64le.rpm"
+          },
+          "sha256:8403cfc97e0e72e37639b8c54d92f1ee427e48a70d52d5260a37fa104f2df20d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/nettle-3.4.1-7.el8.ppc64le.rpm"
+          },
+          "sha256:842ff55b80ac9a5c3357bf52646a5761a4c4786bb3e64b56d8fa5d8fe34ef8bb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/centos-gpg-keys-8-2.el8.noarch.rpm"
+          },
+          "sha256:8540be85295735194e0053eb2ab6b2bda2e27119b9b030877eff43f9272a20cf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/sg3_utils-libs-1.44-5.el8.ppc64le.rpm"
+          },
+          "sha256:8571a2aa115d42f8b5e87ef58d10e9c24e6fbe5470fc2612df96f8740f3d960f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/python3-unbound-1.7.3-17.el8.ppc64le.rpm"
+          },
+          "sha256:85eb614fc608f3b3f4bbd08d4a3b0ff6af188677ea4e009be021680c521cedae": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/python3-jsonpatch-1.21-2.el8.noarch.rpm"
+          },
+          "sha256:8623975eac20e039a7ba14323490db10169cf205ec98f5df2f55f7d410202663": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/cairo-gobject-1.15.12-3.el8.ppc64le.rpm"
+          },
+          "sha256:864f5bf99bf805c3e1143f78a78012d2f910f0d5627519b1f263a4d5cc6fa45e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/isomd5sum-1.2.3-3.el8.ppc64le.rpm"
+          },
+          "sha256:8729b157f0925feccdaef8aacd91c6aebe0109e621675bcc15e1830673b0e19d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/brotli-1.0.6-3.el8.ppc64le.rpm"
+          },
+          "sha256:8781993942f622945aefe59e449a5ff4608f969db79fbe893040890ff08fc1f9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-gobject-base-3.28.3-2.el8.ppc64le.rpm"
+          },
+          "sha256:881b28a3a37d114bc3f046605b24663560009b13a507217e007643f5682efdd5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/dracut-049-188.git20210802.el8.ppc64le.rpm"
+          },
+          "sha256:882a327cb5e2d809bfe695e9622caced76e7d89c96dcb40203ad8b7d281630fa": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-libsemanage-2.9-6.el8.ppc64le.rpm"
+          },
+          "sha256:8891a9a4707611c13a5693b195201dd940254ffdb03cf5742952329282bb8cb7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-pycparser-2.14-14.el8.noarch.rpm"
+          },
+          "sha256:88be5116908aa5013f540c767f6811774342780bb72d3ec197b3429bfb2f9862": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/expat-2.2.5-4.el8.ppc64le.rpm"
+          },
+          "sha256:88ff01f3d3812bc3fb3d18970ecefde7ac8f1a6a29409946ed85173cf8645a3a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/rsync-3.1.3-12.el8.ppc64le.rpm"
+          },
+          "sha256:8904fdb492f34e5242ba483fb6b7b158342662575b3d5ac9abbc380568840d4a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libyaml-0.1.7-5.el8.ppc64le.rpm"
+          },
+          "sha256:8945279d57ad510e018f92571ba8e5d811cf8a3165adf930b0d4015c5a077a35": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/rsyslog-8.2102.0-5.el8.ppc64le.rpm"
+          },
+          "sha256:8a501b9d8016eee68ce62a93a65842b15c8a57192b9f8189ebc85a11f2f47f9e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/systemd-239-49.el8.ppc64le.rpm"
+          },
+          "sha256:8ab06f608f45445bdef489cedb40d419aa7282e127ee26dbfcf417350a3f1630": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libibverbs-35.0-1.el8.ppc64le.rpm"
+          },
+          "sha256:8b73e398f5a3cdc8a7ded303586ca7a50b26cc76213a3cebe36fdfdca769b316": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/PackageKit-1.1.12-6.el8.ppc64le.rpm"
+          },
+          "sha256:8c05fe038c7792203afa47f4534318f6c674672999b444909706ce0826bf1b8f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/hdparm-9.54-4.el8.ppc64le.rpm"
+          },
+          "sha256:8c26cce4231f781db7b37d51ded377f9cfa01a5e6833d967082795f1220e2860": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/tar-1.30-5.el8.ppc64le.rpm"
+          },
+          "sha256:8c893a8300f812ca179e1f8863eff109e1b8f1c70044bc5f08eb38a592ffdecd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/libXau-1.0.9-3.el8.ppc64le.rpm"
+          },
+          "sha256:8cb953ea9ea1bd262bef00112e2c433583929cd7aec86ae60f1a725c6dcf7c09": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/rpm-plugin-systemd-inhibit-4.14.3-15.el8.ppc64le.rpm"
+          },
+          "sha256:8cd6ef9902851f07cfd9682e2d6873648690f0c2ec65345276b557ede042d8b9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/gdbm-1.18-1.el8.ppc64le.rpm"
+          },
+          "sha256:8ced8726c50d2809362c78ddefb876b208a9099e81e2be1c22fd8227190ba063": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/iptables-ebtables-1.8.4-19.el8.ppc64le.rpm"
+          },
+          "sha256:8d19cdf57ba61fecd9e07f24fe88768f58196543f7c032adada8a0cc48eee6b3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/perl-Socket-2.027-3.el8.ppc64le.rpm"
+          },
+          "sha256:8d7777da3f54f965cf3058cabf987c01b93a1dd041e8359eb7822eba57d8c8df": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libnsl2-1.2.0-2.20180605git4a062cf.el8.ppc64le.rpm"
+          },
+          "sha256:906bffa419bdb1a6d3094d7a6f2308527f5ece250bfcb962df79e9867f28236d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/lshw-B.02.19.2-6.el8.ppc64le.rpm"
+          },
+          "sha256:926ce547a03e1bd2aac94b1792d7ccea16d1e6bd91903458e63a095268e1b02f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/perl-macros-5.26.3-420.el8.ppc64le.rpm"
+          },
+          "sha256:946ba273a3a3b6fdf140f3c03112918c0a556a5871c477f5dbbb98600e6ca557": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/platform-python-setuptools-39.2.0-6.el8.noarch.rpm"
+          },
+          "sha256:94e73ee7b1a5e6791a7cdce615f8a7e23fe1e6359b22ee366b71f45a5ef13483": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/lorax-templates-generic-28.14.61-2.el8.ppc64le.rpm"
+          },
+          "sha256:95103f7c339aec4b485b7f569aa8a5e1a54286b3d2acde427328c49e4d8d80d1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libsemanage-2.9-6.el8.ppc64le.rpm"
+          },
+          "sha256:95cb9c201ee3b54fe6331bd7e74f43485632e95448d31fd340ffaa84a32b41ab": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/python3-jinja2-2.10.1-3.el8.noarch.rpm"
+          },
+          "sha256:965dca9dc74ed26f4204debe15b8e4dd1b8e41a80b8608287a9ef22f0b6f507e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/openssh-8.0p1-9.el8.ppc64le.rpm"
+          },
+          "sha256:965ec1b760513e1ae539747624bd241d6575675e8a04c5caa572faadb54007c7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/jansson-2.11-3.el8.ppc64le.rpm"
+          },
+          "sha256:9853341ea14daa32558a3787c318396f5c05e947949848bad4bba16e9ac0d1f6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/iwl6000g2a-firmware-18.168.6.1-103.el8.1.noarch.rpm"
+          },
+          "sha256:98c28a91d41f634edb8c1f001dbc45c0de534332d059a2e8feff448fb7235c49": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/librtas-2.0.2-1.el8.ppc64le.rpm"
+          },
+          "sha256:9936485ac7111967d6962bc539de7b08807e310117adb78b11c21a5db0f0f890": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/memstrack-0.1.11-1.el8.ppc64le.rpm"
+          },
+          "sha256:9b1018a43b1a9245cdc71a342b962aa32fb799bd0ce66ee59b496cdd75200de9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/rpm-plugin-selinux-4.14.3-15.el8.ppc64le.rpm"
+          },
+          "sha256:9b69a221cf9395a110849bb428bb1cfe9fb489322df0fa6017f5978a827ee0e9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libcap-ng-0.7.11-1.el8.ppc64le.rpm"
+          },
+          "sha256:9b8a8a843fe9a972f6433e11b95b5a8d1d2971ed40fe1acda6807e34f0773c62": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libpsl-0.20.2-6.el8.ppc64le.rpm"
+          },
+          "sha256:9c3cc9ed1b5dc277a39403d0aadd4dd8b843d05fe478d40f60249cad2039aae8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/iwl7260-firmware-25.30.13.0-103.el8.1.noarch.rpm"
+          },
+          "sha256:9c4cd61b98253904436180f58c564bda61be1fa1b5523e4ecbbdc174d0c2a9aa": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libassuan-2.5.1-3.el8.ppc64le.rpm"
+          },
+          "sha256:9dc236a8124d1fcbb41b970b5a4c45d6f7f97430c933c775121cae27f5f352a7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/timedatex-0.5-3.el8.ppc64le.rpm"
+          },
+          "sha256:9dc5c484c7821cc737f872973764203376106d643b9adc4ef66bece1b0cc8fdc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/python3-mako-1.0.6-13.el8.noarch.rpm"
+          },
+          "sha256:9e2ef90cb484b37232e829ec400dcddd3f9f0d189eb6f0074b3b5874d4553d1c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/parted-3.2-39.el8.ppc64le.rpm"
+          },
+          "sha256:9e540fe1fcf866ba1e738e012eef5459d34cca30385df73973e6fc7c6eadb55f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/setup-2.12.2-6.el8.noarch.rpm"
+          },
+          "sha256:9e67ac5948125dd165c9a74ec848d48b313ef4264bbbb89630a782dbd972d72c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/e2fsprogs-1.45.6-2.el8.ppc64le.rpm"
+          },
+          "sha256:9ea4e52636b010504bfff1662c57988feb81cdfe97ba7c092f6efe3abdbe2dd7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/qemu-img-4.2.0-52.module_el8.5.0+853+a4d5519d.ppc64le.rpm"
+          },
+          "sha256:9f1a745b208091d4b009ec321a6fdc72c8a5e89167effed81c50571a13f1c87d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/perl-Digest-MD5-2.55-396.el8.ppc64le.rpm"
+          },
+          "sha256:9fb07c2324cccbbc19e3ffade50ee7da41909b2f6c24f49ffd9978ba375de193": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/e2fsprogs-libs-1.45.6-2.el8.ppc64le.rpm"
+          },
+          "sha256:9feaf80c733951790bc3578db42ea2abef65643ebb36779e46dccdaf4c76b525": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/perl-URI-1.73-3.el8.noarch.rpm"
+          },
+          "sha256:a04cb3117395b962edc32bf45d8411f240632476b0706b2df7f4a1a87b2ce34b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-six-1.11.0-8.el8.noarch.rpm"
+          },
+          "sha256:a0a8e31422da7d695a3788a7cae3f929d42cb4982889422588904ecc6879182e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libldb-2.3.0-2.el8.ppc64le.rpm"
+          },
+          "sha256:a0b8a6b2c8dad75290228086dd0af342979604bbf4b9500029e25d766835c0f4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libevent-2.1.8-5.el8.ppc64le.rpm"
+          },
+          "sha256:a14a6628db9ed048511cabda7ba62dc019c2aa0d32c13fee0778d88e112b70e2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/iwl2000-firmware-18.168.6.1-103.el8.1.noarch.rpm"
+          },
+          "sha256:a1af93a1b62e8ca05b7597d5749a2b3d28735a86928f0432064fec61db1ff844": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/perl-HTTP-Tiny-0.074-1.el8.noarch.rpm"
+          },
+          "sha256:a2aeabb3962859069a78acc288bc3bffb35485428e162caafec8134f5ce6ca67": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/xkeyboard-config-2.28-1.el8.noarch.rpm"
+          },
+          "sha256:a2d96efed83ab31d21481af044835a940673ee4ade2763af78c06d2df87b94f7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/gnupg2-smime-2.2.20-2.el8.ppc64le.rpm"
+          },
+          "sha256:a3430017f322fd147130a5572e4f1d357950d304aeef07c8c640be0dfe63b627": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/plymouth-core-libs-0.9.4-9.20200615git1e36e30.el8.ppc64le.rpm"
+          },
+          "sha256:a34e0c5859e5e8757afafba47d83396226b646f32954ef7ecda4ad3be464bed6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/perl-Data-Dumper-2.167-399.el8.ppc64le.rpm"
+          },
+          "sha256:a388c955ace01f09f522c0ccf3afd47e682b22a87756e185f9134bdff72fb2ff": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/GConf2-3.2.6-22.el8.ppc64le.rpm"
+          },
+          "sha256:a3ef96219165bfc64d4f5d50f51fbd43e803c500619240ffe4db1f9f8e337f83": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/kbd-legacy-2.0.4-10.el8.noarch.rpm"
+          },
+          "sha256:a42de8ce71380b1f4e8ac5b4ce720bf565c99a0b09ef983c0550a91a467bc155": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/device-mapper-libs-1.02.177-6.el8.ppc64le.rpm"
+          },
+          "sha256:a4577841148e7e2bf481447ae141eff319007e70a24295a22787bbfaecf4c4fe": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/xz-libs-5.2.4-3.el8.ppc64le.rpm"
+          },
+          "sha256:a49b922f117b9bfb0b07e9848151f8a2948345328ebc534cd28ac187d7ed3f94": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/filesystem-3.8-6.el8.ppc64le.rpm"
+          },
+          "sha256:a571c94456b9a1743e94f4f72159de52bb13fe93437b81da675351553a881a17": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/hostname-3.20-7.el8.0.1.ppc64le.rpm"
+          },
+          "sha256:a5f9f2c4f39f393971f268aebb1b55d18d0d96693d08a9ed70403e8565807bb6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libksba-1.3.5-7.el8.ppc64le.rpm"
+          },
+          "sha256:a6ef8e56d53c29e92b46a7ad62c22380056153b2d5810c39c0cc1658a4250d5b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/NetworkManager-1.32.8-1.el8.ppc64le.rpm"
+          },
+          "sha256:a80c1d6d32db7ce8fdd58bb4f3f488b74e94261a38512dc8a15179ae33697e63": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/kmod-25-18.el8.ppc64le.rpm"
+          },
+          "sha256:a81afd94bec26037880bccdb97937c7662ecb6c1006a8bbf657d8ffafc7c4614": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/rpcbind-1.2.5-8.el8.ppc64le.rpm"
+          },
+          "sha256:a82958266d292f4725fc1981ea57a861b7fc7feeb7a9551d0b61b98ca51a5662": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/centos-stream-repos-8-2.el8.noarch.rpm"
+          },
+          "sha256:a8a27e1ffbb92356d6376334687b9eaa0cb5f2eece2670128f3a01e391e9f3bb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/dejavu-sans-mono-fonts-2.35-7.el8.noarch.rpm"
+          },
+          "sha256:a9d4dd71786b3147d53da1aa44f134e61b1e5527b6c7ece6c2b19474b6ca9270": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/policycoreutils-python-utils-2.9-15.el8.noarch.rpm"
+          },
+          "sha256:aa0007192287faeaecc72d9fa48efdb3108c764d450dc8fea65474476da32c45": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-pyudev-0.21.0-7.el8.noarch.rpm"
+          },
+          "sha256:aa1835fd302a37b84ac256db5dd0de09bd9883a5a07775aedb491faf46b18ee0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-urllib3-1.24.2-5.el8.noarch.rpm"
+          },
+          "sha256:ab2988acbe3a2580703de6070646324e95efe982598a386e69ed9857ab123855": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/sscg-2.3.3-14.el8.ppc64le.rpm"
+          },
+          "sha256:abc36bf7797a427b64c3c99b4f74714bfa66b906b62358be6fdafe493a66415e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-libdnf-0.63.0-2.el8.ppc64le.rpm"
+          },
+          "sha256:ac3b306c193bd20658950da402ae0cbdd8337110117de5e5d7eba970822671fd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/grub2-tools-extra-2.02-99.el8.ppc64le.rpm"
+          },
+          "sha256:acfee60459ffe722b9362696f58a26b606b637094d9439bf5f898310daf8ba24": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-firewall-0.9.3-7.el8.noarch.rpm"
+          },
+          "sha256:ad338b7a3f3bed96300d9ce7f0307e09d758962b8496c10fb3554bf62405d153": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/glib2-2.56.4-156.el8.ppc64le.rpm"
+          },
+          "sha256:adc56041458e556df5663e7da264e151c24aaf1c2a94e49df9790ba191ea1b37": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libsepol-2.9-2.el8.ppc64le.rpm"
+          },
+          "sha256:aea253461d1a34a239b445ee07cb34398a9cbb6ed40e252182a91cddcf59004b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libdnf-0.63.0-2.el8.ppc64le.rpm"
+          },
+          "sha256:af0a4287e302baa7c85655ddfe5a7049b8eaf31aff03886f4fc57c920d26d491": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/gmp-6.1.2-10.el8.ppc64le.rpm"
+          },
+          "sha256:b01c567dbd2b9bf82301b254a8962a8fb8f30d12a8f566145eee0f3936f47b5d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/python3-ordered-set-2.0.2-4.el8.noarch.rpm"
+          },
+          "sha256:b10d8521963a2494fdb2b5f8fb0de837dc86d4016c3b10019fb8970a09582451": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/cryptsetup-libs-2.3.3-4.el8.ppc64le.rpm"
+          },
+          "sha256:b19bd4f106ce301ee21c860183cc1c2ef9c09bdf495059bdf16e8d8ccc71bbe8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-setuptools-wheel-39.2.0-6.el8.noarch.rpm"
+          },
+          "sha256:b29c8cb61ef138fdf00a458f0646cf9390e0f39783f02f6b81a956585dc6b302": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libuser-0.62-23.el8.ppc64le.rpm"
+          },
+          "sha256:b437a08d4670ef440ba6dbaae4ccb39f989f0c2a3d280ea66d6fd9532a313286": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/kmod-libs-25-18.el8.ppc64le.rpm"
+          },
+          "sha256:b4a1ac1ff5cd22a5dab6c96dfc2dbd7cd6ba750691ad5c53a97a1f088fc42abc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libseccomp-2.5.1-1.el8.ppc64le.rpm"
+          },
+          "sha256:b55df489f643b495984915a0671e74262192813e07cff5812d778c8cf4c0b9d1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/libfastjson-0.99.9-1.el8.ppc64le.rpm"
+          },
+          "sha256:b566154cc9b2b1996716def297d58101f3015a1b868187f1f9e4cd3074ae9988": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/perl-threads-shared-1.58-2.el8.ppc64le.rpm"
+          },
+          "sha256:b57141234c3c1d1b2d46dfec037dcae8ba3ebdc534660c661771aab46e38b44b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libnetfilter_conntrack-1.0.6-5.el8.ppc64le.rpm"
+          },
+          "sha256:b58be8f7685340b35e61945b1ab499bc1030b0b021b2ac5576897cf079ff7812": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libpng-1.6.34-5.el8.ppc64le.rpm"
+          },
+          "sha256:b5bd11b47b5b690dc667dc486941331d7cd3aaa4f0e5c4d638ec7b294bcc5012": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/libxkbcommon-0.9.1-1.el8.ppc64le.rpm"
+          },
+          "sha256:b615599db3ac6249e7b18e0c66474e080dc71ee72612bfa0268ea36b1a74e8da": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/python3-pip-9.0.3-20.el8.noarch.rpm"
+          },
+          "sha256:b64219f2278bf3f032b71593da63f563920778230946b66f1037bef2f2a7358b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/newt-0.52.20-11.el8.ppc64le.rpm"
+          },
+          "sha256:b7330d40f75b8ec786e41c45a202e44f0e49ec29ddf8944120fbdb373a6c6617": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/p11-kit-trust-0.23.22-1.el8.ppc64le.rpm"
+          },
+          "sha256:b7d265ac19947ea2a73e9735b63c407dcad881fa8c0d8b2e35dce948efab3d83": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/iwl6050-firmware-41.28.5.1-103.el8.1.noarch.rpm"
+          },
+          "sha256:b83a0199c3d471151f07f6de626a1a4a362dd6aa29d84cf1c0ada2c966ce29c9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libdb-5.3.28-40.el8.ppc64le.rpm"
+          },
+          "sha256:bb4b6716669e27c7619f63751770cb87e7cfecd4e302e2ce6588035509168352": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/openssh-clients-8.0p1-9.el8.ppc64le.rpm"
+          },
+          "sha256:bb82b10a91493d745dc533b5de5335db650adb0c8a90548fdf5dad13569a16f4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/pam-1.3.1-15.el8.ppc64le.rpm"
+          },
+          "sha256:bba1cd75958b43df5e3ceb820449008c19ed5fa562d54c2d46c5c57e79aa6b2a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/sudo-1.8.29-7.el8.ppc64le.rpm"
+          },
+          "sha256:bc3e4dd9194760500ce9731d792f46afa049667185487bae88c23a38fdb10c37": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/yum-4.7.0-2.el8.noarch.rpm"
+          },
+          "sha256:bc7fc2028a29ac7a406719ed4f6740f6bf12c20961223c1e839a2a39069af38d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/quota-nls-4.04-14.el8.noarch.rpm"
+          },
+          "sha256:bcf25aae89f7368b16346bc1ec92850175bcc2312bf7a5e74bc3c512bcd345b0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/crontabs-1.11-17.20190603git.el8.noarch.rpm"
+          },
+          "sha256:bd9a6c7fe7405aaeeeb7d351ca1def52737b8ec2344021263aed64c6dc363d56": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/nfs-utils-2.3.3-46.el8.ppc64le.rpm"
+          },
+          "sha256:be49b69bc5de947ee2151f397993a691a57bc53952058c32cde0fca674da7d8c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/audit-libs-3.0-0.17.20191104git1c2f876.el8.ppc64le.rpm"
+          },
+          "sha256:bf994cb2e5c367d78483662c7de6e69950aaf04bc6cfdbbef4d1ef7ce153717c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/p11-kit-0.23.22-1.el8.ppc64le.rpm"
+          },
+          "sha256:bfa39369bd3c36833126b6f46b747de0736a66835d97196195c0810161c24549": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/python3-pydbus-0.6.0-5.el8.noarch.rpm"
+          },
+          "sha256:bfb45644212cfbbe48b05149f8d53e77d7bd02ca9fc9045cc37115101175a3a0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/glibc-2.28-162.el8.ppc64le.rpm"
+          },
+          "sha256:bff39fef1fc01564156123fcade75b4bc50402a2971a031d9a426c7014b1e681": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libunistring-0.9.9-3.el8.ppc64le.rpm"
+          },
+          "sha256:c1291b69a65a860069195a33cf6640df8667e960f9f030ceeea4497c47858b94": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libuuid-2.32.1-28.el8.ppc64le.rpm"
+          },
+          "sha256:c12c7dc6676c6ccc5ca08ceddfb1b4e46c9f1ed49cbc241292ae6d1fdb0d9d62": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/bc-1.07.1-5.el8.ppc64le.rpm"
+          },
+          "sha256:c238e0a5472c59c54093ffa23af6a963b4ae437eedfb6b9ebbcb482752c6d16b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/perl-Storable-3.11-3.el8.ppc64le.rpm"
+          },
+          "sha256:c23f55b72b4e09c456c2837321dd626cadb9785dec89d31b2e30ca3c752e6d4d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/iwl105-firmware-18.168.6.1-103.el8.1.noarch.rpm"
+          },
+          "sha256:c2479eb811f4d9b8624ef20119e1abdc109f639c2cf576eb945b340362d87b05": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/openssl-1.1.1k-4.el8.ppc64le.rpm"
+          },
+          "sha256:c24b21415b737f18fad7aeb192e60f7d323f7ba69434ecc1e78b3af0003be8dc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/openldap-2.4.46-18.el8.ppc64le.rpm"
+          },
+          "sha256:c2776b30c82ad5566fdbcce83fcf9c699ad83dae57c6499eb64f8b8a7bc00b60": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-setools-4.3.0-2.el8.ppc64le.rpm"
+          },
+          "sha256:c3c1c42a41ab18dc09214bcd3a567bb7ba9b9c2191a6e1079b9770dfe2d3a338": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libtdb-1.4.3-1.el8.ppc64le.rpm"
+          },
+          "sha256:c477e45fe5f8f5bab1ec1711210dd357392ad19eab48cda18d89b60df5067970": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/sssd-kcm-2.5.2-2.el8.ppc64le.rpm"
+          },
+          "sha256:c58b0b900a7ffc778980461d74dc236bf2c790d2e5e8c04e28876e221b48a1c8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/dbus-glib-0.110-2.el8.ppc64le.rpm"
+          },
+          "sha256:c59538d646715fdb1f94c6be3fa0949871b8c860d5c54db4640a1197663a130b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-dbus-1.2.4-15.el8.ppc64le.rpm"
+          },
+          "sha256:c5a60ffb80cd1f9b90c797f1d1ac80e5536eb32a5b276871445e7279ac701c5f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libgcrypt-1.8.5-6.el8.ppc64le.rpm"
+          },
+          "sha256:c5b5967a094ced90899052a82e2c245529b75ba3f46e0ce1a89cfc95edb935ea": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-dateutil-2.6.1-6.el8.noarch.rpm"
+          },
+          "sha256:c5c61536e768553067cee488830c64866d109cade24917dbe23f82c861af07c5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libreport-filesystem-2.9.5-15.el8.ppc64le.rpm"
+          },
+          "sha256:c62991989974533b86a29586b799623a908add501287f2c890be4fc8a6af2c7d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/mozjs60-60.9.0-4.el8.ppc64le.rpm"
+          },
+          "sha256:c64632c85c3a49dc82222cdb3d0ee87eafa64f3096ffeba5bcc16c49ee2d260e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/policycoreutils-2.9-15.el8.ppc64le.rpm"
+          },
+          "sha256:c6f27b6e01d80e756408e3c1451e4af00e7d02da0aa24402644c0785118753fe": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-setuptools-39.2.0-6.el8.noarch.rpm"
+          },
+          "sha256:c7dfa7d5a4917eed3b44af87ffb9c6e18242ecd847a8edd140bcdd178cc8946a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/perl-IO-Socket-IP-0.39-5.el8.noarch.rpm"
+          },
+          "sha256:ca5d70414653e1b769124582699bc2400f05b5382a9a8dc6bb4ab4f28dac9c20": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/dhcp-client-4.3.6-45.el8.ppc64le.rpm"
+          },
+          "sha256:caa0bd6617a8d5e535faedec5f6f3ea7c5e6da1898751f6c9c34a89a95c286ff": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/findutils-4.6.0-20.el8.ppc64le.rpm"
+          },
+          "sha256:caabc61e9aa83275f9d2fefcfda56fddf19e7031bcf9f9b84f858bb1f040e24c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libnl3-3.5.0-1.el8.ppc64le.rpm"
+          },
+          "sha256:cad86777bcb265db0da766952ff63e8d33f0fd4f3b90b22d0a1da587a785db44": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/geolite2-city-20180605-1.el8.noarch.rpm"
+          },
+          "sha256:cb21226326a5a695c993daba749f5d758658d58612b05280a04cca98cba3f83a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-perf-4.18.0-331.el8.ppc64le.rpm"
+          },
+          "sha256:cbe98d6dcf93449d9c2fbf95de75f065f8da67a23f13401c672d78b28c6b7f6a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/irqbalance-1.4.0-6.el8.ppc64le.rpm"
+          },
+          "sha256:cbf4b003c37cd3e44ba6586f02d9f869ef4df49902d409cae6005becb3b93d51": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/iptables-1.8.4-19.el8.ppc64le.rpm"
+          },
+          "sha256:cc5f8dd4e061da3a73aa67112e24f2cc5c0ad0cd4334dc798b8834cf6259a779": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/dbus-libs-1.12.8-14.el8.ppc64le.rpm"
+          },
+          "sha256:cc662127a17d4e08e90f75703f376067eed48f5d6b5b8d106fa3824397f1978e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libedit-3.1-23.20170329cvs.el8.ppc64le.rpm"
+          },
+          "sha256:ccc815d5d4e9ff62f2b666c285ebf27060218ff480c171cc541ccbf1005f05b3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/iprutils-2.4.19-1.el8.ppc64le.rpm"
+          },
+          "sha256:ccf848b42acc0f691b4cb6e2830dc4263c7ce4df89b3f4002c3d6b9cd99b362b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-rpm-4.14.3-15.el8.ppc64le.rpm"
+          },
+          "sha256:ccfa1810aa19fae08aefd29cffe28b65d5123cd17bd7d2d4207f03cf9795594c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-dnf-4.7.0-2.el8.noarch.rpm"
+          },
+          "sha256:cd603035aa26b9d12e6b23680e3f1a908341fd9f2086eb540834aee45b4c8604": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libstemmer-0-10.585svn.el8.ppc64le.rpm"
+          },
+          "sha256:cd8b0adfc4d2467a61ab2aa2b3e617bbd2a2592176da249365eef014faef827c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/xz-5.2.4-3.el8.ppc64le.rpm"
+          },
+          "sha256:cdd6594a3bca71d32a5061b85457cc8148611e7f042ba6e812a1c0a2faebac92": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/platform-python-3.6.8-39.el8.ppc64le.rpm"
+          },
+          "sha256:ce954d3900cb547aea14df6ad5f310ea96bb5e83a155b93e2e64b2c13b686193": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/util-linux-2.32.1-28.el8.ppc64le.rpm"
+          },
+          "sha256:cea5d052286c0a120f6cdd0f3e559f13b0eedf9f83d2538e4369b6e05526d43d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/perl-Mozilla-CA-20160104-7.module_el8.3.0+416+dee7bcef.noarch.rpm"
+          },
+          "sha256:cff4b4ac50fed2ceab6add52a66513ed9ca04b024f07a25c53df49f762eea2d2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/groff-base-1.22.3-18.el8.ppc64le.rpm"
+          },
+          "sha256:cffc31e10891c58edc89cebd211bc0be69d99f54f67682c91f97dc53e6381f0f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/perl-Errno-1.28-420.el8.ppc64le.rpm"
+          },
+          "sha256:d03b9f4b9848e3a88d62bcf6e536d659c325b2dc03b2136be7342b5fe5e2b6a9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/perl-Carp-1.42-396.el8.noarch.rpm"
+          },
+          "sha256:d150e53fa73c3786da9e4f6e23d374100b0dd2923485d4a08e9a56ac2786cf83": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/elfutils-libs-0.185-1.el8.ppc64le.rpm"
+          },
+          "sha256:d1cf2d973db2f1af46f124776b9ab4bd782e7065c8c8428a4ddef60989e4225d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/freetype-2.9.1-4.el8_3.1.ppc64le.rpm"
+          },
+          "sha256:d1d362fd4f8022ad05171efe40e84d15ec6c5e5f419d6099ebc8e46e7da632c1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/gdbm-libs-1.18-1.el8.ppc64le.rpm"
+          },
+          "sha256:d1e8c7a00924d1a6dee44ade189025853a501d4f77c73f3bfc006aa907d97daf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-ply-3.9-9.el8.noarch.rpm"
+          },
+          "sha256:d2748115958b57c9c5125e23bad9462edbabb33c81197424a33d8060745ff646": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/python3-babel-2.5.1-7.el8.noarch.rpm"
+          },
+          "sha256:d2e9ef1d33330a14155d5bd6a8cf122f9390cceb8a7a12c0364ae8e44410fb8d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/net-tools-2.0-0.52.20160912git.el8.ppc64le.rpm"
+          },
+          "sha256:d3a4f367a9c5ba936b1bb5480db390889a303e5ec8ff34bb4274c1d840a1784d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libnghttp2-1.33.0-3.el8_2.1.ppc64le.rpm"
+          },
+          "sha256:d3ad718b08b44e1fca355abd46a6c315a9d73ab38f9f3c3d551642b55866e182": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/NetworkManager-libnm-1.32.8-1.el8.ppc64le.rpm"
+          },
+          "sha256:d3e95ed161acd1ba957b1864e7ca2102d9c39380bbdd56eddebf11d5219b3a04": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libsss_certmap-2.5.2-2.el8.ppc64le.rpm"
+          },
+          "sha256:d46ef49f8ddba1ee8cce6c9764014851cce2dbfb5dcb2457a31495393e6566c1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/tpm2-tss-2.3.2-4.el8.ppc64le.rpm"
+          },
+          "sha256:d539404dafd8ad5d785ab3da6f8bd5a2bf5dff9e01be0ff1bc1d251786dda25c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libtirpc-1.1.4-5.el8.ppc64le.rpm"
+          },
+          "sha256:d5ee453757bd1b479881f0a57b968427404b81d9fed07d04afebcbcfcbf536ab": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/perl-interpreter-5.26.3-420.el8.ppc64le.rpm"
+          },
+          "sha256:d64da85b0e013679fb06eeadad74465d9556d7ad21e97beb1b5f61fb0658cd10": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/dhcp-common-4.3.6-45.el8.noarch.rpm"
+          },
+          "sha256:d6eb27d158b6397e52ab6a952fec4e3c414638a08750a6c011d32eb117accd82": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libmodulemd-2.12.1-1.el8.ppc64le.rpm"
+          },
+          "sha256:d751a4fdecc0dc3c5ff897e3ff4c25e7addc698d590e2bfc4c893e693be7d558": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/initscripts-10.00.15-1.el8.ppc64le.rpm"
+          },
+          "sha256:d77a7b1602a9ab7543171091dcb37100552f4738d40389028cbf2992c3152f52": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-libxml2-2.9.7-11.el8.ppc64le.rpm"
+          },
+          "sha256:d7bacff8f9be89871c6ec98c3356de11008ae574da852bdc15cee7ebb9ac39be": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libmodman-2.0.1-17.el8.ppc64le.rpm"
+          },
+          "sha256:d807e7fb8bf24be50642a6dced954c6ea208199daab2d27c9f73d789ba82fa37": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/gawk-4.2.1-2.el8.ppc64le.rpm"
+          },
+          "sha256:d816e850877d0fdbc5ee0951dbd78ca79613602aa5cccd1b324c10d700968d3b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-audit-3.0-0.17.20191104git1c2f876.el8.ppc64le.rpm"
+          },
+          "sha256:d87f7fa5e637442eb638bcaafdc44ca3895d91a153015ff9af6a87219f0dc372": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/openssl-pkcs11-0.4.10-2.el8.ppc64le.rpm"
+          },
+          "sha256:d8c00baf46e33f9e5f1b9e139bbea9fe0f27badb432c992b9cf8c4f7017094bf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libverto-0.3.0-5.el8.ppc64le.rpm"
+          },
+          "sha256:d8dad22276baffe9496d5e05ef35d21dd6f9d8f910339daced2c3ff42d7a28c5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/grub2-ppc64le-modules-2.02-99.el8.noarch.rpm"
+          },
+          "sha256:d909f0e1b6ddb29ad2d3da21208077e3c976212e07471114745859f70be9738d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libverto-libevent-0.3.0-5.el8.ppc64le.rpm"
+          },
+          "sha256:d967d6bbb33bf7a295a64807f81875c84e82a8ecc59b6c72fe955141b1660d39": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/rootfiles-8.1-22.el8.noarch.rpm"
+          },
+          "sha256:da4c6daa0d5406bc967cc89b02a69689491f42c543aceea1a31136f0f1a8d991": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/perl-Getopt-Long-2.50-4.el8.noarch.rpm"
+          },
+          "sha256:dbc730cf810cc886667a7a9b17883ba15bc40e933a38dd820f2f026cf8007805": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/cockpit-bridge-250-1.el8.ppc64le.rpm"
+          },
+          "sha256:dbde46224833f804d8b92212fa3618ea53d0e0cb84ff07132a5ba36c1bc0b9df": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/sed-4.5-2.el8.ppc64le.rpm"
+          },
+          "sha256:dc1d4f59ba0728e65433bc7f903b3799d61545ed3eed7427ad0fe36dcd0f831b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/perl-MIME-Base64-3.15-396.el8.ppc64le.rpm"
+          },
+          "sha256:dc71fa093b472bf0d59ab44f6f824592bb0e8fcceb88035e980d91aa2626f826": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/ipset-7.1-1.el8.ppc64le.rpm"
+          },
+          "sha256:dc835194ecfa6ebda81e0a764c953eff3422a61863e9a3e0dc74ea4cae7a4d94": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-linux-procfs-0.6.3-1.el8.noarch.rpm"
+          },
+          "sha256:dd80a8169e27959a27651616e998be8b49ffdca141744177cb42126ff0ae12b5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/dejavu-fonts-common-2.35-7.el8.noarch.rpm"
+          },
+          "sha256:dd8998fa42db6769700a41203f5ef0efe523ed24734636ef0dc0d2a4d4a94747": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/slang-2.3.2-3.el8.ppc64le.rpm"
+          },
+          "sha256:dd96950b4282e64ce3e37f0bd1a51834beb286037184f3796f9889bfa1ed0d72": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/pciutils-libs-3.7.0-1.el8.ppc64le.rpm"
+          },
+          "sha256:de9a24cdb3260850b49086745ba6f724aecff0bf7993729ae063c116da6915a4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/teamd-1.31-2.el8.ppc64le.rpm"
+          },
+          "sha256:deeeab9fcf6b9cb47235974158561967e299344e040c408e6b5d7464af2f3882": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/lsscsi-0.32-2.el8.ppc64le.rpm"
+          },
+          "sha256:df40cada982b04336fe8b250b4fdd576ddd03a014bb519a69b34640369bef661": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libarchive-3.3.3-1.el8.ppc64le.rpm"
+          },
+          "sha256:dfb7add4926f9a350755294af3c20f114ac59f32e00cadc9ec625b2a51703ad0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/passwd-0.80-3.el8.ppc64le.rpm"
+          },
+          "sha256:dfecfa1299d11d6a77503e626a2e9a14e1a75666bc8ea2abaf7ff515d2c86332": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/hwdata-0.314-8.9.el8.noarch.rpm"
+          },
+          "sha256:e0a7b9f3b56b4737f5711dc6b03f256fbf2488656b8874acabb494b58ba0c1c1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libcom_err-1.45.6-2.el8.ppc64le.rpm"
+          },
+          "sha256:e1153055b6ea57ee81e6fb41b03023279059513d0fec728517ae0805186a5118": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/shadow-utils-4.6-14.el8.ppc64le.rpm"
+          },
+          "sha256:e14ef6f934d9a20645b9eb781902d6a03b7c8123985c88536e06205b240ba509": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/libusal-1.1.11-39.el8.ppc64le.rpm"
+          },
+          "sha256:e156e6fa9ef6a483f8505ce0eeadbcab12b887c4996233ce5d6258076f6bce50": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/file-5.33-20.el8.ppc64le.rpm"
+          },
+          "sha256:e1e28504928648404a3b652440091eba010cd99221183ef78601cbd152261d91": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/gzip-1.9-12.el8.ppc64le.rpm"
+          },
+          "sha256:e217c2687212d931ad9a6a02afb20cc34f6d051786d136e337f91079c9f73d22": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libutempter-1.1.6-14.el8.ppc64le.rpm"
+          },
+          "sha256:e21a84107568047432e474e08da24aea2340409d57ea8cf170182927dc76de12": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libcurl-7.61.1-18.el8_4.1.ppc64le.rpm"
+          },
+          "sha256:e269f7d33abbb790311ffa95fa7df9766cac8bf31ace24fce6ed732ba0db19ae": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/perl-File-Temp-0.230.600-1.el8.noarch.rpm"
+          },
+          "sha256:e392a6b41381ffad04626d092fd2af9477c72e197a74efddf987832c3bfa521f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/gettext-libs-0.19.8.1-17.el8.ppc64le.rpm"
+          },
+          "sha256:e403c9839742c4b13e715541237f79ffe52870d59867bebd39e19e7080948db1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/fontconfig-2.13.1-3.el8.ppc64le.rpm"
+          },
+          "sha256:e45848a3fbfa1d46709448593fa7929fee4c5a83d2168c0d41d498251e4b5dae": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/kernel-tools-4.18.0-331.el8.ppc64le.rpm"
+          },
+          "sha256:e525544166da577edcd03c6596f1e8787a257caaa19eef98c3a481681d2d978a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/libestr-0.1.10-1.el8.ppc64le.rpm"
+          },
+          "sha256:e526de1fefb832b3e6a025642c77ac2527595925933412a7921606eb072e5ca9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/authselect-compat-1.2.2-3.el8.ppc64le.rpm"
+          },
+          "sha256:e65f7d7c8def6b168e013914bc0d1137aed65c3010e9796df3b823854472f3e1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/file-libs-5.33-20.el8.ppc64le.rpm"
+          },
+          "sha256:e716fd0130980916f4b1aeac8f98dbcd8ced81e2c119b7877204cc6b1a058418": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/polkit-0.115-12.el8.ppc64le.rpm"
+          },
+          "sha256:e778fc7e5d62fe488e250a1916cdb7f692e98e23d0c2b4264672b2574ff416e5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libappstream-glib-0.7.14-3.el8.ppc64le.rpm"
+          },
+          "sha256:e83928bd4552ecdf8e71d283e2358c7eccd006d284ba31fbc9c89e407989fd60": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/perl-File-Path-2.15-2.el8.noarch.rpm"
+          },
+          "sha256:e87acf226a9511b3a5f83e7fed9c5c20addbbdae47ab67c614404a9392b77e50": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/elfutils-libelf-0.185-1.el8.ppc64le.rpm"
+          },
+          "sha256:e8b7968fe6613c4cd6324436089cc9c1558cd63fb7da87fd46cc7c15c4ab7f66": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/ethtool-5.8-6.el8.ppc64le.rpm"
+          },
+          "sha256:e95bb05fa5defeb16dd0e0957de676374b22b9daaf405273e636d1ce91001574": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/systemd-pam-239-49.el8.ppc64le.rpm"
+          },
+          "sha256:ebd64ac5cc7b9f58a40072fe9afefa2fd835e0eb18cdeaf085395c7e84affac3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/unbound-libs-1.7.3-17.el8.ppc64le.rpm"
+          },
+          "sha256:ebeb05a4a9cdd5d060859eabac1349029c0120615c98fc939e26664c030655c1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-jwt-1.6.1-2.el8.noarch.rpm"
+          },
+          "sha256:ec85355744a8b37aa7fbe48d6f8afd8d0538129b70e82d238c3b57ae08559430": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/cockpit-ws-250-1.el8.ppc64le.rpm"
+          },
+          "sha256:ed40678aa26d63b71a122bd394b46b362df083c8f4ae3267f205a7d77ff69fdf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/dhcp-libs-4.3.6-45.el8.ppc64le.rpm"
+          },
+          "sha256:edf00207b603cbfe86b07f8be5c4ee14ff1dd85ec4b7d82d760483ffcea43891": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/cronie-1.5.2-4.el8.ppc64le.rpm"
+          },
+          "sha256:eee92733e8989029929d5cb1f673b15fdb814dac32e148d5bc02378b44c8699a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/chkconfig-1.19.1-1.el8.ppc64le.rpm"
+          },
+          "sha256:ef86061338fa321c959cadc75ecbdfd405eebaa1042eec9d9c737d4d9d92568f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/kbd-misc-2.0.4-10.el8.noarch.rpm"
+          },
+          "sha256:f0c20dff5211f9c133ad5703daedcbe148528c634b0a1eea7887b420da4dc00c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/virt-what-1.18-12.el8.ppc64le.rpm"
+          },
+          "sha256:f14cc62cf70a187384adff6bedf8b09858b8f441a9be87ebf3ae975c4e6b0d73": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/authselect-1.2.2-3.el8.ppc64le.rpm"
+          },
+          "sha256:f24bce642ec88622490b2f09a45fa3985da7f6511a1aae131853c4ea4c309e6b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/lz4-libs-1.8.3-3.el8_4.ppc64le.rpm"
+          },
+          "sha256:f342cdc282518eab3c87bc964306092b77eeeed8ca1d815272f6d4e3431c9037": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/plymouth-scripts-0.9.4-9.20200615git1e36e30.el8.ppc64le.rpm"
+          },
+          "sha256:f3d9ccb762146dc97f2d201d979fbb0e9171d1203fb985f3ef48b5c2a176c2a9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libgcc-8.5.0-3.el8.ppc64le.rpm"
+          },
+          "sha256:f4e3607f242bbca7ec2379822ca961860e6d9c276da51c6e2dfd17a29469ec78": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/perl-Term-ANSIColor-4.06-396.el8.noarch.rpm"
+          },
+          "sha256:f4eca686b314edb06d3fe1c526f573c7248c811af70cba76132cdc9c541cadc1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/elfutils-debuginfod-client-0.185-1.el8.ppc64le.rpm"
+          },
+          "sha256:f5bcb82a732c02d6f31bbf156887049883c76cedc9c6a11b049358a74f4d45d0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libssh-config-0.9.4-3.el8.noarch.rpm"
+          },
+          "sha256:f5e73bbd776a2426a796971d8d38664f2e94898479fb76947dccdd28cf9fe1d0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/perl-parent-0.237-1.el8.noarch.rpm"
+          },
+          "sha256:f6cd5ed6305952c1cd842fbca0e5d9613f736646cfac2082a2db37f5d065468c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/lmdb-libs-0.9.24-1.el8.ppc64le.rpm"
+          },
+          "sha256:f7a2eddcda47cb75108add34c0ce919ceb847605830ad33aeb4bd64d6bed24f3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libdaemon-0.14-15.el8.ppc64le.rpm"
+          },
+          "sha256:f8130aecd446f997d0e2011481275db0552bf57bd7af0d7a655eded5f52ca94e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/openssh-server-8.0p1-9.el8.ppc64le.rpm"
+          },
+          "sha256:f97b5915b3f75d2878104c198f205841813712103f1b3657d71d2c8d079cc947": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/shared-mime-info-1.9-3.el8.ppc64le.rpm"
+          },
+          "sha256:fa7bef727ba8657208bb3df95916f0bc912332cb8534c695facef32ffbd72f20": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/glibc-all-langpacks-2.28-162.el8.ppc64le.rpm"
+          },
+          "sha256:fb1aa2fc7bbe75deca5b66f2151742b4afeb5c75a668b11b9875c81894bb2a3f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/nftables-0.9.3-20.el8.ppc64le.rpm"
+          },
+          "sha256:fb276cc0ebc6bd27d344f7e0811f26cb3f0e59da09182489095724bdf2a075f8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/grub2-tools-minimal-2.02-99.el8.ppc64le.rpm"
+          },
+          "sha256:fb6e437a24450106c03f25dc1c3f6b78549b82c2d0bd4387dce1350ca3c5f1f5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libpath_utils-0.2.1-39.el8.ppc64le.rpm"
+          },
+          "sha256:fc8e4e96da6ee6201a5126473666831314938e98bf699677be296e7811f6b7dd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/libXext-1.3.4-1.el8.ppc64le.rpm"
+          },
+          "sha256:fc9d3ee3946b87efcd9531f876d23a9e8d5769aab3e0ad6007ac2cdb4068499c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/perl-Encode-2.97-3.el8.ppc64le.rpm"
+          },
+          "sha256:fd6e1803ff367036da5b52b2183e1408691b379cc1320971bb664737507f89a4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libkcapi-1.2.0-2.el8.ppc64le.rpm"
+          },
+          "sha256:ff02d15997cec2391c7d49203e49f88068993252ac1f496a11e182c92d9d0e88": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/PackageKit-glib-1.1.12-6.el8.ppc64le.rpm"
+          },
+          "sha256:ff1580bd4ec5841d4937b383917fa30f318b4f419b8067a77468eb4a9630ba10": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libacl-2.2.53-1.el8.ppc64le.rpm"
+          },
+          "sha256:ff8b51c6a8bacc5ef6b5da0f049d170ab1c1ecebad50ded3c04ed384eca9a2c0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/coreutils-8.30-12.el8.ppc64le.rpm"
+          },
+          "sha256:ffb6d471f5c82b0407cc41a25aea25bf83d6779b3ef20f0557c4fd0da6111bb7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/gssproxy-0.8.0-19.el8.ppc64le.rpm"
+          }
+        }
+      }
+    }
+  },
+  "rpmmd": {
+    "blueprint": [
+      {
+        "name": "NetworkManager",
+        "epoch": 1,
+        "version": "1.32.8",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/NetworkManager-1.32.8-1.el8.ppc64le.rpm",
+        "checksum": "sha256:a6ef8e56d53c29e92b46a7ad62c22380056153b2d5810c39c0cc1658a4250d5b",
+        "check_gpg": true
+      },
+      {
+        "name": "NetworkManager-libnm",
+        "epoch": 1,
+        "version": "1.32.8",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/NetworkManager-libnm-1.32.8-1.el8.ppc64le.rpm",
+        "checksum": "sha256:d3ad718b08b44e1fca355abd46a6c315a9d73ab38f9f3c3d551642b55866e182",
+        "check_gpg": true
+      },
+      {
+        "name": "NetworkManager-team",
+        "epoch": 1,
+        "version": "1.32.8",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/NetworkManager-team-1.32.8-1.el8.ppc64le.rpm",
+        "checksum": "sha256:3ed20aba45a8c175e818de998d906fb2759387c607bd9b15dbbefee8c73097ba",
+        "check_gpg": true
+      },
+      {
+        "name": "NetworkManager-tui",
+        "epoch": 1,
+        "version": "1.32.8",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/NetworkManager-tui-1.32.8-1.el8.ppc64le.rpm",
+        "checksum": "sha256:5f068787bd9a0190b03e64cd770e44ace593c5aa09e3f4c470c44d8d484b4674",
+        "check_gpg": true
+      },
+      {
+        "name": "acl",
+        "epoch": 0,
+        "version": "2.2.53",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/acl-2.2.53-1.el8.ppc64le.rpm",
+        "checksum": "sha256:2c1baefd0f802507d9741da8da54f6eae42b04967f9d433d7f9e0f124434c70d",
+        "check_gpg": true
+      },
+      {
+        "name": "audit",
+        "epoch": 0,
+        "version": "3.0",
+        "release": "0.17.20191104git1c2f876.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/audit-3.0-0.17.20191104git1c2f876.el8.ppc64le.rpm",
+        "checksum": "sha256:42829311fe40b7487530ee432aeb8e1df86e5168373f038cccb60d0db94601d3",
+        "check_gpg": true
+      },
+      {
+        "name": "audit-libs",
+        "epoch": 0,
+        "version": "3.0",
+        "release": "0.17.20191104git1c2f876.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/audit-libs-3.0-0.17.20191104git1c2f876.el8.ppc64le.rpm",
+        "checksum": "sha256:be49b69bc5de947ee2151f397993a691a57bc53952058c32cde0fca674da7d8c",
+        "check_gpg": true
+      },
+      {
+        "name": "authselect",
+        "epoch": 0,
+        "version": "1.2.2",
+        "release": "3.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/authselect-1.2.2-3.el8.ppc64le.rpm",
+        "checksum": "sha256:f14cc62cf70a187384adff6bedf8b09858b8f441a9be87ebf3ae975c4e6b0d73",
+        "check_gpg": true
+      },
+      {
+        "name": "authselect-libs",
+        "epoch": 0,
+        "version": "1.2.2",
+        "release": "3.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/authselect-libs-1.2.2-3.el8.ppc64le.rpm",
+        "checksum": "sha256:4966b1832e9eccd8f83ecc20143fb6f18215107bdecd7267b4605cdae4a6562a",
+        "check_gpg": true
+      },
+      {
+        "name": "basesystem",
+        "epoch": 0,
+        "version": "11",
+        "release": "5.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/basesystem-11-5.el8.noarch.rpm",
+        "checksum": "sha256:48226934763e4c412c1eb65df314e6879720b4b1ebcb3d07c126c9526639cb68",
+        "check_gpg": true
+      },
+      {
+        "name": "bash",
+        "epoch": 0,
+        "version": "4.4.20",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/bash-4.4.20-2.el8.ppc64le.rpm",
+        "checksum": "sha256:3a438b53e8377eccf90cac0fd42ed2b513fc869bfb7b96e3d2a4f6984a287f90",
+        "check_gpg": true
+      },
+      {
+        "name": "bc",
+        "epoch": 0,
+        "version": "1.07.1",
+        "release": "5.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/bc-1.07.1-5.el8.ppc64le.rpm",
+        "checksum": "sha256:c12c7dc6676c6ccc5ca08ceddfb1b4e46c9f1ed49cbc241292ae6d1fdb0d9d62",
+        "check_gpg": true
+      },
+      {
+        "name": "brotli",
+        "epoch": 0,
+        "version": "1.0.6",
+        "release": "3.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/brotli-1.0.6-3.el8.ppc64le.rpm",
+        "checksum": "sha256:8729b157f0925feccdaef8aacd91c6aebe0109e621675bcc15e1830673b0e19d",
+        "check_gpg": true
+      },
+      {
+        "name": "bzip2-libs",
+        "epoch": 0,
+        "version": "1.0.6",
+        "release": "26.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/bzip2-libs-1.0.6-26.el8.ppc64le.rpm",
+        "checksum": "sha256:56c3d429ea949467dc0bca882646cf40a58fb6f27750f5664ff2919f5d38ada5",
+        "check_gpg": true
+      },
+      {
+        "name": "c-ares",
+        "epoch": 0,
+        "version": "1.13.0",
+        "release": "5.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/c-ares-1.13.0-5.el8.ppc64le.rpm",
+        "checksum": "sha256:1f2a096d6a75662a86a06ff2859e6ba916bbc8c6d8cb7b73810ffbb9fef4b089",
+        "check_gpg": true
+      },
+      {
+        "name": "ca-certificates",
+        "epoch": 0,
+        "version": "2021.2.50",
+        "release": "82.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/ca-certificates-2021.2.50-82.el8.noarch.rpm",
+        "checksum": "sha256:1fad1d1f8b56e6967863aeb60f5fa3615e6a35b0f6532d8a23066e6823b50860",
+        "check_gpg": true
+      },
+      {
+        "name": "centos-gpg-keys",
+        "epoch": 1,
+        "version": "8",
+        "release": "2.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/centos-gpg-keys-8-2.el8.noarch.rpm",
+        "checksum": "sha256:842ff55b80ac9a5c3357bf52646a5761a4c4786bb3e64b56d8fa5d8fe34ef8bb",
+        "check_gpg": true
+      },
+      {
+        "name": "centos-stream-release",
+        "epoch": 0,
+        "version": "8.5",
+        "release": "3.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/centos-stream-release-8.5-3.el8.noarch.rpm",
+        "checksum": "sha256:15b17b95cf9cb9fb64e0c8e56110836bdcaf70de81b8cbdb60e181fc90456e06",
+        "check_gpg": true
+      },
+      {
+        "name": "centos-stream-repos",
+        "epoch": 0,
+        "version": "8",
+        "release": "2.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/centos-stream-repos-8-2.el8.noarch.rpm",
+        "checksum": "sha256:a82958266d292f4725fc1981ea57a861b7fc7feeb7a9551d0b61b98ca51a5662",
+        "check_gpg": true
+      },
+      {
+        "name": "chkconfig",
+        "epoch": 0,
+        "version": "1.19.1",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/chkconfig-1.19.1-1.el8.ppc64le.rpm",
+        "checksum": "sha256:eee92733e8989029929d5cb1f673b15fdb814dac32e148d5bc02378b44c8699a",
+        "check_gpg": true
+      },
+      {
+        "name": "chrony",
+        "epoch": 0,
+        "version": "4.1",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/chrony-4.1-1.el8.ppc64le.rpm",
+        "checksum": "sha256:24fcc5bc49b059b221075989f25875fb821079088dca694aec262446cde50cb7",
+        "check_gpg": true
+      },
+      {
+        "name": "coreutils",
+        "epoch": 0,
+        "version": "8.30",
+        "release": "12.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/coreutils-8.30-12.el8.ppc64le.rpm",
+        "checksum": "sha256:ff8b51c6a8bacc5ef6b5da0f049d170ab1c1ecebad50ded3c04ed384eca9a2c0",
+        "check_gpg": true
+      },
+      {
+        "name": "coreutils-common",
+        "epoch": 0,
+        "version": "8.30",
+        "release": "12.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/coreutils-common-8.30-12.el8.ppc64le.rpm",
+        "checksum": "sha256:383a5e6bb9e94de53baaf5c7493cd50a68c893c6a30acfbe28407d33bb133efc",
+        "check_gpg": true
+      },
+      {
+        "name": "cpio",
+        "epoch": 0,
+        "version": "2.12",
+        "release": "10.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/cpio-2.12-10.el8.ppc64le.rpm",
+        "checksum": "sha256:19061d12407c0c4bca6abcaef01695b70dcd3967ff102dd07178a2193a280e29",
+        "check_gpg": true
+      },
+      {
+        "name": "cracklib",
+        "epoch": 0,
+        "version": "2.9.6",
+        "release": "15.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/cracklib-2.9.6-15.el8.ppc64le.rpm",
+        "checksum": "sha256:4e3e93a3d2039c2a8305030b7960bd1100d7d20705a1afb1325a4ee79478a74a",
+        "check_gpg": true
+      },
+      {
+        "name": "cracklib-dicts",
+        "epoch": 0,
+        "version": "2.9.6",
+        "release": "15.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/cracklib-dicts-2.9.6-15.el8.ppc64le.rpm",
+        "checksum": "sha256:084d79ed3d7127e6d46e9ac6e654d8ef181a156435808dc8eb32968b6c1b4946",
+        "check_gpg": true
+      },
+      {
+        "name": "cronie",
+        "epoch": 0,
+        "version": "1.5.2",
+        "release": "4.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/cronie-1.5.2-4.el8.ppc64le.rpm",
+        "checksum": "sha256:edf00207b603cbfe86b07f8be5c4ee14ff1dd85ec4b7d82d760483ffcea43891",
+        "check_gpg": true
+      },
+      {
+        "name": "cronie-anacron",
+        "epoch": 0,
+        "version": "1.5.2",
+        "release": "4.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/cronie-anacron-1.5.2-4.el8.ppc64le.rpm",
+        "checksum": "sha256:6faee589c5a7454502e5ec07586a4856e7f1376bd551741af2acf03afb9716e6",
+        "check_gpg": true
+      },
+      {
+        "name": "crontabs",
+        "epoch": 0,
+        "version": "1.11",
+        "release": "17.20190603git.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/crontabs-1.11-17.20190603git.el8.noarch.rpm",
+        "checksum": "sha256:bcf25aae89f7368b16346bc1ec92850175bcc2312bf7a5e74bc3c512bcd345b0",
+        "check_gpg": true
+      },
+      {
+        "name": "crypto-policies",
+        "epoch": 0,
+        "version": "20210617",
+        "release": "1.gitc776d3e.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/crypto-policies-20210617-1.gitc776d3e.el8.noarch.rpm",
+        "checksum": "sha256:2a8f9e5119a034801904185dcbf1bc29db67e9e9b0cf5893615722d7bb33099c",
+        "check_gpg": true
+      },
+      {
+        "name": "crypto-policies-scripts",
+        "epoch": 0,
+        "version": "20210617",
+        "release": "1.gitc776d3e.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/crypto-policies-scripts-20210617-1.gitc776d3e.el8.noarch.rpm",
+        "checksum": "sha256:67f37cee02ba744dfc7957725f5ef9df229778f6a2f7afc659625b458da6167e",
+        "check_gpg": true
+      },
+      {
+        "name": "cryptsetup-libs",
+        "epoch": 0,
+        "version": "2.3.3",
+        "release": "4.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/cryptsetup-libs-2.3.3-4.el8.ppc64le.rpm",
+        "checksum": "sha256:b10d8521963a2494fdb2b5f8fb0de837dc86d4016c3b10019fb8970a09582451",
+        "check_gpg": true
+      },
+      {
+        "name": "curl",
+        "epoch": 0,
+        "version": "7.61.1",
+        "release": "18.el8_4.1",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/curl-7.61.1-18.el8_4.1.ppc64le.rpm",
+        "checksum": "sha256:47ad43730c8bc72c90f2fb3dbd3526d716ada2fad94e62cb443658e94c6503c5",
+        "check_gpg": true
+      },
+      {
+        "name": "cyrus-sasl-lib",
+        "epoch": 0,
+        "version": "2.1.27",
+        "release": "5.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/cyrus-sasl-lib-2.1.27-5.el8.ppc64le.rpm",
+        "checksum": "sha256:5c1940e1f173e22b053f3a89022903cea34a6af20dff81c65548c4e2ba3a8293",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus",
+        "epoch": 1,
+        "version": "1.12.8",
+        "release": "14.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/dbus-1.12.8-14.el8.ppc64le.rpm",
+        "checksum": "sha256:1a4e44583a767289bb0d354db93c6a9132420e13376d4fcae866d69620bb11bb",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-common",
+        "epoch": 1,
+        "version": "1.12.8",
+        "release": "14.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/dbus-common-1.12.8-14.el8.noarch.rpm",
+        "checksum": "sha256:7baac88adafdc5958fb818c7685d3c6548f6e2e585e4435ceee4a168edc3597e",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-daemon",
+        "epoch": 1,
+        "version": "1.12.8",
+        "release": "14.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/dbus-daemon-1.12.8-14.el8.ppc64le.rpm",
+        "checksum": "sha256:090563f18409c228274bb61dcf1001f63a55c1246fb2838a998cb3c5fd8c3874",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-glib",
+        "epoch": 0,
+        "version": "0.110",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/dbus-glib-0.110-2.el8.ppc64le.rpm",
+        "checksum": "sha256:c58b0b900a7ffc778980461d74dc236bf2c790d2e5e8c04e28876e221b48a1c8",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-libs",
+        "epoch": 1,
+        "version": "1.12.8",
+        "release": "14.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/dbus-libs-1.12.8-14.el8.ppc64le.rpm",
+        "checksum": "sha256:cc5f8dd4e061da3a73aa67112e24f2cc5c0ad0cd4334dc798b8834cf6259a779",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-tools",
+        "epoch": 1,
+        "version": "1.12.8",
+        "release": "14.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/dbus-tools-1.12.8-14.el8.ppc64le.rpm",
+        "checksum": "sha256:698e8ecaf71719dafacae79de05080d567b69fad3511e8b8d42b9af96a7c41db",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper",
+        "epoch": 8,
+        "version": "1.02.177",
+        "release": "6.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/device-mapper-1.02.177-6.el8.ppc64le.rpm",
+        "checksum": "sha256:441b3862f5a0fd504bbbba18d96d1b2b920fb95a79dc45a753a6a664ad285b07",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper-libs",
+        "epoch": 8,
+        "version": "1.02.177",
+        "release": "6.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/device-mapper-libs-1.02.177-6.el8.ppc64le.rpm",
+        "checksum": "sha256:a42de8ce71380b1f4e8ac5b4ce720bf565c99a0b09ef983c0550a91a467bc155",
+        "check_gpg": true
+      },
+      {
+        "name": "diffutils",
+        "epoch": 0,
+        "version": "3.6",
+        "release": "6.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/diffutils-3.6-6.el8.ppc64le.rpm",
+        "checksum": "sha256:4f92835a6e4ee4276df49019e068d1871b75821f52b405c699bd9f199df58b80",
+        "check_gpg": true
+      },
+      {
+        "name": "dnf",
+        "epoch": 0,
+        "version": "4.7.0",
+        "release": "2.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/dnf-4.7.0-2.el8.noarch.rpm",
+        "checksum": "sha256:42464424b9fa731f8122fe748aad0005519fc87b770dbbdb71f29f514ea0e889",
+        "check_gpg": true
+      },
+      {
+        "name": "dnf-data",
+        "epoch": 0,
+        "version": "4.7.0",
+        "release": "2.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/dnf-data-4.7.0-2.el8.noarch.rpm",
+        "checksum": "sha256:45c48d32120739734ae97479cc0f3ca19796ea47e360ba39d52b77ce3ada61d7",
+        "check_gpg": true
+      },
+      {
+        "name": "dnf-plugins-core",
+        "epoch": 0,
+        "version": "4.0.21",
+        "release": "2.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/dnf-plugins-core-4.0.21-2.el8.noarch.rpm",
+        "checksum": "sha256:47b61754a278c4ca378871c874ccf6a0a07bffaef38505315cfa94f262887845",
+        "check_gpg": true
+      },
+      {
+        "name": "dracut",
+        "epoch": 0,
+        "version": "049",
+        "release": "188.git20210802.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/dracut-049-188.git20210802.el8.ppc64le.rpm",
+        "checksum": "sha256:881b28a3a37d114bc3f046605b24663560009b13a507217e007643f5682efdd5",
+        "check_gpg": true
+      },
+      {
+        "name": "dracut-config-rescue",
+        "epoch": 0,
+        "version": "049",
+        "release": "188.git20210802.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/dracut-config-rescue-049-188.git20210802.el8.ppc64le.rpm",
+        "checksum": "sha256:37a5d2adbe9e34309731885445decdf722ed7bc18d971c5a7f6a536f8876fd90",
+        "check_gpg": true
+      },
+      {
+        "name": "dracut-network",
+        "epoch": 0,
+        "version": "049",
+        "release": "188.git20210802.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/dracut-network-049-188.git20210802.el8.ppc64le.rpm",
+        "checksum": "sha256:2588ff56ab340c06ce8b5be22cbe23de89d4f336b38ae930daf11db1c6a24391",
+        "check_gpg": true
+      },
+      {
+        "name": "dracut-squash",
+        "epoch": 0,
+        "version": "049",
+        "release": "188.git20210802.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/dracut-squash-049-188.git20210802.el8.ppc64le.rpm",
+        "checksum": "sha256:412f3eaa5f7e226fdc4678a3266edab76d8998f7d76763075f690a01362ef89c",
+        "check_gpg": true
+      },
+      {
+        "name": "e2fsprogs",
+        "epoch": 0,
+        "version": "1.45.6",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/e2fsprogs-1.45.6-2.el8.ppc64le.rpm",
+        "checksum": "sha256:9e67ac5948125dd165c9a74ec848d48b313ef4264bbbb89630a782dbd972d72c",
+        "check_gpg": true
+      },
+      {
+        "name": "e2fsprogs-libs",
+        "epoch": 0,
+        "version": "1.45.6",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/e2fsprogs-libs-1.45.6-2.el8.ppc64le.rpm",
+        "checksum": "sha256:9fb07c2324cccbbc19e3ffade50ee7da41909b2f6c24f49ffd9978ba375de193",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-debuginfod-client",
+        "epoch": 0,
+        "version": "0.185",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/elfutils-debuginfod-client-0.185-1.el8.ppc64le.rpm",
+        "checksum": "sha256:f4eca686b314edb06d3fe1c526f573c7248c811af70cba76132cdc9c541cadc1",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-default-yama-scope",
+        "epoch": 0,
+        "version": "0.185",
+        "release": "1.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/elfutils-default-yama-scope-0.185-1.el8.noarch.rpm",
+        "checksum": "sha256:30ceeb5a6cadaeccdbde088bfb52ba88190fa530c11f4a2aafd62b4b4ad6b404",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-libelf",
+        "epoch": 0,
+        "version": "0.185",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/elfutils-libelf-0.185-1.el8.ppc64le.rpm",
+        "checksum": "sha256:e87acf226a9511b3a5f83e7fed9c5c20addbbdae47ab67c614404a9392b77e50",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-libs",
+        "epoch": 0,
+        "version": "0.185",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/elfutils-libs-0.185-1.el8.ppc64le.rpm",
+        "checksum": "sha256:d150e53fa73c3786da9e4f6e23d374100b0dd2923485d4a08e9a56ac2786cf83",
+        "check_gpg": true
+      },
+      {
+        "name": "ethtool",
+        "epoch": 2,
+        "version": "5.8",
+        "release": "6.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/ethtool-5.8-6.el8.ppc64le.rpm",
+        "checksum": "sha256:e8b7968fe6613c4cd6324436089cc9c1558cd63fb7da87fd46cc7c15c4ab7f66",
+        "check_gpg": true
+      },
+      {
+        "name": "expat",
+        "epoch": 0,
+        "version": "2.2.5",
+        "release": "4.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/expat-2.2.5-4.el8.ppc64le.rpm",
+        "checksum": "sha256:88be5116908aa5013f540c767f6811774342780bb72d3ec197b3429bfb2f9862",
+        "check_gpg": true
+      },
+      {
+        "name": "file",
+        "epoch": 0,
+        "version": "5.33",
+        "release": "20.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/file-5.33-20.el8.ppc64le.rpm",
+        "checksum": "sha256:e156e6fa9ef6a483f8505ce0eeadbcab12b887c4996233ce5d6258076f6bce50",
+        "check_gpg": true
+      },
+      {
+        "name": "file-libs",
+        "epoch": 0,
+        "version": "5.33",
+        "release": "20.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/file-libs-5.33-20.el8.ppc64le.rpm",
+        "checksum": "sha256:e65f7d7c8def6b168e013914bc0d1137aed65c3010e9796df3b823854472f3e1",
+        "check_gpg": true
+      },
+      {
+        "name": "filesystem",
+        "epoch": 0,
+        "version": "3.8",
+        "release": "6.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/filesystem-3.8-6.el8.ppc64le.rpm",
+        "checksum": "sha256:a49b922f117b9bfb0b07e9848151f8a2948345328ebc534cd28ac187d7ed3f94",
+        "check_gpg": true
+      },
+      {
+        "name": "findutils",
+        "epoch": 1,
+        "version": "4.6.0",
+        "release": "20.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/findutils-4.6.0-20.el8.ppc64le.rpm",
+        "checksum": "sha256:caa0bd6617a8d5e535faedec5f6f3ea7c5e6da1898751f6c9c34a89a95c286ff",
+        "check_gpg": true
+      },
+      {
+        "name": "firewalld",
+        "epoch": 0,
+        "version": "0.9.3",
+        "release": "7.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/firewalld-0.9.3-7.el8.noarch.rpm",
+        "checksum": "sha256:5e34865a724e4e08cda721b66f24d4806d4b0b5ce059c340759d0a1a861a907d",
+        "check_gpg": true
+      },
+      {
+        "name": "firewalld-filesystem",
+        "epoch": 0,
+        "version": "0.9.3",
+        "release": "7.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/firewalld-filesystem-0.9.3-7.el8.noarch.rpm",
+        "checksum": "sha256:56cd753773415b5f3cafa693992e158d98dacdd1053d5018118b7685e1f8fb45",
+        "check_gpg": true
+      },
+      {
+        "name": "fuse-libs",
+        "epoch": 0,
+        "version": "2.9.7",
+        "release": "12.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/fuse-libs-2.9.7-12.el8.ppc64le.rpm",
+        "checksum": "sha256:4992eb036c0797daf9b984af1a34fe27a30287ee5d2bd5e2f5a0df3a09bdbb59",
+        "check_gpg": true
+      },
+      {
+        "name": "gawk",
+        "epoch": 0,
+        "version": "4.2.1",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/gawk-4.2.1-2.el8.ppc64le.rpm",
+        "checksum": "sha256:d807e7fb8bf24be50642a6dced954c6ea208199daab2d27c9f73d789ba82fa37",
+        "check_gpg": true
+      },
+      {
+        "name": "gdbm",
+        "epoch": 1,
+        "version": "1.18",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/gdbm-1.18-1.el8.ppc64le.rpm",
+        "checksum": "sha256:8cd6ef9902851f07cfd9682e2d6873648690f0c2ec65345276b557ede042d8b9",
+        "check_gpg": true
+      },
+      {
+        "name": "gdbm-libs",
+        "epoch": 1,
+        "version": "1.18",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/gdbm-libs-1.18-1.el8.ppc64le.rpm",
+        "checksum": "sha256:d1d362fd4f8022ad05171efe40e84d15ec6c5e5f419d6099ebc8e46e7da632c1",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext",
+        "epoch": 0,
+        "version": "0.19.8.1",
+        "release": "17.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/gettext-0.19.8.1-17.el8.ppc64le.rpm",
+        "checksum": "sha256:78fd472a1c7f49b8a432788ea2dfc1119f155a394f41585b4e715d2585fc92ab",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext-libs",
+        "epoch": 0,
+        "version": "0.19.8.1",
+        "release": "17.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/gettext-libs-0.19.8.1-17.el8.ppc64le.rpm",
+        "checksum": "sha256:e392a6b41381ffad04626d092fd2af9477c72e197a74efddf987832c3bfa521f",
+        "check_gpg": true
+      },
+      {
+        "name": "glib2",
+        "epoch": 0,
+        "version": "2.56.4",
+        "release": "156.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/glib2-2.56.4-156.el8.ppc64le.rpm",
+        "checksum": "sha256:ad338b7a3f3bed96300d9ce7f0307e09d758962b8496c10fb3554bf62405d153",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc",
+        "epoch": 0,
+        "version": "2.28",
+        "release": "162.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/glibc-2.28-162.el8.ppc64le.rpm",
+        "checksum": "sha256:bfb45644212cfbbe48b05149f8d53e77d7bd02ca9fc9045cc37115101175a3a0",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-all-langpacks",
+        "epoch": 0,
+        "version": "2.28",
+        "release": "162.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/glibc-all-langpacks-2.28-162.el8.ppc64le.rpm",
+        "checksum": "sha256:fa7bef727ba8657208bb3df95916f0bc912332cb8534c695facef32ffbd72f20",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-common",
+        "epoch": 0,
+        "version": "2.28",
+        "release": "162.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/glibc-common-2.28-162.el8.ppc64le.rpm",
+        "checksum": "sha256:257e086bb52086254fa8cc95a5c4998668b4fcb5203ad3c2275c1150816acc9b",
+        "check_gpg": true
+      },
+      {
+        "name": "gmp",
+        "epoch": 1,
+        "version": "6.1.2",
+        "release": "10.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/gmp-6.1.2-10.el8.ppc64le.rpm",
+        "checksum": "sha256:af0a4287e302baa7c85655ddfe5a7049b8eaf31aff03886f4fc57c920d26d491",
+        "check_gpg": true
+      },
+      {
+        "name": "gnupg2",
+        "epoch": 0,
+        "version": "2.2.20",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/gnupg2-2.2.20-2.el8.ppc64le.rpm",
+        "checksum": "sha256:11ff811a72c82084c7c14700b23d29643e153442a34b3b486e270e5b40e38d0a",
+        "check_gpg": true
+      },
+      {
+        "name": "gnupg2-smime",
+        "epoch": 0,
+        "version": "2.2.20",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/gnupg2-smime-2.2.20-2.el8.ppc64le.rpm",
+        "checksum": "sha256:a2d96efed83ab31d21481af044835a940673ee4ade2763af78c06d2df87b94f7",
+        "check_gpg": true
+      },
+      {
+        "name": "gnutls",
+        "epoch": 0,
+        "version": "3.6.16",
+        "release": "4.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/gnutls-3.6.16-4.el8.ppc64le.rpm",
+        "checksum": "sha256:51760acfb6ca87db5be7a9296d6a3d1220767956c576a26c6d46784e25db85bb",
+        "check_gpg": true
+      },
+      {
+        "name": "gobject-introspection",
+        "epoch": 0,
+        "version": "1.56.1",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/gobject-introspection-1.56.1-1.el8.ppc64le.rpm",
+        "checksum": "sha256:754bf53a39cea727d9d89d59df32e020842dc71f6a0561ea36f8203aff2d5d69",
+        "check_gpg": true
+      },
+      {
+        "name": "gpgme",
+        "epoch": 0,
+        "version": "1.13.1",
+        "release": "9.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/gpgme-1.13.1-9.el8.ppc64le.rpm",
+        "checksum": "sha256:24f5cd46a7395cd046b10d6ddc4de435ec6595d0dcdb2d179c94cc9082a12f14",
+        "check_gpg": true
+      },
+      {
+        "name": "grep",
+        "epoch": 0,
+        "version": "3.1",
+        "release": "6.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/grep-3.1-6.el8.ppc64le.rpm",
+        "checksum": "sha256:2451a475f248a4c66e64d149fefa8bfc195fcd7b3f369bae221a94f8ce4c2d67",
+        "check_gpg": true
+      },
+      {
+        "name": "groff-base",
+        "epoch": 0,
+        "version": "1.22.3",
+        "release": "18.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/groff-base-1.22.3-18.el8.ppc64le.rpm",
+        "checksum": "sha256:cff4b4ac50fed2ceab6add52a66513ed9ca04b024f07a25c53df49f762eea2d2",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-common",
+        "epoch": 1,
+        "version": "2.02",
+        "release": "99.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/grub2-common-2.02-99.el8.noarch.rpm",
+        "checksum": "sha256:4a08d5264e865548e65d31886c91b659b33a2c2ba39fd115b00af3ea0bc91a83",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-tools",
+        "epoch": 1,
+        "version": "2.02",
+        "release": "99.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/grub2-tools-2.02-99.el8.ppc64le.rpm",
+        "checksum": "sha256:78b2b9cbf041d4461daf7ac11a24d1e79a9c57f47aa265dba4d09067efe3d96b",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-tools-minimal",
+        "epoch": 1,
+        "version": "2.02",
+        "release": "99.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/grub2-tools-minimal-2.02-99.el8.ppc64le.rpm",
+        "checksum": "sha256:fb276cc0ebc6bd27d344f7e0811f26cb3f0e59da09182489095724bdf2a075f8",
+        "check_gpg": true
+      },
+      {
+        "name": "grubby",
+        "epoch": 0,
+        "version": "8.40",
+        "release": "41.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/grubby-8.40-41.el8.ppc64le.rpm",
+        "checksum": "sha256:5a0927d231fbafa8b865591922fc07d39d9b4b263a1e9c0bbef691282f706cd0",
+        "check_gpg": true
+      },
+      {
+        "name": "gzip",
+        "epoch": 0,
+        "version": "1.9",
+        "release": "12.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/gzip-1.9-12.el8.ppc64le.rpm",
+        "checksum": "sha256:e1e28504928648404a3b652440091eba010cd99221183ef78601cbd152261d91",
+        "check_gpg": true
+      },
+      {
+        "name": "hardlink",
+        "epoch": 1,
+        "version": "1.3",
+        "release": "6.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/hardlink-1.3-6.el8.ppc64le.rpm",
+        "checksum": "sha256:42bb566be1936bdb40937f9c0a96c4acc93057379385f1807cba18f60443d3e4",
+        "check_gpg": true
+      },
+      {
+        "name": "hdparm",
+        "epoch": 0,
+        "version": "9.54",
+        "release": "4.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/hdparm-9.54-4.el8.ppc64le.rpm",
+        "checksum": "sha256:8c05fe038c7792203afa47f4534318f6c674672999b444909706ce0826bf1b8f",
+        "check_gpg": true
+      },
+      {
+        "name": "hostname",
+        "epoch": 0,
+        "version": "3.20",
+        "release": "7.el8.0.1",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/hostname-3.20-7.el8.0.1.ppc64le.rpm",
+        "checksum": "sha256:a571c94456b9a1743e94f4f72159de52bb13fe93437b81da675351553a881a17",
+        "check_gpg": true
+      },
+      {
+        "name": "hwdata",
+        "epoch": 0,
+        "version": "0.314",
+        "release": "8.9.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/hwdata-0.314-8.9.el8.noarch.rpm",
+        "checksum": "sha256:dfecfa1299d11d6a77503e626a2e9a14e1a75666bc8ea2abaf7ff515d2c86332",
+        "check_gpg": true
+      },
+      {
+        "name": "ima-evm-utils",
+        "epoch": 0,
+        "version": "1.3.2",
+        "release": "12.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/ima-evm-utils-1.3.2-12.el8.ppc64le.rpm",
+        "checksum": "sha256:8119d276749b35cd9c283c1a8d970b3528bea58427eb37eafc22b6093a978f08",
+        "check_gpg": true
+      },
+      {
+        "name": "info",
+        "epoch": 0,
+        "version": "6.5",
+        "release": "6.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/info-6.5-6.el8.ppc64le.rpm",
+        "checksum": "sha256:6d1ac29b3a38408f6d238d6718384e05be7346789c6200b354335b0e0c9c77df",
+        "check_gpg": true
+      },
+      {
+        "name": "initscripts",
+        "epoch": 0,
+        "version": "10.00.15",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/initscripts-10.00.15-1.el8.ppc64le.rpm",
+        "checksum": "sha256:d751a4fdecc0dc3c5ff897e3ff4c25e7addc698d590e2bfc4c893e693be7d558",
+        "check_gpg": true
+      },
+      {
+        "name": "iproute",
+        "epoch": 0,
+        "version": "5.12.0",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/iproute-5.12.0-2.el8.ppc64le.rpm",
+        "checksum": "sha256:12b0565d080311c7804d8fb1d697ecdef8807563ebeee4443e2fa6d35b1d958f",
+        "check_gpg": true
+      },
+      {
+        "name": "iprutils",
+        "epoch": 0,
+        "version": "2.4.19",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/iprutils-2.4.19-1.el8.ppc64le.rpm",
+        "checksum": "sha256:ccc815d5d4e9ff62f2b666c285ebf27060218ff480c171cc541ccbf1005f05b3",
+        "check_gpg": true
+      },
+      {
+        "name": "ipset",
+        "epoch": 0,
+        "version": "7.1",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/ipset-7.1-1.el8.ppc64le.rpm",
+        "checksum": "sha256:dc71fa093b472bf0d59ab44f6f824592bb0e8fcceb88035e980d91aa2626f826",
+        "check_gpg": true
+      },
+      {
+        "name": "ipset-libs",
+        "epoch": 0,
+        "version": "7.1",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/ipset-libs-7.1-1.el8.ppc64le.rpm",
+        "checksum": "sha256:7a550ec0bb8be2920abc6198faac70132027bc672c7bc3897ba0331727b94aa7",
+        "check_gpg": true
+      },
+      {
+        "name": "iptables",
+        "epoch": 0,
+        "version": "1.8.4",
+        "release": "19.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/iptables-1.8.4-19.el8.ppc64le.rpm",
+        "checksum": "sha256:cbf4b003c37cd3e44ba6586f02d9f869ef4df49902d409cae6005becb3b93d51",
+        "check_gpg": true
+      },
+      {
+        "name": "iptables-ebtables",
+        "epoch": 0,
+        "version": "1.8.4",
+        "release": "19.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/iptables-ebtables-1.8.4-19.el8.ppc64le.rpm",
+        "checksum": "sha256:8ced8726c50d2809362c78ddefb876b208a9099e81e2be1c22fd8227190ba063",
+        "check_gpg": true
+      },
+      {
+        "name": "iptables-libs",
+        "epoch": 0,
+        "version": "1.8.4",
+        "release": "19.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/iptables-libs-1.8.4-19.el8.ppc64le.rpm",
+        "checksum": "sha256:3bbc114c65c8ecada03b8c4e0fd4a53b7cf3059177e927011f64bf2d87a38a35",
+        "check_gpg": true
+      },
+      {
+        "name": "iputils",
+        "epoch": 0,
+        "version": "20180629",
+        "release": "7.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/iputils-20180629-7.el8.ppc64le.rpm",
+        "checksum": "sha256:6d02615212a88eb204b8f6d2a7cfbf6183a12f29d72ca5dbfbe5c45c63068ef8",
+        "check_gpg": true
+      },
+      {
+        "name": "irqbalance",
+        "epoch": 2,
+        "version": "1.4.0",
+        "release": "6.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/irqbalance-1.4.0-6.el8.ppc64le.rpm",
+        "checksum": "sha256:cbe98d6dcf93449d9c2fbf95de75f065f8da67a23f13401c672d78b28c6b7f6a",
+        "check_gpg": true
+      },
+      {
+        "name": "iwl100-firmware",
+        "epoch": 0,
+        "version": "39.31.5.1",
+        "release": "103.el8.1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/iwl100-firmware-39.31.5.1-103.el8.1.noarch.rpm",
+        "checksum": "sha256:4c0deab7bf49d21c6dd0ab568880a2da8180df52f15d9388aed61e169d63f8dd",
+        "check_gpg": true
+      },
+      {
+        "name": "iwl1000-firmware",
+        "epoch": 1,
+        "version": "39.31.5.1",
+        "release": "103.el8.1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/iwl1000-firmware-39.31.5.1-103.el8.1.noarch.rpm",
+        "checksum": "sha256:07ce52eb60e4fbe4906e160a8e166002a4b8edb66b6813f68c08d67c4d644b82",
+        "check_gpg": true
+      },
+      {
+        "name": "iwl105-firmware",
+        "epoch": 0,
+        "version": "18.168.6.1",
+        "release": "103.el8.1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/iwl105-firmware-18.168.6.1-103.el8.1.noarch.rpm",
+        "checksum": "sha256:c23f55b72b4e09c456c2837321dd626cadb9785dec89d31b2e30ca3c752e6d4d",
+        "check_gpg": true
+      },
+      {
+        "name": "iwl135-firmware",
+        "epoch": 0,
+        "version": "18.168.6.1",
+        "release": "103.el8.1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/iwl135-firmware-18.168.6.1-103.el8.1.noarch.rpm",
+        "checksum": "sha256:067c25522b7ae516b4df454a01d4798126b8d6004812d5476272f8159fe66c02",
+        "check_gpg": true
+      },
+      {
+        "name": "iwl2000-firmware",
+        "epoch": 0,
+        "version": "18.168.6.1",
+        "release": "103.el8.1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/iwl2000-firmware-18.168.6.1-103.el8.1.noarch.rpm",
+        "checksum": "sha256:a14a6628db9ed048511cabda7ba62dc019c2aa0d32c13fee0778d88e112b70e2",
+        "check_gpg": true
+      },
+      {
+        "name": "iwl2030-firmware",
+        "epoch": 0,
+        "version": "18.168.6.1",
+        "release": "103.el8.1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/iwl2030-firmware-18.168.6.1-103.el8.1.noarch.rpm",
+        "checksum": "sha256:59ec15255141f3d0d2e0907c9e48ba9a3a93694da1b5414fddb5868ecdf76377",
+        "check_gpg": true
+      },
+      {
+        "name": "iwl3160-firmware",
+        "epoch": 1,
+        "version": "25.30.13.0",
+        "release": "103.el8.1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/iwl3160-firmware-25.30.13.0-103.el8.1.noarch.rpm",
+        "checksum": "sha256:10814d88ff647e12aeceae4c3815f9eeb66ce7327099c642f934a391fd915f2c",
+        "check_gpg": true
+      },
+      {
+        "name": "iwl5000-firmware",
+        "epoch": 0,
+        "version": "8.83.5.1_1",
+        "release": "103.el8.1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/iwl5000-firmware-8.83.5.1_1-103.el8.1.noarch.rpm",
+        "checksum": "sha256:686e82956e8f875e0dc8b4bac509813a2b63bd39226baea5a3b79e4fd7483a97",
+        "check_gpg": true
+      },
+      {
+        "name": "iwl5150-firmware",
+        "epoch": 0,
+        "version": "8.24.2.2",
+        "release": "103.el8.1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/iwl5150-firmware-8.24.2.2-103.el8.1.noarch.rpm",
+        "checksum": "sha256:3b777b51480977dd90050524eec747d73b635a17775228037617fe1d145a6fcf",
+        "check_gpg": true
+      },
+      {
+        "name": "iwl6000-firmware",
+        "epoch": 0,
+        "version": "9.221.4.1",
+        "release": "103.el8.1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/iwl6000-firmware-9.221.4.1-103.el8.1.noarch.rpm",
+        "checksum": "sha256:7a67a83093c0a23619de1e2b489166940a0195a9ddb84e44bb523e5c93306331",
+        "check_gpg": true
+      },
+      {
+        "name": "iwl6000g2a-firmware",
+        "epoch": 0,
+        "version": "18.168.6.1",
+        "release": "103.el8.1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/iwl6000g2a-firmware-18.168.6.1-103.el8.1.noarch.rpm",
+        "checksum": "sha256:9853341ea14daa32558a3787c318396f5c05e947949848bad4bba16e9ac0d1f6",
+        "check_gpg": true
+      },
+      {
+        "name": "iwl6050-firmware",
+        "epoch": 0,
+        "version": "41.28.5.1",
+        "release": "103.el8.1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/iwl6050-firmware-41.28.5.1-103.el8.1.noarch.rpm",
+        "checksum": "sha256:b7d265ac19947ea2a73e9735b63c407dcad881fa8c0d8b2e35dce948efab3d83",
+        "check_gpg": true
+      },
+      {
+        "name": "iwl7260-firmware",
+        "epoch": 1,
+        "version": "25.30.13.0",
+        "release": "103.el8.1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/iwl7260-firmware-25.30.13.0-103.el8.1.noarch.rpm",
+        "checksum": "sha256:9c3cc9ed1b5dc277a39403d0aadd4dd8b843d05fe478d40f60249cad2039aae8",
+        "check_gpg": true
+      },
+      {
+        "name": "jansson",
+        "epoch": 0,
+        "version": "2.11",
+        "release": "3.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/jansson-2.11-3.el8.ppc64le.rpm",
+        "checksum": "sha256:965ec1b760513e1ae539747624bd241d6575675e8a04c5caa572faadb54007c7",
+        "check_gpg": true
+      },
+      {
+        "name": "json-c",
+        "epoch": 0,
+        "version": "0.13.1",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/json-c-0.13.1-2.el8.ppc64le.rpm",
+        "checksum": "sha256:331b91a0928c05618c7fed3e12bbe9ecb9e4619d08c7e85d3de344a08d2f0f1a",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd",
+        "epoch": 0,
+        "version": "2.0.4",
+        "release": "10.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/kbd-2.0.4-10.el8.ppc64le.rpm",
+        "checksum": "sha256:49c7c718cb4e2b6f0effd0dec4f4cb4e109d260c192b2b329a58a1da9a24ad1d",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd-legacy",
+        "epoch": 0,
+        "version": "2.0.4",
+        "release": "10.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/kbd-legacy-2.0.4-10.el8.noarch.rpm",
+        "checksum": "sha256:a3ef96219165bfc64d4f5d50f51fbd43e803c500619240ffe4db1f9f8e337f83",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd-misc",
+        "epoch": 0,
+        "version": "2.0.4",
+        "release": "10.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/kbd-misc-2.0.4-10.el8.noarch.rpm",
+        "checksum": "sha256:ef86061338fa321c959cadc75ecbdfd405eebaa1042eec9d9c737d4d9d92568f",
+        "check_gpg": true
+      },
+      {
+        "name": "kernel",
+        "epoch": 0,
+        "version": "4.18.0",
+        "release": "331.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/kernel-4.18.0-331.el8.ppc64le.rpm",
+        "checksum": "sha256:7bb5051dee5f6633a02cf5a3285dd86890cc6521e497526a8149dc5c5ebad062",
+        "check_gpg": true
+      },
+      {
+        "name": "kernel-core",
+        "epoch": 0,
+        "version": "4.18.0",
+        "release": "331.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/kernel-core-4.18.0-331.el8.ppc64le.rpm",
+        "checksum": "sha256:4aca3cee9de1a4cd7ac56a12550f286894a215cac593c18857278f7b0e48f328",
+        "check_gpg": true
+      },
+      {
+        "name": "kernel-modules",
+        "epoch": 0,
+        "version": "4.18.0",
+        "release": "331.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/kernel-modules-4.18.0-331.el8.ppc64le.rpm",
+        "checksum": "sha256:1d6551bce8f8a1e53682fafe4f67fa830c333f0b37db7acbeaca0095b5ce870b",
+        "check_gpg": true
+      },
+      {
+        "name": "kernel-tools",
+        "epoch": 0,
+        "version": "4.18.0",
+        "release": "331.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/kernel-tools-4.18.0-331.el8.ppc64le.rpm",
+        "checksum": "sha256:e45848a3fbfa1d46709448593fa7929fee4c5a83d2168c0d41d498251e4b5dae",
+        "check_gpg": true
+      },
+      {
+        "name": "kernel-tools-libs",
+        "epoch": 0,
+        "version": "4.18.0",
+        "release": "331.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/kernel-tools-libs-4.18.0-331.el8.ppc64le.rpm",
+        "checksum": "sha256:83cb349e65d5b783518b735d8fb477264f0a6bd7cdd6f4096f8493dbd45f2ff7",
+        "check_gpg": true
+      },
+      {
+        "name": "kexec-tools",
+        "epoch": 0,
+        "version": "2.0.20",
+        "release": "56.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/kexec-tools-2.0.20-56.el8.ppc64le.rpm",
+        "checksum": "sha256:30dd1d58b7b963d052341f4583a7417823cf4dbbe7ac4b536f3a5250c4d34582",
+        "check_gpg": true
+      },
+      {
+        "name": "keyutils-libs",
+        "epoch": 0,
+        "version": "1.5.10",
+        "release": "9.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/keyutils-libs-1.5.10-9.el8.ppc64le.rpm",
+        "checksum": "sha256:6fe1188081e441595ce29ebed4d1985e5890815158244f69f092ee930656f755",
+        "check_gpg": true
+      },
+      {
+        "name": "kmod",
+        "epoch": 0,
+        "version": "25",
+        "release": "18.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/kmod-25-18.el8.ppc64le.rpm",
+        "checksum": "sha256:a80c1d6d32db7ce8fdd58bb4f3f488b74e94261a38512dc8a15179ae33697e63",
+        "check_gpg": true
+      },
+      {
+        "name": "kmod-libs",
+        "epoch": 0,
+        "version": "25",
+        "release": "18.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/kmod-libs-25-18.el8.ppc64le.rpm",
+        "checksum": "sha256:b437a08d4670ef440ba6dbaae4ccb39f989f0c2a3d280ea66d6fd9532a313286",
+        "check_gpg": true
+      },
+      {
+        "name": "kpartx",
+        "epoch": 0,
+        "version": "0.8.4",
+        "release": "17.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/kpartx-0.8.4-17.el8.ppc64le.rpm",
+        "checksum": "sha256:230731b577f8d29e7e8e8fd6d1ea02702fb4364fcc7034d838ccddc4d66da8c3",
+        "check_gpg": true
+      },
+      {
+        "name": "krb5-libs",
+        "epoch": 0,
+        "version": "1.18.2",
+        "release": "13.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/krb5-libs-1.18.2-13.el8.ppc64le.rpm",
+        "checksum": "sha256:54f59ddb56e89a5330373e07ea05934fc58360eb7480615ede2a3ed6982e1eef",
+        "check_gpg": true
+      },
+      {
+        "name": "less",
+        "epoch": 0,
+        "version": "530",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/less-530-1.el8.ppc64le.rpm",
+        "checksum": "sha256:427eba707b42761a0ef57107ba5a22f80fc6379d1537c757fe1929d6d066b05c",
+        "check_gpg": true
+      },
+      {
+        "name": "libacl",
+        "epoch": 0,
+        "version": "2.2.53",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libacl-2.2.53-1.el8.ppc64le.rpm",
+        "checksum": "sha256:ff1580bd4ec5841d4937b383917fa30f318b4f419b8067a77468eb4a9630ba10",
+        "check_gpg": true
+      },
+      {
+        "name": "libarchive",
+        "epoch": 0,
+        "version": "3.3.3",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libarchive-3.3.3-1.el8.ppc64le.rpm",
+        "checksum": "sha256:df40cada982b04336fe8b250b4fdd576ddd03a014bb519a69b34640369bef661",
+        "check_gpg": true
+      },
+      {
+        "name": "libassuan",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "3.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libassuan-2.5.1-3.el8.ppc64le.rpm",
+        "checksum": "sha256:9c4cd61b98253904436180f58c564bda61be1fa1b5523e4ecbbdc174d0c2a9aa",
+        "check_gpg": true
+      },
+      {
+        "name": "libattr",
+        "epoch": 0,
+        "version": "2.4.48",
+        "release": "3.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libattr-2.4.48-3.el8.ppc64le.rpm",
+        "checksum": "sha256:43bfc890caf7855f2fb55c24474b58cd5c8c7b51e4db4f40d1f302fffd31985b",
+        "check_gpg": true
+      },
+      {
+        "name": "libbasicobjects",
+        "epoch": 0,
+        "version": "0.1.1",
+        "release": "39.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libbasicobjects-0.1.1-39.el8.ppc64le.rpm",
+        "checksum": "sha256:2f6c73fdcd5c5e5b6d8b58663e498a0099db8029386869a4aca670471f6c298e",
+        "check_gpg": true
+      },
+      {
+        "name": "libblkid",
+        "epoch": 0,
+        "version": "2.32.1",
+        "release": "28.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libblkid-2.32.1-28.el8.ppc64le.rpm",
+        "checksum": "sha256:30ae4489980021a727f247d48b4d74d4c6c7667d00bd1a670f045ea24a885541",
+        "check_gpg": true
+      },
+      {
+        "name": "libbpf",
+        "epoch": 0,
+        "version": "0.3.0",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libbpf-0.3.0-1.el8.ppc64le.rpm",
+        "checksum": "sha256:4a8899d3b91a0f847ce793480700b26dc8336c5ee20d9b66067c76fe0dab2f17",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap",
+        "epoch": 0,
+        "version": "2.26",
+        "release": "4.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libcap-2.26-4.el8.ppc64le.rpm",
+        "checksum": "sha256:77e4cfbc823e3764308822ccf03b257861f9360f3b948829f1d73148b321b00e",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap-ng",
+        "epoch": 0,
+        "version": "0.7.11",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libcap-ng-0.7.11-1.el8.ppc64le.rpm",
+        "checksum": "sha256:9b69a221cf9395a110849bb428bb1cfe9fb489322df0fa6017f5978a827ee0e9",
+        "check_gpg": true
+      },
+      {
+        "name": "libcollection",
+        "epoch": 0,
+        "version": "0.7.0",
+        "release": "39.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libcollection-0.7.0-39.el8.ppc64le.rpm",
+        "checksum": "sha256:360be5b93e106d77a8f4e84b318ee8dc14349f223540e0e200e0dfce2676ec04",
+        "check_gpg": true
+      },
+      {
+        "name": "libcom_err",
+        "epoch": 0,
+        "version": "1.45.6",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libcom_err-1.45.6-2.el8.ppc64le.rpm",
+        "checksum": "sha256:e0a7b9f3b56b4737f5711dc6b03f256fbf2488656b8874acabb494b58ba0c1c1",
+        "check_gpg": true
+      },
+      {
+        "name": "libcomps",
+        "epoch": 0,
+        "version": "0.1.16",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libcomps-0.1.16-2.el8.ppc64le.rpm",
+        "checksum": "sha256:5c74a0e3005ea3cb90dff80cfa1e7d64c97f5c01612d253cf4e65aca962b7be4",
+        "check_gpg": true
+      },
+      {
+        "name": "libcroco",
+        "epoch": 0,
+        "version": "0.6.12",
+        "release": "4.el8_2.1",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libcroco-0.6.12-4.el8_2.1.ppc64le.rpm",
+        "checksum": "sha256:194dbe332ccdb33d58f040da07667257e176975f6b2f17343bbf33fb99deb097",
+        "check_gpg": true
+      },
+      {
+        "name": "libcurl",
+        "epoch": 0,
+        "version": "7.61.1",
+        "release": "18.el8_4.1",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libcurl-7.61.1-18.el8_4.1.ppc64le.rpm",
+        "checksum": "sha256:e21a84107568047432e474e08da24aea2340409d57ea8cf170182927dc76de12",
+        "check_gpg": true
+      },
+      {
+        "name": "libdaemon",
+        "epoch": 0,
+        "version": "0.14",
+        "release": "15.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libdaemon-0.14-15.el8.ppc64le.rpm",
+        "checksum": "sha256:f7a2eddcda47cb75108add34c0ce919ceb847605830ad33aeb4bd64d6bed24f3",
+        "check_gpg": true
+      },
+      {
+        "name": "libdb",
+        "epoch": 0,
+        "version": "5.3.28",
+        "release": "40.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libdb-5.3.28-40.el8.ppc64le.rpm",
+        "checksum": "sha256:b83a0199c3d471151f07f6de626a1a4a362dd6aa29d84cf1c0ada2c966ce29c9",
+        "check_gpg": true
+      },
+      {
+        "name": "libdb-utils",
+        "epoch": 0,
+        "version": "5.3.28",
+        "release": "40.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libdb-utils-5.3.28-40.el8.ppc64le.rpm",
+        "checksum": "sha256:709ea71f36495ac2ac89d72d2eb603b6aa55b2c1a70633f23514dd897936f02b",
+        "check_gpg": true
+      },
+      {
+        "name": "libdhash",
+        "epoch": 0,
+        "version": "0.5.0",
+        "release": "39.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libdhash-0.5.0-39.el8.ppc64le.rpm",
+        "checksum": "sha256:6ac918d2bc175b3f356926ca96a998c29bffe256f7d802e8ef654b1226da3ef6",
+        "check_gpg": true
+      },
+      {
+        "name": "libdnf",
+        "epoch": 0,
+        "version": "0.63.0",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libdnf-0.63.0-2.el8.ppc64le.rpm",
+        "checksum": "sha256:aea253461d1a34a239b445ee07cb34398a9cbb6ed40e252182a91cddcf59004b",
+        "check_gpg": true
+      },
+      {
+        "name": "libedit",
+        "epoch": 0,
+        "version": "3.1",
+        "release": "23.20170329cvs.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libedit-3.1-23.20170329cvs.el8.ppc64le.rpm",
+        "checksum": "sha256:cc662127a17d4e08e90f75703f376067eed48f5d6b5b8d106fa3824397f1978e",
+        "check_gpg": true
+      },
+      {
+        "name": "libevent",
+        "epoch": 0,
+        "version": "2.1.8",
+        "release": "5.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libevent-2.1.8-5.el8.ppc64le.rpm",
+        "checksum": "sha256:a0b8a6b2c8dad75290228086dd0af342979604bbf4b9500029e25d766835c0f4",
+        "check_gpg": true
+      },
+      {
+        "name": "libfdisk",
+        "epoch": 0,
+        "version": "2.32.1",
+        "release": "28.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libfdisk-2.32.1-28.el8.ppc64le.rpm",
+        "checksum": "sha256:0afac6f4f9ed1c59510675d87da45c7966c0f7aae6e8dd056961aceed8c4fe0a",
+        "check_gpg": true
+      },
+      {
+        "name": "libffi",
+        "epoch": 0,
+        "version": "3.1",
+        "release": "22.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libffi-3.1-22.el8.ppc64le.rpm",
+        "checksum": "sha256:12696f5638ad2068c5c8940495d15c3bb1c57990000dbda7428b008e9e63ab5b",
+        "check_gpg": true
+      },
+      {
+        "name": "libgcc",
+        "epoch": 0,
+        "version": "8.5.0",
+        "release": "3.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libgcc-8.5.0-3.el8.ppc64le.rpm",
+        "checksum": "sha256:f3d9ccb762146dc97f2d201d979fbb0e9171d1203fb985f3ef48b5c2a176c2a9",
+        "check_gpg": true
+      },
+      {
+        "name": "libgcrypt",
+        "epoch": 0,
+        "version": "1.8.5",
+        "release": "6.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libgcrypt-1.8.5-6.el8.ppc64le.rpm",
+        "checksum": "sha256:c5a60ffb80cd1f9b90c797f1d1ac80e5536eb32a5b276871445e7279ac701c5f",
+        "check_gpg": true
+      },
+      {
+        "name": "libgomp",
+        "epoch": 0,
+        "version": "8.5.0",
+        "release": "3.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libgomp-8.5.0-3.el8.ppc64le.rpm",
+        "checksum": "sha256:0515afdac097ad54cf4b24e0644f0789cab5535a54107aa44940ffd991a6cef3",
+        "check_gpg": true
+      },
+      {
+        "name": "libgpg-error",
+        "epoch": 0,
+        "version": "1.31",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libgpg-error-1.31-1.el8.ppc64le.rpm",
+        "checksum": "sha256:020abac486839c7be29fae37a686dc7749398c333cb8ba94b3390b386ffcbff7",
+        "check_gpg": true
+      },
+      {
+        "name": "libibverbs",
+        "epoch": 0,
+        "version": "35.0",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libibverbs-35.0-1.el8.ppc64le.rpm",
+        "checksum": "sha256:8ab06f608f45445bdef489cedb40d419aa7282e127ee26dbfcf417350a3f1630",
+        "check_gpg": true
+      },
+      {
+        "name": "libidn2",
+        "epoch": 0,
+        "version": "2.2.0",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libidn2-2.2.0-1.el8.ppc64le.rpm",
+        "checksum": "sha256:31d924d1540dd4e927a4c3aa936cec4bfb54ed302d3e8acc1be8b52dd5deb10c",
+        "check_gpg": true
+      },
+      {
+        "name": "libini_config",
+        "epoch": 0,
+        "version": "1.3.1",
+        "release": "39.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libini_config-1.3.1-39.el8.ppc64le.rpm",
+        "checksum": "sha256:1b95698d64dd299827f62cbe43d373e985da2d8900c4489a49475f53fa04f414",
+        "check_gpg": true
+      },
+      {
+        "name": "libkcapi",
+        "epoch": 0,
+        "version": "1.2.0",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libkcapi-1.2.0-2.el8.ppc64le.rpm",
+        "checksum": "sha256:fd6e1803ff367036da5b52b2183e1408691b379cc1320971bb664737507f89a4",
+        "check_gpg": true
+      },
+      {
+        "name": "libkcapi-hmaccalc",
+        "epoch": 0,
+        "version": "1.2.0",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libkcapi-hmaccalc-1.2.0-2.el8.ppc64le.rpm",
+        "checksum": "sha256:6b312faed4a0508da2f15d3f31a6daccfc0ec6621e5fb7b20956027dce5fa395",
+        "check_gpg": true
+      },
+      {
+        "name": "libksba",
+        "epoch": 0,
+        "version": "1.3.5",
+        "release": "7.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libksba-1.3.5-7.el8.ppc64le.rpm",
+        "checksum": "sha256:a5f9f2c4f39f393971f268aebb1b55d18d0d96693d08a9ed70403e8565807bb6",
+        "check_gpg": true
+      },
+      {
+        "name": "libldb",
+        "epoch": 0,
+        "version": "2.3.0",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libldb-2.3.0-2.el8.ppc64le.rpm",
+        "checksum": "sha256:a0a8e31422da7d695a3788a7cae3f929d42cb4982889422588904ecc6879182e",
+        "check_gpg": true
+      },
+      {
+        "name": "libmnl",
+        "epoch": 0,
+        "version": "1.0.4",
+        "release": "6.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libmnl-1.0.4-6.el8.ppc64le.rpm",
+        "checksum": "sha256:59008e3619cae0f40e183b7003e722cb312b00bdba775ec9f06cdd833b53c26a",
+        "check_gpg": true
+      },
+      {
+        "name": "libmodulemd",
+        "epoch": 0,
+        "version": "2.12.1",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libmodulemd-2.12.1-1.el8.ppc64le.rpm",
+        "checksum": "sha256:d6eb27d158b6397e52ab6a952fec4e3c414638a08750a6c011d32eb117accd82",
+        "check_gpg": true
+      },
+      {
+        "name": "libmount",
+        "epoch": 0,
+        "version": "2.32.1",
+        "release": "28.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libmount-2.32.1-28.el8.ppc64le.rpm",
+        "checksum": "sha256:4e497225fe36781735cc92c0886f6858b19d4557ed9ecafe1247b8233c206075",
+        "check_gpg": true
+      },
+      {
+        "name": "libndp",
+        "epoch": 0,
+        "version": "1.7",
+        "release": "6.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libndp-1.7-6.el8.ppc64le.rpm",
+        "checksum": "sha256:2812ae39c665069f4b27e9bd26dde9141d4f4e7802befb1b14ac4e27a8225b4b",
+        "check_gpg": true
+      },
+      {
+        "name": "libnetfilter_conntrack",
+        "epoch": 0,
+        "version": "1.0.6",
+        "release": "5.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libnetfilter_conntrack-1.0.6-5.el8.ppc64le.rpm",
+        "checksum": "sha256:b57141234c3c1d1b2d46dfec037dcae8ba3ebdc534660c661771aab46e38b44b",
+        "check_gpg": true
+      },
+      {
+        "name": "libnfnetlink",
+        "epoch": 0,
+        "version": "1.0.1",
+        "release": "13.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libnfnetlink-1.0.1-13.el8.ppc64le.rpm",
+        "checksum": "sha256:6d9b770c5d34ee0fb93e78b6ce44c3e0e99ecaa9d57265e32256e14a3bba8190",
+        "check_gpg": true
+      },
+      {
+        "name": "libnfsidmap",
+        "epoch": 1,
+        "version": "2.3.3",
+        "release": "46.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libnfsidmap-2.3.3-46.el8.ppc64le.rpm",
+        "checksum": "sha256:07fb48b313f6d4c1c8b1ffd9c5226c68f99616e46bbd04b325527d817b500577",
+        "check_gpg": true
+      },
+      {
+        "name": "libnftnl",
+        "epoch": 0,
+        "version": "1.1.5",
+        "release": "4.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libnftnl-1.1.5-4.el8.ppc64le.rpm",
+        "checksum": "sha256:037b950664c45aadf7476e208cca5908c2415c7a7da15071fea51cd1bcae4795",
+        "check_gpg": true
+      },
+      {
+        "name": "libnghttp2",
+        "epoch": 0,
+        "version": "1.33.0",
+        "release": "3.el8_2.1",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libnghttp2-1.33.0-3.el8_2.1.ppc64le.rpm",
+        "checksum": "sha256:d3a4f367a9c5ba936b1bb5480db390889a303e5ec8ff34bb4274c1d840a1784d",
+        "check_gpg": true
+      },
+      {
+        "name": "libnl3",
+        "epoch": 0,
+        "version": "3.5.0",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libnl3-3.5.0-1.el8.ppc64le.rpm",
+        "checksum": "sha256:caabc61e9aa83275f9d2fefcfda56fddf19e7031bcf9f9b84f858bb1f040e24c",
+        "check_gpg": true
+      },
+      {
+        "name": "libnl3-cli",
+        "epoch": 0,
+        "version": "3.5.0",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libnl3-cli-3.5.0-1.el8.ppc64le.rpm",
+        "checksum": "sha256:35bd989d63522f9699b1a90dd453f866818cc3d247096a910a27fd7e49b09ac2",
+        "check_gpg": true
+      },
+      {
+        "name": "libnsl2",
+        "epoch": 0,
+        "version": "1.2.0",
+        "release": "2.20180605git4a062cf.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libnsl2-1.2.0-2.20180605git4a062cf.el8.ppc64le.rpm",
+        "checksum": "sha256:8d7777da3f54f965cf3058cabf987c01b93a1dd041e8359eb7822eba57d8c8df",
+        "check_gpg": true
+      },
+      {
+        "name": "libpath_utils",
+        "epoch": 0,
+        "version": "0.2.1",
+        "release": "39.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libpath_utils-0.2.1-39.el8.ppc64le.rpm",
+        "checksum": "sha256:fb6e437a24450106c03f25dc1c3f6b78549b82c2d0bd4387dce1350ca3c5f1f5",
+        "check_gpg": true
+      },
+      {
+        "name": "libpcap",
+        "epoch": 14,
+        "version": "1.9.1",
+        "release": "5.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libpcap-1.9.1-5.el8.ppc64le.rpm",
+        "checksum": "sha256:61ba252d7ee5d955b929f6d7d39d65d25c62e3d3cfc65ee6cf55c764b1c64a90",
+        "check_gpg": true
+      },
+      {
+        "name": "libpipeline",
+        "epoch": 0,
+        "version": "1.5.0",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libpipeline-1.5.0-2.el8.ppc64le.rpm",
+        "checksum": "sha256:7adc584a7d43968d22706da5ffa127020536375f82beea5ef677cab39c5f64c5",
+        "check_gpg": true
+      },
+      {
+        "name": "libpsl",
+        "epoch": 0,
+        "version": "0.20.2",
+        "release": "6.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libpsl-0.20.2-6.el8.ppc64le.rpm",
+        "checksum": "sha256:9b8a8a843fe9a972f6433e11b95b5a8d1d2971ed40fe1acda6807e34f0773c62",
+        "check_gpg": true
+      },
+      {
+        "name": "libpwquality",
+        "epoch": 0,
+        "version": "1.4.4",
+        "release": "3.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libpwquality-1.4.4-3.el8.ppc64le.rpm",
+        "checksum": "sha256:1aa321c66a3661e78d938b805e5c311d519f04bf3496545ffdacc7c152bc9b21",
+        "check_gpg": true
+      },
+      {
+        "name": "libref_array",
+        "epoch": 0,
+        "version": "0.1.5",
+        "release": "39.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libref_array-0.1.5-39.el8.ppc64le.rpm",
+        "checksum": "sha256:419f9c08de110eee9b2ff0a61e9aa1bbb56939f9239739c17a753a0d9210d10f",
+        "check_gpg": true
+      },
+      {
+        "name": "librepo",
+        "epoch": 0,
+        "version": "1.14.0",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/librepo-1.14.0-2.el8.ppc64le.rpm",
+        "checksum": "sha256:3dfffdadfb10def9a3671a255e4fa71d8b22231ccf2c929e96689101dda8ce2c",
+        "check_gpg": true
+      },
+      {
+        "name": "libreport-filesystem",
+        "epoch": 0,
+        "version": "2.9.5",
+        "release": "15.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libreport-filesystem-2.9.5-15.el8.ppc64le.rpm",
+        "checksum": "sha256:c5c61536e768553067cee488830c64866d109cade24917dbe23f82c861af07c5",
+        "check_gpg": true
+      },
+      {
+        "name": "librtas",
+        "epoch": 0,
+        "version": "2.0.2",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/librtas-2.0.2-1.el8.ppc64le.rpm",
+        "checksum": "sha256:98c28a91d41f634edb8c1f001dbc45c0de534332d059a2e8feff448fb7235c49",
+        "check_gpg": true
+      },
+      {
+        "name": "libseccomp",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libseccomp-2.5.1-1.el8.ppc64le.rpm",
+        "checksum": "sha256:b4a1ac1ff5cd22a5dab6c96dfc2dbd7cd6ba750691ad5c53a97a1f088fc42abc",
+        "check_gpg": true
+      },
+      {
+        "name": "libsecret",
+        "epoch": 0,
+        "version": "0.18.6",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libsecret-0.18.6-1.el8.ppc64le.rpm",
+        "checksum": "sha256:01b0562b890a80c202fff9175dc845500660c7f1655292d4ee13ca667acab081",
+        "check_gpg": true
+      },
+      {
+        "name": "libselinux",
+        "epoch": 0,
+        "version": "2.9",
+        "release": "5.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libselinux-2.9-5.el8.ppc64le.rpm",
+        "checksum": "sha256:56c866bcff69fd60b630841ff990296b26c2f45d8c6054311b5c476bc67466ac",
+        "check_gpg": true
+      },
+      {
+        "name": "libselinux-utils",
+        "epoch": 0,
+        "version": "2.9",
+        "release": "5.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libselinux-utils-2.9-5.el8.ppc64le.rpm",
+        "checksum": "sha256:4fe264ed1cfd0c074f4601354b0128a9e5068f0fcde7382fd5429585f0d4cd2c",
+        "check_gpg": true
+      },
+      {
+        "name": "libsemanage",
+        "epoch": 0,
+        "version": "2.9",
+        "release": "6.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libsemanage-2.9-6.el8.ppc64le.rpm",
+        "checksum": "sha256:95103f7c339aec4b485b7f569aa8a5e1a54286b3d2acde427328c49e4d8d80d1",
+        "check_gpg": true
+      },
+      {
+        "name": "libsepol",
+        "epoch": 0,
+        "version": "2.9",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libsepol-2.9-2.el8.ppc64le.rpm",
+        "checksum": "sha256:adc56041458e556df5663e7da264e151c24aaf1c2a94e49df9790ba191ea1b37",
+        "check_gpg": true
+      },
+      {
+        "name": "libservicelog",
+        "epoch": 0,
+        "version": "1.1.19",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libservicelog-1.1.19-2.el8.ppc64le.rpm",
+        "checksum": "sha256:2669ab8439093418c6c437c1f2e931d4152f5ac371e5a0f2d20b18455483c3a1",
+        "check_gpg": true
+      },
+      {
+        "name": "libsigsegv",
+        "epoch": 0,
+        "version": "2.11",
+        "release": "5.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libsigsegv-2.11-5.el8.ppc64le.rpm",
+        "checksum": "sha256:0f57b051654b6d75789b437dafd7040b6c90daee17827be24352c0f11a74bba7",
+        "check_gpg": true
+      },
+      {
+        "name": "libsmartcols",
+        "epoch": 0,
+        "version": "2.32.1",
+        "release": "28.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libsmartcols-2.32.1-28.el8.ppc64le.rpm",
+        "checksum": "sha256:1b5136570cefb8273dd5affc73c1456cf239cc8b18be72d6c4d09794af7f3352",
+        "check_gpg": true
+      },
+      {
+        "name": "libsolv",
+        "epoch": 0,
+        "version": "0.7.19",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libsolv-0.7.19-1.el8.ppc64le.rpm",
+        "checksum": "sha256:679724b45157b4d4c9ebe2eb32e188b9a65d47c23be886498d7a178caaf113bb",
+        "check_gpg": true
+      },
+      {
+        "name": "libss",
+        "epoch": 0,
+        "version": "1.45.6",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libss-1.45.6-2.el8.ppc64le.rpm",
+        "checksum": "sha256:767dd64d91c23adda537c7759ae3b4f720d3c76e03b52bc9231e52e0113db3ab",
+        "check_gpg": true
+      },
+      {
+        "name": "libssh",
+        "epoch": 0,
+        "version": "0.9.4",
+        "release": "3.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libssh-0.9.4-3.el8.ppc64le.rpm",
+        "checksum": "sha256:2dbfe3cb37c18b39393870baa77f3bbd42be53517abffdd990b13ed70ee3dd3e",
+        "check_gpg": true
+      },
+      {
+        "name": "libssh-config",
+        "epoch": 0,
+        "version": "0.9.4",
+        "release": "3.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libssh-config-0.9.4-3.el8.noarch.rpm",
+        "checksum": "sha256:f5bcb82a732c02d6f31bbf156887049883c76cedc9c6a11b049358a74f4d45d0",
+        "check_gpg": true
+      },
+      {
+        "name": "libsss_autofs",
+        "epoch": 0,
+        "version": "2.5.2",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libsss_autofs-2.5.2-2.el8.ppc64le.rpm",
+        "checksum": "sha256:2d1655f040141384ec8760e4a47e0455ce518989f7bb1a830ab9534bfb38a78a",
+        "check_gpg": true
+      },
+      {
+        "name": "libsss_certmap",
+        "epoch": 0,
+        "version": "2.5.2",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libsss_certmap-2.5.2-2.el8.ppc64le.rpm",
+        "checksum": "sha256:d3e95ed161acd1ba957b1864e7ca2102d9c39380bbdd56eddebf11d5219b3a04",
+        "check_gpg": true
+      },
+      {
+        "name": "libsss_idmap",
+        "epoch": 0,
+        "version": "2.5.2",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libsss_idmap-2.5.2-2.el8.ppc64le.rpm",
+        "checksum": "sha256:572bec3deb2f8ae7a6ad46976738c2630023eec1d9bd13ab1ccca7b54256daee",
+        "check_gpg": true
+      },
+      {
+        "name": "libsss_nss_idmap",
+        "epoch": 0,
+        "version": "2.5.2",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libsss_nss_idmap-2.5.2-2.el8.ppc64le.rpm",
+        "checksum": "sha256:466601cf2b7bebf49a6a8e936b32dffc844c9ed4cd82961d008d17cfccc596e8",
+        "check_gpg": true
+      },
+      {
+        "name": "libsss_sudo",
+        "epoch": 0,
+        "version": "2.5.2",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libsss_sudo-2.5.2-2.el8.ppc64le.rpm",
+        "checksum": "sha256:70fe40ffb2fb3eb2c3626afbfdb200a2429e000c2fbb172886c23b1908000501",
+        "check_gpg": true
+      },
+      {
+        "name": "libstdc++",
+        "epoch": 0,
+        "version": "8.5.0",
+        "release": "3.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libstdc++-8.5.0-3.el8.ppc64le.rpm",
+        "checksum": "sha256:32ebba6472cdc331bd3366ca996ad3039b3a1b41c61a849b88074e1b722cad2c",
+        "check_gpg": true
+      },
+      {
+        "name": "libsysfs",
+        "epoch": 0,
+        "version": "2.1.0",
+        "release": "24.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libsysfs-2.1.0-24.el8.ppc64le.rpm",
+        "checksum": "sha256:4fb1b85fe3712a292f8dd8f1d65805607485dbf97307cf146bbc6e0293a7c725",
+        "check_gpg": true
+      },
+      {
+        "name": "libtalloc",
+        "epoch": 0,
+        "version": "2.3.2",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libtalloc-2.3.2-1.el8.ppc64le.rpm",
+        "checksum": "sha256:5f76a72e58cd374ec83e26f42778adb3b90aacd091527a34c8a347089034d398",
+        "check_gpg": true
+      },
+      {
+        "name": "libtasn1",
+        "epoch": 0,
+        "version": "4.13",
+        "release": "3.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libtasn1-4.13-3.el8.ppc64le.rpm",
+        "checksum": "sha256:75e9ed16ace51ba04a62505aaed215bf9c722d6f4b1c33cc3e3962076c300ee8",
+        "check_gpg": true
+      },
+      {
+        "name": "libtdb",
+        "epoch": 0,
+        "version": "1.4.3",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libtdb-1.4.3-1.el8.ppc64le.rpm",
+        "checksum": "sha256:c3c1c42a41ab18dc09214bcd3a567bb7ba9b9c2191a6e1079b9770dfe2d3a338",
+        "check_gpg": true
+      },
+      {
+        "name": "libteam",
+        "epoch": 0,
+        "version": "1.31",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libteam-1.31-2.el8.ppc64le.rpm",
+        "checksum": "sha256:60eb345663d2f6ec4b5c304cd21685dc7148d34739477136d96ab6bc131d9c4d",
+        "check_gpg": true
+      },
+      {
+        "name": "libtevent",
+        "epoch": 0,
+        "version": "0.11.0",
+        "release": "0.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libtevent-0.11.0-0.el8.ppc64le.rpm",
+        "checksum": "sha256:7962bed04e961194d64769b4b7d5c85836808361c606e943b013098fe53df782",
+        "check_gpg": true
+      },
+      {
+        "name": "libtirpc",
+        "epoch": 0,
+        "version": "1.1.4",
+        "release": "5.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libtirpc-1.1.4-5.el8.ppc64le.rpm",
+        "checksum": "sha256:d539404dafd8ad5d785ab3da6f8bd5a2bf5dff9e01be0ff1bc1d251786dda25c",
+        "check_gpg": true
+      },
+      {
+        "name": "libunistring",
+        "epoch": 0,
+        "version": "0.9.9",
+        "release": "3.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libunistring-0.9.9-3.el8.ppc64le.rpm",
+        "checksum": "sha256:bff39fef1fc01564156123fcade75b4bc50402a2971a031d9a426c7014b1e681",
+        "check_gpg": true
+      },
+      {
+        "name": "libusbx",
+        "epoch": 0,
+        "version": "1.0.23",
+        "release": "4.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libusbx-1.0.23-4.el8.ppc64le.rpm",
+        "checksum": "sha256:6b9875495111bcd2d3c5e9e380b3be17fb0a730891468fb45bdba3b3692b00ea",
+        "check_gpg": true
+      },
+      {
+        "name": "libuser",
+        "epoch": 0,
+        "version": "0.62",
+        "release": "23.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libuser-0.62-23.el8.ppc64le.rpm",
+        "checksum": "sha256:b29c8cb61ef138fdf00a458f0646cf9390e0f39783f02f6b81a956585dc6b302",
+        "check_gpg": true
+      },
+      {
+        "name": "libutempter",
+        "epoch": 0,
+        "version": "1.1.6",
+        "release": "14.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libutempter-1.1.6-14.el8.ppc64le.rpm",
+        "checksum": "sha256:e217c2687212d931ad9a6a02afb20cc34f6d051786d136e337f91079c9f73d22",
+        "check_gpg": true
+      },
+      {
+        "name": "libuuid",
+        "epoch": 0,
+        "version": "2.32.1",
+        "release": "28.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libuuid-2.32.1-28.el8.ppc64le.rpm",
+        "checksum": "sha256:c1291b69a65a860069195a33cf6640df8667e960f9f030ceeea4497c47858b94",
+        "check_gpg": true
+      },
+      {
+        "name": "libverto",
+        "epoch": 0,
+        "version": "0.3.0",
+        "release": "5.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libverto-0.3.0-5.el8.ppc64le.rpm",
+        "checksum": "sha256:d8c00baf46e33f9e5f1b9e139bbea9fe0f27badb432c992b9cf8c4f7017094bf",
+        "check_gpg": true
+      },
+      {
+        "name": "libvpd",
+        "epoch": 0,
+        "version": "2.2.8",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libvpd-2.2.8-1.el8.ppc64le.rpm",
+        "checksum": "sha256:62ac185c4d6d242b187022c8376469073c211e8deca2a7b2badf1d775e2fd5a3",
+        "check_gpg": true
+      },
+      {
+        "name": "libxcrypt",
+        "epoch": 0,
+        "version": "4.1.1",
+        "release": "6.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libxcrypt-4.1.1-6.el8.ppc64le.rpm",
+        "checksum": "sha256:1a968f65db066243cbd0a6e12d193ef674637f044299a15b5d6b910e91411812",
+        "check_gpg": true
+      },
+      {
+        "name": "libxml2",
+        "epoch": 0,
+        "version": "2.9.7",
+        "release": "11.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libxml2-2.9.7-11.el8.ppc64le.rpm",
+        "checksum": "sha256:4a167fa4a7238bd94b3134173f6267b19cdebc2fde98b583344749e1f4c9bf09",
+        "check_gpg": true
+      },
+      {
+        "name": "libyaml",
+        "epoch": 0,
+        "version": "0.1.7",
+        "release": "5.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libyaml-0.1.7-5.el8.ppc64le.rpm",
+        "checksum": "sha256:8904fdb492f34e5242ba483fb6b7b158342662575b3d5ac9abbc380568840d4a",
+        "check_gpg": true
+      },
+      {
+        "name": "libzstd",
+        "epoch": 0,
+        "version": "1.4.4",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libzstd-1.4.4-1.el8.ppc64le.rpm",
+        "checksum": "sha256:6bfc201a12dc7bba21069a663aa692a96c5e8920b0d94a4e355c332d7ead15ba",
+        "check_gpg": true
+      },
+      {
+        "name": "linux-firmware",
+        "epoch": 0,
+        "version": "20210702",
+        "release": "103.gitd79c2677.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/linux-firmware-20210702-103.gitd79c2677.el8.noarch.rpm",
+        "checksum": "sha256:7aeb44195a1c984aff87cf8429d2aa40f6947b0a47d3603e1ca5c3cf8d284459",
+        "check_gpg": true
+      },
+      {
+        "name": "lmdb-libs",
+        "epoch": 0,
+        "version": "0.9.24",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/lmdb-libs-0.9.24-1.el8.ppc64le.rpm",
+        "checksum": "sha256:f6cd5ed6305952c1cd842fbca0e5d9613f736646cfac2082a2db37f5d065468c",
+        "check_gpg": true
+      },
+      {
+        "name": "logrotate",
+        "epoch": 0,
+        "version": "3.14.0",
+        "release": "4.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/logrotate-3.14.0-4.el8.ppc64le.rpm",
+        "checksum": "sha256:791acd72bc40be9ba5fa6b77d78def5da623544408b72baa4c81181c03a205cb",
+        "check_gpg": true
+      },
+      {
+        "name": "lshw",
+        "epoch": 0,
+        "version": "B.02.19.2",
+        "release": "6.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/lshw-B.02.19.2-6.el8.ppc64le.rpm",
+        "checksum": "sha256:906bffa419bdb1a6d3094d7a6f2308527f5ece250bfcb962df79e9867f28236d",
+        "check_gpg": true
+      },
+      {
+        "name": "lsscsi",
+        "epoch": 0,
+        "version": "0.32",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/lsscsi-0.32-2.el8.ppc64le.rpm",
+        "checksum": "sha256:deeeab9fcf6b9cb47235974158561967e299344e040c408e6b5d7464af2f3882",
+        "check_gpg": true
+      },
+      {
+        "name": "lsvpd",
+        "epoch": 0,
+        "version": "1.7.12",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/lsvpd-1.7.12-1.el8.ppc64le.rpm",
+        "checksum": "sha256:0eb36aba0f471119ccb001ea4f1819002ae535882df63e871be80e01f4f776bb",
+        "check_gpg": true
+      },
+      {
+        "name": "lua-libs",
+        "epoch": 0,
+        "version": "5.3.4",
+        "release": "11.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/lua-libs-5.3.4-11.el8.ppc64le.rpm",
+        "checksum": "sha256:393e7bb9f93ffb3cbba620fbfeb229f2b8345454bc60ac0508f76735544ed289",
+        "check_gpg": true
+      },
+      {
+        "name": "lz4-libs",
+        "epoch": 0,
+        "version": "1.8.3",
+        "release": "3.el8_4",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/lz4-libs-1.8.3-3.el8_4.ppc64le.rpm",
+        "checksum": "sha256:f24bce642ec88622490b2f09a45fa3985da7f6511a1aae131853c4ea4c309e6b",
+        "check_gpg": true
+      },
+      {
+        "name": "lzo",
+        "epoch": 0,
+        "version": "2.08",
+        "release": "14.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/lzo-2.08-14.el8.ppc64le.rpm",
+        "checksum": "sha256:4c5aabda0cd9edb40e141066d400d2e4b232bc22ab60e806a6399691c391cabc",
+        "check_gpg": true
+      },
+      {
+        "name": "man-db",
+        "epoch": 0,
+        "version": "2.7.6.1",
+        "release": "18.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/man-db-2.7.6.1-18.el8.ppc64le.rpm",
+        "checksum": "sha256:4079a1edf72a60c97ee48f0a98820b3b014575b402ea05a64cbc5f2b8af674de",
+        "check_gpg": true
+      },
+      {
+        "name": "memstrack",
+        "epoch": 0,
+        "version": "0.1.11",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/memstrack-0.1.11-1.el8.ppc64le.rpm",
+        "checksum": "sha256:9936485ac7111967d6962bc539de7b08807e310117adb78b11c21a5db0f0f890",
+        "check_gpg": true
+      },
+      {
+        "name": "mozjs60",
+        "epoch": 0,
+        "version": "60.9.0",
+        "release": "4.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/mozjs60-60.9.0-4.el8.ppc64le.rpm",
+        "checksum": "sha256:c62991989974533b86a29586b799623a908add501287f2c890be4fc8a6af2c7d",
+        "check_gpg": true
+      },
+      {
+        "name": "mpfr",
+        "epoch": 0,
+        "version": "3.1.6",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/mpfr-3.1.6-1.el8.ppc64le.rpm",
+        "checksum": "sha256:0230acdbc9da4b36da812f0e585a7602eda4982c899b3b3a4c2bc9b4546d8e74",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses",
+        "epoch": 0,
+        "version": "6.1",
+        "release": "9.20180224.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/ncurses-6.1-9.20180224.el8.ppc64le.rpm",
+        "checksum": "sha256:7abf49cabbaf996afc0c2604f10ea18f8f22a903fc4ba3728a18f5892353c5c9",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses-base",
+        "epoch": 0,
+        "version": "6.1",
+        "release": "9.20180224.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/ncurses-base-6.1-9.20180224.el8.noarch.rpm",
+        "checksum": "sha256:41716536ea16798238ac89fbc3041b3f9dc80f9a64ea4b19d6e67ad2c909269a",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses-libs",
+        "epoch": 0,
+        "version": "6.1",
+        "release": "9.20180224.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/ncurses-libs-6.1-9.20180224.el8.ppc64le.rpm",
+        "checksum": "sha256:17ffe1d683dbff48f9b2ef903401e471e5e51a992bf0890632bceb94561893de",
+        "check_gpg": true
+      },
+      {
+        "name": "nettle",
+        "epoch": 0,
+        "version": "3.4.1",
+        "release": "7.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/nettle-3.4.1-7.el8.ppc64le.rpm",
+        "checksum": "sha256:8403cfc97e0e72e37639b8c54d92f1ee427e48a70d52d5260a37fa104f2df20d",
+        "check_gpg": true
+      },
+      {
+        "name": "newt",
+        "epoch": 0,
+        "version": "0.52.20",
+        "release": "11.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/newt-0.52.20-11.el8.ppc64le.rpm",
+        "checksum": "sha256:b64219f2278bf3f032b71593da63f563920778230946b66f1037bef2f2a7358b",
+        "check_gpg": true
+      },
+      {
+        "name": "nftables",
+        "epoch": 1,
+        "version": "0.9.3",
+        "release": "20.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/nftables-0.9.3-20.el8.ppc64le.rpm",
+        "checksum": "sha256:fb1aa2fc7bbe75deca5b66f2151742b4afeb5c75a668b11b9875c81894bb2a3f",
+        "check_gpg": true
+      },
+      {
+        "name": "npth",
+        "epoch": 0,
+        "version": "1.5",
+        "release": "4.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/npth-1.5-4.el8.ppc64le.rpm",
+        "checksum": "sha256:7a66928044c3478964aeaf6f9e981fdbcfa6b2ff7fad9f2ad57a8c09387cbbf2",
+        "check_gpg": true
+      },
+      {
+        "name": "numactl-libs",
+        "epoch": 0,
+        "version": "2.0.12",
+        "release": "13.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/numactl-libs-2.0.12-13.el8.ppc64le.rpm",
+        "checksum": "sha256:5bcb506bd5559870631aa838711e683a5a2a07c6c0171be6bbeda9ba92dcdf5e",
+        "check_gpg": true
+      },
+      {
+        "name": "opal-prd",
+        "epoch": 0,
+        "version": "6.7.1",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/opal-prd-6.7.1-1.el8.ppc64le.rpm",
+        "checksum": "sha256:6495f3b729a1ceecd7cfdf318cfaa8ecf776ffa16293aad9f97cc542b6901ef7",
+        "check_gpg": true
+      },
+      {
+        "name": "openldap",
+        "epoch": 0,
+        "version": "2.4.46",
+        "release": "18.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/openldap-2.4.46-18.el8.ppc64le.rpm",
+        "checksum": "sha256:c24b21415b737f18fad7aeb192e60f7d323f7ba69434ecc1e78b3af0003be8dc",
+        "check_gpg": true
+      },
+      {
+        "name": "openssh",
+        "epoch": 0,
+        "version": "8.0p1",
+        "release": "9.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/openssh-8.0p1-9.el8.ppc64le.rpm",
+        "checksum": "sha256:965dca9dc74ed26f4204debe15b8e4dd1b8e41a80b8608287a9ef22f0b6f507e",
+        "check_gpg": true
+      },
+      {
+        "name": "openssh-clients",
+        "epoch": 0,
+        "version": "8.0p1",
+        "release": "9.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/openssh-clients-8.0p1-9.el8.ppc64le.rpm",
+        "checksum": "sha256:bb4b6716669e27c7619f63751770cb87e7cfecd4e302e2ce6588035509168352",
+        "check_gpg": true
+      },
+      {
+        "name": "openssh-server",
+        "epoch": 0,
+        "version": "8.0p1",
+        "release": "9.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/openssh-server-8.0p1-9.el8.ppc64le.rpm",
+        "checksum": "sha256:f8130aecd446f997d0e2011481275db0552bf57bd7af0d7a655eded5f52ca94e",
+        "check_gpg": true
+      },
+      {
+        "name": "openssl",
+        "epoch": 1,
+        "version": "1.1.1k",
+        "release": "4.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/openssl-1.1.1k-4.el8.ppc64le.rpm",
+        "checksum": "sha256:c2479eb811f4d9b8624ef20119e1abdc109f639c2cf576eb945b340362d87b05",
+        "check_gpg": true
+      },
+      {
+        "name": "openssl-libs",
+        "epoch": 1,
+        "version": "1.1.1k",
+        "release": "4.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/openssl-libs-1.1.1k-4.el8.ppc64le.rpm",
+        "checksum": "sha256:46606c1ed76a4da2a9d18016aeb50f4dddf58e1b45d665c983c58f8e605bf73e",
+        "check_gpg": true
+      },
+      {
+        "name": "openssl-pkcs11",
+        "epoch": 0,
+        "version": "0.4.10",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/openssl-pkcs11-0.4.10-2.el8.ppc64le.rpm",
+        "checksum": "sha256:d87f7fa5e637442eb638bcaafdc44ca3895d91a153015ff9af6a87219f0dc372",
+        "check_gpg": true
+      },
+      {
+        "name": "os-prober",
+        "epoch": 0,
+        "version": "1.74",
+        "release": "6.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/os-prober-1.74-6.el8.ppc64le.rpm",
+        "checksum": "sha256:71c88f04921ae61a7009f9443f95c70ec3424a798429fc01e6c1432c1077aacb",
+        "check_gpg": true
+      },
+      {
+        "name": "p11-kit",
+        "epoch": 0,
+        "version": "0.23.22",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/p11-kit-0.23.22-1.el8.ppc64le.rpm",
+        "checksum": "sha256:bf994cb2e5c367d78483662c7de6e69950aaf04bc6cfdbbef4d1ef7ce153717c",
+        "check_gpg": true
+      },
+      {
+        "name": "p11-kit-trust",
+        "epoch": 0,
+        "version": "0.23.22",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/p11-kit-trust-0.23.22-1.el8.ppc64le.rpm",
+        "checksum": "sha256:b7330d40f75b8ec786e41c45a202e44f0e49ec29ddf8944120fbdb373a6c6617",
+        "check_gpg": true
+      },
+      {
+        "name": "pam",
+        "epoch": 0,
+        "version": "1.3.1",
+        "release": "15.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/pam-1.3.1-15.el8.ppc64le.rpm",
+        "checksum": "sha256:bb82b10a91493d745dc533b5de5335db650adb0c8a90548fdf5dad13569a16f4",
+        "check_gpg": true
+      },
+      {
+        "name": "parted",
+        "epoch": 0,
+        "version": "3.2",
+        "release": "39.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/parted-3.2-39.el8.ppc64le.rpm",
+        "checksum": "sha256:9e2ef90cb484b37232e829ec400dcddd3f9f0d189eb6f0074b3b5874d4553d1c",
+        "check_gpg": true
+      },
+      {
+        "name": "passwd",
+        "epoch": 0,
+        "version": "0.80",
+        "release": "3.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/passwd-0.80-3.el8.ppc64le.rpm",
+        "checksum": "sha256:dfb7add4926f9a350755294af3c20f114ac59f32e00cadc9ec625b2a51703ad0",
+        "check_gpg": true
+      },
+      {
+        "name": "pciutils",
+        "epoch": 0,
+        "version": "3.7.0",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/pciutils-3.7.0-1.el8.ppc64le.rpm",
+        "checksum": "sha256:7b334d84bf03876c5738efa3857faaa35ede5c8eab30a5621ecfd4efa7ce39a5",
+        "check_gpg": true
+      },
+      {
+        "name": "pciutils-libs",
+        "epoch": 0,
+        "version": "3.7.0",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/pciutils-libs-3.7.0-1.el8.ppc64le.rpm",
+        "checksum": "sha256:dd96950b4282e64ce3e37f0bd1a51834beb286037184f3796f9889bfa1ed0d72",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre",
+        "epoch": 0,
+        "version": "8.42",
+        "release": "6.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/pcre-8.42-6.el8.ppc64le.rpm",
+        "checksum": "sha256:3ed319e31a9c38e5f4e336195b5cbd253b3f8b17f93f185829f078c5ef420305",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre2",
+        "epoch": 0,
+        "version": "10.32",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/pcre2-10.32-2.el8.ppc64le.rpm",
+        "checksum": "sha256:5c46bef8c0e95e05716e9a53b77970c1378d93bcb9a800018a24f7e1763b45b9",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Carp",
+        "epoch": 0,
+        "version": "1.42",
+        "release": "396.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/perl-Carp-1.42-396.el8.noarch.rpm",
+        "checksum": "sha256:d03b9f4b9848e3a88d62bcf6e536d659c325b2dc03b2136be7342b5fe5e2b6a9",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Data-Dumper",
+        "epoch": 0,
+        "version": "2.167",
+        "release": "399.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/perl-Data-Dumper-2.167-399.el8.ppc64le.rpm",
+        "checksum": "sha256:a34e0c5859e5e8757afafba47d83396226b646f32954ef7ecda4ad3be464bed6",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Encode",
+        "epoch": 4,
+        "version": "2.97",
+        "release": "3.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/perl-Encode-2.97-3.el8.ppc64le.rpm",
+        "checksum": "sha256:fc9d3ee3946b87efcd9531f876d23a9e8d5769aab3e0ad6007ac2cdb4068499c",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Errno",
+        "epoch": 0,
+        "version": "1.28",
+        "release": "420.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/perl-Errno-1.28-420.el8.ppc64le.rpm",
+        "checksum": "sha256:cffc31e10891c58edc89cebd211bc0be69d99f54f67682c91f97dc53e6381f0f",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Exporter",
+        "epoch": 0,
+        "version": "5.72",
+        "release": "396.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/perl-Exporter-5.72-396.el8.noarch.rpm",
+        "checksum": "sha256:7edc503f5a919c489b651757095d8031982d530cc88088fdaeb743188364e9b0",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-File-Path",
+        "epoch": 0,
+        "version": "2.15",
+        "release": "2.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/perl-File-Path-2.15-2.el8.noarch.rpm",
+        "checksum": "sha256:e83928bd4552ecdf8e71d283e2358c7eccd006d284ba31fbc9c89e407989fd60",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-File-Temp",
+        "epoch": 0,
+        "version": "0.230.600",
+        "release": "1.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/perl-File-Temp-0.230.600-1.el8.noarch.rpm",
+        "checksum": "sha256:e269f7d33abbb790311ffa95fa7df9766cac8bf31ace24fce6ed732ba0db19ae",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Getopt-Long",
+        "epoch": 1,
+        "version": "2.50",
+        "release": "4.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/perl-Getopt-Long-2.50-4.el8.noarch.rpm",
+        "checksum": "sha256:da4c6daa0d5406bc967cc89b02a69689491f42c543aceea1a31136f0f1a8d991",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-HTTP-Tiny",
+        "epoch": 0,
+        "version": "0.074",
+        "release": "1.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/perl-HTTP-Tiny-0.074-1.el8.noarch.rpm",
+        "checksum": "sha256:a1af93a1b62e8ca05b7597d5749a2b3d28735a86928f0432064fec61db1ff844",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-IO",
+        "epoch": 0,
+        "version": "1.38",
+        "release": "420.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/perl-IO-1.38-420.el8.ppc64le.rpm",
+        "checksum": "sha256:74e11b9013f81bd30ec7934ea695d267d164967fec27a02652aa48602b94bc51",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-MIME-Base64",
+        "epoch": 0,
+        "version": "3.15",
+        "release": "396.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/perl-MIME-Base64-3.15-396.el8.ppc64le.rpm",
+        "checksum": "sha256:dc1d4f59ba0728e65433bc7f903b3799d61545ed3eed7427ad0fe36dcd0f831b",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-PathTools",
+        "epoch": 0,
+        "version": "3.74",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/perl-PathTools-3.74-1.el8.ppc64le.rpm",
+        "checksum": "sha256:6b588ff47d46d33b02bc296e6e5cc263d6c8ff51ee97b59ca8b34d5c45d57912",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Pod-Escapes",
+        "epoch": 1,
+        "version": "1.07",
+        "release": "395.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/perl-Pod-Escapes-1.07-395.el8.noarch.rpm",
+        "checksum": "sha256:545cd23ad8e4f71a5109551093668fd4b5e1a50d6a60364ce0f04f64eecd99d1",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Pod-Perldoc",
+        "epoch": 0,
+        "version": "3.28",
+        "release": "396.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/perl-Pod-Perldoc-3.28-396.el8.noarch.rpm",
+        "checksum": "sha256:0225dc3999e3d7b1bb57186a2fc93c98bd1e4e08e062fb51c966e1f2a2c91bb4",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Pod-Simple",
+        "epoch": 1,
+        "version": "3.35",
+        "release": "395.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/perl-Pod-Simple-3.35-395.el8.noarch.rpm",
+        "checksum": "sha256:51c3ee5d824bdde0a8faa10c99841c2590c0c26edfb17125aa97945a688c83ed",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Pod-Usage",
+        "epoch": 4,
+        "version": "1.69",
+        "release": "395.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/perl-Pod-Usage-1.69-395.el8.noarch.rpm",
+        "checksum": "sha256:794f970f498af07b37f914c19ad5dedc6b6c2f89d343af9dd1768d17232555de",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Scalar-List-Utils",
+        "epoch": 3,
+        "version": "1.49",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/perl-Scalar-List-Utils-1.49-2.el8.ppc64le.rpm",
+        "checksum": "sha256:61ee52dfdcbcd98acc765b45781ea5de94831f55675c0faaf615872f92268757",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Socket",
+        "epoch": 4,
+        "version": "2.027",
+        "release": "3.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/perl-Socket-2.027-3.el8.ppc64le.rpm",
+        "checksum": "sha256:8d19cdf57ba61fecd9e07f24fe88768f58196543f7c032adada8a0cc48eee6b3",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Storable",
+        "epoch": 1,
+        "version": "3.11",
+        "release": "3.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/perl-Storable-3.11-3.el8.ppc64le.rpm",
+        "checksum": "sha256:c238e0a5472c59c54093ffa23af6a963b4ae437eedfb6b9ebbcb482752c6d16b",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Term-ANSIColor",
+        "epoch": 0,
+        "version": "4.06",
+        "release": "396.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/perl-Term-ANSIColor-4.06-396.el8.noarch.rpm",
+        "checksum": "sha256:f4e3607f242bbca7ec2379822ca961860e6d9c276da51c6e2dfd17a29469ec78",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Term-Cap",
+        "epoch": 0,
+        "version": "1.17",
+        "release": "395.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/perl-Term-Cap-1.17-395.el8.noarch.rpm",
+        "checksum": "sha256:6bbb721dd2c411c85c75f7477b14c54c776d78ee9b93557615e919ef47577440",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Text-ParseWords",
+        "epoch": 0,
+        "version": "3.30",
+        "release": "395.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/perl-Text-ParseWords-3.30-395.el8.noarch.rpm",
+        "checksum": "sha256:2975de6545b4ca7907ae368a1716c531764e4afccbf27fb0a694d90e983c38e2",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Text-Tabs+Wrap",
+        "epoch": 0,
+        "version": "2013.0523",
+        "release": "395.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/perl-Text-Tabs+Wrap-2013.0523-395.el8.noarch.rpm",
+        "checksum": "sha256:7e50a5d0f2fbd8c95375f72f5772c7731186e999a447121b8247f448b065a4ef",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Time-Local",
+        "epoch": 1,
+        "version": "1.280",
+        "release": "1.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/perl-Time-Local-1.280-1.el8.noarch.rpm",
+        "checksum": "sha256:1edcf2b441ddf21417ef2b33e1ab2a30900758819335d7fabafe3b16bb3eab62",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Unicode-Normalize",
+        "epoch": 0,
+        "version": "1.25",
+        "release": "396.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/perl-Unicode-Normalize-1.25-396.el8.ppc64le.rpm",
+        "checksum": "sha256:04ee771fad226ade609b0e879d15c32898379360db27ef1bc6d9f5a77127d5a8",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-constant",
+        "epoch": 0,
+        "version": "1.33",
+        "release": "396.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/perl-constant-1.33-396.el8.noarch.rpm",
+        "checksum": "sha256:7559c097998db5e5d14dab1a7a1637a5749e9dab234ca68d17c9c21f8cfbf8d6",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-interpreter",
+        "epoch": 4,
+        "version": "5.26.3",
+        "release": "420.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/perl-interpreter-5.26.3-420.el8.ppc64le.rpm",
+        "checksum": "sha256:d5ee453757bd1b479881f0a57b968427404b81d9fed07d04afebcbcfcbf536ab",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-libs",
+        "epoch": 4,
+        "version": "5.26.3",
+        "release": "420.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/perl-libs-5.26.3-420.el8.ppc64le.rpm",
+        "checksum": "sha256:4b40402374fc4a9202a67d3ede77dedbe5ed1bab57479a5b5cb5cd6c45283bf4",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-macros",
+        "epoch": 4,
+        "version": "5.26.3",
+        "release": "420.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/perl-macros-5.26.3-420.el8.ppc64le.rpm",
+        "checksum": "sha256:926ce547a03e1bd2aac94b1792d7ccea16d1e6bd91903458e63a095268e1b02f",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-parent",
+        "epoch": 1,
+        "version": "0.237",
+        "release": "1.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/perl-parent-0.237-1.el8.noarch.rpm",
+        "checksum": "sha256:f5e73bbd776a2426a796971d8d38664f2e94898479fb76947dccdd28cf9fe1d0",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-podlators",
+        "epoch": 0,
+        "version": "4.11",
+        "release": "1.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/perl-podlators-4.11-1.el8.noarch.rpm",
+        "checksum": "sha256:78d17ed089151e7fa3d1a3cdbbac8ca3b1b5c484fae5ba025642cc9107991037",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-threads",
+        "epoch": 1,
+        "version": "2.21",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/perl-threads-2.21-2.el8.ppc64le.rpm",
+        "checksum": "sha256:47f414f515a2c3103d0e7dae67c47a3b2bc76ea2413d666052012b11dbdd0feb",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-threads-shared",
+        "epoch": 0,
+        "version": "1.58",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/perl-threads-shared-1.58-2.el8.ppc64le.rpm",
+        "checksum": "sha256:b566154cc9b2b1996716def297d58101f3015a1b868187f1f9e4cd3074ae9988",
+        "check_gpg": true
+      },
+      {
+        "name": "pigz",
+        "epoch": 0,
+        "version": "2.4",
+        "release": "4.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/pigz-2.4-4.el8.ppc64le.rpm",
+        "checksum": "sha256:3edfdbc82f97ec12e59c80c67897fc1eeb44c3d16820f761a8f15272965ea3a1",
+        "check_gpg": true
+      },
+      {
+        "name": "platform-python",
+        "epoch": 0,
+        "version": "3.6.8",
+        "release": "39.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/platform-python-3.6.8-39.el8.ppc64le.rpm",
+        "checksum": "sha256:cdd6594a3bca71d32a5061b85457cc8148611e7f042ba6e812a1c0a2faebac92",
+        "check_gpg": true
+      },
+      {
+        "name": "platform-python-pip",
+        "epoch": 0,
+        "version": "9.0.3",
+        "release": "20.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/platform-python-pip-9.0.3-20.el8.noarch.rpm",
+        "checksum": "sha256:56650f8b8f2b01c1090d184d7d6d396f0109f8a02f915c97b081be73ea12df08",
+        "check_gpg": true
+      },
+      {
+        "name": "platform-python-setuptools",
+        "epoch": 0,
+        "version": "39.2.0",
+        "release": "6.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/platform-python-setuptools-39.2.0-6.el8.noarch.rpm",
+        "checksum": "sha256:946ba273a3a3b6fdf140f3c03112918c0a556a5871c477f5dbbb98600e6ca557",
+        "check_gpg": true
+      },
+      {
+        "name": "policycoreutils",
+        "epoch": 0,
+        "version": "2.9",
+        "release": "15.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/policycoreutils-2.9-15.el8.ppc64le.rpm",
+        "checksum": "sha256:c64632c85c3a49dc82222cdb3d0ee87eafa64f3096ffeba5bcc16c49ee2d260e",
+        "check_gpg": true
+      },
+      {
+        "name": "polkit",
+        "epoch": 0,
+        "version": "0.115",
+        "release": "12.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/polkit-0.115-12.el8.ppc64le.rpm",
+        "checksum": "sha256:e716fd0130980916f4b1aeac8f98dbcd8ced81e2c119b7877204cc6b1a058418",
+        "check_gpg": true
+      },
+      {
+        "name": "polkit-libs",
+        "epoch": 0,
+        "version": "0.115",
+        "release": "12.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/polkit-libs-0.115-12.el8.ppc64le.rpm",
+        "checksum": "sha256:15554476d03595246aec194e63ec9db7469d5b3ed81a27a8a2720e82df1f8bf4",
+        "check_gpg": true
+      },
+      {
+        "name": "polkit-pkla-compat",
+        "epoch": 0,
+        "version": "0.1",
+        "release": "12.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/polkit-pkla-compat-0.1-12.el8.ppc64le.rpm",
+        "checksum": "sha256:0727078eff2abaf1e5770b331ed8162d8e95cf2cf1de06de7540d034999d72ef",
+        "check_gpg": true
+      },
+      {
+        "name": "popt",
+        "epoch": 0,
+        "version": "1.18",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/popt-1.18-1.el8.ppc64le.rpm",
+        "checksum": "sha256:3b00ac82c31b447e306fcb47b4469fdc4e6d87385b42358c2e76badb51b074a3",
+        "check_gpg": true
+      },
+      {
+        "name": "powerpc-utils",
+        "epoch": 0,
+        "version": "1.3.8",
+        "release": "7.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/powerpc-utils-1.3.8-7.el8.ppc64le.rpm",
+        "checksum": "sha256:401a2690658194fdd92994c29aa57c18cc5e3100fe7bbdba33d0fa26f2213eb3",
+        "check_gpg": true
+      },
+      {
+        "name": "powerpc-utils-core",
+        "epoch": 0,
+        "version": "1.3.8",
+        "release": "7.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/powerpc-utils-core-1.3.8-7.el8.ppc64le.rpm",
+        "checksum": "sha256:720088f184124166386634a523f3566a7fc56f802dbd6e6f816e959236542770",
+        "check_gpg": true
+      },
+      {
+        "name": "ppc64-diag",
+        "epoch": 0,
+        "version": "2.7.7",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/ppc64-diag-2.7.7-1.el8.ppc64le.rpm",
+        "checksum": "sha256:2d77f4a2166122e3f7c5ace1bbfe5319ec6c2d24fff1c6f3e22ccb3e8b2327e0",
+        "check_gpg": true
+      },
+      {
+        "name": "ppc64-diag-rtas",
+        "epoch": 0,
+        "version": "2.7.7",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/ppc64-diag-rtas-2.7.7-1.el8.ppc64le.rpm",
+        "checksum": "sha256:0ad85fe7a6b42dae9248268706940b12c01e83141858df79e43223e173fe9840",
+        "check_gpg": true
+      },
+      {
+        "name": "prefixdevname",
+        "epoch": 0,
+        "version": "0.1.0",
+        "release": "6.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/prefixdevname-0.1.0-6.el8.ppc64le.rpm",
+        "checksum": "sha256:35983fb2e9104b81caaa9e6d40352ea8b2b987fb811f935602d04cc90fdee76a",
+        "check_gpg": true
+      },
+      {
+        "name": "procps-ng",
+        "epoch": 0,
+        "version": "3.3.15",
+        "release": "6.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/procps-ng-3.3.15-6.el8.ppc64le.rpm",
+        "checksum": "sha256:1cfa672c25cb5849bb2aa652e045e4a4a272c025befb1fe5e58cb32823faa30d",
+        "check_gpg": true
+      },
+      {
+        "name": "publicsuffix-list-dafsa",
+        "epoch": 0,
+        "version": "20180723",
+        "release": "1.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/publicsuffix-list-dafsa-20180723-1.el8.noarch.rpm",
+        "checksum": "sha256:65ecf1e479dc2b2f7f09c2e86d7457043b3470b3eab3c4ee8909b50b0a669fc2",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-configobj",
+        "epoch": 0,
+        "version": "5.0.6",
+        "release": "11.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-configobj-5.0.6-11.el8.noarch.rpm",
+        "checksum": "sha256:1bd969e0521820374122f5132e5998d9bd2ab185be66565a7266096297419c8e",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-dateutil",
+        "epoch": 1,
+        "version": "2.6.1",
+        "release": "6.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-dateutil-2.6.1-6.el8.noarch.rpm",
+        "checksum": "sha256:c5b5967a094ced90899052a82e2c245529b75ba3f46e0ce1a89cfc95edb935ea",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-dbus",
+        "epoch": 0,
+        "version": "1.2.4",
+        "release": "15.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-dbus-1.2.4-15.el8.ppc64le.rpm",
+        "checksum": "sha256:c59538d646715fdb1f94c6be3fa0949871b8c860d5c54db4640a1197663a130b",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-decorator",
+        "epoch": 0,
+        "version": "4.2.1",
+        "release": "2.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-decorator-4.2.1-2.el8.noarch.rpm",
+        "checksum": "sha256:0e9a8a0f823bf0ef948862f0ccb62353460bd07931e756c98f23908c1c526578",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-dnf",
+        "epoch": 0,
+        "version": "4.7.0",
+        "release": "2.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-dnf-4.7.0-2.el8.noarch.rpm",
+        "checksum": "sha256:ccfa1810aa19fae08aefd29cffe28b65d5123cd17bd7d2d4207f03cf9795594c",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-dnf-plugins-core",
+        "epoch": 0,
+        "version": "4.0.21",
+        "release": "2.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-dnf-plugins-core-4.0.21-2.el8.noarch.rpm",
+        "checksum": "sha256:28c0f457d67213319f0313d993a3b2f8a778a077b202cd75bf45eb2792949d32",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-firewall",
+        "epoch": 0,
+        "version": "0.9.3",
+        "release": "7.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-firewall-0.9.3-7.el8.noarch.rpm",
+        "checksum": "sha256:acfee60459ffe722b9362696f58a26b606b637094d9439bf5f898310daf8ba24",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-gobject-base",
+        "epoch": 0,
+        "version": "3.28.3",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-gobject-base-3.28.3-2.el8.ppc64le.rpm",
+        "checksum": "sha256:8781993942f622945aefe59e449a5ff4608f969db79fbe893040890ff08fc1f9",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-gpg",
+        "epoch": 0,
+        "version": "1.13.1",
+        "release": "9.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-gpg-1.13.1-9.el8.ppc64le.rpm",
+        "checksum": "sha256:111d88db3a52121f04f2741cc72ce8dda6d6f6ef2cc36452c042e0141b316334",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-hawkey",
+        "epoch": 0,
+        "version": "0.63.0",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-hawkey-0.63.0-2.el8.ppc64le.rpm",
+        "checksum": "sha256:4715730da2b4a5bf6cc2ab85208071f00c7b279e4b2f75df0bd954446185e14c",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libcomps",
+        "epoch": 0,
+        "version": "0.1.16",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-libcomps-0.1.16-2.el8.ppc64le.rpm",
+        "checksum": "sha256:594d8b368013caa4eaba4eade896fc1cec8ef569052bd491f493c193e07c6d80",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libdnf",
+        "epoch": 0,
+        "version": "0.63.0",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-libdnf-0.63.0-2.el8.ppc64le.rpm",
+        "checksum": "sha256:abc36bf7797a427b64c3c99b4f74714bfa66b906b62358be6fdafe493a66415e",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libs",
+        "epoch": 0,
+        "version": "3.6.8",
+        "release": "39.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-libs-3.6.8-39.el8.ppc64le.rpm",
+        "checksum": "sha256:405bda98fe97c1a5cf70511ae2d167256b25dd8721b88899465e9847525e2068",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libselinux",
+        "epoch": 0,
+        "version": "2.9",
+        "release": "5.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-libselinux-2.9-5.el8.ppc64le.rpm",
+        "checksum": "sha256:3b5d31b89683be71c72b77cfceb59238f4c76a796de6ae85525b3d5cfe2a8f23",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-linux-procfs",
+        "epoch": 0,
+        "version": "0.6.3",
+        "release": "1.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-linux-procfs-0.6.3-1.el8.noarch.rpm",
+        "checksum": "sha256:dc835194ecfa6ebda81e0a764c953eff3422a61863e9a3e0dc74ea4cae7a4d94",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-nftables",
+        "epoch": 1,
+        "version": "0.9.3",
+        "release": "20.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-nftables-0.9.3-20.el8.ppc64le.rpm",
+        "checksum": "sha256:73ff0ee3bef442e48df0f95d26fee18606cfb1aee81617c3202a6b35bb0fca0c",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-perf",
+        "epoch": 0,
+        "version": "4.18.0",
+        "release": "331.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-perf-4.18.0-331.el8.ppc64le.rpm",
+        "checksum": "sha256:cb21226326a5a695c993daba749f5d758658d58612b05280a04cca98cba3f83a",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-pip-wheel",
+        "epoch": 0,
+        "version": "9.0.3",
+        "release": "20.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-pip-wheel-9.0.3-20.el8.noarch.rpm",
+        "checksum": "sha256:6c9dfb73e199975275633f05d31388cd61c5a77dec5678db958b4e6624eb21ba",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-pyudev",
+        "epoch": 0,
+        "version": "0.21.0",
+        "release": "7.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-pyudev-0.21.0-7.el8.noarch.rpm",
+        "checksum": "sha256:aa0007192287faeaecc72d9fa48efdb3108c764d450dc8fea65474476da32c45",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-rpm",
+        "epoch": 0,
+        "version": "4.14.3",
+        "release": "15.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-rpm-4.14.3-15.el8.ppc64le.rpm",
+        "checksum": "sha256:ccf848b42acc0f691b4cb6e2830dc4263c7ce4df89b3f4002c3d6b9cd99b362b",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-setuptools-wheel",
+        "epoch": 0,
+        "version": "39.2.0",
+        "release": "6.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-setuptools-wheel-39.2.0-6.el8.noarch.rpm",
+        "checksum": "sha256:b19bd4f106ce301ee21c860183cc1c2ef9c09bdf495059bdf16e8d8ccc71bbe8",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-six",
+        "epoch": 0,
+        "version": "1.11.0",
+        "release": "8.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-six-1.11.0-8.el8.noarch.rpm",
+        "checksum": "sha256:a04cb3117395b962edc32bf45d8411f240632476b0706b2df7f4a1a87b2ce34b",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-slip",
+        "epoch": 0,
+        "version": "0.6.4",
+        "release": "11.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-slip-0.6.4-11.el8.noarch.rpm",
+        "checksum": "sha256:233e5f78027b684e5aaac1395cc574aea3039059bf86eb4494422bc74216a396",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-slip-dbus",
+        "epoch": 0,
+        "version": "0.6.4",
+        "release": "11.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-slip-dbus-0.6.4-11.el8.noarch.rpm",
+        "checksum": "sha256:563b3741d26b6af963fdb7b0634e0791445a707d0b6093ac71c3224299241639",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-syspurpose",
+        "epoch": 0,
+        "version": "1.28.20",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-syspurpose-1.28.20-1.el8.ppc64le.rpm",
+        "checksum": "sha256:07c65a3efc2bb32027206df4f117b893268d028cbb3741208d73615a63525158",
+        "check_gpg": true
+      },
+      {
+        "name": "rdma-core",
+        "epoch": 0,
+        "version": "35.0",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/rdma-core-35.0-1.el8.ppc64le.rpm",
+        "checksum": "sha256:4cc53ff12e7b8fcfafdd32eaac7b13266876766f22b3262b653eaa7b06fbbaaf",
+        "check_gpg": true
+      },
+      {
+        "name": "readline",
+        "epoch": 0,
+        "version": "7.0",
+        "release": "10.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/readline-7.0-10.el8.ppc64le.rpm",
+        "checksum": "sha256:0320663709136d07690fe299903700cc1dcc526d574fe8b952a01e1d24024ae4",
+        "check_gpg": true
+      },
+      {
+        "name": "rootfiles",
+        "epoch": 0,
+        "version": "8.1",
+        "release": "22.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/rootfiles-8.1-22.el8.noarch.rpm",
+        "checksum": "sha256:d967d6bbb33bf7a295a64807f81875c84e82a8ecc59b6c72fe955141b1660d39",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm",
+        "epoch": 0,
+        "version": "4.14.3",
+        "release": "15.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/rpm-4.14.3-15.el8.ppc64le.rpm",
+        "checksum": "sha256:4fae16ca54207cb952e3904b8eb8cc424f3f056f400e5e802ab1a9ef3e575834",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-build-libs",
+        "epoch": 0,
+        "version": "4.14.3",
+        "release": "15.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/rpm-build-libs-4.14.3-15.el8.ppc64le.rpm",
+        "checksum": "sha256:03ba1e86a04d912fd2878b457b06a6a7abad0ce96cd9a6932bf58cb4641b8fb7",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-libs",
+        "epoch": 0,
+        "version": "4.14.3",
+        "release": "15.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/rpm-libs-4.14.3-15.el8.ppc64le.rpm",
+        "checksum": "sha256:4e22015880d16cb7148d70895a2361f4fa05804f0391386e0e50554e6fd868b0",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-plugin-selinux",
+        "epoch": 0,
+        "version": "4.14.3",
+        "release": "15.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/rpm-plugin-selinux-4.14.3-15.el8.ppc64le.rpm",
+        "checksum": "sha256:9b1018a43b1a9245cdc71a342b962aa32fb799bd0ce66ee59b496cdd75200de9",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-plugin-systemd-inhibit",
+        "epoch": 0,
+        "version": "4.14.3",
+        "release": "15.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/rpm-plugin-systemd-inhibit-4.14.3-15.el8.ppc64le.rpm",
+        "checksum": "sha256:8cb953ea9ea1bd262bef00112e2c433583929cd7aec86ae60f1a725c6dcf7c09",
+        "check_gpg": true
+      },
+      {
+        "name": "sed",
+        "epoch": 0,
+        "version": "4.5",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/sed-4.5-2.el8.ppc64le.rpm",
+        "checksum": "sha256:dbde46224833f804d8b92212fa3618ea53d0e0cb84ff07132a5ba36c1bc0b9df",
+        "check_gpg": true
+      },
+      {
+        "name": "selinux-policy",
+        "epoch": 0,
+        "version": "3.14.3",
+        "release": "76.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/selinux-policy-3.14.3-76.el8.noarch.rpm",
+        "checksum": "sha256:561a61d2d81bccb14d22a53b32301e0b6b9e9b9d80ad75991ee6ff796cae0ef7",
+        "check_gpg": true
+      },
+      {
+        "name": "selinux-policy-targeted",
+        "epoch": 0,
+        "version": "3.14.3",
+        "release": "76.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/selinux-policy-targeted-3.14.3-76.el8.noarch.rpm",
+        "checksum": "sha256:76df9e0fc779fcd7d3ee836ae254ead30b5f9492022b55901d1f8bd914d38ef6",
+        "check_gpg": true
+      },
+      {
+        "name": "servicelog",
+        "epoch": 0,
+        "version": "1.1.15",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/servicelog-1.1.15-1.el8.ppc64le.rpm",
+        "checksum": "sha256:605033c50f750dad4c344495a0d6b18dcfb2a091bba072441a38cbf9001c0363",
+        "check_gpg": true
+      },
+      {
+        "name": "setup",
+        "epoch": 0,
+        "version": "2.12.2",
+        "release": "6.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/setup-2.12.2-6.el8.noarch.rpm",
+        "checksum": "sha256:9e540fe1fcf866ba1e738e012eef5459d34cca30385df73973e6fc7c6eadb55f",
+        "check_gpg": true
+      },
+      {
+        "name": "sg3_utils",
+        "epoch": 0,
+        "version": "1.44",
+        "release": "5.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/sg3_utils-1.44-5.el8.ppc64le.rpm",
+        "checksum": "sha256:7d4c363f4a746f3a0946d19f303fe9c60c5fe178892528ec4f34d8ddd2c4c359",
+        "check_gpg": true
+      },
+      {
+        "name": "sg3_utils-libs",
+        "epoch": 0,
+        "version": "1.44",
+        "release": "5.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/sg3_utils-libs-1.44-5.el8.ppc64le.rpm",
+        "checksum": "sha256:8540be85295735194e0053eb2ab6b2bda2e27119b9b030877eff43f9272a20cf",
+        "check_gpg": true
+      },
+      {
+        "name": "shadow-utils",
+        "epoch": 2,
+        "version": "4.6",
+        "release": "14.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/shadow-utils-4.6-14.el8.ppc64le.rpm",
+        "checksum": "sha256:e1153055b6ea57ee81e6fb41b03023279059513d0fec728517ae0805186a5118",
+        "check_gpg": true
+      },
+      {
+        "name": "shared-mime-info",
+        "epoch": 0,
+        "version": "1.9",
+        "release": "3.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/shared-mime-info-1.9-3.el8.ppc64le.rpm",
+        "checksum": "sha256:f97b5915b3f75d2878104c198f205841813712103f1b3657d71d2c8d079cc947",
+        "check_gpg": true
+      },
+      {
+        "name": "slang",
+        "epoch": 0,
+        "version": "2.3.2",
+        "release": "3.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/slang-2.3.2-3.el8.ppc64le.rpm",
+        "checksum": "sha256:dd8998fa42db6769700a41203f5ef0efe523ed24734636ef0dc0d2a4d4a94747",
+        "check_gpg": true
+      },
+      {
+        "name": "snappy",
+        "epoch": 0,
+        "version": "1.1.8",
+        "release": "3.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/snappy-1.1.8-3.el8.ppc64le.rpm",
+        "checksum": "sha256:17c615aa31cf2afa434d1d1d42e0db85b564fe416d346721bd38c0db75f73119",
+        "check_gpg": true
+      },
+      {
+        "name": "sqlite-libs",
+        "epoch": 0,
+        "version": "3.26.0",
+        "release": "15.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/sqlite-libs-3.26.0-15.el8.ppc64le.rpm",
+        "checksum": "sha256:31277c01ac529cc1c6a55fd87d6ce4dbb20290575d4e1e89cd40600eac9f3405",
+        "check_gpg": true
+      },
+      {
+        "name": "squashfs-tools",
+        "epoch": 0,
+        "version": "4.3",
+        "release": "20.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/squashfs-tools-4.3-20.el8.ppc64le.rpm",
+        "checksum": "sha256:4b00562fa291e956d910bb056c6120f0079f30093ea107757758683a6d418206",
+        "check_gpg": true
+      },
+      {
+        "name": "sssd-client",
+        "epoch": 0,
+        "version": "2.5.2",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/sssd-client-2.5.2-2.el8.ppc64le.rpm",
+        "checksum": "sha256:5796882ac3059835583bc399e8522c19646b717713ef553a71b20ca0535a1718",
+        "check_gpg": true
+      },
+      {
+        "name": "sssd-common",
+        "epoch": 0,
+        "version": "2.5.2",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/sssd-common-2.5.2-2.el8.ppc64le.rpm",
+        "checksum": "sha256:697f5bf30fbe44dd4dcba8392b85680952b7a1be9a0221349f4fde011a8cdd3c",
+        "check_gpg": true
+      },
+      {
+        "name": "sssd-kcm",
+        "epoch": 0,
+        "version": "2.5.2",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/sssd-kcm-2.5.2-2.el8.ppc64le.rpm",
+        "checksum": "sha256:c477e45fe5f8f5bab1ec1711210dd357392ad19eab48cda18d89b60df5067970",
+        "check_gpg": true
+      },
+      {
+        "name": "sssd-nfs-idmap",
+        "epoch": 0,
+        "version": "2.5.2",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/sssd-nfs-idmap-2.5.2-2.el8.ppc64le.rpm",
+        "checksum": "sha256:61b1d3440b078f35a3fe2b35c51d6d38498fb3dc8d8f5fedf52c7f0f8f6d8ecf",
+        "check_gpg": true
+      },
+      {
+        "name": "sudo",
+        "epoch": 0,
+        "version": "1.8.29",
+        "release": "7.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/sudo-1.8.29-7.el8.ppc64le.rpm",
+        "checksum": "sha256:bba1cd75958b43df5e3ceb820449008c19ed5fa562d54c2d46c5c57e79aa6b2a",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd",
+        "epoch": 0,
+        "version": "239",
+        "release": "49.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/systemd-239-49.el8.ppc64le.rpm",
+        "checksum": "sha256:8a501b9d8016eee68ce62a93a65842b15c8a57192b9f8189ebc85a11f2f47f9e",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-libs",
+        "epoch": 0,
+        "version": "239",
+        "release": "49.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/systemd-libs-239-49.el8.ppc64le.rpm",
+        "checksum": "sha256:3d175382237a94330d72af67ad2c41535dee7eade3e42178b86d2dc87478d030",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-pam",
+        "epoch": 0,
+        "version": "239",
+        "release": "49.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/systemd-pam-239-49.el8.ppc64le.rpm",
+        "checksum": "sha256:e95bb05fa5defeb16dd0e0957de676374b22b9daaf405273e636d1ce91001574",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-udev",
+        "epoch": 0,
+        "version": "239",
+        "release": "49.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/systemd-udev-239-49.el8.ppc64le.rpm",
+        "checksum": "sha256:3898e2ac4e04e80373bc7fe4092b26d502d4705177719117e25c083d44a9a150",
+        "check_gpg": true
+      },
+      {
+        "name": "teamd",
+        "epoch": 0,
+        "version": "1.31",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/teamd-1.31-2.el8.ppc64le.rpm",
+        "checksum": "sha256:de9a24cdb3260850b49086745ba6f724aecff0bf7993729ae063c116da6915a4",
+        "check_gpg": true
+      },
+      {
+        "name": "timedatex",
+        "epoch": 0,
+        "version": "0.5",
+        "release": "3.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/timedatex-0.5-3.el8.ppc64le.rpm",
+        "checksum": "sha256:9dc236a8124d1fcbb41b970b5a4c45d6f7f97430c933c775121cae27f5f352a7",
+        "check_gpg": true
+      },
+      {
+        "name": "tpm2-tss",
+        "epoch": 0,
+        "version": "2.3.2",
+        "release": "4.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/tpm2-tss-2.3.2-4.el8.ppc64le.rpm",
+        "checksum": "sha256:d46ef49f8ddba1ee8cce6c9764014851cce2dbfb5dcb2457a31495393e6566c1",
+        "check_gpg": true
+      },
+      {
+        "name": "trousers",
+        "epoch": 0,
+        "version": "0.3.15",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/trousers-0.3.15-1.el8.ppc64le.rpm",
+        "checksum": "sha256:4164089bf1754c0ef18ae051e047f11299907204839ad4b7978f146a543a2e91",
+        "check_gpg": true
+      },
+      {
+        "name": "trousers-lib",
+        "epoch": 0,
+        "version": "0.3.15",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/trousers-lib-0.3.15-1.el8.ppc64le.rpm",
+        "checksum": "sha256:09096bc32e37443417cd625364df32674f9d5ff4ddbeb175e6d60637ed3d573f",
+        "check_gpg": true
+      },
+      {
+        "name": "tuned",
+        "epoch": 0,
+        "version": "2.16.0",
+        "release": "1.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/tuned-2.16.0-1.el8.noarch.rpm",
+        "checksum": "sha256:654d9074dc8ebb93230fe258188a17ba3f7dbac2f360f9f79cc4fb1516953018",
+        "check_gpg": true
+      },
+      {
+        "name": "tzdata",
+        "epoch": 0,
+        "version": "2021a",
+        "release": "1.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/tzdata-2021a-1.el8.noarch.rpm",
+        "checksum": "sha256:44999c555a6e4bb6cf5e6f6a79819e76912d036732cb50efaeefc20a180dd839",
+        "check_gpg": true
+      },
+      {
+        "name": "util-linux",
+        "epoch": 0,
+        "version": "2.32.1",
+        "release": "28.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/util-linux-2.32.1-28.el8.ppc64le.rpm",
+        "checksum": "sha256:ce954d3900cb547aea14df6ad5f310ea96bb5e83a155b93e2e64b2c13b686193",
+        "check_gpg": true
+      },
+      {
+        "name": "vim-minimal",
+        "epoch": 2,
+        "version": "8.0.1763",
+        "release": "15.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/vim-minimal-8.0.1763-15.el8.ppc64le.rpm",
+        "checksum": "sha256:368779f00f427680d954899dd73ad3b6a59c42baafb91cb100ea177f51185198",
+        "check_gpg": true
+      },
+      {
+        "name": "virt-what",
+        "epoch": 0,
+        "version": "1.18",
+        "release": "12.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/virt-what-1.18-12.el8.ppc64le.rpm",
+        "checksum": "sha256:f0c20dff5211f9c133ad5703daedcbe148528c634b0a1eea7887b420da4dc00c",
+        "check_gpg": true
+      },
+      {
+        "name": "which",
+        "epoch": 0,
+        "version": "2.21",
+        "release": "16.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/which-2.21-16.el8.ppc64le.rpm",
+        "checksum": "sha256:15cd74b4ad9d82417072fe867f086d68667afd4291b710b6c7feef985c492990",
+        "check_gpg": true
+      },
+      {
+        "name": "xfsprogs",
+        "epoch": 0,
+        "version": "5.0.0",
+        "release": "9.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/xfsprogs-5.0.0-9.el8.ppc64le.rpm",
+        "checksum": "sha256:480e0f1a9dcce6ed0728e9aba709e33f5522273da1e4b0859cf9d3bbe2216532",
+        "check_gpg": true
+      },
+      {
+        "name": "xz",
+        "epoch": 0,
+        "version": "5.2.4",
+        "release": "3.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/xz-5.2.4-3.el8.ppc64le.rpm",
+        "checksum": "sha256:cd8b0adfc4d2467a61ab2aa2b3e617bbd2a2592176da249365eef014faef827c",
+        "check_gpg": true
+      },
+      {
+        "name": "xz-libs",
+        "epoch": 0,
+        "version": "5.2.4",
+        "release": "3.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/xz-libs-5.2.4-3.el8.ppc64le.rpm",
+        "checksum": "sha256:a4577841148e7e2bf481447ae141eff319007e70a24295a22787bbfaecf4c4fe",
+        "check_gpg": true
+      },
+      {
+        "name": "yum",
+        "epoch": 0,
+        "version": "4.7.0",
+        "release": "2.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/yum-4.7.0-2.el8.noarch.rpm",
+        "checksum": "sha256:bc3e4dd9194760500ce9731d792f46afa049667185487bae88c23a38fdb10c37",
+        "check_gpg": true
+      },
+      {
+        "name": "zlib",
+        "epoch": 0,
+        "version": "1.2.11",
+        "release": "17.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/zlib-1.2.11-17.el8.ppc64le.rpm",
+        "checksum": "sha256:33a92d88496e8aa410976f073e324f761b2ae02a94c20c0f291072df84f648be",
+        "check_gpg": true
+      },
+      {
+        "name": "libestr",
+        "epoch": 0,
+        "version": "0.1.10",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/libestr-0.1.10-1.el8.ppc64le.rpm",
+        "checksum": "sha256:e525544166da577edcd03c6596f1e8787a257caaa19eef98c3a481681d2d978a",
+        "check_gpg": true
+      },
+      {
+        "name": "libfastjson",
+        "epoch": 0,
+        "version": "0.99.9",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/libfastjson-0.99.9-1.el8.ppc64le.rpm",
+        "checksum": "sha256:b55df489f643b495984915a0671e74262192813e07cff5812d778c8cf4c0b9d1",
+        "check_gpg": true
+      },
+      {
+        "name": "libxkbcommon",
+        "epoch": 0,
+        "version": "0.9.1",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/libxkbcommon-0.9.1-1.el8.ppc64le.rpm",
+        "checksum": "sha256:b5bd11b47b5b690dc667dc486941331d7cd3aaa4f0e5c4d638ec7b294bcc5012",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Digest",
+        "epoch": 0,
+        "version": "1.17",
+        "release": "395.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/perl-Digest-1.17-395.el8.noarch.rpm",
+        "checksum": "sha256:7e67dba2509f90064325e62e49412d5284a55f09b7b6878b9c8222692c500dde",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Digest-MD5",
+        "epoch": 0,
+        "version": "2.55",
+        "release": "396.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/perl-Digest-MD5-2.55-396.el8.ppc64le.rpm",
+        "checksum": "sha256:9f1a745b208091d4b009ec321a6fdc72c8a5e89167effed81c50571a13f1c87d",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-IO-Socket-IP",
+        "epoch": 0,
+        "version": "0.39",
+        "release": "5.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/perl-IO-Socket-IP-0.39-5.el8.noarch.rpm",
+        "checksum": "sha256:c7dfa7d5a4917eed3b44af87ffb9c6e18242ecd847a8edd140bcdd178cc8946a",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-IO-Socket-SSL",
+        "epoch": 0,
+        "version": "2.066",
+        "release": "4.module_el8.4.0+517+be1595ff",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/perl-IO-Socket-SSL-2.066-4.module_el8.4.0+517+be1595ff.noarch.rpm",
+        "checksum": "sha256:46e371b6245113ebca446adcbd2db39f2887b67dc5a640f62f6d346ec9f6980f",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Mozilla-CA",
+        "epoch": 0,
+        "version": "20160104",
+        "release": "7.module_el8.3.0+416+dee7bcef",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/perl-Mozilla-CA-20160104-7.module_el8.3.0+416+dee7bcef.noarch.rpm",
+        "checksum": "sha256:cea5d052286c0a120f6cdd0f3e559f13b0eedf9f83d2538e4369b6e05526d43d",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Net-SSLeay",
+        "epoch": 0,
+        "version": "1.88",
+        "release": "1.module_el8.4.0+517+be1595ff",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/perl-Net-SSLeay-1.88-1.module_el8.4.0+517+be1595ff.ppc64le.rpm",
+        "checksum": "sha256:62da6a936871ab7b8c3efc0332fe41b4ac10ff96b357fb2bd67deecb312f9277",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-URI",
+        "epoch": 0,
+        "version": "1.73",
+        "release": "3.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/perl-URI-1.73-3.el8.noarch.rpm",
+        "checksum": "sha256:9feaf80c733951790bc3578db42ea2abef65643ebb36779e46dccdaf4c76b525",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-libnet",
+        "epoch": 0,
+        "version": "3.11",
+        "release": "3.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/perl-libnet-3.11-3.el8.noarch.rpm",
+        "checksum": "sha256:627d792d7cca1e97c121be5f0808c9da96f54d6c986622af246c60354b9c316e",
+        "check_gpg": true
+      },
+      {
+        "name": "pinentry",
+        "epoch": 0,
+        "version": "1.1.0",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/pinentry-1.1.0-2.el8.ppc64le.rpm",
+        "checksum": "sha256:12fda64dea45a7b085a35a816a7d8035be6600cae38f7df04a3bc22ced4d4502",
+        "check_gpg": true
+      },
+      {
+        "name": "plymouth",
+        "epoch": 0,
+        "version": "0.9.4",
+        "release": "9.20200615git1e36e30.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/plymouth-0.9.4-9.20200615git1e36e30.el8.ppc64le.rpm",
+        "checksum": "sha256:24a37dea79558196e493bfdf202f5e29503e266d9e944457d3fd212b41264466",
+        "check_gpg": true
+      },
+      {
+        "name": "plymouth-core-libs",
+        "epoch": 0,
+        "version": "0.9.4",
+        "release": "9.20200615git1e36e30.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/plymouth-core-libs-0.9.4-9.20200615git1e36e30.el8.ppc64le.rpm",
+        "checksum": "sha256:a3430017f322fd147130a5572e4f1d357950d304aeef07c8c640be0dfe63b627",
+        "check_gpg": true
+      },
+      {
+        "name": "plymouth-scripts",
+        "epoch": 0,
+        "version": "0.9.4",
+        "release": "9.20200615git1e36e30.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/plymouth-scripts-0.9.4-9.20200615git1e36e30.el8.ppc64le.rpm",
+        "checksum": "sha256:f342cdc282518eab3c87bc964306092b77eeeed8ca1d815272f6d4e3431c9037",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-unbound",
+        "epoch": 0,
+        "version": "1.7.3",
+        "release": "17.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/python3-unbound-1.7.3-17.el8.ppc64le.rpm",
+        "checksum": "sha256:8571a2aa115d42f8b5e87ef58d10e9c24e6fbe5470fc2612df96f8740f3d960f",
+        "check_gpg": true
+      },
+      {
+        "name": "rsyslog",
+        "epoch": 0,
+        "version": "8.2102.0",
+        "release": "5.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/rsyslog-8.2102.0-5.el8.ppc64le.rpm",
+        "checksum": "sha256:8945279d57ad510e018f92571ba8e5d811cf8a3165adf930b0d4015c5a077a35",
+        "check_gpg": true
+      },
+      {
+        "name": "unbound-libs",
+        "epoch": 0,
+        "version": "1.7.3",
+        "release": "17.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/unbound-libs-1.7.3-17.el8.ppc64le.rpm",
+        "checksum": "sha256:ebd64ac5cc7b9f58a40072fe9afefa2fd835e0eb18cdeaf085395c7e84affac3",
+        "check_gpg": true
+      },
+      {
+        "name": "xkeyboard-config",
+        "epoch": 0,
+        "version": "2.28",
+        "release": "1.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/xkeyboard-config-2.28-1.el8.noarch.rpm",
+        "checksum": "sha256:a2aeabb3962859069a78acc288bc3bffb35485428e162caafec8134f5ce6ca67",
+        "check_gpg": true
+      }
+    ],
+    "build": [
+      {
+        "name": "acl",
+        "epoch": 0,
+        "version": "2.2.53",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/acl-2.2.53-1.el8.ppc64le.rpm",
+        "checksum": "sha256:2c1baefd0f802507d9741da8da54f6eae42b04967f9d433d7f9e0f124434c70d",
+        "check_gpg": true
+      },
+      {
+        "name": "audit-libs",
+        "epoch": 0,
+        "version": "3.0",
+        "release": "0.17.20191104git1c2f876.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/audit-libs-3.0-0.17.20191104git1c2f876.el8.ppc64le.rpm",
+        "checksum": "sha256:be49b69bc5de947ee2151f397993a691a57bc53952058c32cde0fca674da7d8c",
+        "check_gpg": true
+      },
+      {
+        "name": "basesystem",
+        "epoch": 0,
+        "version": "11",
+        "release": "5.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/basesystem-11-5.el8.noarch.rpm",
+        "checksum": "sha256:48226934763e4c412c1eb65df314e6879720b4b1ebcb3d07c126c9526639cb68",
+        "check_gpg": true
+      },
+      {
+        "name": "bash",
+        "epoch": 0,
+        "version": "4.4.20",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/bash-4.4.20-2.el8.ppc64le.rpm",
+        "checksum": "sha256:3a438b53e8377eccf90cac0fd42ed2b513fc869bfb7b96e3d2a4f6984a287f90",
+        "check_gpg": true
+      },
+      {
+        "name": "brotli",
+        "epoch": 0,
+        "version": "1.0.6",
+        "release": "3.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/brotli-1.0.6-3.el8.ppc64le.rpm",
+        "checksum": "sha256:8729b157f0925feccdaef8aacd91c6aebe0109e621675bcc15e1830673b0e19d",
+        "check_gpg": true
+      },
+      {
+        "name": "bzip2-libs",
+        "epoch": 0,
+        "version": "1.0.6",
+        "release": "26.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/bzip2-libs-1.0.6-26.el8.ppc64le.rpm",
+        "checksum": "sha256:56c3d429ea949467dc0bca882646cf40a58fb6f27750f5664ff2919f5d38ada5",
+        "check_gpg": true
+      },
+      {
+        "name": "ca-certificates",
+        "epoch": 0,
+        "version": "2021.2.50",
+        "release": "82.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/ca-certificates-2021.2.50-82.el8.noarch.rpm",
+        "checksum": "sha256:1fad1d1f8b56e6967863aeb60f5fa3615e6a35b0f6532d8a23066e6823b50860",
+        "check_gpg": true
+      },
+      {
+        "name": "centos-gpg-keys",
+        "epoch": 1,
+        "version": "8",
+        "release": "2.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/centos-gpg-keys-8-2.el8.noarch.rpm",
+        "checksum": "sha256:842ff55b80ac9a5c3357bf52646a5761a4c4786bb3e64b56d8fa5d8fe34ef8bb",
+        "check_gpg": true
+      },
+      {
+        "name": "centos-stream-release",
+        "epoch": 0,
+        "version": "8.5",
+        "release": "3.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/centos-stream-release-8.5-3.el8.noarch.rpm",
+        "checksum": "sha256:15b17b95cf9cb9fb64e0c8e56110836bdcaf70de81b8cbdb60e181fc90456e06",
+        "check_gpg": true
+      },
+      {
+        "name": "centos-stream-repos",
+        "epoch": 0,
+        "version": "8",
+        "release": "2.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/centos-stream-repos-8-2.el8.noarch.rpm",
+        "checksum": "sha256:a82958266d292f4725fc1981ea57a861b7fc7feeb7a9551d0b61b98ca51a5662",
+        "check_gpg": true
+      },
+      {
+        "name": "chkconfig",
+        "epoch": 0,
+        "version": "1.19.1",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/chkconfig-1.19.1-1.el8.ppc64le.rpm",
+        "checksum": "sha256:eee92733e8989029929d5cb1f673b15fdb814dac32e148d5bc02378b44c8699a",
+        "check_gpg": true
+      },
+      {
+        "name": "coreutils",
+        "epoch": 0,
+        "version": "8.30",
+        "release": "12.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/coreutils-8.30-12.el8.ppc64le.rpm",
+        "checksum": "sha256:ff8b51c6a8bacc5ef6b5da0f049d170ab1c1ecebad50ded3c04ed384eca9a2c0",
+        "check_gpg": true
+      },
+      {
+        "name": "coreutils-common",
+        "epoch": 0,
+        "version": "8.30",
+        "release": "12.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/coreutils-common-8.30-12.el8.ppc64le.rpm",
+        "checksum": "sha256:383a5e6bb9e94de53baaf5c7493cd50a68c893c6a30acfbe28407d33bb133efc",
+        "check_gpg": true
+      },
+      {
+        "name": "cpio",
+        "epoch": 0,
+        "version": "2.12",
+        "release": "10.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/cpio-2.12-10.el8.ppc64le.rpm",
+        "checksum": "sha256:19061d12407c0c4bca6abcaef01695b70dcd3967ff102dd07178a2193a280e29",
+        "check_gpg": true
+      },
+      {
+        "name": "cracklib",
+        "epoch": 0,
+        "version": "2.9.6",
+        "release": "15.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/cracklib-2.9.6-15.el8.ppc64le.rpm",
+        "checksum": "sha256:4e3e93a3d2039c2a8305030b7960bd1100d7d20705a1afb1325a4ee79478a74a",
+        "check_gpg": true
+      },
+      {
+        "name": "cracklib-dicts",
+        "epoch": 0,
+        "version": "2.9.6",
+        "release": "15.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/cracklib-dicts-2.9.6-15.el8.ppc64le.rpm",
+        "checksum": "sha256:084d79ed3d7127e6d46e9ac6e654d8ef181a156435808dc8eb32968b6c1b4946",
+        "check_gpg": true
+      },
+      {
+        "name": "crypto-policies",
+        "epoch": 0,
+        "version": "20210617",
+        "release": "1.gitc776d3e.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/crypto-policies-20210617-1.gitc776d3e.el8.noarch.rpm",
+        "checksum": "sha256:2a8f9e5119a034801904185dcbf1bc29db67e9e9b0cf5893615722d7bb33099c",
+        "check_gpg": true
+      },
+      {
+        "name": "crypto-policies-scripts",
+        "epoch": 0,
+        "version": "20210617",
+        "release": "1.gitc776d3e.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/crypto-policies-scripts-20210617-1.gitc776d3e.el8.noarch.rpm",
+        "checksum": "sha256:67f37cee02ba744dfc7957725f5ef9df229778f6a2f7afc659625b458da6167e",
+        "check_gpg": true
+      },
+      {
+        "name": "cryptsetup-libs",
+        "epoch": 0,
+        "version": "2.3.3",
+        "release": "4.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/cryptsetup-libs-2.3.3-4.el8.ppc64le.rpm",
+        "checksum": "sha256:b10d8521963a2494fdb2b5f8fb0de837dc86d4016c3b10019fb8970a09582451",
+        "check_gpg": true
+      },
+      {
+        "name": "curl",
+        "epoch": 0,
+        "version": "7.61.1",
+        "release": "18.el8_4.1",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/curl-7.61.1-18.el8_4.1.ppc64le.rpm",
+        "checksum": "sha256:47ad43730c8bc72c90f2fb3dbd3526d716ada2fad94e62cb443658e94c6503c5",
+        "check_gpg": true
+      },
+      {
+        "name": "cyrus-sasl-lib",
+        "epoch": 0,
+        "version": "2.1.27",
+        "release": "5.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/cyrus-sasl-lib-2.1.27-5.el8.ppc64le.rpm",
+        "checksum": "sha256:5c1940e1f173e22b053f3a89022903cea34a6af20dff81c65548c4e2ba3a8293",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus",
+        "epoch": 1,
+        "version": "1.12.8",
+        "release": "14.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/dbus-1.12.8-14.el8.ppc64le.rpm",
+        "checksum": "sha256:1a4e44583a767289bb0d354db93c6a9132420e13376d4fcae866d69620bb11bb",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-common",
+        "epoch": 1,
+        "version": "1.12.8",
+        "release": "14.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/dbus-common-1.12.8-14.el8.noarch.rpm",
+        "checksum": "sha256:7baac88adafdc5958fb818c7685d3c6548f6e2e585e4435ceee4a168edc3597e",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-daemon",
+        "epoch": 1,
+        "version": "1.12.8",
+        "release": "14.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/dbus-daemon-1.12.8-14.el8.ppc64le.rpm",
+        "checksum": "sha256:090563f18409c228274bb61dcf1001f63a55c1246fb2838a998cb3c5fd8c3874",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-glib",
+        "epoch": 0,
+        "version": "0.110",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/dbus-glib-0.110-2.el8.ppc64le.rpm",
+        "checksum": "sha256:c58b0b900a7ffc778980461d74dc236bf2c790d2e5e8c04e28876e221b48a1c8",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-libs",
+        "epoch": 1,
+        "version": "1.12.8",
+        "release": "14.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/dbus-libs-1.12.8-14.el8.ppc64le.rpm",
+        "checksum": "sha256:cc5f8dd4e061da3a73aa67112e24f2cc5c0ad0cd4334dc798b8834cf6259a779",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-tools",
+        "epoch": 1,
+        "version": "1.12.8",
+        "release": "14.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/dbus-tools-1.12.8-14.el8.ppc64le.rpm",
+        "checksum": "sha256:698e8ecaf71719dafacae79de05080d567b69fad3511e8b8d42b9af96a7c41db",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper",
+        "epoch": 8,
+        "version": "1.02.177",
+        "release": "6.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/device-mapper-1.02.177-6.el8.ppc64le.rpm",
+        "checksum": "sha256:441b3862f5a0fd504bbbba18d96d1b2b920fb95a79dc45a753a6a664ad285b07",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper-libs",
+        "epoch": 8,
+        "version": "1.02.177",
+        "release": "6.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/device-mapper-libs-1.02.177-6.el8.ppc64le.rpm",
+        "checksum": "sha256:a42de8ce71380b1f4e8ac5b4ce720bf565c99a0b09ef983c0550a91a467bc155",
+        "check_gpg": true
+      },
+      {
+        "name": "diffutils",
+        "epoch": 0,
+        "version": "3.6",
+        "release": "6.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/diffutils-3.6-6.el8.ppc64le.rpm",
+        "checksum": "sha256:4f92835a6e4ee4276df49019e068d1871b75821f52b405c699bd9f199df58b80",
+        "check_gpg": true
+      },
+      {
+        "name": "dnf",
+        "epoch": 0,
+        "version": "4.7.0",
+        "release": "2.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/dnf-4.7.0-2.el8.noarch.rpm",
+        "checksum": "sha256:42464424b9fa731f8122fe748aad0005519fc87b770dbbdb71f29f514ea0e889",
+        "check_gpg": true
+      },
+      {
+        "name": "dnf-data",
+        "epoch": 0,
+        "version": "4.7.0",
+        "release": "2.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/dnf-data-4.7.0-2.el8.noarch.rpm",
+        "checksum": "sha256:45c48d32120739734ae97479cc0f3ca19796ea47e360ba39d52b77ce3ada61d7",
+        "check_gpg": true
+      },
+      {
+        "name": "dosfstools",
+        "epoch": 0,
+        "version": "4.1",
+        "release": "6.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/dosfstools-4.1-6.el8.ppc64le.rpm",
+        "checksum": "sha256:04eee0a9c079186aa58b5536ac8bcbd2a360700b83fa7b9f6eb127c1386b7ef4",
+        "check_gpg": true
+      },
+      {
+        "name": "dracut",
+        "epoch": 0,
+        "version": "049",
+        "release": "188.git20210802.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/dracut-049-188.git20210802.el8.ppc64le.rpm",
+        "checksum": "sha256:881b28a3a37d114bc3f046605b24663560009b13a507217e007643f5682efdd5",
+        "check_gpg": true
+      },
+      {
+        "name": "e2fsprogs",
+        "epoch": 0,
+        "version": "1.45.6",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/e2fsprogs-1.45.6-2.el8.ppc64le.rpm",
+        "checksum": "sha256:9e67ac5948125dd165c9a74ec848d48b313ef4264bbbb89630a782dbd972d72c",
+        "check_gpg": true
+      },
+      {
+        "name": "e2fsprogs-libs",
+        "epoch": 0,
+        "version": "1.45.6",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/e2fsprogs-libs-1.45.6-2.el8.ppc64le.rpm",
+        "checksum": "sha256:9fb07c2324cccbbc19e3ffade50ee7da41909b2f6c24f49ffd9978ba375de193",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-debuginfod-client",
+        "epoch": 0,
+        "version": "0.185",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/elfutils-debuginfod-client-0.185-1.el8.ppc64le.rpm",
+        "checksum": "sha256:f4eca686b314edb06d3fe1c526f573c7248c811af70cba76132cdc9c541cadc1",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-default-yama-scope",
+        "epoch": 0,
+        "version": "0.185",
+        "release": "1.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/elfutils-default-yama-scope-0.185-1.el8.noarch.rpm",
+        "checksum": "sha256:30ceeb5a6cadaeccdbde088bfb52ba88190fa530c11f4a2aafd62b4b4ad6b404",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-libelf",
+        "epoch": 0,
+        "version": "0.185",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/elfutils-libelf-0.185-1.el8.ppc64le.rpm",
+        "checksum": "sha256:e87acf226a9511b3a5f83e7fed9c5c20addbbdae47ab67c614404a9392b77e50",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-libs",
+        "epoch": 0,
+        "version": "0.185",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/elfutils-libs-0.185-1.el8.ppc64le.rpm",
+        "checksum": "sha256:d150e53fa73c3786da9e4f6e23d374100b0dd2923485d4a08e9a56ac2786cf83",
+        "check_gpg": true
+      },
+      {
+        "name": "expat",
+        "epoch": 0,
+        "version": "2.2.5",
+        "release": "4.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/expat-2.2.5-4.el8.ppc64le.rpm",
+        "checksum": "sha256:88be5116908aa5013f540c767f6811774342780bb72d3ec197b3429bfb2f9862",
+        "check_gpg": true
+      },
+      {
+        "name": "file",
+        "epoch": 0,
+        "version": "5.33",
+        "release": "20.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/file-5.33-20.el8.ppc64le.rpm",
+        "checksum": "sha256:e156e6fa9ef6a483f8505ce0eeadbcab12b887c4996233ce5d6258076f6bce50",
+        "check_gpg": true
+      },
+      {
+        "name": "file-libs",
+        "epoch": 0,
+        "version": "5.33",
+        "release": "20.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/file-libs-5.33-20.el8.ppc64le.rpm",
+        "checksum": "sha256:e65f7d7c8def6b168e013914bc0d1137aed65c3010e9796df3b823854472f3e1",
+        "check_gpg": true
+      },
+      {
+        "name": "filesystem",
+        "epoch": 0,
+        "version": "3.8",
+        "release": "6.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/filesystem-3.8-6.el8.ppc64le.rpm",
+        "checksum": "sha256:a49b922f117b9bfb0b07e9848151f8a2948345328ebc534cd28ac187d7ed3f94",
+        "check_gpg": true
+      },
+      {
+        "name": "findutils",
+        "epoch": 1,
+        "version": "4.6.0",
+        "release": "20.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/findutils-4.6.0-20.el8.ppc64le.rpm",
+        "checksum": "sha256:caa0bd6617a8d5e535faedec5f6f3ea7c5e6da1898751f6c9c34a89a95c286ff",
+        "check_gpg": true
+      },
+      {
+        "name": "freetype",
+        "epoch": 0,
+        "version": "2.9.1",
+        "release": "4.el8_3.1",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/freetype-2.9.1-4.el8_3.1.ppc64le.rpm",
+        "checksum": "sha256:d1cf2d973db2f1af46f124776b9ab4bd782e7065c8c8428a4ddef60989e4225d",
+        "check_gpg": true
+      },
+      {
+        "name": "fuse-libs",
+        "epoch": 0,
+        "version": "2.9.7",
+        "release": "12.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/fuse-libs-2.9.7-12.el8.ppc64le.rpm",
+        "checksum": "sha256:4992eb036c0797daf9b984af1a34fe27a30287ee5d2bd5e2f5a0df3a09bdbb59",
+        "check_gpg": true
+      },
+      {
+        "name": "gawk",
+        "epoch": 0,
+        "version": "4.2.1",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/gawk-4.2.1-2.el8.ppc64le.rpm",
+        "checksum": "sha256:d807e7fb8bf24be50642a6dced954c6ea208199daab2d27c9f73d789ba82fa37",
+        "check_gpg": true
+      },
+      {
+        "name": "gdbm",
+        "epoch": 1,
+        "version": "1.18",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/gdbm-1.18-1.el8.ppc64le.rpm",
+        "checksum": "sha256:8cd6ef9902851f07cfd9682e2d6873648690f0c2ec65345276b557ede042d8b9",
+        "check_gpg": true
+      },
+      {
+        "name": "gdbm-libs",
+        "epoch": 1,
+        "version": "1.18",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/gdbm-libs-1.18-1.el8.ppc64le.rpm",
+        "checksum": "sha256:d1d362fd4f8022ad05171efe40e84d15ec6c5e5f419d6099ebc8e46e7da632c1",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext",
+        "epoch": 0,
+        "version": "0.19.8.1",
+        "release": "17.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/gettext-0.19.8.1-17.el8.ppc64le.rpm",
+        "checksum": "sha256:78fd472a1c7f49b8a432788ea2dfc1119f155a394f41585b4e715d2585fc92ab",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext-libs",
+        "epoch": 0,
+        "version": "0.19.8.1",
+        "release": "17.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/gettext-libs-0.19.8.1-17.el8.ppc64le.rpm",
+        "checksum": "sha256:e392a6b41381ffad04626d092fd2af9477c72e197a74efddf987832c3bfa521f",
+        "check_gpg": true
+      },
+      {
+        "name": "glib2",
+        "epoch": 0,
+        "version": "2.56.4",
+        "release": "156.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/glib2-2.56.4-156.el8.ppc64le.rpm",
+        "checksum": "sha256:ad338b7a3f3bed96300d9ce7f0307e09d758962b8496c10fb3554bf62405d153",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc",
+        "epoch": 0,
+        "version": "2.28",
+        "release": "162.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/glibc-2.28-162.el8.ppc64le.rpm",
+        "checksum": "sha256:bfb45644212cfbbe48b05149f8d53e77d7bd02ca9fc9045cc37115101175a3a0",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-all-langpacks",
+        "epoch": 0,
+        "version": "2.28",
+        "release": "162.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/glibc-all-langpacks-2.28-162.el8.ppc64le.rpm",
+        "checksum": "sha256:fa7bef727ba8657208bb3df95916f0bc912332cb8534c695facef32ffbd72f20",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-common",
+        "epoch": 0,
+        "version": "2.28",
+        "release": "162.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/glibc-common-2.28-162.el8.ppc64le.rpm",
+        "checksum": "sha256:257e086bb52086254fa8cc95a5c4998668b4fcb5203ad3c2275c1150816acc9b",
+        "check_gpg": true
+      },
+      {
+        "name": "gmp",
+        "epoch": 1,
+        "version": "6.1.2",
+        "release": "10.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/gmp-6.1.2-10.el8.ppc64le.rpm",
+        "checksum": "sha256:af0a4287e302baa7c85655ddfe5a7049b8eaf31aff03886f4fc57c920d26d491",
+        "check_gpg": true
+      },
+      {
+        "name": "gnupg2",
+        "epoch": 0,
+        "version": "2.2.20",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/gnupg2-2.2.20-2.el8.ppc64le.rpm",
+        "checksum": "sha256:11ff811a72c82084c7c14700b23d29643e153442a34b3b486e270e5b40e38d0a",
+        "check_gpg": true
+      },
+      {
+        "name": "gnupg2-smime",
+        "epoch": 0,
+        "version": "2.2.20",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/gnupg2-smime-2.2.20-2.el8.ppc64le.rpm",
+        "checksum": "sha256:a2d96efed83ab31d21481af044835a940673ee4ade2763af78c06d2df87b94f7",
+        "check_gpg": true
+      },
+      {
+        "name": "gnutls",
+        "epoch": 0,
+        "version": "3.6.16",
+        "release": "4.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/gnutls-3.6.16-4.el8.ppc64le.rpm",
+        "checksum": "sha256:51760acfb6ca87db5be7a9296d6a3d1220767956c576a26c6d46784e25db85bb",
+        "check_gpg": true
+      },
+      {
+        "name": "gpgme",
+        "epoch": 0,
+        "version": "1.13.1",
+        "release": "9.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/gpgme-1.13.1-9.el8.ppc64le.rpm",
+        "checksum": "sha256:24f5cd46a7395cd046b10d6ddc4de435ec6595d0dcdb2d179c94cc9082a12f14",
+        "check_gpg": true
+      },
+      {
+        "name": "grep",
+        "epoch": 0,
+        "version": "3.1",
+        "release": "6.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/grep-3.1-6.el8.ppc64le.rpm",
+        "checksum": "sha256:2451a475f248a4c66e64d149fefa8bfc195fcd7b3f369bae221a94f8ce4c2d67",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-common",
+        "epoch": 1,
+        "version": "2.02",
+        "release": "99.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/grub2-common-2.02-99.el8.noarch.rpm",
+        "checksum": "sha256:4a08d5264e865548e65d31886c91b659b33a2c2ba39fd115b00af3ea0bc91a83",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-ppc64le",
+        "epoch": 1,
+        "version": "2.02",
+        "release": "99.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/grub2-ppc64le-2.02-99.el8.ppc64le.rpm",
+        "checksum": "sha256:7cccedcc359f2a2542858088704bf3d0ec3e46cb7b72f602408fbab937a522d3",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-ppc64le-modules",
+        "epoch": 1,
+        "version": "2.02",
+        "release": "99.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/grub2-ppc64le-modules-2.02-99.el8.noarch.rpm",
+        "checksum": "sha256:d8dad22276baffe9496d5e05ef35d21dd6f9d8f910339daced2c3ff42d7a28c5",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-tools",
+        "epoch": 1,
+        "version": "2.02",
+        "release": "99.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/grub2-tools-2.02-99.el8.ppc64le.rpm",
+        "checksum": "sha256:78b2b9cbf041d4461daf7ac11a24d1e79a9c57f47aa265dba4d09067efe3d96b",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-tools-extra",
+        "epoch": 1,
+        "version": "2.02",
+        "release": "99.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/grub2-tools-extra-2.02-99.el8.ppc64le.rpm",
+        "checksum": "sha256:ac3b306c193bd20658950da402ae0cbdd8337110117de5e5d7eba970822671fd",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-tools-minimal",
+        "epoch": 1,
+        "version": "2.02",
+        "release": "99.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/grub2-tools-minimal-2.02-99.el8.ppc64le.rpm",
+        "checksum": "sha256:fb276cc0ebc6bd27d344f7e0811f26cb3f0e59da09182489095724bdf2a075f8",
+        "check_gpg": true
+      },
+      {
+        "name": "grubby",
+        "epoch": 0,
+        "version": "8.40",
+        "release": "41.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/grubby-8.40-41.el8.ppc64le.rpm",
+        "checksum": "sha256:5a0927d231fbafa8b865591922fc07d39d9b4b263a1e9c0bbef691282f706cd0",
+        "check_gpg": true
+      },
+      {
+        "name": "gzip",
+        "epoch": 0,
+        "version": "1.9",
+        "release": "12.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/gzip-1.9-12.el8.ppc64le.rpm",
+        "checksum": "sha256:e1e28504928648404a3b652440091eba010cd99221183ef78601cbd152261d91",
+        "check_gpg": true
+      },
+      {
+        "name": "hardlink",
+        "epoch": 1,
+        "version": "1.3",
+        "release": "6.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/hardlink-1.3-6.el8.ppc64le.rpm",
+        "checksum": "sha256:42bb566be1936bdb40937f9c0a96c4acc93057379385f1807cba18f60443d3e4",
+        "check_gpg": true
+      },
+      {
+        "name": "ima-evm-utils",
+        "epoch": 0,
+        "version": "1.3.2",
+        "release": "12.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/ima-evm-utils-1.3.2-12.el8.ppc64le.rpm",
+        "checksum": "sha256:8119d276749b35cd9c283c1a8d970b3528bea58427eb37eafc22b6093a978f08",
+        "check_gpg": true
+      },
+      {
+        "name": "info",
+        "epoch": 0,
+        "version": "6.5",
+        "release": "6.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/info-6.5-6.el8.ppc64le.rpm",
+        "checksum": "sha256:6d1ac29b3a38408f6d238d6718384e05be7346789c6200b354335b0e0c9c77df",
+        "check_gpg": true
+      },
+      {
+        "name": "json-c",
+        "epoch": 0,
+        "version": "0.13.1",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/json-c-0.13.1-2.el8.ppc64le.rpm",
+        "checksum": "sha256:331b91a0928c05618c7fed3e12bbe9ecb9e4619d08c7e85d3de344a08d2f0f1a",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd",
+        "epoch": 0,
+        "version": "2.0.4",
+        "release": "10.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/kbd-2.0.4-10.el8.ppc64le.rpm",
+        "checksum": "sha256:49c7c718cb4e2b6f0effd0dec4f4cb4e109d260c192b2b329a58a1da9a24ad1d",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd-legacy",
+        "epoch": 0,
+        "version": "2.0.4",
+        "release": "10.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/kbd-legacy-2.0.4-10.el8.noarch.rpm",
+        "checksum": "sha256:a3ef96219165bfc64d4f5d50f51fbd43e803c500619240ffe4db1f9f8e337f83",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd-misc",
+        "epoch": 0,
+        "version": "2.0.4",
+        "release": "10.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/kbd-misc-2.0.4-10.el8.noarch.rpm",
+        "checksum": "sha256:ef86061338fa321c959cadc75ecbdfd405eebaa1042eec9d9c737d4d9d92568f",
+        "check_gpg": true
+      },
+      {
+        "name": "keyutils-libs",
+        "epoch": 0,
+        "version": "1.5.10",
+        "release": "9.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/keyutils-libs-1.5.10-9.el8.ppc64le.rpm",
+        "checksum": "sha256:6fe1188081e441595ce29ebed4d1985e5890815158244f69f092ee930656f755",
+        "check_gpg": true
+      },
+      {
+        "name": "kmod",
+        "epoch": 0,
+        "version": "25",
+        "release": "18.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/kmod-25-18.el8.ppc64le.rpm",
+        "checksum": "sha256:a80c1d6d32db7ce8fdd58bb4f3f488b74e94261a38512dc8a15179ae33697e63",
+        "check_gpg": true
+      },
+      {
+        "name": "kmod-libs",
+        "epoch": 0,
+        "version": "25",
+        "release": "18.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/kmod-libs-25-18.el8.ppc64le.rpm",
+        "checksum": "sha256:b437a08d4670ef440ba6dbaae4ccb39f989f0c2a3d280ea66d6fd9532a313286",
+        "check_gpg": true
+      },
+      {
+        "name": "kpartx",
+        "epoch": 0,
+        "version": "0.8.4",
+        "release": "17.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/kpartx-0.8.4-17.el8.ppc64le.rpm",
+        "checksum": "sha256:230731b577f8d29e7e8e8fd6d1ea02702fb4364fcc7034d838ccddc4d66da8c3",
+        "check_gpg": true
+      },
+      {
+        "name": "krb5-libs",
+        "epoch": 0,
+        "version": "1.18.2",
+        "release": "13.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/krb5-libs-1.18.2-13.el8.ppc64le.rpm",
+        "checksum": "sha256:54f59ddb56e89a5330373e07ea05934fc58360eb7480615ede2a3ed6982e1eef",
+        "check_gpg": true
+      },
+      {
+        "name": "libacl",
+        "epoch": 0,
+        "version": "2.2.53",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libacl-2.2.53-1.el8.ppc64le.rpm",
+        "checksum": "sha256:ff1580bd4ec5841d4937b383917fa30f318b4f419b8067a77468eb4a9630ba10",
+        "check_gpg": true
+      },
+      {
+        "name": "libaio",
+        "epoch": 0,
+        "version": "0.3.112",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libaio-0.3.112-1.el8.ppc64le.rpm",
+        "checksum": "sha256:3303f41952491bad2b31ee507eaabaf13dabe5ec9624c4b58a4a8301c4cd89dd",
+        "check_gpg": true
+      },
+      {
+        "name": "libarchive",
+        "epoch": 0,
+        "version": "3.3.3",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libarchive-3.3.3-1.el8.ppc64le.rpm",
+        "checksum": "sha256:df40cada982b04336fe8b250b4fdd576ddd03a014bb519a69b34640369bef661",
+        "check_gpg": true
+      },
+      {
+        "name": "libassuan",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "3.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libassuan-2.5.1-3.el8.ppc64le.rpm",
+        "checksum": "sha256:9c4cd61b98253904436180f58c564bda61be1fa1b5523e4ecbbdc174d0c2a9aa",
+        "check_gpg": true
+      },
+      {
+        "name": "libattr",
+        "epoch": 0,
+        "version": "2.4.48",
+        "release": "3.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libattr-2.4.48-3.el8.ppc64le.rpm",
+        "checksum": "sha256:43bfc890caf7855f2fb55c24474b58cd5c8c7b51e4db4f40d1f302fffd31985b",
+        "check_gpg": true
+      },
+      {
+        "name": "libblkid",
+        "epoch": 0,
+        "version": "2.32.1",
+        "release": "28.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libblkid-2.32.1-28.el8.ppc64le.rpm",
+        "checksum": "sha256:30ae4489980021a727f247d48b4d74d4c6c7667d00bd1a670f045ea24a885541",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap",
+        "epoch": 0,
+        "version": "2.26",
+        "release": "4.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libcap-2.26-4.el8.ppc64le.rpm",
+        "checksum": "sha256:77e4cfbc823e3764308822ccf03b257861f9360f3b948829f1d73148b321b00e",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap-ng",
+        "epoch": 0,
+        "version": "0.7.11",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libcap-ng-0.7.11-1.el8.ppc64le.rpm",
+        "checksum": "sha256:9b69a221cf9395a110849bb428bb1cfe9fb489322df0fa6017f5978a827ee0e9",
+        "check_gpg": true
+      },
+      {
+        "name": "libcom_err",
+        "epoch": 0,
+        "version": "1.45.6",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libcom_err-1.45.6-2.el8.ppc64le.rpm",
+        "checksum": "sha256:e0a7b9f3b56b4737f5711dc6b03f256fbf2488656b8874acabb494b58ba0c1c1",
+        "check_gpg": true
+      },
+      {
+        "name": "libcomps",
+        "epoch": 0,
+        "version": "0.1.16",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libcomps-0.1.16-2.el8.ppc64le.rpm",
+        "checksum": "sha256:5c74a0e3005ea3cb90dff80cfa1e7d64c97f5c01612d253cf4e65aca962b7be4",
+        "check_gpg": true
+      },
+      {
+        "name": "libcroco",
+        "epoch": 0,
+        "version": "0.6.12",
+        "release": "4.el8_2.1",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libcroco-0.6.12-4.el8_2.1.ppc64le.rpm",
+        "checksum": "sha256:194dbe332ccdb33d58f040da07667257e176975f6b2f17343bbf33fb99deb097",
+        "check_gpg": true
+      },
+      {
+        "name": "libcurl",
+        "epoch": 0,
+        "version": "7.61.1",
+        "release": "18.el8_4.1",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libcurl-7.61.1-18.el8_4.1.ppc64le.rpm",
+        "checksum": "sha256:e21a84107568047432e474e08da24aea2340409d57ea8cf170182927dc76de12",
+        "check_gpg": true
+      },
+      {
+        "name": "libdb",
+        "epoch": 0,
+        "version": "5.3.28",
+        "release": "40.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libdb-5.3.28-40.el8.ppc64le.rpm",
+        "checksum": "sha256:b83a0199c3d471151f07f6de626a1a4a362dd6aa29d84cf1c0ada2c966ce29c9",
+        "check_gpg": true
+      },
+      {
+        "name": "libdb-utils",
+        "epoch": 0,
+        "version": "5.3.28",
+        "release": "40.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libdb-utils-5.3.28-40.el8.ppc64le.rpm",
+        "checksum": "sha256:709ea71f36495ac2ac89d72d2eb603b6aa55b2c1a70633f23514dd897936f02b",
+        "check_gpg": true
+      },
+      {
+        "name": "libdnf",
+        "epoch": 0,
+        "version": "0.63.0",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libdnf-0.63.0-2.el8.ppc64le.rpm",
+        "checksum": "sha256:aea253461d1a34a239b445ee07cb34398a9cbb6ed40e252182a91cddcf59004b",
+        "check_gpg": true
+      },
+      {
+        "name": "libevent",
+        "epoch": 0,
+        "version": "2.1.8",
+        "release": "5.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libevent-2.1.8-5.el8.ppc64le.rpm",
+        "checksum": "sha256:a0b8a6b2c8dad75290228086dd0af342979604bbf4b9500029e25d766835c0f4",
+        "check_gpg": true
+      },
+      {
+        "name": "libfdisk",
+        "epoch": 0,
+        "version": "2.32.1",
+        "release": "28.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libfdisk-2.32.1-28.el8.ppc64le.rpm",
+        "checksum": "sha256:0afac6f4f9ed1c59510675d87da45c7966c0f7aae6e8dd056961aceed8c4fe0a",
+        "check_gpg": true
+      },
+      {
+        "name": "libffi",
+        "epoch": 0,
+        "version": "3.1",
+        "release": "22.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libffi-3.1-22.el8.ppc64le.rpm",
+        "checksum": "sha256:12696f5638ad2068c5c8940495d15c3bb1c57990000dbda7428b008e9e63ab5b",
+        "check_gpg": true
+      },
+      {
+        "name": "libgcc",
+        "epoch": 0,
+        "version": "8.5.0",
+        "release": "3.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libgcc-8.5.0-3.el8.ppc64le.rpm",
+        "checksum": "sha256:f3d9ccb762146dc97f2d201d979fbb0e9171d1203fb985f3ef48b5c2a176c2a9",
+        "check_gpg": true
+      },
+      {
+        "name": "libgcrypt",
+        "epoch": 0,
+        "version": "1.8.5",
+        "release": "6.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libgcrypt-1.8.5-6.el8.ppc64le.rpm",
+        "checksum": "sha256:c5a60ffb80cd1f9b90c797f1d1ac80e5536eb32a5b276871445e7279ac701c5f",
+        "check_gpg": true
+      },
+      {
+        "name": "libgomp",
+        "epoch": 0,
+        "version": "8.5.0",
+        "release": "3.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libgomp-8.5.0-3.el8.ppc64le.rpm",
+        "checksum": "sha256:0515afdac097ad54cf4b24e0644f0789cab5535a54107aa44940ffd991a6cef3",
+        "check_gpg": true
+      },
+      {
+        "name": "libgpg-error",
+        "epoch": 0,
+        "version": "1.31",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libgpg-error-1.31-1.el8.ppc64le.rpm",
+        "checksum": "sha256:020abac486839c7be29fae37a686dc7749398c333cb8ba94b3390b386ffcbff7",
+        "check_gpg": true
+      },
+      {
+        "name": "libidn2",
+        "epoch": 0,
+        "version": "2.2.0",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libidn2-2.2.0-1.el8.ppc64le.rpm",
+        "checksum": "sha256:31d924d1540dd4e927a4c3aa936cec4bfb54ed302d3e8acc1be8b52dd5deb10c",
+        "check_gpg": true
+      },
+      {
+        "name": "libkcapi",
+        "epoch": 0,
+        "version": "1.2.0",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libkcapi-1.2.0-2.el8.ppc64le.rpm",
+        "checksum": "sha256:fd6e1803ff367036da5b52b2183e1408691b379cc1320971bb664737507f89a4",
+        "check_gpg": true
+      },
+      {
+        "name": "libkcapi-hmaccalc",
+        "epoch": 0,
+        "version": "1.2.0",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libkcapi-hmaccalc-1.2.0-2.el8.ppc64le.rpm",
+        "checksum": "sha256:6b312faed4a0508da2f15d3f31a6daccfc0ec6621e5fb7b20956027dce5fa395",
+        "check_gpg": true
+      },
+      {
+        "name": "libksba",
+        "epoch": 0,
+        "version": "1.3.5",
+        "release": "7.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libksba-1.3.5-7.el8.ppc64le.rpm",
+        "checksum": "sha256:a5f9f2c4f39f393971f268aebb1b55d18d0d96693d08a9ed70403e8565807bb6",
+        "check_gpg": true
+      },
+      {
+        "name": "libmodulemd",
+        "epoch": 0,
+        "version": "2.12.1",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libmodulemd-2.12.1-1.el8.ppc64le.rpm",
+        "checksum": "sha256:d6eb27d158b6397e52ab6a952fec4e3c414638a08750a6c011d32eb117accd82",
+        "check_gpg": true
+      },
+      {
+        "name": "libmount",
+        "epoch": 0,
+        "version": "2.32.1",
+        "release": "28.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libmount-2.32.1-28.el8.ppc64le.rpm",
+        "checksum": "sha256:4e497225fe36781735cc92c0886f6858b19d4557ed9ecafe1247b8233c206075",
+        "check_gpg": true
+      },
+      {
+        "name": "libnghttp2",
+        "epoch": 0,
+        "version": "1.33.0",
+        "release": "3.el8_2.1",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libnghttp2-1.33.0-3.el8_2.1.ppc64le.rpm",
+        "checksum": "sha256:d3a4f367a9c5ba936b1bb5480db390889a303e5ec8ff34bb4274c1d840a1784d",
+        "check_gpg": true
+      },
+      {
+        "name": "libnsl2",
+        "epoch": 0,
+        "version": "1.2.0",
+        "release": "2.20180605git4a062cf.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libnsl2-1.2.0-2.20180605git4a062cf.el8.ppc64le.rpm",
+        "checksum": "sha256:8d7777da3f54f965cf3058cabf987c01b93a1dd041e8359eb7822eba57d8c8df",
+        "check_gpg": true
+      },
+      {
+        "name": "libpng",
+        "epoch": 2,
+        "version": "1.6.34",
+        "release": "5.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libpng-1.6.34-5.el8.ppc64le.rpm",
+        "checksum": "sha256:b58be8f7685340b35e61945b1ab499bc1030b0b021b2ac5576897cf079ff7812",
+        "check_gpg": true
+      },
+      {
+        "name": "libpsl",
+        "epoch": 0,
+        "version": "0.20.2",
+        "release": "6.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libpsl-0.20.2-6.el8.ppc64le.rpm",
+        "checksum": "sha256:9b8a8a843fe9a972f6433e11b95b5a8d1d2971ed40fe1acda6807e34f0773c62",
+        "check_gpg": true
+      },
+      {
+        "name": "libpwquality",
+        "epoch": 0,
+        "version": "1.4.4",
+        "release": "3.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libpwquality-1.4.4-3.el8.ppc64le.rpm",
+        "checksum": "sha256:1aa321c66a3661e78d938b805e5c311d519f04bf3496545ffdacc7c152bc9b21",
+        "check_gpg": true
+      },
+      {
+        "name": "librepo",
+        "epoch": 0,
+        "version": "1.14.0",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/librepo-1.14.0-2.el8.ppc64le.rpm",
+        "checksum": "sha256:3dfffdadfb10def9a3671a255e4fa71d8b22231ccf2c929e96689101dda8ce2c",
+        "check_gpg": true
+      },
+      {
+        "name": "libreport-filesystem",
+        "epoch": 0,
+        "version": "2.9.5",
+        "release": "15.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libreport-filesystem-2.9.5-15.el8.ppc64le.rpm",
+        "checksum": "sha256:c5c61536e768553067cee488830c64866d109cade24917dbe23f82c861af07c5",
+        "check_gpg": true
+      },
+      {
+        "name": "librtas",
+        "epoch": 0,
+        "version": "2.0.2",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/librtas-2.0.2-1.el8.ppc64le.rpm",
+        "checksum": "sha256:98c28a91d41f634edb8c1f001dbc45c0de534332d059a2e8feff448fb7235c49",
+        "check_gpg": true
+      },
+      {
+        "name": "libseccomp",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libseccomp-2.5.1-1.el8.ppc64le.rpm",
+        "checksum": "sha256:b4a1ac1ff5cd22a5dab6c96dfc2dbd7cd6ba750691ad5c53a97a1f088fc42abc",
+        "check_gpg": true
+      },
+      {
+        "name": "libsecret",
+        "epoch": 0,
+        "version": "0.18.6",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libsecret-0.18.6-1.el8.ppc64le.rpm",
+        "checksum": "sha256:01b0562b890a80c202fff9175dc845500660c7f1655292d4ee13ca667acab081",
+        "check_gpg": true
+      },
+      {
+        "name": "libselinux",
+        "epoch": 0,
+        "version": "2.9",
+        "release": "5.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libselinux-2.9-5.el8.ppc64le.rpm",
+        "checksum": "sha256:56c866bcff69fd60b630841ff990296b26c2f45d8c6054311b5c476bc67466ac",
+        "check_gpg": true
+      },
+      {
+        "name": "libselinux-utils",
+        "epoch": 0,
+        "version": "2.9",
+        "release": "5.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libselinux-utils-2.9-5.el8.ppc64le.rpm",
+        "checksum": "sha256:4fe264ed1cfd0c074f4601354b0128a9e5068f0fcde7382fd5429585f0d4cd2c",
+        "check_gpg": true
+      },
+      {
+        "name": "libsemanage",
+        "epoch": 0,
+        "version": "2.9",
+        "release": "6.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libsemanage-2.9-6.el8.ppc64le.rpm",
+        "checksum": "sha256:95103f7c339aec4b485b7f569aa8a5e1a54286b3d2acde427328c49e4d8d80d1",
+        "check_gpg": true
+      },
+      {
+        "name": "libsepol",
+        "epoch": 0,
+        "version": "2.9",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libsepol-2.9-2.el8.ppc64le.rpm",
+        "checksum": "sha256:adc56041458e556df5663e7da264e151c24aaf1c2a94e49df9790ba191ea1b37",
+        "check_gpg": true
+      },
+      {
+        "name": "libsigsegv",
+        "epoch": 0,
+        "version": "2.11",
+        "release": "5.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libsigsegv-2.11-5.el8.ppc64le.rpm",
+        "checksum": "sha256:0f57b051654b6d75789b437dafd7040b6c90daee17827be24352c0f11a74bba7",
+        "check_gpg": true
+      },
+      {
+        "name": "libsmartcols",
+        "epoch": 0,
+        "version": "2.32.1",
+        "release": "28.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libsmartcols-2.32.1-28.el8.ppc64le.rpm",
+        "checksum": "sha256:1b5136570cefb8273dd5affc73c1456cf239cc8b18be72d6c4d09794af7f3352",
+        "check_gpg": true
+      },
+      {
+        "name": "libsolv",
+        "epoch": 0,
+        "version": "0.7.19",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libsolv-0.7.19-1.el8.ppc64le.rpm",
+        "checksum": "sha256:679724b45157b4d4c9ebe2eb32e188b9a65d47c23be886498d7a178caaf113bb",
+        "check_gpg": true
+      },
+      {
+        "name": "libss",
+        "epoch": 0,
+        "version": "1.45.6",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libss-1.45.6-2.el8.ppc64le.rpm",
+        "checksum": "sha256:767dd64d91c23adda537c7759ae3b4f720d3c76e03b52bc9231e52e0113db3ab",
+        "check_gpg": true
+      },
+      {
+        "name": "libssh",
+        "epoch": 0,
+        "version": "0.9.4",
+        "release": "3.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libssh-0.9.4-3.el8.ppc64le.rpm",
+        "checksum": "sha256:2dbfe3cb37c18b39393870baa77f3bbd42be53517abffdd990b13ed70ee3dd3e",
+        "check_gpg": true
+      },
+      {
+        "name": "libssh-config",
+        "epoch": 0,
+        "version": "0.9.4",
+        "release": "3.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libssh-config-0.9.4-3.el8.noarch.rpm",
+        "checksum": "sha256:f5bcb82a732c02d6f31bbf156887049883c76cedc9c6a11b049358a74f4d45d0",
+        "check_gpg": true
+      },
+      {
+        "name": "libstdc++",
+        "epoch": 0,
+        "version": "8.5.0",
+        "release": "3.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libstdc++-8.5.0-3.el8.ppc64le.rpm",
+        "checksum": "sha256:32ebba6472cdc331bd3366ca996ad3039b3a1b41c61a849b88074e1b722cad2c",
+        "check_gpg": true
+      },
+      {
+        "name": "libtasn1",
+        "epoch": 0,
+        "version": "4.13",
+        "release": "3.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libtasn1-4.13-3.el8.ppc64le.rpm",
+        "checksum": "sha256:75e9ed16ace51ba04a62505aaed215bf9c722d6f4b1c33cc3e3962076c300ee8",
+        "check_gpg": true
+      },
+      {
+        "name": "libtirpc",
+        "epoch": 0,
+        "version": "1.1.4",
+        "release": "5.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libtirpc-1.1.4-5.el8.ppc64le.rpm",
+        "checksum": "sha256:d539404dafd8ad5d785ab3da6f8bd5a2bf5dff9e01be0ff1bc1d251786dda25c",
+        "check_gpg": true
+      },
+      {
+        "name": "libunistring",
+        "epoch": 0,
+        "version": "0.9.9",
+        "release": "3.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libunistring-0.9.9-3.el8.ppc64le.rpm",
+        "checksum": "sha256:bff39fef1fc01564156123fcade75b4bc50402a2971a031d9a426c7014b1e681",
+        "check_gpg": true
+      },
+      {
+        "name": "libusbx",
+        "epoch": 0,
+        "version": "1.0.23",
+        "release": "4.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libusbx-1.0.23-4.el8.ppc64le.rpm",
+        "checksum": "sha256:6b9875495111bcd2d3c5e9e380b3be17fb0a730891468fb45bdba3b3692b00ea",
+        "check_gpg": true
+      },
+      {
+        "name": "libutempter",
+        "epoch": 0,
+        "version": "1.1.6",
+        "release": "14.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libutempter-1.1.6-14.el8.ppc64le.rpm",
+        "checksum": "sha256:e217c2687212d931ad9a6a02afb20cc34f6d051786d136e337f91079c9f73d22",
+        "check_gpg": true
+      },
+      {
+        "name": "libuuid",
+        "epoch": 0,
+        "version": "2.32.1",
+        "release": "28.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libuuid-2.32.1-28.el8.ppc64le.rpm",
+        "checksum": "sha256:c1291b69a65a860069195a33cf6640df8667e960f9f030ceeea4497c47858b94",
+        "check_gpg": true
+      },
+      {
+        "name": "libverto",
+        "epoch": 0,
+        "version": "0.3.0",
+        "release": "5.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libverto-0.3.0-5.el8.ppc64le.rpm",
+        "checksum": "sha256:d8c00baf46e33f9e5f1b9e139bbea9fe0f27badb432c992b9cf8c4f7017094bf",
+        "check_gpg": true
+      },
+      {
+        "name": "libxcrypt",
+        "epoch": 0,
+        "version": "4.1.1",
+        "release": "6.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libxcrypt-4.1.1-6.el8.ppc64le.rpm",
+        "checksum": "sha256:1a968f65db066243cbd0a6e12d193ef674637f044299a15b5d6b910e91411812",
+        "check_gpg": true
+      },
+      {
+        "name": "libxml2",
+        "epoch": 0,
+        "version": "2.9.7",
+        "release": "11.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libxml2-2.9.7-11.el8.ppc64le.rpm",
+        "checksum": "sha256:4a167fa4a7238bd94b3134173f6267b19cdebc2fde98b583344749e1f4c9bf09",
+        "check_gpg": true
+      },
+      {
+        "name": "libyaml",
+        "epoch": 0,
+        "version": "0.1.7",
+        "release": "5.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libyaml-0.1.7-5.el8.ppc64le.rpm",
+        "checksum": "sha256:8904fdb492f34e5242ba483fb6b7b158342662575b3d5ac9abbc380568840d4a",
+        "check_gpg": true
+      },
+      {
+        "name": "libzstd",
+        "epoch": 0,
+        "version": "1.4.4",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libzstd-1.4.4-1.el8.ppc64le.rpm",
+        "checksum": "sha256:6bfc201a12dc7bba21069a663aa692a96c5e8920b0d94a4e355c332d7ead15ba",
+        "check_gpg": true
+      },
+      {
+        "name": "lua-libs",
+        "epoch": 0,
+        "version": "5.3.4",
+        "release": "11.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/lua-libs-5.3.4-11.el8.ppc64le.rpm",
+        "checksum": "sha256:393e7bb9f93ffb3cbba620fbfeb229f2b8345454bc60ac0508f76735544ed289",
+        "check_gpg": true
+      },
+      {
+        "name": "lz4-libs",
+        "epoch": 0,
+        "version": "1.8.3",
+        "release": "3.el8_4",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/lz4-libs-1.8.3-3.el8_4.ppc64le.rpm",
+        "checksum": "sha256:f24bce642ec88622490b2f09a45fa3985da7f6511a1aae131853c4ea4c309e6b",
+        "check_gpg": true
+      },
+      {
+        "name": "lzo",
+        "epoch": 0,
+        "version": "2.08",
+        "release": "14.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/lzo-2.08-14.el8.ppc64le.rpm",
+        "checksum": "sha256:4c5aabda0cd9edb40e141066d400d2e4b232bc22ab60e806a6399691c391cabc",
+        "check_gpg": true
+      },
+      {
+        "name": "memstrack",
+        "epoch": 0,
+        "version": "0.1.11",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/memstrack-0.1.11-1.el8.ppc64le.rpm",
+        "checksum": "sha256:9936485ac7111967d6962bc539de7b08807e310117adb78b11c21a5db0f0f890",
+        "check_gpg": true
+      },
+      {
+        "name": "mpfr",
+        "epoch": 0,
+        "version": "3.1.6",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/mpfr-3.1.6-1.el8.ppc64le.rpm",
+        "checksum": "sha256:0230acdbc9da4b36da812f0e585a7602eda4982c899b3b3a4c2bc9b4546d8e74",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses",
+        "epoch": 0,
+        "version": "6.1",
+        "release": "9.20180224.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/ncurses-6.1-9.20180224.el8.ppc64le.rpm",
+        "checksum": "sha256:7abf49cabbaf996afc0c2604f10ea18f8f22a903fc4ba3728a18f5892353c5c9",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses-base",
+        "epoch": 0,
+        "version": "6.1",
+        "release": "9.20180224.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/ncurses-base-6.1-9.20180224.el8.noarch.rpm",
+        "checksum": "sha256:41716536ea16798238ac89fbc3041b3f9dc80f9a64ea4b19d6e67ad2c909269a",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses-libs",
+        "epoch": 0,
+        "version": "6.1",
+        "release": "9.20180224.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/ncurses-libs-6.1-9.20180224.el8.ppc64le.rpm",
+        "checksum": "sha256:17ffe1d683dbff48f9b2ef903401e471e5e51a992bf0890632bceb94561893de",
+        "check_gpg": true
+      },
+      {
+        "name": "nettle",
+        "epoch": 0,
+        "version": "3.4.1",
+        "release": "7.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/nettle-3.4.1-7.el8.ppc64le.rpm",
+        "checksum": "sha256:8403cfc97e0e72e37639b8c54d92f1ee427e48a70d52d5260a37fa104f2df20d",
+        "check_gpg": true
+      },
+      {
+        "name": "npth",
+        "epoch": 0,
+        "version": "1.5",
+        "release": "4.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/npth-1.5-4.el8.ppc64le.rpm",
+        "checksum": "sha256:7a66928044c3478964aeaf6f9e981fdbcfa6b2ff7fad9f2ad57a8c09387cbbf2",
+        "check_gpg": true
+      },
+      {
+        "name": "openldap",
+        "epoch": 0,
+        "version": "2.4.46",
+        "release": "18.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/openldap-2.4.46-18.el8.ppc64le.rpm",
+        "checksum": "sha256:c24b21415b737f18fad7aeb192e60f7d323f7ba69434ecc1e78b3af0003be8dc",
+        "check_gpg": true
+      },
+      {
+        "name": "openssl",
+        "epoch": 1,
+        "version": "1.1.1k",
+        "release": "4.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/openssl-1.1.1k-4.el8.ppc64le.rpm",
+        "checksum": "sha256:c2479eb811f4d9b8624ef20119e1abdc109f639c2cf576eb945b340362d87b05",
+        "check_gpg": true
+      },
+      {
+        "name": "openssl-libs",
+        "epoch": 1,
+        "version": "1.1.1k",
+        "release": "4.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/openssl-libs-1.1.1k-4.el8.ppc64le.rpm",
+        "checksum": "sha256:46606c1ed76a4da2a9d18016aeb50f4dddf58e1b45d665c983c58f8e605bf73e",
+        "check_gpg": true
+      },
+      {
+        "name": "openssl-pkcs11",
+        "epoch": 0,
+        "version": "0.4.10",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/openssl-pkcs11-0.4.10-2.el8.ppc64le.rpm",
+        "checksum": "sha256:d87f7fa5e637442eb638bcaafdc44ca3895d91a153015ff9af6a87219f0dc372",
+        "check_gpg": true
+      },
+      {
+        "name": "os-prober",
+        "epoch": 0,
+        "version": "1.74",
+        "release": "6.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/os-prober-1.74-6.el8.ppc64le.rpm",
+        "checksum": "sha256:71c88f04921ae61a7009f9443f95c70ec3424a798429fc01e6c1432c1077aacb",
+        "check_gpg": true
+      },
+      {
+        "name": "p11-kit",
+        "epoch": 0,
+        "version": "0.23.22",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/p11-kit-0.23.22-1.el8.ppc64le.rpm",
+        "checksum": "sha256:bf994cb2e5c367d78483662c7de6e69950aaf04bc6cfdbbef4d1ef7ce153717c",
+        "check_gpg": true
+      },
+      {
+        "name": "p11-kit-trust",
+        "epoch": 0,
+        "version": "0.23.22",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/p11-kit-trust-0.23.22-1.el8.ppc64le.rpm",
+        "checksum": "sha256:b7330d40f75b8ec786e41c45a202e44f0e49ec29ddf8944120fbdb373a6c6617",
+        "check_gpg": true
+      },
+      {
+        "name": "pam",
+        "epoch": 0,
+        "version": "1.3.1",
+        "release": "15.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/pam-1.3.1-15.el8.ppc64le.rpm",
+        "checksum": "sha256:bb82b10a91493d745dc533b5de5335db650adb0c8a90548fdf5dad13569a16f4",
+        "check_gpg": true
+      },
+      {
+        "name": "parted",
+        "epoch": 0,
+        "version": "3.2",
+        "release": "39.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/parted-3.2-39.el8.ppc64le.rpm",
+        "checksum": "sha256:9e2ef90cb484b37232e829ec400dcddd3f9f0d189eb6f0074b3b5874d4553d1c",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre",
+        "epoch": 0,
+        "version": "8.42",
+        "release": "6.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/pcre-8.42-6.el8.ppc64le.rpm",
+        "checksum": "sha256:3ed319e31a9c38e5f4e336195b5cbd253b3f8b17f93f185829f078c5ef420305",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre2",
+        "epoch": 0,
+        "version": "10.32",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/pcre2-10.32-2.el8.ppc64le.rpm",
+        "checksum": "sha256:5c46bef8c0e95e05716e9a53b77970c1378d93bcb9a800018a24f7e1763b45b9",
+        "check_gpg": true
+      },
+      {
+        "name": "pigz",
+        "epoch": 0,
+        "version": "2.4",
+        "release": "4.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/pigz-2.4-4.el8.ppc64le.rpm",
+        "checksum": "sha256:3edfdbc82f97ec12e59c80c67897fc1eeb44c3d16820f761a8f15272965ea3a1",
+        "check_gpg": true
+      },
+      {
+        "name": "platform-python",
+        "epoch": 0,
+        "version": "3.6.8",
+        "release": "39.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/platform-python-3.6.8-39.el8.ppc64le.rpm",
+        "checksum": "sha256:cdd6594a3bca71d32a5061b85457cc8148611e7f042ba6e812a1c0a2faebac92",
+        "check_gpg": true
+      },
+      {
+        "name": "platform-python-pip",
+        "epoch": 0,
+        "version": "9.0.3",
+        "release": "20.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/platform-python-pip-9.0.3-20.el8.noarch.rpm",
+        "checksum": "sha256:56650f8b8f2b01c1090d184d7d6d396f0109f8a02f915c97b081be73ea12df08",
+        "check_gpg": true
+      },
+      {
+        "name": "platform-python-setuptools",
+        "epoch": 0,
+        "version": "39.2.0",
+        "release": "6.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/platform-python-setuptools-39.2.0-6.el8.noarch.rpm",
+        "checksum": "sha256:946ba273a3a3b6fdf140f3c03112918c0a556a5871c477f5dbbb98600e6ca557",
+        "check_gpg": true
+      },
+      {
+        "name": "policycoreutils",
+        "epoch": 0,
+        "version": "2.9",
+        "release": "15.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/policycoreutils-2.9-15.el8.ppc64le.rpm",
+        "checksum": "sha256:c64632c85c3a49dc82222cdb3d0ee87eafa64f3096ffeba5bcc16c49ee2d260e",
+        "check_gpg": true
+      },
+      {
+        "name": "polkit-libs",
+        "epoch": 0,
+        "version": "0.115",
+        "release": "12.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/polkit-libs-0.115-12.el8.ppc64le.rpm",
+        "checksum": "sha256:15554476d03595246aec194e63ec9db7469d5b3ed81a27a8a2720e82df1f8bf4",
+        "check_gpg": true
+      },
+      {
+        "name": "popt",
+        "epoch": 0,
+        "version": "1.18",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/popt-1.18-1.el8.ppc64le.rpm",
+        "checksum": "sha256:3b00ac82c31b447e306fcb47b4469fdc4e6d87385b42358c2e76badb51b074a3",
+        "check_gpg": true
+      },
+      {
+        "name": "procps-ng",
+        "epoch": 0,
+        "version": "3.3.15",
+        "release": "6.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/procps-ng-3.3.15-6.el8.ppc64le.rpm",
+        "checksum": "sha256:1cfa672c25cb5849bb2aa652e045e4a4a272c025befb1fe5e58cb32823faa30d",
+        "check_gpg": true
+      },
+      {
+        "name": "psmisc",
+        "epoch": 0,
+        "version": "23.1",
+        "release": "5.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/psmisc-23.1-5.el8.ppc64le.rpm",
+        "checksum": "sha256:2394d6a1ce4de90590e65111d870b172cb9d4e30e1e6f58a334b29e717fdd031",
+        "check_gpg": true
+      },
+      {
+        "name": "publicsuffix-list-dafsa",
+        "epoch": 0,
+        "version": "20180723",
+        "release": "1.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/publicsuffix-list-dafsa-20180723-1.el8.noarch.rpm",
+        "checksum": "sha256:65ecf1e479dc2b2f7f09c2e86d7457043b3470b3eab3c4ee8909b50b0a669fc2",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-chardet",
+        "epoch": 0,
+        "version": "3.0.4",
+        "release": "7.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-chardet-3.0.4-7.el8.noarch.rpm",
+        "checksum": "sha256:176ffcb2cf0fdcbdd2d8119cbd98eef60a30fdb0fb065a9382d2c95e90c79652",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-dnf",
+        "epoch": 0,
+        "version": "4.7.0",
+        "release": "2.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-dnf-4.7.0-2.el8.noarch.rpm",
+        "checksum": "sha256:ccfa1810aa19fae08aefd29cffe28b65d5123cd17bd7d2d4207f03cf9795594c",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-gpg",
+        "epoch": 0,
+        "version": "1.13.1",
+        "release": "9.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-gpg-1.13.1-9.el8.ppc64le.rpm",
+        "checksum": "sha256:111d88db3a52121f04f2741cc72ce8dda6d6f6ef2cc36452c042e0141b316334",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-hawkey",
+        "epoch": 0,
+        "version": "0.63.0",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-hawkey-0.63.0-2.el8.ppc64le.rpm",
+        "checksum": "sha256:4715730da2b4a5bf6cc2ab85208071f00c7b279e4b2f75df0bd954446185e14c",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-idna",
+        "epoch": 0,
+        "version": "2.5",
+        "release": "5.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-idna-2.5-5.el8.noarch.rpm",
+        "checksum": "sha256:78c43d8a15ca018de1803e4baac5819e1baab1963fd31f1e44e54e8a573acbfc",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-iniparse",
+        "epoch": 0,
+        "version": "0.4",
+        "release": "31.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-iniparse-0.4-31.el8.noarch.rpm",
+        "checksum": "sha256:5c0957decce3babef9864904be13190b0072aef720e9f4ca820bab6c02a20178",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libcomps",
+        "epoch": 0,
+        "version": "0.1.16",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-libcomps-0.1.16-2.el8.ppc64le.rpm",
+        "checksum": "sha256:594d8b368013caa4eaba4eade896fc1cec8ef569052bd491f493c193e07c6d80",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libdnf",
+        "epoch": 0,
+        "version": "0.63.0",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-libdnf-0.63.0-2.el8.ppc64le.rpm",
+        "checksum": "sha256:abc36bf7797a427b64c3c99b4f74714bfa66b906b62358be6fdafe493a66415e",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-librepo",
+        "epoch": 0,
+        "version": "1.14.0",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-librepo-1.14.0-2.el8.ppc64le.rpm",
+        "checksum": "sha256:35eb77080d99941b137da8c6cb25305ad4ff64cf2a7ba1f8adbf8d0998b5fe45",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libs",
+        "epoch": 0,
+        "version": "3.6.8",
+        "release": "39.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-libs-3.6.8-39.el8.ppc64le.rpm",
+        "checksum": "sha256:405bda98fe97c1a5cf70511ae2d167256b25dd8721b88899465e9847525e2068",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libselinux",
+        "epoch": 0,
+        "version": "2.9",
+        "release": "5.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-libselinux-2.9-5.el8.ppc64le.rpm",
+        "checksum": "sha256:3b5d31b89683be71c72b77cfceb59238f4c76a796de6ae85525b3d5cfe2a8f23",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-pip-wheel",
+        "epoch": 0,
+        "version": "9.0.3",
+        "release": "20.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-pip-wheel-9.0.3-20.el8.noarch.rpm",
+        "checksum": "sha256:6c9dfb73e199975275633f05d31388cd61c5a77dec5678db958b4e6624eb21ba",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-pysocks",
+        "epoch": 0,
+        "version": "1.6.8",
+        "release": "3.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-pysocks-1.6.8-3.el8.noarch.rpm",
+        "checksum": "sha256:7f506879c64e0bb4d98782d025f46fb9a07517487ae4cbebbb3985a98f4e2154",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-requests",
+        "epoch": 0,
+        "version": "2.20.0",
+        "release": "2.1.el8_1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-requests-2.20.0-2.1.el8_1.noarch.rpm",
+        "checksum": "sha256:003ee19ec5b88de212c3246bdfdb3e97a9910a25a219fd7cf5030b7bc666fea9",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-rpm",
+        "epoch": 0,
+        "version": "4.14.3",
+        "release": "15.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-rpm-4.14.3-15.el8.ppc64le.rpm",
+        "checksum": "sha256:ccf848b42acc0f691b4cb6e2830dc4263c7ce4df89b3f4002c3d6b9cd99b362b",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-setuptools",
+        "epoch": 0,
+        "version": "39.2.0",
+        "release": "6.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-setuptools-39.2.0-6.el8.noarch.rpm",
+        "checksum": "sha256:c6f27b6e01d80e756408e3c1451e4af00e7d02da0aa24402644c0785118753fe",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-setuptools-wheel",
+        "epoch": 0,
+        "version": "39.2.0",
+        "release": "6.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-setuptools-wheel-39.2.0-6.el8.noarch.rpm",
+        "checksum": "sha256:b19bd4f106ce301ee21c860183cc1c2ef9c09bdf495059bdf16e8d8ccc71bbe8",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-six",
+        "epoch": 0,
+        "version": "1.11.0",
+        "release": "8.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-six-1.11.0-8.el8.noarch.rpm",
+        "checksum": "sha256:a04cb3117395b962edc32bf45d8411f240632476b0706b2df7f4a1a87b2ce34b",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-urllib3",
+        "epoch": 0,
+        "version": "1.24.2",
+        "release": "5.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-urllib3-1.24.2-5.el8.noarch.rpm",
+        "checksum": "sha256:aa1835fd302a37b84ac256db5dd0de09bd9883a5a07775aedb491faf46b18ee0",
+        "check_gpg": true
+      },
+      {
+        "name": "readline",
+        "epoch": 0,
+        "version": "7.0",
+        "release": "10.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/readline-7.0-10.el8.ppc64le.rpm",
+        "checksum": "sha256:0320663709136d07690fe299903700cc1dcc526d574fe8b952a01e1d24024ae4",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm",
+        "epoch": 0,
+        "version": "4.14.3",
+        "release": "15.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/rpm-4.14.3-15.el8.ppc64le.rpm",
+        "checksum": "sha256:4fae16ca54207cb952e3904b8eb8cc424f3f056f400e5e802ab1a9ef3e575834",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-build-libs",
+        "epoch": 0,
+        "version": "4.14.3",
+        "release": "15.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/rpm-build-libs-4.14.3-15.el8.ppc64le.rpm",
+        "checksum": "sha256:03ba1e86a04d912fd2878b457b06a6a7abad0ce96cd9a6932bf58cb4641b8fb7",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-libs",
+        "epoch": 0,
+        "version": "4.14.3",
+        "release": "15.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/rpm-libs-4.14.3-15.el8.ppc64le.rpm",
+        "checksum": "sha256:4e22015880d16cb7148d70895a2361f4fa05804f0391386e0e50554e6fd868b0",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-plugin-selinux",
+        "epoch": 0,
+        "version": "4.14.3",
+        "release": "15.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/rpm-plugin-selinux-4.14.3-15.el8.ppc64le.rpm",
+        "checksum": "sha256:9b1018a43b1a9245cdc71a342b962aa32fb799bd0ce66ee59b496cdd75200de9",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-plugin-systemd-inhibit",
+        "epoch": 0,
+        "version": "4.14.3",
+        "release": "15.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/rpm-plugin-systemd-inhibit-4.14.3-15.el8.ppc64le.rpm",
+        "checksum": "sha256:8cb953ea9ea1bd262bef00112e2c433583929cd7aec86ae60f1a725c6dcf7c09",
+        "check_gpg": true
+      },
+      {
+        "name": "sed",
+        "epoch": 0,
+        "version": "4.5",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/sed-4.5-2.el8.ppc64le.rpm",
+        "checksum": "sha256:dbde46224833f804d8b92212fa3618ea53d0e0cb84ff07132a5ba36c1bc0b9df",
+        "check_gpg": true
+      },
+      {
+        "name": "selinux-policy",
+        "epoch": 0,
+        "version": "3.14.3",
+        "release": "76.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/selinux-policy-3.14.3-76.el8.noarch.rpm",
+        "checksum": "sha256:561a61d2d81bccb14d22a53b32301e0b6b9e9b9d80ad75991ee6ff796cae0ef7",
+        "check_gpg": true
+      },
+      {
+        "name": "selinux-policy-targeted",
+        "epoch": 0,
+        "version": "3.14.3",
+        "release": "76.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/selinux-policy-targeted-3.14.3-76.el8.noarch.rpm",
+        "checksum": "sha256:76df9e0fc779fcd7d3ee836ae254ead30b5f9492022b55901d1f8bd914d38ef6",
+        "check_gpg": true
+      },
+      {
+        "name": "setup",
+        "epoch": 0,
+        "version": "2.12.2",
+        "release": "6.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/setup-2.12.2-6.el8.noarch.rpm",
+        "checksum": "sha256:9e540fe1fcf866ba1e738e012eef5459d34cca30385df73973e6fc7c6eadb55f",
+        "check_gpg": true
+      },
+      {
+        "name": "shadow-utils",
+        "epoch": 2,
+        "version": "4.6",
+        "release": "14.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/shadow-utils-4.6-14.el8.ppc64le.rpm",
+        "checksum": "sha256:e1153055b6ea57ee81e6fb41b03023279059513d0fec728517ae0805186a5118",
+        "check_gpg": true
+      },
+      {
+        "name": "shared-mime-info",
+        "epoch": 0,
+        "version": "1.9",
+        "release": "3.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/shared-mime-info-1.9-3.el8.ppc64le.rpm",
+        "checksum": "sha256:f97b5915b3f75d2878104c198f205841813712103f1b3657d71d2c8d079cc947",
+        "check_gpg": true
+      },
+      {
+        "name": "sqlite-libs",
+        "epoch": 0,
+        "version": "3.26.0",
+        "release": "15.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/sqlite-libs-3.26.0-15.el8.ppc64le.rpm",
+        "checksum": "sha256:31277c01ac529cc1c6a55fd87d6ce4dbb20290575d4e1e89cd40600eac9f3405",
+        "check_gpg": true
+      },
+      {
+        "name": "squashfs-tools",
+        "epoch": 0,
+        "version": "4.3",
+        "release": "20.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/squashfs-tools-4.3-20.el8.ppc64le.rpm",
+        "checksum": "sha256:4b00562fa291e956d910bb056c6120f0079f30093ea107757758683a6d418206",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd",
+        "epoch": 0,
+        "version": "239",
+        "release": "49.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/systemd-239-49.el8.ppc64le.rpm",
+        "checksum": "sha256:8a501b9d8016eee68ce62a93a65842b15c8a57192b9f8189ebc85a11f2f47f9e",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-libs",
+        "epoch": 0,
+        "version": "239",
+        "release": "49.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/systemd-libs-239-49.el8.ppc64le.rpm",
+        "checksum": "sha256:3d175382237a94330d72af67ad2c41535dee7eade3e42178b86d2dc87478d030",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-pam",
+        "epoch": 0,
+        "version": "239",
+        "release": "49.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/systemd-pam-239-49.el8.ppc64le.rpm",
+        "checksum": "sha256:e95bb05fa5defeb16dd0e0957de676374b22b9daaf405273e636d1ce91001574",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-udev",
+        "epoch": 0,
+        "version": "239",
+        "release": "49.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/systemd-udev-239-49.el8.ppc64le.rpm",
+        "checksum": "sha256:3898e2ac4e04e80373bc7fe4092b26d502d4705177719117e25c083d44a9a150",
+        "check_gpg": true
+      },
+      {
+        "name": "tar",
+        "epoch": 2,
+        "version": "1.30",
+        "release": "5.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/tar-1.30-5.el8.ppc64le.rpm",
+        "checksum": "sha256:8c26cce4231f781db7b37d51ded377f9cfa01a5e6833d967082795f1220e2860",
+        "check_gpg": true
+      },
+      {
+        "name": "tpm2-tss",
+        "epoch": 0,
+        "version": "2.3.2",
+        "release": "4.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/tpm2-tss-2.3.2-4.el8.ppc64le.rpm",
+        "checksum": "sha256:d46ef49f8ddba1ee8cce6c9764014851cce2dbfb5dcb2457a31495393e6566c1",
+        "check_gpg": true
+      },
+      {
+        "name": "trousers",
+        "epoch": 0,
+        "version": "0.3.15",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/trousers-0.3.15-1.el8.ppc64le.rpm",
+        "checksum": "sha256:4164089bf1754c0ef18ae051e047f11299907204839ad4b7978f146a543a2e91",
+        "check_gpg": true
+      },
+      {
+        "name": "trousers-lib",
+        "epoch": 0,
+        "version": "0.3.15",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/trousers-lib-0.3.15-1.el8.ppc64le.rpm",
+        "checksum": "sha256:09096bc32e37443417cd625364df32674f9d5ff4ddbeb175e6d60637ed3d573f",
+        "check_gpg": true
+      },
+      {
+        "name": "tzdata",
+        "epoch": 0,
+        "version": "2021a",
+        "release": "1.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/tzdata-2021a-1.el8.noarch.rpm",
+        "checksum": "sha256:44999c555a6e4bb6cf5e6f6a79819e76912d036732cb50efaeefc20a180dd839",
+        "check_gpg": true
+      },
+      {
+        "name": "util-linux",
+        "epoch": 0,
+        "version": "2.32.1",
+        "release": "28.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/util-linux-2.32.1-28.el8.ppc64le.rpm",
+        "checksum": "sha256:ce954d3900cb547aea14df6ad5f310ea96bb5e83a155b93e2e64b2c13b686193",
+        "check_gpg": true
+      },
+      {
+        "name": "which",
+        "epoch": 0,
+        "version": "2.21",
+        "release": "16.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/which-2.21-16.el8.ppc64le.rpm",
+        "checksum": "sha256:15cd74b4ad9d82417072fe867f086d68667afd4291b710b6c7feef985c492990",
+        "check_gpg": true
+      },
+      {
+        "name": "xfsprogs",
+        "epoch": 0,
+        "version": "5.0.0",
+        "release": "9.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/xfsprogs-5.0.0-9.el8.ppc64le.rpm",
+        "checksum": "sha256:480e0f1a9dcce6ed0728e9aba709e33f5522273da1e4b0859cf9d3bbe2216532",
+        "check_gpg": true
+      },
+      {
+        "name": "xz",
+        "epoch": 0,
+        "version": "5.2.4",
+        "release": "3.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/xz-5.2.4-3.el8.ppc64le.rpm",
+        "checksum": "sha256:cd8b0adfc4d2467a61ab2aa2b3e617bbd2a2592176da249365eef014faef827c",
+        "check_gpg": true
+      },
+      {
+        "name": "xz-libs",
+        "epoch": 0,
+        "version": "5.2.4",
+        "release": "3.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/xz-libs-5.2.4-3.el8.ppc64le.rpm",
+        "checksum": "sha256:a4577841148e7e2bf481447ae141eff319007e70a24295a22787bbfaecf4c4fe",
+        "check_gpg": true
+      },
+      {
+        "name": "zlib",
+        "epoch": 0,
+        "version": "1.2.11",
+        "release": "17.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/zlib-1.2.11-17.el8.ppc64le.rpm",
+        "checksum": "sha256:33a92d88496e8aa410976f073e324f761b2ae02a94c20c0f291072df84f648be",
+        "check_gpg": true
+      },
+      {
+        "name": "GConf2",
+        "epoch": 0,
+        "version": "3.2.6",
+        "release": "22.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/GConf2-3.2.6-22.el8.ppc64le.rpm",
+        "checksum": "sha256:a388c955ace01f09f522c0ccf3afd47e682b22a87756e185f9134bdff72fb2ff",
+        "check_gpg": true
+      },
+      {
+        "name": "genisoimage",
+        "epoch": 0,
+        "version": "1.1.11",
+        "release": "39.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/genisoimage-1.1.11-39.el8.ppc64le.rpm",
+        "checksum": "sha256:5374ef6981f9a29d08c3400488b010f477fe7722367fcd6d29244ba8bd29b89c",
+        "check_gpg": true
+      },
+      {
+        "name": "isomd5sum",
+        "epoch": 1,
+        "version": "1.2.3",
+        "release": "3.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/isomd5sum-1.2.3-3.el8.ppc64le.rpm",
+        "checksum": "sha256:864f5bf99bf805c3e1143f78a78012d2f910f0d5627519b1f263a4d5cc6fa45e",
+        "check_gpg": true
+      },
+      {
+        "name": "libusal",
+        "epoch": 0,
+        "version": "1.1.11",
+        "release": "39.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/libusal-1.1.11-39.el8.ppc64le.rpm",
+        "checksum": "sha256:e14ef6f934d9a20645b9eb781902d6a03b7c8123985c88536e06205b240ba509",
+        "check_gpg": true
+      },
+      {
+        "name": "libxkbcommon",
+        "epoch": 0,
+        "version": "0.9.1",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/libxkbcommon-0.9.1-1.el8.ppc64le.rpm",
+        "checksum": "sha256:b5bd11b47b5b690dc667dc486941331d7cd3aaa4f0e5c4d638ec7b294bcc5012",
+        "check_gpg": true
+      },
+      {
+        "name": "lorax",
+        "epoch": 0,
+        "version": "28.14.61",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/lorax-28.14.61-2.el8.ppc64le.rpm",
+        "checksum": "sha256:0bad67cd4773d94db37a39c77f44b6eb380febc0de33fa51cacc2140c9c699b9",
+        "check_gpg": true
+      },
+      {
+        "name": "lorax-templates-generic",
+        "epoch": 0,
+        "version": "28.14.61",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/lorax-templates-generic-28.14.61-2.el8.ppc64le.rpm",
+        "checksum": "sha256:94e73ee7b1a5e6791a7cdce615f8a7e23fe1e6359b22ee366b71f45a5ef13483",
+        "check_gpg": true
+      },
+      {
+        "name": "lorax-templates-rhel",
+        "epoch": 0,
+        "version": "8.5",
+        "release": "2.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/lorax-templates-rhel-8.5-2.el8.noarch.rpm",
+        "checksum": "sha256:41512b492c3020571b4d8c671160758ec0e4b78212d75808291a5c56224b644b",
+        "check_gpg": true
+      },
+      {
+        "name": "pinentry",
+        "epoch": 0,
+        "version": "1.1.0",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/pinentry-1.1.0-2.el8.ppc64le.rpm",
+        "checksum": "sha256:12fda64dea45a7b085a35a816a7d8035be6600cae38f7df04a3bc22ced4d4502",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-kickstart",
+        "epoch": 0,
+        "version": "3.16.13",
+        "release": "1.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/python3-kickstart-3.16.13-1.el8.noarch.rpm",
+        "checksum": "sha256:3c9de6673cb840c3c6925bd1df87da0ef3b118d35dbe8f30bbafd0dfc67a939c",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-mako",
+        "epoch": 0,
+        "version": "1.0.6",
+        "release": "13.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/python3-mako-1.0.6-13.el8.noarch.rpm",
+        "checksum": "sha256:9dc5c484c7821cc737f872973764203376106d643b9adc4ef66bece1b0cc8fdc",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-markupsafe",
+        "epoch": 0,
+        "version": "0.23",
+        "release": "19.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/python3-markupsafe-0.23-19.el8.ppc64le.rpm",
+        "checksum": "sha256:0f54422e17766a9e7385a553d941d1849c9e7ca4caea085305ba9fb1e15ae607",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-ordered-set",
+        "epoch": 0,
+        "version": "2.0.2",
+        "release": "4.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/python3-ordered-set-2.0.2-4.el8.noarch.rpm",
+        "checksum": "sha256:b01c567dbd2b9bf82301b254a8962a8fb8f30d12a8f566145eee0f3936f47b5d",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-pip",
+        "epoch": 0,
+        "version": "9.0.3",
+        "release": "20.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/python3-pip-9.0.3-20.el8.noarch.rpm",
+        "checksum": "sha256:b615599db3ac6249e7b18e0c66474e080dc71ee72612bfa0268ea36b1a74e8da",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-unbound",
+        "epoch": 0,
+        "version": "1.7.3",
+        "release": "17.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/python3-unbound-1.7.3-17.el8.ppc64le.rpm",
+        "checksum": "sha256:8571a2aa115d42f8b5e87ef58d10e9c24e6fbe5470fc2612df96f8740f3d960f",
+        "check_gpg": true
+      },
+      {
+        "name": "python36",
+        "epoch": 0,
+        "version": "3.6.8",
+        "release": "37.module_el8.5.0+771+e5d9a225",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/python36-3.6.8-37.module_el8.5.0+771+e5d9a225.ppc64le.rpm",
+        "checksum": "sha256:3973aa7ac4416f1d33ffa8f4e9a5b126e7e2f77ed1ec63a70312b509b4934a9d",
+        "check_gpg": true
+      },
+      {
+        "name": "qemu-img",
+        "epoch": 15,
+        "version": "4.2.0",
+        "release": "52.module_el8.5.0+853+a4d5519d",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/qemu-img-4.2.0-52.module_el8.5.0+853+a4d5519d.ppc64le.rpm",
+        "checksum": "sha256:9ea4e52636b010504bfff1662c57988feb81cdfe97ba7c092f6efe3abdbe2dd7",
+        "check_gpg": true
+      },
+      {
+        "name": "unbound-libs",
+        "epoch": 0,
+        "version": "1.7.3",
+        "release": "17.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/unbound-libs-1.7.3-17.el8.ppc64le.rpm",
+        "checksum": "sha256:ebd64ac5cc7b9f58a40072fe9afefa2fd835e0eb18cdeaf085395c7e84affac3",
+        "check_gpg": true
+      },
+      {
+        "name": "xkeyboard-config",
+        "epoch": 0,
+        "version": "2.28",
+        "release": "1.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/xkeyboard-config-2.28-1.el8.noarch.rpm",
+        "checksum": "sha256:a2aeabb3962859069a78acc288bc3bffb35485428e162caafec8134f5ce6ca67",
+        "check_gpg": true
+      }
+    ],
+    "packages": [
+      {
+        "name": "NetworkManager",
+        "epoch": 1,
+        "version": "1.32.8",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/NetworkManager-1.32.8-1.el8.ppc64le.rpm",
+        "checksum": "sha256:a6ef8e56d53c29e92b46a7ad62c22380056153b2d5810c39c0cc1658a4250d5b",
+        "check_gpg": true
+      },
+      {
+        "name": "NetworkManager-libnm",
+        "epoch": 1,
+        "version": "1.32.8",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/NetworkManager-libnm-1.32.8-1.el8.ppc64le.rpm",
+        "checksum": "sha256:d3ad718b08b44e1fca355abd46a6c315a9d73ab38f9f3c3d551642b55866e182",
+        "check_gpg": true
+      },
+      {
+        "name": "NetworkManager-team",
+        "epoch": 1,
+        "version": "1.32.8",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/NetworkManager-team-1.32.8-1.el8.ppc64le.rpm",
+        "checksum": "sha256:3ed20aba45a8c175e818de998d906fb2759387c607bd9b15dbbefee8c73097ba",
+        "check_gpg": true
+      },
+      {
+        "name": "NetworkManager-tui",
+        "epoch": 1,
+        "version": "1.32.8",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/NetworkManager-tui-1.32.8-1.el8.ppc64le.rpm",
+        "checksum": "sha256:5f068787bd9a0190b03e64cd770e44ace593c5aa09e3f4c470c44d8d484b4674",
+        "check_gpg": true
+      },
+      {
+        "name": "acl",
+        "epoch": 0,
+        "version": "2.2.53",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/acl-2.2.53-1.el8.ppc64le.rpm",
+        "checksum": "sha256:2c1baefd0f802507d9741da8da54f6eae42b04967f9d433d7f9e0f124434c70d",
+        "check_gpg": true
+      },
+      {
+        "name": "audit",
+        "epoch": 0,
+        "version": "3.0",
+        "release": "0.17.20191104git1c2f876.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/audit-3.0-0.17.20191104git1c2f876.el8.ppc64le.rpm",
+        "checksum": "sha256:42829311fe40b7487530ee432aeb8e1df86e5168373f038cccb60d0db94601d3",
+        "check_gpg": true
+      },
+      {
+        "name": "audit-libs",
+        "epoch": 0,
+        "version": "3.0",
+        "release": "0.17.20191104git1c2f876.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/audit-libs-3.0-0.17.20191104git1c2f876.el8.ppc64le.rpm",
+        "checksum": "sha256:be49b69bc5de947ee2151f397993a691a57bc53952058c32cde0fca674da7d8c",
+        "check_gpg": true
+      },
+      {
+        "name": "authselect",
+        "epoch": 0,
+        "version": "1.2.2",
+        "release": "3.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/authselect-1.2.2-3.el8.ppc64le.rpm",
+        "checksum": "sha256:f14cc62cf70a187384adff6bedf8b09858b8f441a9be87ebf3ae975c4e6b0d73",
+        "check_gpg": true
+      },
+      {
+        "name": "authselect-libs",
+        "epoch": 0,
+        "version": "1.2.2",
+        "release": "3.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/authselect-libs-1.2.2-3.el8.ppc64le.rpm",
+        "checksum": "sha256:4966b1832e9eccd8f83ecc20143fb6f18215107bdecd7267b4605cdae4a6562a",
+        "check_gpg": true
+      },
+      {
+        "name": "basesystem",
+        "epoch": 0,
+        "version": "11",
+        "release": "5.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/basesystem-11-5.el8.noarch.rpm",
+        "checksum": "sha256:48226934763e4c412c1eb65df314e6879720b4b1ebcb3d07c126c9526639cb68",
+        "check_gpg": true
+      },
+      {
+        "name": "bash",
+        "epoch": 0,
+        "version": "4.4.20",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/bash-4.4.20-2.el8.ppc64le.rpm",
+        "checksum": "sha256:3a438b53e8377eccf90cac0fd42ed2b513fc869bfb7b96e3d2a4f6984a287f90",
+        "check_gpg": true
+      },
+      {
+        "name": "bc",
+        "epoch": 0,
+        "version": "1.07.1",
+        "release": "5.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/bc-1.07.1-5.el8.ppc64le.rpm",
+        "checksum": "sha256:c12c7dc6676c6ccc5ca08ceddfb1b4e46c9f1ed49cbc241292ae6d1fdb0d9d62",
+        "check_gpg": true
+      },
+      {
+        "name": "bind-export-libs",
+        "epoch": 32,
+        "version": "9.11.26",
+        "release": "4.el8_4",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/bind-export-libs-9.11.26-4.el8_4.ppc64le.rpm",
+        "checksum": "sha256:297b8a7b336dfc298d86d76d400459d2fa63af8628f5e19e35314a33a6478234",
+        "check_gpg": true
+      },
+      {
+        "name": "brotli",
+        "epoch": 0,
+        "version": "1.0.6",
+        "release": "3.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/brotli-1.0.6-3.el8.ppc64le.rpm",
+        "checksum": "sha256:8729b157f0925feccdaef8aacd91c6aebe0109e621675bcc15e1830673b0e19d",
+        "check_gpg": true
+      },
+      {
+        "name": "bzip2",
+        "epoch": 0,
+        "version": "1.0.6",
+        "release": "26.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/bzip2-1.0.6-26.el8.ppc64le.rpm",
+        "checksum": "sha256:06c8c530fb914e07375c183f13b8431456377cec33376423f6589d1047277587",
+        "check_gpg": true
+      },
+      {
+        "name": "bzip2-libs",
+        "epoch": 0,
+        "version": "1.0.6",
+        "release": "26.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/bzip2-libs-1.0.6-26.el8.ppc64le.rpm",
+        "checksum": "sha256:56c3d429ea949467dc0bca882646cf40a58fb6f27750f5664ff2919f5d38ada5",
+        "check_gpg": true
+      },
+      {
+        "name": "c-ares",
+        "epoch": 0,
+        "version": "1.13.0",
+        "release": "5.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/c-ares-1.13.0-5.el8.ppc64le.rpm",
+        "checksum": "sha256:1f2a096d6a75662a86a06ff2859e6ba916bbc8c6d8cb7b73810ffbb9fef4b089",
+        "check_gpg": true
+      },
+      {
+        "name": "ca-certificates",
+        "epoch": 0,
+        "version": "2021.2.50",
+        "release": "82.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/ca-certificates-2021.2.50-82.el8.noarch.rpm",
+        "checksum": "sha256:1fad1d1f8b56e6967863aeb60f5fa3615e6a35b0f6532d8a23066e6823b50860",
+        "check_gpg": true
+      },
+      {
+        "name": "centos-gpg-keys",
+        "epoch": 1,
+        "version": "8",
+        "release": "2.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/centos-gpg-keys-8-2.el8.noarch.rpm",
+        "checksum": "sha256:842ff55b80ac9a5c3357bf52646a5761a4c4786bb3e64b56d8fa5d8fe34ef8bb",
+        "check_gpg": true
+      },
+      {
+        "name": "centos-stream-release",
+        "epoch": 0,
+        "version": "8.5",
+        "release": "3.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/centos-stream-release-8.5-3.el8.noarch.rpm",
+        "checksum": "sha256:15b17b95cf9cb9fb64e0c8e56110836bdcaf70de81b8cbdb60e181fc90456e06",
+        "check_gpg": true
+      },
+      {
+        "name": "centos-stream-repos",
+        "epoch": 0,
+        "version": "8",
+        "release": "2.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/centos-stream-repos-8-2.el8.noarch.rpm",
+        "checksum": "sha256:a82958266d292f4725fc1981ea57a861b7fc7feeb7a9551d0b61b98ca51a5662",
+        "check_gpg": true
+      },
+      {
+        "name": "checkpolicy",
+        "epoch": 0,
+        "version": "2.9",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/checkpolicy-2.9-1.el8.ppc64le.rpm",
+        "checksum": "sha256:38fe7db64baf2d4804a14466a6244f3c1de3bd5deca0ad4044e96d0d3f3751c7",
+        "check_gpg": true
+      },
+      {
+        "name": "chkconfig",
+        "epoch": 0,
+        "version": "1.19.1",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/chkconfig-1.19.1-1.el8.ppc64le.rpm",
+        "checksum": "sha256:eee92733e8989029929d5cb1f673b15fdb814dac32e148d5bc02378b44c8699a",
+        "check_gpg": true
+      },
+      {
+        "name": "chrony",
+        "epoch": 0,
+        "version": "4.1",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/chrony-4.1-1.el8.ppc64le.rpm",
+        "checksum": "sha256:24fcc5bc49b059b221075989f25875fb821079088dca694aec262446cde50cb7",
+        "check_gpg": true
+      },
+      {
+        "name": "cockpit-bridge",
+        "epoch": 0,
+        "version": "250",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/cockpit-bridge-250-1.el8.ppc64le.rpm",
+        "checksum": "sha256:dbc730cf810cc886667a7a9b17883ba15bc40e933a38dd820f2f026cf8007805",
+        "check_gpg": true
+      },
+      {
+        "name": "cockpit-system",
+        "epoch": 0,
+        "version": "250",
+        "release": "1.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/cockpit-system-250-1.el8.noarch.rpm",
+        "checksum": "sha256:3818fe6ec4996402b718827ba40ca01cc3c8276646d80030b652a26153aea2b7",
+        "check_gpg": true
+      },
+      {
+        "name": "cockpit-ws",
+        "epoch": 0,
+        "version": "250",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/cockpit-ws-250-1.el8.ppc64le.rpm",
+        "checksum": "sha256:ec85355744a8b37aa7fbe48d6f8afd8d0538129b70e82d238c3b57ae08559430",
+        "check_gpg": true
+      },
+      {
+        "name": "coreutils",
+        "epoch": 0,
+        "version": "8.30",
+        "release": "12.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/coreutils-8.30-12.el8.ppc64le.rpm",
+        "checksum": "sha256:ff8b51c6a8bacc5ef6b5da0f049d170ab1c1ecebad50ded3c04ed384eca9a2c0",
+        "check_gpg": true
+      },
+      {
+        "name": "coreutils-common",
+        "epoch": 0,
+        "version": "8.30",
+        "release": "12.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/coreutils-common-8.30-12.el8.ppc64le.rpm",
+        "checksum": "sha256:383a5e6bb9e94de53baaf5c7493cd50a68c893c6a30acfbe28407d33bb133efc",
+        "check_gpg": true
+      },
+      {
+        "name": "cpio",
+        "epoch": 0,
+        "version": "2.12",
+        "release": "10.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/cpio-2.12-10.el8.ppc64le.rpm",
+        "checksum": "sha256:19061d12407c0c4bca6abcaef01695b70dcd3967ff102dd07178a2193a280e29",
+        "check_gpg": true
+      },
+      {
+        "name": "cracklib",
+        "epoch": 0,
+        "version": "2.9.6",
+        "release": "15.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/cracklib-2.9.6-15.el8.ppc64le.rpm",
+        "checksum": "sha256:4e3e93a3d2039c2a8305030b7960bd1100d7d20705a1afb1325a4ee79478a74a",
+        "check_gpg": true
+      },
+      {
+        "name": "cracklib-dicts",
+        "epoch": 0,
+        "version": "2.9.6",
+        "release": "15.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/cracklib-dicts-2.9.6-15.el8.ppc64le.rpm",
+        "checksum": "sha256:084d79ed3d7127e6d46e9ac6e654d8ef181a156435808dc8eb32968b6c1b4946",
+        "check_gpg": true
+      },
+      {
+        "name": "cronie",
+        "epoch": 0,
+        "version": "1.5.2",
+        "release": "4.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/cronie-1.5.2-4.el8.ppc64le.rpm",
+        "checksum": "sha256:edf00207b603cbfe86b07f8be5c4ee14ff1dd85ec4b7d82d760483ffcea43891",
+        "check_gpg": true
+      },
+      {
+        "name": "cronie-anacron",
+        "epoch": 0,
+        "version": "1.5.2",
+        "release": "4.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/cronie-anacron-1.5.2-4.el8.ppc64le.rpm",
+        "checksum": "sha256:6faee589c5a7454502e5ec07586a4856e7f1376bd551741af2acf03afb9716e6",
+        "check_gpg": true
+      },
+      {
+        "name": "crontabs",
+        "epoch": 0,
+        "version": "1.11",
+        "release": "17.20190603git.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/crontabs-1.11-17.20190603git.el8.noarch.rpm",
+        "checksum": "sha256:bcf25aae89f7368b16346bc1ec92850175bcc2312bf7a5e74bc3c512bcd345b0",
+        "check_gpg": true
+      },
+      {
+        "name": "crypto-policies",
+        "epoch": 0,
+        "version": "20210617",
+        "release": "1.gitc776d3e.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/crypto-policies-20210617-1.gitc776d3e.el8.noarch.rpm",
+        "checksum": "sha256:2a8f9e5119a034801904185dcbf1bc29db67e9e9b0cf5893615722d7bb33099c",
+        "check_gpg": true
+      },
+      {
+        "name": "crypto-policies-scripts",
+        "epoch": 0,
+        "version": "20210617",
+        "release": "1.gitc776d3e.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/crypto-policies-scripts-20210617-1.gitc776d3e.el8.noarch.rpm",
+        "checksum": "sha256:67f37cee02ba744dfc7957725f5ef9df229778f6a2f7afc659625b458da6167e",
+        "check_gpg": true
+      },
+      {
+        "name": "cryptsetup-libs",
+        "epoch": 0,
+        "version": "2.3.3",
+        "release": "4.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/cryptsetup-libs-2.3.3-4.el8.ppc64le.rpm",
+        "checksum": "sha256:b10d8521963a2494fdb2b5f8fb0de837dc86d4016c3b10019fb8970a09582451",
+        "check_gpg": true
+      },
+      {
+        "name": "curl",
+        "epoch": 0,
+        "version": "7.61.1",
+        "release": "18.el8_4.1",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/curl-7.61.1-18.el8_4.1.ppc64le.rpm",
+        "checksum": "sha256:47ad43730c8bc72c90f2fb3dbd3526d716ada2fad94e62cb443658e94c6503c5",
+        "check_gpg": true
+      },
+      {
+        "name": "cyrus-sasl-lib",
+        "epoch": 0,
+        "version": "2.1.27",
+        "release": "5.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/cyrus-sasl-lib-2.1.27-5.el8.ppc64le.rpm",
+        "checksum": "sha256:5c1940e1f173e22b053f3a89022903cea34a6af20dff81c65548c4e2ba3a8293",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus",
+        "epoch": 1,
+        "version": "1.12.8",
+        "release": "14.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/dbus-1.12.8-14.el8.ppc64le.rpm",
+        "checksum": "sha256:1a4e44583a767289bb0d354db93c6a9132420e13376d4fcae866d69620bb11bb",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-common",
+        "epoch": 1,
+        "version": "1.12.8",
+        "release": "14.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/dbus-common-1.12.8-14.el8.noarch.rpm",
+        "checksum": "sha256:7baac88adafdc5958fb818c7685d3c6548f6e2e585e4435ceee4a168edc3597e",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-daemon",
+        "epoch": 1,
+        "version": "1.12.8",
+        "release": "14.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/dbus-daemon-1.12.8-14.el8.ppc64le.rpm",
+        "checksum": "sha256:090563f18409c228274bb61dcf1001f63a55c1246fb2838a998cb3c5fd8c3874",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-glib",
+        "epoch": 0,
+        "version": "0.110",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/dbus-glib-0.110-2.el8.ppc64le.rpm",
+        "checksum": "sha256:c58b0b900a7ffc778980461d74dc236bf2c790d2e5e8c04e28876e221b48a1c8",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-libs",
+        "epoch": 1,
+        "version": "1.12.8",
+        "release": "14.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/dbus-libs-1.12.8-14.el8.ppc64le.rpm",
+        "checksum": "sha256:cc5f8dd4e061da3a73aa67112e24f2cc5c0ad0cd4334dc798b8834cf6259a779",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-tools",
+        "epoch": 1,
+        "version": "1.12.8",
+        "release": "14.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/dbus-tools-1.12.8-14.el8.ppc64le.rpm",
+        "checksum": "sha256:698e8ecaf71719dafacae79de05080d567b69fad3511e8b8d42b9af96a7c41db",
+        "check_gpg": true
+      },
+      {
+        "name": "dejavu-fonts-common",
+        "epoch": 0,
+        "version": "2.35",
+        "release": "7.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/dejavu-fonts-common-2.35-7.el8.noarch.rpm",
+        "checksum": "sha256:dd80a8169e27959a27651616e998be8b49ffdca141744177cb42126ff0ae12b5",
+        "check_gpg": true
+      },
+      {
+        "name": "dejavu-sans-mono-fonts",
+        "epoch": 0,
+        "version": "2.35",
+        "release": "7.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/dejavu-sans-mono-fonts-2.35-7.el8.noarch.rpm",
+        "checksum": "sha256:a8a27e1ffbb92356d6376334687b9eaa0cb5f2eece2670128f3a01e391e9f3bb",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper",
+        "epoch": 8,
+        "version": "1.02.177",
+        "release": "6.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/device-mapper-1.02.177-6.el8.ppc64le.rpm",
+        "checksum": "sha256:441b3862f5a0fd504bbbba18d96d1b2b920fb95a79dc45a753a6a664ad285b07",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper-libs",
+        "epoch": 8,
+        "version": "1.02.177",
+        "release": "6.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/device-mapper-libs-1.02.177-6.el8.ppc64le.rpm",
+        "checksum": "sha256:a42de8ce71380b1f4e8ac5b4ce720bf565c99a0b09ef983c0550a91a467bc155",
+        "check_gpg": true
+      },
+      {
+        "name": "dhcp-client",
+        "epoch": 12,
+        "version": "4.3.6",
+        "release": "45.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/dhcp-client-4.3.6-45.el8.ppc64le.rpm",
+        "checksum": "sha256:ca5d70414653e1b769124582699bc2400f05b5382a9a8dc6bb4ab4f28dac9c20",
+        "check_gpg": true
+      },
+      {
+        "name": "dhcp-common",
+        "epoch": 12,
+        "version": "4.3.6",
+        "release": "45.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/dhcp-common-4.3.6-45.el8.noarch.rpm",
+        "checksum": "sha256:d64da85b0e013679fb06eeadad74465d9556d7ad21e97beb1b5f61fb0658cd10",
+        "check_gpg": true
+      },
+      {
+        "name": "dhcp-libs",
+        "epoch": 12,
+        "version": "4.3.6",
+        "release": "45.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/dhcp-libs-4.3.6-45.el8.ppc64le.rpm",
+        "checksum": "sha256:ed40678aa26d63b71a122bd394b46b362df083c8f4ae3267f205a7d77ff69fdf",
+        "check_gpg": true
+      },
+      {
+        "name": "diffutils",
+        "epoch": 0,
+        "version": "3.6",
+        "release": "6.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/diffutils-3.6-6.el8.ppc64le.rpm",
+        "checksum": "sha256:4f92835a6e4ee4276df49019e068d1871b75821f52b405c699bd9f199df58b80",
+        "check_gpg": true
+      },
+      {
+        "name": "dnf",
+        "epoch": 0,
+        "version": "4.7.0",
+        "release": "2.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/dnf-4.7.0-2.el8.noarch.rpm",
+        "checksum": "sha256:42464424b9fa731f8122fe748aad0005519fc87b770dbbdb71f29f514ea0e889",
+        "check_gpg": true
+      },
+      {
+        "name": "dnf-data",
+        "epoch": 0,
+        "version": "4.7.0",
+        "release": "2.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/dnf-data-4.7.0-2.el8.noarch.rpm",
+        "checksum": "sha256:45c48d32120739734ae97479cc0f3ca19796ea47e360ba39d52b77ce3ada61d7",
+        "check_gpg": true
+      },
+      {
+        "name": "dnf-plugins-core",
+        "epoch": 0,
+        "version": "4.0.21",
+        "release": "2.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/dnf-plugins-core-4.0.21-2.el8.noarch.rpm",
+        "checksum": "sha256:47b61754a278c4ca378871c874ccf6a0a07bffaef38505315cfa94f262887845",
+        "check_gpg": true
+      },
+      {
+        "name": "dosfstools",
+        "epoch": 0,
+        "version": "4.1",
+        "release": "6.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/dosfstools-4.1-6.el8.ppc64le.rpm",
+        "checksum": "sha256:04eee0a9c079186aa58b5536ac8bcbd2a360700b83fa7b9f6eb127c1386b7ef4",
+        "check_gpg": true
+      },
+      {
+        "name": "dracut",
+        "epoch": 0,
+        "version": "049",
+        "release": "188.git20210802.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/dracut-049-188.git20210802.el8.ppc64le.rpm",
+        "checksum": "sha256:881b28a3a37d114bc3f046605b24663560009b13a507217e007643f5682efdd5",
+        "check_gpg": true
+      },
+      {
+        "name": "dracut-config-generic",
+        "epoch": 0,
+        "version": "049",
+        "release": "188.git20210802.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/dracut-config-generic-049-188.git20210802.el8.ppc64le.rpm",
+        "checksum": "sha256:71d45853b0a8673e6354892df7a420ad77200a018ee5334b30b893862d030fa9",
+        "check_gpg": true
+      },
+      {
+        "name": "dracut-network",
+        "epoch": 0,
+        "version": "049",
+        "release": "188.git20210802.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/dracut-network-049-188.git20210802.el8.ppc64le.rpm",
+        "checksum": "sha256:2588ff56ab340c06ce8b5be22cbe23de89d4f336b38ae930daf11db1c6a24391",
+        "check_gpg": true
+      },
+      {
+        "name": "dracut-squash",
+        "epoch": 0,
+        "version": "049",
+        "release": "188.git20210802.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/dracut-squash-049-188.git20210802.el8.ppc64le.rpm",
+        "checksum": "sha256:412f3eaa5f7e226fdc4678a3266edab76d8998f7d76763075f690a01362ef89c",
+        "check_gpg": true
+      },
+      {
+        "name": "e2fsprogs",
+        "epoch": 0,
+        "version": "1.45.6",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/e2fsprogs-1.45.6-2.el8.ppc64le.rpm",
+        "checksum": "sha256:9e67ac5948125dd165c9a74ec848d48b313ef4264bbbb89630a782dbd972d72c",
+        "check_gpg": true
+      },
+      {
+        "name": "e2fsprogs-libs",
+        "epoch": 0,
+        "version": "1.45.6",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/e2fsprogs-libs-1.45.6-2.el8.ppc64le.rpm",
+        "checksum": "sha256:9fb07c2324cccbbc19e3ffade50ee7da41909b2f6c24f49ffd9978ba375de193",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-debuginfod-client",
+        "epoch": 0,
+        "version": "0.185",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/elfutils-debuginfod-client-0.185-1.el8.ppc64le.rpm",
+        "checksum": "sha256:f4eca686b314edb06d3fe1c526f573c7248c811af70cba76132cdc9c541cadc1",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-default-yama-scope",
+        "epoch": 0,
+        "version": "0.185",
+        "release": "1.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/elfutils-default-yama-scope-0.185-1.el8.noarch.rpm",
+        "checksum": "sha256:30ceeb5a6cadaeccdbde088bfb52ba88190fa530c11f4a2aafd62b4b4ad6b404",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-libelf",
+        "epoch": 0,
+        "version": "0.185",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/elfutils-libelf-0.185-1.el8.ppc64le.rpm",
+        "checksum": "sha256:e87acf226a9511b3a5f83e7fed9c5c20addbbdae47ab67c614404a9392b77e50",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-libs",
+        "epoch": 0,
+        "version": "0.185",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/elfutils-libs-0.185-1.el8.ppc64le.rpm",
+        "checksum": "sha256:d150e53fa73c3786da9e4f6e23d374100b0dd2923485d4a08e9a56ac2786cf83",
+        "check_gpg": true
+      },
+      {
+        "name": "ethtool",
+        "epoch": 2,
+        "version": "5.8",
+        "release": "6.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/ethtool-5.8-6.el8.ppc64le.rpm",
+        "checksum": "sha256:e8b7968fe6613c4cd6324436089cc9c1558cd63fb7da87fd46cc7c15c4ab7f66",
+        "check_gpg": true
+      },
+      {
+        "name": "expat",
+        "epoch": 0,
+        "version": "2.2.5",
+        "release": "4.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/expat-2.2.5-4.el8.ppc64le.rpm",
+        "checksum": "sha256:88be5116908aa5013f540c767f6811774342780bb72d3ec197b3429bfb2f9862",
+        "check_gpg": true
+      },
+      {
+        "name": "file",
+        "epoch": 0,
+        "version": "5.33",
+        "release": "20.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/file-5.33-20.el8.ppc64le.rpm",
+        "checksum": "sha256:e156e6fa9ef6a483f8505ce0eeadbcab12b887c4996233ce5d6258076f6bce50",
+        "check_gpg": true
+      },
+      {
+        "name": "file-libs",
+        "epoch": 0,
+        "version": "5.33",
+        "release": "20.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/file-libs-5.33-20.el8.ppc64le.rpm",
+        "checksum": "sha256:e65f7d7c8def6b168e013914bc0d1137aed65c3010e9796df3b823854472f3e1",
+        "check_gpg": true
+      },
+      {
+        "name": "filesystem",
+        "epoch": 0,
+        "version": "3.8",
+        "release": "6.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/filesystem-3.8-6.el8.ppc64le.rpm",
+        "checksum": "sha256:a49b922f117b9bfb0b07e9848151f8a2948345328ebc534cd28ac187d7ed3f94",
+        "check_gpg": true
+      },
+      {
+        "name": "findutils",
+        "epoch": 1,
+        "version": "4.6.0",
+        "release": "20.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/findutils-4.6.0-20.el8.ppc64le.rpm",
+        "checksum": "sha256:caa0bd6617a8d5e535faedec5f6f3ea7c5e6da1898751f6c9c34a89a95c286ff",
+        "check_gpg": true
+      },
+      {
+        "name": "fontconfig",
+        "epoch": 0,
+        "version": "2.13.1",
+        "release": "3.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/fontconfig-2.13.1-3.el8.ppc64le.rpm",
+        "checksum": "sha256:e403c9839742c4b13e715541237f79ffe52870d59867bebd39e19e7080948db1",
+        "check_gpg": true
+      },
+      {
+        "name": "fontpackages-filesystem",
+        "epoch": 0,
+        "version": "1.44",
+        "release": "22.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/fontpackages-filesystem-1.44-22.el8.noarch.rpm",
+        "checksum": "sha256:700b9050aa490b5eca6d1f8630cbebceb122fce11c370689b5ccb37f5a43ee2f",
+        "check_gpg": true
+      },
+      {
+        "name": "freetype",
+        "epoch": 0,
+        "version": "2.9.1",
+        "release": "4.el8_3.1",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/freetype-2.9.1-4.el8_3.1.ppc64le.rpm",
+        "checksum": "sha256:d1cf2d973db2f1af46f124776b9ab4bd782e7065c8c8428a4ddef60989e4225d",
+        "check_gpg": true
+      },
+      {
+        "name": "fuse-libs",
+        "epoch": 0,
+        "version": "2.9.7",
+        "release": "12.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/fuse-libs-2.9.7-12.el8.ppc64le.rpm",
+        "checksum": "sha256:4992eb036c0797daf9b984af1a34fe27a30287ee5d2bd5e2f5a0df3a09bdbb59",
+        "check_gpg": true
+      },
+      {
+        "name": "gawk",
+        "epoch": 0,
+        "version": "4.2.1",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/gawk-4.2.1-2.el8.ppc64le.rpm",
+        "checksum": "sha256:d807e7fb8bf24be50642a6dced954c6ea208199daab2d27c9f73d789ba82fa37",
+        "check_gpg": true
+      },
+      {
+        "name": "gdbm",
+        "epoch": 1,
+        "version": "1.18",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/gdbm-1.18-1.el8.ppc64le.rpm",
+        "checksum": "sha256:8cd6ef9902851f07cfd9682e2d6873648690f0c2ec65345276b557ede042d8b9",
+        "check_gpg": true
+      },
+      {
+        "name": "gdbm-libs",
+        "epoch": 1,
+        "version": "1.18",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/gdbm-libs-1.18-1.el8.ppc64le.rpm",
+        "checksum": "sha256:d1d362fd4f8022ad05171efe40e84d15ec6c5e5f419d6099ebc8e46e7da632c1",
+        "check_gpg": true
+      },
+      {
+        "name": "gdk-pixbuf2",
+        "epoch": 0,
+        "version": "2.36.12",
+        "release": "5.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/gdk-pixbuf2-2.36.12-5.el8.ppc64le.rpm",
+        "checksum": "sha256:4fc1c84b4434df8a5ccd960d906896e4094236f43ad4aea083a12fb5b8a824f9",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext",
+        "epoch": 0,
+        "version": "0.19.8.1",
+        "release": "17.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/gettext-0.19.8.1-17.el8.ppc64le.rpm",
+        "checksum": "sha256:78fd472a1c7f49b8a432788ea2dfc1119f155a394f41585b4e715d2585fc92ab",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext-libs",
+        "epoch": 0,
+        "version": "0.19.8.1",
+        "release": "17.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/gettext-libs-0.19.8.1-17.el8.ppc64le.rpm",
+        "checksum": "sha256:e392a6b41381ffad04626d092fd2af9477c72e197a74efddf987832c3bfa521f",
+        "check_gpg": true
+      },
+      {
+        "name": "glib-networking",
+        "epoch": 0,
+        "version": "2.56.1",
+        "release": "1.1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/glib-networking-2.56.1-1.1.el8.ppc64le.rpm",
+        "checksum": "sha256:4942002f6e3a471b8d51801047ea2584d5cd1dad5d4c4e44bce7af50c5b7cb14",
+        "check_gpg": true
+      },
+      {
+        "name": "glib2",
+        "epoch": 0,
+        "version": "2.56.4",
+        "release": "156.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/glib2-2.56.4-156.el8.ppc64le.rpm",
+        "checksum": "sha256:ad338b7a3f3bed96300d9ce7f0307e09d758962b8496c10fb3554bf62405d153",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc",
+        "epoch": 0,
+        "version": "2.28",
+        "release": "162.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/glibc-2.28-162.el8.ppc64le.rpm",
+        "checksum": "sha256:bfb45644212cfbbe48b05149f8d53e77d7bd02ca9fc9045cc37115101175a3a0",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-all-langpacks",
+        "epoch": 0,
+        "version": "2.28",
+        "release": "162.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/glibc-all-langpacks-2.28-162.el8.ppc64le.rpm",
+        "checksum": "sha256:fa7bef727ba8657208bb3df95916f0bc912332cb8534c695facef32ffbd72f20",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-common",
+        "epoch": 0,
+        "version": "2.28",
+        "release": "162.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/glibc-common-2.28-162.el8.ppc64le.rpm",
+        "checksum": "sha256:257e086bb52086254fa8cc95a5c4998668b4fcb5203ad3c2275c1150816acc9b",
+        "check_gpg": true
+      },
+      {
+        "name": "gmp",
+        "epoch": 1,
+        "version": "6.1.2",
+        "release": "10.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/gmp-6.1.2-10.el8.ppc64le.rpm",
+        "checksum": "sha256:af0a4287e302baa7c85655ddfe5a7049b8eaf31aff03886f4fc57c920d26d491",
+        "check_gpg": true
+      },
+      {
+        "name": "gnupg2",
+        "epoch": 0,
+        "version": "2.2.20",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/gnupg2-2.2.20-2.el8.ppc64le.rpm",
+        "checksum": "sha256:11ff811a72c82084c7c14700b23d29643e153442a34b3b486e270e5b40e38d0a",
+        "check_gpg": true
+      },
+      {
+        "name": "gnupg2-smime",
+        "epoch": 0,
+        "version": "2.2.20",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/gnupg2-smime-2.2.20-2.el8.ppc64le.rpm",
+        "checksum": "sha256:a2d96efed83ab31d21481af044835a940673ee4ade2763af78c06d2df87b94f7",
+        "check_gpg": true
+      },
+      {
+        "name": "gnutls",
+        "epoch": 0,
+        "version": "3.6.16",
+        "release": "4.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/gnutls-3.6.16-4.el8.ppc64le.rpm",
+        "checksum": "sha256:51760acfb6ca87db5be7a9296d6a3d1220767956c576a26c6d46784e25db85bb",
+        "check_gpg": true
+      },
+      {
+        "name": "gobject-introspection",
+        "epoch": 0,
+        "version": "1.56.1",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/gobject-introspection-1.56.1-1.el8.ppc64le.rpm",
+        "checksum": "sha256:754bf53a39cea727d9d89d59df32e020842dc71f6a0561ea36f8203aff2d5d69",
+        "check_gpg": true
+      },
+      {
+        "name": "gpgme",
+        "epoch": 0,
+        "version": "1.13.1",
+        "release": "9.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/gpgme-1.13.1-9.el8.ppc64le.rpm",
+        "checksum": "sha256:24f5cd46a7395cd046b10d6ddc4de435ec6595d0dcdb2d179c94cc9082a12f14",
+        "check_gpg": true
+      },
+      {
+        "name": "grep",
+        "epoch": 0,
+        "version": "3.1",
+        "release": "6.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/grep-3.1-6.el8.ppc64le.rpm",
+        "checksum": "sha256:2451a475f248a4c66e64d149fefa8bfc195fcd7b3f369bae221a94f8ce4c2d67",
+        "check_gpg": true
+      },
+      {
+        "name": "groff-base",
+        "epoch": 0,
+        "version": "1.22.3",
+        "release": "18.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/groff-base-1.22.3-18.el8.ppc64le.rpm",
+        "checksum": "sha256:cff4b4ac50fed2ceab6add52a66513ed9ca04b024f07a25c53df49f762eea2d2",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-common",
+        "epoch": 1,
+        "version": "2.02",
+        "release": "99.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/grub2-common-2.02-99.el8.noarch.rpm",
+        "checksum": "sha256:4a08d5264e865548e65d31886c91b659b33a2c2ba39fd115b00af3ea0bc91a83",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-ppc64le",
+        "epoch": 1,
+        "version": "2.02",
+        "release": "99.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/grub2-ppc64le-2.02-99.el8.ppc64le.rpm",
+        "checksum": "sha256:7cccedcc359f2a2542858088704bf3d0ec3e46cb7b72f602408fbab937a522d3",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-ppc64le-modules",
+        "epoch": 1,
+        "version": "2.02",
+        "release": "99.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/grub2-ppc64le-modules-2.02-99.el8.noarch.rpm",
+        "checksum": "sha256:d8dad22276baffe9496d5e05ef35d21dd6f9d8f910339daced2c3ff42d7a28c5",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-tools",
+        "epoch": 1,
+        "version": "2.02",
+        "release": "99.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/grub2-tools-2.02-99.el8.ppc64le.rpm",
+        "checksum": "sha256:78b2b9cbf041d4461daf7ac11a24d1e79a9c57f47aa265dba4d09067efe3d96b",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-tools-extra",
+        "epoch": 1,
+        "version": "2.02",
+        "release": "99.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/grub2-tools-extra-2.02-99.el8.ppc64le.rpm",
+        "checksum": "sha256:ac3b306c193bd20658950da402ae0cbdd8337110117de5e5d7eba970822671fd",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-tools-minimal",
+        "epoch": 1,
+        "version": "2.02",
+        "release": "99.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/grub2-tools-minimal-2.02-99.el8.ppc64le.rpm",
+        "checksum": "sha256:fb276cc0ebc6bd27d344f7e0811f26cb3f0e59da09182489095724bdf2a075f8",
+        "check_gpg": true
+      },
+      {
+        "name": "grubby",
+        "epoch": 0,
+        "version": "8.40",
+        "release": "41.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/grubby-8.40-41.el8.ppc64le.rpm",
+        "checksum": "sha256:5a0927d231fbafa8b865591922fc07d39d9b4b263a1e9c0bbef691282f706cd0",
+        "check_gpg": true
+      },
+      {
+        "name": "gsettings-desktop-schemas",
+        "epoch": 0,
+        "version": "3.32.0",
+        "release": "6.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/gsettings-desktop-schemas-3.32.0-6.el8.ppc64le.rpm",
+        "checksum": "sha256:7cced5f47c4035e01fffce0989b62113a75016e5220e7b207c4b96be7ed90403",
+        "check_gpg": true
+      },
+      {
+        "name": "gssproxy",
+        "epoch": 0,
+        "version": "0.8.0",
+        "release": "19.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/gssproxy-0.8.0-19.el8.ppc64le.rpm",
+        "checksum": "sha256:ffb6d471f5c82b0407cc41a25aea25bf83d6779b3ef20f0557c4fd0da6111bb7",
+        "check_gpg": true
+      },
+      {
+        "name": "gzip",
+        "epoch": 0,
+        "version": "1.9",
+        "release": "12.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/gzip-1.9-12.el8.ppc64le.rpm",
+        "checksum": "sha256:e1e28504928648404a3b652440091eba010cd99221183ef78601cbd152261d91",
+        "check_gpg": true
+      },
+      {
+        "name": "hardlink",
+        "epoch": 1,
+        "version": "1.3",
+        "release": "6.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/hardlink-1.3-6.el8.ppc64le.rpm",
+        "checksum": "sha256:42bb566be1936bdb40937f9c0a96c4acc93057379385f1807cba18f60443d3e4",
+        "check_gpg": true
+      },
+      {
+        "name": "hdparm",
+        "epoch": 0,
+        "version": "9.54",
+        "release": "4.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/hdparm-9.54-4.el8.ppc64le.rpm",
+        "checksum": "sha256:8c05fe038c7792203afa47f4534318f6c674672999b444909706ce0826bf1b8f",
+        "check_gpg": true
+      },
+      {
+        "name": "hostname",
+        "epoch": 0,
+        "version": "3.20",
+        "release": "7.el8.0.1",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/hostname-3.20-7.el8.0.1.ppc64le.rpm",
+        "checksum": "sha256:a571c94456b9a1743e94f4f72159de52bb13fe93437b81da675351553a881a17",
+        "check_gpg": true
+      },
+      {
+        "name": "hwdata",
+        "epoch": 0,
+        "version": "0.314",
+        "release": "8.9.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/hwdata-0.314-8.9.el8.noarch.rpm",
+        "checksum": "sha256:dfecfa1299d11d6a77503e626a2e9a14e1a75666bc8ea2abaf7ff515d2c86332",
+        "check_gpg": true
+      },
+      {
+        "name": "ima-evm-utils",
+        "epoch": 0,
+        "version": "1.3.2",
+        "release": "12.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/ima-evm-utils-1.3.2-12.el8.ppc64le.rpm",
+        "checksum": "sha256:8119d276749b35cd9c283c1a8d970b3528bea58427eb37eafc22b6093a978f08",
+        "check_gpg": true
+      },
+      {
+        "name": "info",
+        "epoch": 0,
+        "version": "6.5",
+        "release": "6.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/info-6.5-6.el8.ppc64le.rpm",
+        "checksum": "sha256:6d1ac29b3a38408f6d238d6718384e05be7346789c6200b354335b0e0c9c77df",
+        "check_gpg": true
+      },
+      {
+        "name": "initscripts",
+        "epoch": 0,
+        "version": "10.00.15",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/initscripts-10.00.15-1.el8.ppc64le.rpm",
+        "checksum": "sha256:d751a4fdecc0dc3c5ff897e3ff4c25e7addc698d590e2bfc4c893e693be7d558",
+        "check_gpg": true
+      },
+      {
+        "name": "ipcalc",
+        "epoch": 0,
+        "version": "0.2.4",
+        "release": "4.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/ipcalc-0.2.4-4.el8.ppc64le.rpm",
+        "checksum": "sha256:5418cf17fad308fe9a8d3acdf4ae10f433da50c32f10ae4089be2f8423dea4cf",
+        "check_gpg": true
+      },
+      {
+        "name": "iproute",
+        "epoch": 0,
+        "version": "5.12.0",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/iproute-5.12.0-2.el8.ppc64le.rpm",
+        "checksum": "sha256:12b0565d080311c7804d8fb1d697ecdef8807563ebeee4443e2fa6d35b1d958f",
+        "check_gpg": true
+      },
+      {
+        "name": "iputils",
+        "epoch": 0,
+        "version": "20180629",
+        "release": "7.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/iputils-20180629-7.el8.ppc64le.rpm",
+        "checksum": "sha256:6d02615212a88eb204b8f6d2a7cfbf6183a12f29d72ca5dbfbe5c45c63068ef8",
+        "check_gpg": true
+      },
+      {
+        "name": "irqbalance",
+        "epoch": 2,
+        "version": "1.4.0",
+        "release": "6.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/irqbalance-1.4.0-6.el8.ppc64le.rpm",
+        "checksum": "sha256:cbe98d6dcf93449d9c2fbf95de75f065f8da67a23f13401c672d78b28c6b7f6a",
+        "check_gpg": true
+      },
+      {
+        "name": "jansson",
+        "epoch": 0,
+        "version": "2.11",
+        "release": "3.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/jansson-2.11-3.el8.ppc64le.rpm",
+        "checksum": "sha256:965ec1b760513e1ae539747624bd241d6575675e8a04c5caa572faadb54007c7",
+        "check_gpg": true
+      },
+      {
+        "name": "json-c",
+        "epoch": 0,
+        "version": "0.13.1",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/json-c-0.13.1-2.el8.ppc64le.rpm",
+        "checksum": "sha256:331b91a0928c05618c7fed3e12bbe9ecb9e4619d08c7e85d3de344a08d2f0f1a",
+        "check_gpg": true
+      },
+      {
+        "name": "json-glib",
+        "epoch": 0,
+        "version": "1.4.4",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/json-glib-1.4.4-1.el8.ppc64le.rpm",
+        "checksum": "sha256:36c05d62567b455f2722c6e5cf431071174adf4c1d3b7450f0c1aaa903210bc3",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd",
+        "epoch": 0,
+        "version": "2.0.4",
+        "release": "10.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/kbd-2.0.4-10.el8.ppc64le.rpm",
+        "checksum": "sha256:49c7c718cb4e2b6f0effd0dec4f4cb4e109d260c192b2b329a58a1da9a24ad1d",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd-legacy",
+        "epoch": 0,
+        "version": "2.0.4",
+        "release": "10.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/kbd-legacy-2.0.4-10.el8.noarch.rpm",
+        "checksum": "sha256:a3ef96219165bfc64d4f5d50f51fbd43e803c500619240ffe4db1f9f8e337f83",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd-misc",
+        "epoch": 0,
+        "version": "2.0.4",
+        "release": "10.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/kbd-misc-2.0.4-10.el8.noarch.rpm",
+        "checksum": "sha256:ef86061338fa321c959cadc75ecbdfd405eebaa1042eec9d9c737d4d9d92568f",
+        "check_gpg": true
+      },
+      {
+        "name": "kernel",
+        "epoch": 0,
+        "version": "4.18.0",
+        "release": "331.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/kernel-4.18.0-331.el8.ppc64le.rpm",
+        "checksum": "sha256:7bb5051dee5f6633a02cf5a3285dd86890cc6521e497526a8149dc5c5ebad062",
+        "check_gpg": true
+      },
+      {
+        "name": "kernel-core",
+        "epoch": 0,
+        "version": "4.18.0",
+        "release": "331.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/kernel-core-4.18.0-331.el8.ppc64le.rpm",
+        "checksum": "sha256:4aca3cee9de1a4cd7ac56a12550f286894a215cac593c18857278f7b0e48f328",
+        "check_gpg": true
+      },
+      {
+        "name": "kernel-modules",
+        "epoch": 0,
+        "version": "4.18.0",
+        "release": "331.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/kernel-modules-4.18.0-331.el8.ppc64le.rpm",
+        "checksum": "sha256:1d6551bce8f8a1e53682fafe4f67fa830c333f0b37db7acbeaca0095b5ce870b",
+        "check_gpg": true
+      },
+      {
+        "name": "kernel-tools",
+        "epoch": 0,
+        "version": "4.18.0",
+        "release": "331.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/kernel-tools-4.18.0-331.el8.ppc64le.rpm",
+        "checksum": "sha256:e45848a3fbfa1d46709448593fa7929fee4c5a83d2168c0d41d498251e4b5dae",
+        "check_gpg": true
+      },
+      {
+        "name": "kernel-tools-libs",
+        "epoch": 0,
+        "version": "4.18.0",
+        "release": "331.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/kernel-tools-libs-4.18.0-331.el8.ppc64le.rpm",
+        "checksum": "sha256:83cb349e65d5b783518b735d8fb477264f0a6bd7cdd6f4096f8493dbd45f2ff7",
+        "check_gpg": true
+      },
+      {
+        "name": "kexec-tools",
+        "epoch": 0,
+        "version": "2.0.20",
+        "release": "56.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/kexec-tools-2.0.20-56.el8.ppc64le.rpm",
+        "checksum": "sha256:30dd1d58b7b963d052341f4583a7417823cf4dbbe7ac4b536f3a5250c4d34582",
+        "check_gpg": true
+      },
+      {
+        "name": "keyutils",
+        "epoch": 0,
+        "version": "1.5.10",
+        "release": "9.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/keyutils-1.5.10-9.el8.ppc64le.rpm",
+        "checksum": "sha256:588874c2fc18a927a479aac7affef52f52d09e5b20102dfab70836d420ae553e",
+        "check_gpg": true
+      },
+      {
+        "name": "keyutils-libs",
+        "epoch": 0,
+        "version": "1.5.10",
+        "release": "9.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/keyutils-libs-1.5.10-9.el8.ppc64le.rpm",
+        "checksum": "sha256:6fe1188081e441595ce29ebed4d1985e5890815158244f69f092ee930656f755",
+        "check_gpg": true
+      },
+      {
+        "name": "kmod",
+        "epoch": 0,
+        "version": "25",
+        "release": "18.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/kmod-25-18.el8.ppc64le.rpm",
+        "checksum": "sha256:a80c1d6d32db7ce8fdd58bb4f3f488b74e94261a38512dc8a15179ae33697e63",
+        "check_gpg": true
+      },
+      {
+        "name": "kmod-libs",
+        "epoch": 0,
+        "version": "25",
+        "release": "18.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/kmod-libs-25-18.el8.ppc64le.rpm",
+        "checksum": "sha256:b437a08d4670ef440ba6dbaae4ccb39f989f0c2a3d280ea66d6fd9532a313286",
+        "check_gpg": true
+      },
+      {
+        "name": "kpartx",
+        "epoch": 0,
+        "version": "0.8.4",
+        "release": "17.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/kpartx-0.8.4-17.el8.ppc64le.rpm",
+        "checksum": "sha256:230731b577f8d29e7e8e8fd6d1ea02702fb4364fcc7034d838ccddc4d66da8c3",
+        "check_gpg": true
+      },
+      {
+        "name": "krb5-libs",
+        "epoch": 0,
+        "version": "1.18.2",
+        "release": "13.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/krb5-libs-1.18.2-13.el8.ppc64le.rpm",
+        "checksum": "sha256:54f59ddb56e89a5330373e07ea05934fc58360eb7480615ede2a3ed6982e1eef",
+        "check_gpg": true
+      },
+      {
+        "name": "less",
+        "epoch": 0,
+        "version": "530",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/less-530-1.el8.ppc64le.rpm",
+        "checksum": "sha256:427eba707b42761a0ef57107ba5a22f80fc6379d1537c757fe1929d6d066b05c",
+        "check_gpg": true
+      },
+      {
+        "name": "libacl",
+        "epoch": 0,
+        "version": "2.2.53",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libacl-2.2.53-1.el8.ppc64le.rpm",
+        "checksum": "sha256:ff1580bd4ec5841d4937b383917fa30f318b4f419b8067a77468eb4a9630ba10",
+        "check_gpg": true
+      },
+      {
+        "name": "libappstream-glib",
+        "epoch": 0,
+        "version": "0.7.14",
+        "release": "3.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libappstream-glib-0.7.14-3.el8.ppc64le.rpm",
+        "checksum": "sha256:e778fc7e5d62fe488e250a1916cdb7f692e98e23d0c2b4264672b2574ff416e5",
+        "check_gpg": true
+      },
+      {
+        "name": "libarchive",
+        "epoch": 0,
+        "version": "3.3.3",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libarchive-3.3.3-1.el8.ppc64le.rpm",
+        "checksum": "sha256:df40cada982b04336fe8b250b4fdd576ddd03a014bb519a69b34640369bef661",
+        "check_gpg": true
+      },
+      {
+        "name": "libassuan",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "3.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libassuan-2.5.1-3.el8.ppc64le.rpm",
+        "checksum": "sha256:9c4cd61b98253904436180f58c564bda61be1fa1b5523e4ecbbdc174d0c2a9aa",
+        "check_gpg": true
+      },
+      {
+        "name": "libattr",
+        "epoch": 0,
+        "version": "2.4.48",
+        "release": "3.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libattr-2.4.48-3.el8.ppc64le.rpm",
+        "checksum": "sha256:43bfc890caf7855f2fb55c24474b58cd5c8c7b51e4db4f40d1f302fffd31985b",
+        "check_gpg": true
+      },
+      {
+        "name": "libbasicobjects",
+        "epoch": 0,
+        "version": "0.1.1",
+        "release": "39.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libbasicobjects-0.1.1-39.el8.ppc64le.rpm",
+        "checksum": "sha256:2f6c73fdcd5c5e5b6d8b58663e498a0099db8029386869a4aca670471f6c298e",
+        "check_gpg": true
+      },
+      {
+        "name": "libblkid",
+        "epoch": 0,
+        "version": "2.32.1",
+        "release": "28.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libblkid-2.32.1-28.el8.ppc64le.rpm",
+        "checksum": "sha256:30ae4489980021a727f247d48b4d74d4c6c7667d00bd1a670f045ea24a885541",
+        "check_gpg": true
+      },
+      {
+        "name": "libbpf",
+        "epoch": 0,
+        "version": "0.3.0",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libbpf-0.3.0-1.el8.ppc64le.rpm",
+        "checksum": "sha256:4a8899d3b91a0f847ce793480700b26dc8336c5ee20d9b66067c76fe0dab2f17",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap",
+        "epoch": 0,
+        "version": "2.26",
+        "release": "4.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libcap-2.26-4.el8.ppc64le.rpm",
+        "checksum": "sha256:77e4cfbc823e3764308822ccf03b257861f9360f3b948829f1d73148b321b00e",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap-ng",
+        "epoch": 0,
+        "version": "0.7.11",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libcap-ng-0.7.11-1.el8.ppc64le.rpm",
+        "checksum": "sha256:9b69a221cf9395a110849bb428bb1cfe9fb489322df0fa6017f5978a827ee0e9",
+        "check_gpg": true
+      },
+      {
+        "name": "libcollection",
+        "epoch": 0,
+        "version": "0.7.0",
+        "release": "39.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libcollection-0.7.0-39.el8.ppc64le.rpm",
+        "checksum": "sha256:360be5b93e106d77a8f4e84b318ee8dc14349f223540e0e200e0dfce2676ec04",
+        "check_gpg": true
+      },
+      {
+        "name": "libcom_err",
+        "epoch": 0,
+        "version": "1.45.6",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libcom_err-1.45.6-2.el8.ppc64le.rpm",
+        "checksum": "sha256:e0a7b9f3b56b4737f5711dc6b03f256fbf2488656b8874acabb494b58ba0c1c1",
+        "check_gpg": true
+      },
+      {
+        "name": "libcomps",
+        "epoch": 0,
+        "version": "0.1.16",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libcomps-0.1.16-2.el8.ppc64le.rpm",
+        "checksum": "sha256:5c74a0e3005ea3cb90dff80cfa1e7d64c97f5c01612d253cf4e65aca962b7be4",
+        "check_gpg": true
+      },
+      {
+        "name": "libcroco",
+        "epoch": 0,
+        "version": "0.6.12",
+        "release": "4.el8_2.1",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libcroco-0.6.12-4.el8_2.1.ppc64le.rpm",
+        "checksum": "sha256:194dbe332ccdb33d58f040da07667257e176975f6b2f17343bbf33fb99deb097",
+        "check_gpg": true
+      },
+      {
+        "name": "libcurl",
+        "epoch": 0,
+        "version": "7.61.1",
+        "release": "18.el8_4.1",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libcurl-7.61.1-18.el8_4.1.ppc64le.rpm",
+        "checksum": "sha256:e21a84107568047432e474e08da24aea2340409d57ea8cf170182927dc76de12",
+        "check_gpg": true
+      },
+      {
+        "name": "libdaemon",
+        "epoch": 0,
+        "version": "0.14",
+        "release": "15.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libdaemon-0.14-15.el8.ppc64le.rpm",
+        "checksum": "sha256:f7a2eddcda47cb75108add34c0ce919ceb847605830ad33aeb4bd64d6bed24f3",
+        "check_gpg": true
+      },
+      {
+        "name": "libdb",
+        "epoch": 0,
+        "version": "5.3.28",
+        "release": "40.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libdb-5.3.28-40.el8.ppc64le.rpm",
+        "checksum": "sha256:b83a0199c3d471151f07f6de626a1a4a362dd6aa29d84cf1c0ada2c966ce29c9",
+        "check_gpg": true
+      },
+      {
+        "name": "libdb-utils",
+        "epoch": 0,
+        "version": "5.3.28",
+        "release": "40.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libdb-utils-5.3.28-40.el8.ppc64le.rpm",
+        "checksum": "sha256:709ea71f36495ac2ac89d72d2eb603b6aa55b2c1a70633f23514dd897936f02b",
+        "check_gpg": true
+      },
+      {
+        "name": "libdhash",
+        "epoch": 0,
+        "version": "0.5.0",
+        "release": "39.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libdhash-0.5.0-39.el8.ppc64le.rpm",
+        "checksum": "sha256:6ac918d2bc175b3f356926ca96a998c29bffe256f7d802e8ef654b1226da3ef6",
+        "check_gpg": true
+      },
+      {
+        "name": "libdnf",
+        "epoch": 0,
+        "version": "0.63.0",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libdnf-0.63.0-2.el8.ppc64le.rpm",
+        "checksum": "sha256:aea253461d1a34a239b445ee07cb34398a9cbb6ed40e252182a91cddcf59004b",
+        "check_gpg": true
+      },
+      {
+        "name": "libedit",
+        "epoch": 0,
+        "version": "3.1",
+        "release": "23.20170329cvs.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libedit-3.1-23.20170329cvs.el8.ppc64le.rpm",
+        "checksum": "sha256:cc662127a17d4e08e90f75703f376067eed48f5d6b5b8d106fa3824397f1978e",
+        "check_gpg": true
+      },
+      {
+        "name": "libevent",
+        "epoch": 0,
+        "version": "2.1.8",
+        "release": "5.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libevent-2.1.8-5.el8.ppc64le.rpm",
+        "checksum": "sha256:a0b8a6b2c8dad75290228086dd0af342979604bbf4b9500029e25d766835c0f4",
+        "check_gpg": true
+      },
+      {
+        "name": "libfdisk",
+        "epoch": 0,
+        "version": "2.32.1",
+        "release": "28.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libfdisk-2.32.1-28.el8.ppc64le.rpm",
+        "checksum": "sha256:0afac6f4f9ed1c59510675d87da45c7966c0f7aae6e8dd056961aceed8c4fe0a",
+        "check_gpg": true
+      },
+      {
+        "name": "libffi",
+        "epoch": 0,
+        "version": "3.1",
+        "release": "22.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libffi-3.1-22.el8.ppc64le.rpm",
+        "checksum": "sha256:12696f5638ad2068c5c8940495d15c3bb1c57990000dbda7428b008e9e63ab5b",
+        "check_gpg": true
+      },
+      {
+        "name": "libgcc",
+        "epoch": 0,
+        "version": "8.5.0",
+        "release": "3.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libgcc-8.5.0-3.el8.ppc64le.rpm",
+        "checksum": "sha256:f3d9ccb762146dc97f2d201d979fbb0e9171d1203fb985f3ef48b5c2a176c2a9",
+        "check_gpg": true
+      },
+      {
+        "name": "libgcrypt",
+        "epoch": 0,
+        "version": "1.8.5",
+        "release": "6.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libgcrypt-1.8.5-6.el8.ppc64le.rpm",
+        "checksum": "sha256:c5a60ffb80cd1f9b90c797f1d1ac80e5536eb32a5b276871445e7279ac701c5f",
+        "check_gpg": true
+      },
+      {
+        "name": "libgomp",
+        "epoch": 0,
+        "version": "8.5.0",
+        "release": "3.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libgomp-8.5.0-3.el8.ppc64le.rpm",
+        "checksum": "sha256:0515afdac097ad54cf4b24e0644f0789cab5535a54107aa44940ffd991a6cef3",
+        "check_gpg": true
+      },
+      {
+        "name": "libgpg-error",
+        "epoch": 0,
+        "version": "1.31",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libgpg-error-1.31-1.el8.ppc64le.rpm",
+        "checksum": "sha256:020abac486839c7be29fae37a686dc7749398c333cb8ba94b3390b386ffcbff7",
+        "check_gpg": true
+      },
+      {
+        "name": "libibverbs",
+        "epoch": 0,
+        "version": "35.0",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libibverbs-35.0-1.el8.ppc64le.rpm",
+        "checksum": "sha256:8ab06f608f45445bdef489cedb40d419aa7282e127ee26dbfcf417350a3f1630",
+        "check_gpg": true
+      },
+      {
+        "name": "libidn2",
+        "epoch": 0,
+        "version": "2.2.0",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libidn2-2.2.0-1.el8.ppc64le.rpm",
+        "checksum": "sha256:31d924d1540dd4e927a4c3aa936cec4bfb54ed302d3e8acc1be8b52dd5deb10c",
+        "check_gpg": true
+      },
+      {
+        "name": "libini_config",
+        "epoch": 0,
+        "version": "1.3.1",
+        "release": "39.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libini_config-1.3.1-39.el8.ppc64le.rpm",
+        "checksum": "sha256:1b95698d64dd299827f62cbe43d373e985da2d8900c4489a49475f53fa04f414",
+        "check_gpg": true
+      },
+      {
+        "name": "libkcapi",
+        "epoch": 0,
+        "version": "1.2.0",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libkcapi-1.2.0-2.el8.ppc64le.rpm",
+        "checksum": "sha256:fd6e1803ff367036da5b52b2183e1408691b379cc1320971bb664737507f89a4",
+        "check_gpg": true
+      },
+      {
+        "name": "libkcapi-hmaccalc",
+        "epoch": 0,
+        "version": "1.2.0",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libkcapi-hmaccalc-1.2.0-2.el8.ppc64le.rpm",
+        "checksum": "sha256:6b312faed4a0508da2f15d3f31a6daccfc0ec6621e5fb7b20956027dce5fa395",
+        "check_gpg": true
+      },
+      {
+        "name": "libksba",
+        "epoch": 0,
+        "version": "1.3.5",
+        "release": "7.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libksba-1.3.5-7.el8.ppc64le.rpm",
+        "checksum": "sha256:a5f9f2c4f39f393971f268aebb1b55d18d0d96693d08a9ed70403e8565807bb6",
+        "check_gpg": true
+      },
+      {
+        "name": "libldb",
+        "epoch": 0,
+        "version": "2.3.0",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libldb-2.3.0-2.el8.ppc64le.rpm",
+        "checksum": "sha256:a0a8e31422da7d695a3788a7cae3f929d42cb4982889422588904ecc6879182e",
+        "check_gpg": true
+      },
+      {
+        "name": "libmnl",
+        "epoch": 0,
+        "version": "1.0.4",
+        "release": "6.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libmnl-1.0.4-6.el8.ppc64le.rpm",
+        "checksum": "sha256:59008e3619cae0f40e183b7003e722cb312b00bdba775ec9f06cdd833b53c26a",
+        "check_gpg": true
+      },
+      {
+        "name": "libmodman",
+        "epoch": 0,
+        "version": "2.0.1",
+        "release": "17.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libmodman-2.0.1-17.el8.ppc64le.rpm",
+        "checksum": "sha256:d7bacff8f9be89871c6ec98c3356de11008ae574da852bdc15cee7ebb9ac39be",
+        "check_gpg": true
+      },
+      {
+        "name": "libmodulemd",
+        "epoch": 0,
+        "version": "2.12.1",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libmodulemd-2.12.1-1.el8.ppc64le.rpm",
+        "checksum": "sha256:d6eb27d158b6397e52ab6a952fec4e3c414638a08750a6c011d32eb117accd82",
+        "check_gpg": true
+      },
+      {
+        "name": "libmount",
+        "epoch": 0,
+        "version": "2.32.1",
+        "release": "28.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libmount-2.32.1-28.el8.ppc64le.rpm",
+        "checksum": "sha256:4e497225fe36781735cc92c0886f6858b19d4557ed9ecafe1247b8233c206075",
+        "check_gpg": true
+      },
+      {
+        "name": "libndp",
+        "epoch": 0,
+        "version": "1.7",
+        "release": "6.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libndp-1.7-6.el8.ppc64le.rpm",
+        "checksum": "sha256:2812ae39c665069f4b27e9bd26dde9141d4f4e7802befb1b14ac4e27a8225b4b",
+        "check_gpg": true
+      },
+      {
+        "name": "libnfsidmap",
+        "epoch": 1,
+        "version": "2.3.3",
+        "release": "46.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libnfsidmap-2.3.3-46.el8.ppc64le.rpm",
+        "checksum": "sha256:07fb48b313f6d4c1c8b1ffd9c5226c68f99616e46bbd04b325527d817b500577",
+        "check_gpg": true
+      },
+      {
+        "name": "libnghttp2",
+        "epoch": 0,
+        "version": "1.33.0",
+        "release": "3.el8_2.1",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libnghttp2-1.33.0-3.el8_2.1.ppc64le.rpm",
+        "checksum": "sha256:d3a4f367a9c5ba936b1bb5480db390889a303e5ec8ff34bb4274c1d840a1784d",
+        "check_gpg": true
+      },
+      {
+        "name": "libnl3",
+        "epoch": 0,
+        "version": "3.5.0",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libnl3-3.5.0-1.el8.ppc64le.rpm",
+        "checksum": "sha256:caabc61e9aa83275f9d2fefcfda56fddf19e7031bcf9f9b84f858bb1f040e24c",
+        "check_gpg": true
+      },
+      {
+        "name": "libnl3-cli",
+        "epoch": 0,
+        "version": "3.5.0",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libnl3-cli-3.5.0-1.el8.ppc64le.rpm",
+        "checksum": "sha256:35bd989d63522f9699b1a90dd453f866818cc3d247096a910a27fd7e49b09ac2",
+        "check_gpg": true
+      },
+      {
+        "name": "libnsl2",
+        "epoch": 0,
+        "version": "1.2.0",
+        "release": "2.20180605git4a062cf.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libnsl2-1.2.0-2.20180605git4a062cf.el8.ppc64le.rpm",
+        "checksum": "sha256:8d7777da3f54f965cf3058cabf987c01b93a1dd041e8359eb7822eba57d8c8df",
+        "check_gpg": true
+      },
+      {
+        "name": "libpath_utils",
+        "epoch": 0,
+        "version": "0.2.1",
+        "release": "39.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libpath_utils-0.2.1-39.el8.ppc64le.rpm",
+        "checksum": "sha256:fb6e437a24450106c03f25dc1c3f6b78549b82c2d0bd4387dce1350ca3c5f1f5",
+        "check_gpg": true
+      },
+      {
+        "name": "libpcap",
+        "epoch": 14,
+        "version": "1.9.1",
+        "release": "5.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libpcap-1.9.1-5.el8.ppc64le.rpm",
+        "checksum": "sha256:61ba252d7ee5d955b929f6d7d39d65d25c62e3d3cfc65ee6cf55c764b1c64a90",
+        "check_gpg": true
+      },
+      {
+        "name": "libpipeline",
+        "epoch": 0,
+        "version": "1.5.0",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libpipeline-1.5.0-2.el8.ppc64le.rpm",
+        "checksum": "sha256:7adc584a7d43968d22706da5ffa127020536375f82beea5ef677cab39c5f64c5",
+        "check_gpg": true
+      },
+      {
+        "name": "libpng",
+        "epoch": 2,
+        "version": "1.6.34",
+        "release": "5.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libpng-1.6.34-5.el8.ppc64le.rpm",
+        "checksum": "sha256:b58be8f7685340b35e61945b1ab499bc1030b0b021b2ac5576897cf079ff7812",
+        "check_gpg": true
+      },
+      {
+        "name": "libproxy",
+        "epoch": 0,
+        "version": "0.4.15",
+        "release": "5.2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libproxy-0.4.15-5.2.el8.ppc64le.rpm",
+        "checksum": "sha256:6051967b12b097d0027dc1a1aac68448c1bea901fd76c6ea0d43450f24605252",
+        "check_gpg": true
+      },
+      {
+        "name": "libpsl",
+        "epoch": 0,
+        "version": "0.20.2",
+        "release": "6.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libpsl-0.20.2-6.el8.ppc64le.rpm",
+        "checksum": "sha256:9b8a8a843fe9a972f6433e11b95b5a8d1d2971ed40fe1acda6807e34f0773c62",
+        "check_gpg": true
+      },
+      {
+        "name": "libpwquality",
+        "epoch": 0,
+        "version": "1.4.4",
+        "release": "3.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libpwquality-1.4.4-3.el8.ppc64le.rpm",
+        "checksum": "sha256:1aa321c66a3661e78d938b805e5c311d519f04bf3496545ffdacc7c152bc9b21",
+        "check_gpg": true
+      },
+      {
+        "name": "libref_array",
+        "epoch": 0,
+        "version": "0.1.5",
+        "release": "39.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libref_array-0.1.5-39.el8.ppc64le.rpm",
+        "checksum": "sha256:419f9c08de110eee9b2ff0a61e9aa1bbb56939f9239739c17a753a0d9210d10f",
+        "check_gpg": true
+      },
+      {
+        "name": "librepo",
+        "epoch": 0,
+        "version": "1.14.0",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/librepo-1.14.0-2.el8.ppc64le.rpm",
+        "checksum": "sha256:3dfffdadfb10def9a3671a255e4fa71d8b22231ccf2c929e96689101dda8ce2c",
+        "check_gpg": true
+      },
+      {
+        "name": "libreport-filesystem",
+        "epoch": 0,
+        "version": "2.9.5",
+        "release": "15.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libreport-filesystem-2.9.5-15.el8.ppc64le.rpm",
+        "checksum": "sha256:c5c61536e768553067cee488830c64866d109cade24917dbe23f82c861af07c5",
+        "check_gpg": true
+      },
+      {
+        "name": "librtas",
+        "epoch": 0,
+        "version": "2.0.2",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/librtas-2.0.2-1.el8.ppc64le.rpm",
+        "checksum": "sha256:98c28a91d41f634edb8c1f001dbc45c0de534332d059a2e8feff448fb7235c49",
+        "check_gpg": true
+      },
+      {
+        "name": "libseccomp",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libseccomp-2.5.1-1.el8.ppc64le.rpm",
+        "checksum": "sha256:b4a1ac1ff5cd22a5dab6c96dfc2dbd7cd6ba750691ad5c53a97a1f088fc42abc",
+        "check_gpg": true
+      },
+      {
+        "name": "libsecret",
+        "epoch": 0,
+        "version": "0.18.6",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libsecret-0.18.6-1.el8.ppc64le.rpm",
+        "checksum": "sha256:01b0562b890a80c202fff9175dc845500660c7f1655292d4ee13ca667acab081",
+        "check_gpg": true
+      },
+      {
+        "name": "libselinux",
+        "epoch": 0,
+        "version": "2.9",
+        "release": "5.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libselinux-2.9-5.el8.ppc64le.rpm",
+        "checksum": "sha256:56c866bcff69fd60b630841ff990296b26c2f45d8c6054311b5c476bc67466ac",
+        "check_gpg": true
+      },
+      {
+        "name": "libselinux-utils",
+        "epoch": 0,
+        "version": "2.9",
+        "release": "5.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libselinux-utils-2.9-5.el8.ppc64le.rpm",
+        "checksum": "sha256:4fe264ed1cfd0c074f4601354b0128a9e5068f0fcde7382fd5429585f0d4cd2c",
+        "check_gpg": true
+      },
+      {
+        "name": "libsemanage",
+        "epoch": 0,
+        "version": "2.9",
+        "release": "6.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libsemanage-2.9-6.el8.ppc64le.rpm",
+        "checksum": "sha256:95103f7c339aec4b485b7f569aa8a5e1a54286b3d2acde427328c49e4d8d80d1",
+        "check_gpg": true
+      },
+      {
+        "name": "libsepol",
+        "epoch": 0,
+        "version": "2.9",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libsepol-2.9-2.el8.ppc64le.rpm",
+        "checksum": "sha256:adc56041458e556df5663e7da264e151c24aaf1c2a94e49df9790ba191ea1b37",
+        "check_gpg": true
+      },
+      {
+        "name": "libservicelog",
+        "epoch": 0,
+        "version": "1.1.19",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libservicelog-1.1.19-2.el8.ppc64le.rpm",
+        "checksum": "sha256:2669ab8439093418c6c437c1f2e931d4152f5ac371e5a0f2d20b18455483c3a1",
+        "check_gpg": true
+      },
+      {
+        "name": "libsigsegv",
+        "epoch": 0,
+        "version": "2.11",
+        "release": "5.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libsigsegv-2.11-5.el8.ppc64le.rpm",
+        "checksum": "sha256:0f57b051654b6d75789b437dafd7040b6c90daee17827be24352c0f11a74bba7",
+        "check_gpg": true
+      },
+      {
+        "name": "libsmartcols",
+        "epoch": 0,
+        "version": "2.32.1",
+        "release": "28.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libsmartcols-2.32.1-28.el8.ppc64le.rpm",
+        "checksum": "sha256:1b5136570cefb8273dd5affc73c1456cf239cc8b18be72d6c4d09794af7f3352",
+        "check_gpg": true
+      },
+      {
+        "name": "libsolv",
+        "epoch": 0,
+        "version": "0.7.19",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libsolv-0.7.19-1.el8.ppc64le.rpm",
+        "checksum": "sha256:679724b45157b4d4c9ebe2eb32e188b9a65d47c23be886498d7a178caaf113bb",
+        "check_gpg": true
+      },
+      {
+        "name": "libsoup",
+        "epoch": 0,
+        "version": "2.62.3",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libsoup-2.62.3-2.el8.ppc64le.rpm",
+        "checksum": "sha256:1649f9d356cda961dd08dafa92475557ac398da9a657ee019de0c1f2c0593c8a",
+        "check_gpg": true
+      },
+      {
+        "name": "libss",
+        "epoch": 0,
+        "version": "1.45.6",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libss-1.45.6-2.el8.ppc64le.rpm",
+        "checksum": "sha256:767dd64d91c23adda537c7759ae3b4f720d3c76e03b52bc9231e52e0113db3ab",
+        "check_gpg": true
+      },
+      {
+        "name": "libssh",
+        "epoch": 0,
+        "version": "0.9.4",
+        "release": "3.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libssh-0.9.4-3.el8.ppc64le.rpm",
+        "checksum": "sha256:2dbfe3cb37c18b39393870baa77f3bbd42be53517abffdd990b13ed70ee3dd3e",
+        "check_gpg": true
+      },
+      {
+        "name": "libssh-config",
+        "epoch": 0,
+        "version": "0.9.4",
+        "release": "3.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libssh-config-0.9.4-3.el8.noarch.rpm",
+        "checksum": "sha256:f5bcb82a732c02d6f31bbf156887049883c76cedc9c6a11b049358a74f4d45d0",
+        "check_gpg": true
+      },
+      {
+        "name": "libsss_autofs",
+        "epoch": 0,
+        "version": "2.5.2",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libsss_autofs-2.5.2-2.el8.ppc64le.rpm",
+        "checksum": "sha256:2d1655f040141384ec8760e4a47e0455ce518989f7bb1a830ab9534bfb38a78a",
+        "check_gpg": true
+      },
+      {
+        "name": "libsss_certmap",
+        "epoch": 0,
+        "version": "2.5.2",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libsss_certmap-2.5.2-2.el8.ppc64le.rpm",
+        "checksum": "sha256:d3e95ed161acd1ba957b1864e7ca2102d9c39380bbdd56eddebf11d5219b3a04",
+        "check_gpg": true
+      },
+      {
+        "name": "libsss_idmap",
+        "epoch": 0,
+        "version": "2.5.2",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libsss_idmap-2.5.2-2.el8.ppc64le.rpm",
+        "checksum": "sha256:572bec3deb2f8ae7a6ad46976738c2630023eec1d9bd13ab1ccca7b54256daee",
+        "check_gpg": true
+      },
+      {
+        "name": "libsss_nss_idmap",
+        "epoch": 0,
+        "version": "2.5.2",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libsss_nss_idmap-2.5.2-2.el8.ppc64le.rpm",
+        "checksum": "sha256:466601cf2b7bebf49a6a8e936b32dffc844c9ed4cd82961d008d17cfccc596e8",
+        "check_gpg": true
+      },
+      {
+        "name": "libsss_sudo",
+        "epoch": 0,
+        "version": "2.5.2",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libsss_sudo-2.5.2-2.el8.ppc64le.rpm",
+        "checksum": "sha256:70fe40ffb2fb3eb2c3626afbfdb200a2429e000c2fbb172886c23b1908000501",
+        "check_gpg": true
+      },
+      {
+        "name": "libstdc++",
+        "epoch": 0,
+        "version": "8.5.0",
+        "release": "3.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libstdc++-8.5.0-3.el8.ppc64le.rpm",
+        "checksum": "sha256:32ebba6472cdc331bd3366ca996ad3039b3a1b41c61a849b88074e1b722cad2c",
+        "check_gpg": true
+      },
+      {
+        "name": "libstemmer",
+        "epoch": 0,
+        "version": "0",
+        "release": "10.585svn.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libstemmer-0-10.585svn.el8.ppc64le.rpm",
+        "checksum": "sha256:cd603035aa26b9d12e6b23680e3f1a908341fd9f2086eb540834aee45b4c8604",
+        "check_gpg": true
+      },
+      {
+        "name": "libsysfs",
+        "epoch": 0,
+        "version": "2.1.0",
+        "release": "24.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libsysfs-2.1.0-24.el8.ppc64le.rpm",
+        "checksum": "sha256:4fb1b85fe3712a292f8dd8f1d65805607485dbf97307cf146bbc6e0293a7c725",
+        "check_gpg": true
+      },
+      {
+        "name": "libtalloc",
+        "epoch": 0,
+        "version": "2.3.2",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libtalloc-2.3.2-1.el8.ppc64le.rpm",
+        "checksum": "sha256:5f76a72e58cd374ec83e26f42778adb3b90aacd091527a34c8a347089034d398",
+        "check_gpg": true
+      },
+      {
+        "name": "libtasn1",
+        "epoch": 0,
+        "version": "4.13",
+        "release": "3.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libtasn1-4.13-3.el8.ppc64le.rpm",
+        "checksum": "sha256:75e9ed16ace51ba04a62505aaed215bf9c722d6f4b1c33cc3e3962076c300ee8",
+        "check_gpg": true
+      },
+      {
+        "name": "libtdb",
+        "epoch": 0,
+        "version": "1.4.3",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libtdb-1.4.3-1.el8.ppc64le.rpm",
+        "checksum": "sha256:c3c1c42a41ab18dc09214bcd3a567bb7ba9b9c2191a6e1079b9770dfe2d3a338",
+        "check_gpg": true
+      },
+      {
+        "name": "libteam",
+        "epoch": 0,
+        "version": "1.31",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libteam-1.31-2.el8.ppc64le.rpm",
+        "checksum": "sha256:60eb345663d2f6ec4b5c304cd21685dc7148d34739477136d96ab6bc131d9c4d",
+        "check_gpg": true
+      },
+      {
+        "name": "libtevent",
+        "epoch": 0,
+        "version": "0.11.0",
+        "release": "0.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libtevent-0.11.0-0.el8.ppc64le.rpm",
+        "checksum": "sha256:7962bed04e961194d64769b4b7d5c85836808361c606e943b013098fe53df782",
+        "check_gpg": true
+      },
+      {
+        "name": "libtirpc",
+        "epoch": 0,
+        "version": "1.1.4",
+        "release": "5.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libtirpc-1.1.4-5.el8.ppc64le.rpm",
+        "checksum": "sha256:d539404dafd8ad5d785ab3da6f8bd5a2bf5dff9e01be0ff1bc1d251786dda25c",
+        "check_gpg": true
+      },
+      {
+        "name": "libunistring",
+        "epoch": 0,
+        "version": "0.9.9",
+        "release": "3.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libunistring-0.9.9-3.el8.ppc64le.rpm",
+        "checksum": "sha256:bff39fef1fc01564156123fcade75b4bc50402a2971a031d9a426c7014b1e681",
+        "check_gpg": true
+      },
+      {
+        "name": "libusbx",
+        "epoch": 0,
+        "version": "1.0.23",
+        "release": "4.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libusbx-1.0.23-4.el8.ppc64le.rpm",
+        "checksum": "sha256:6b9875495111bcd2d3c5e9e380b3be17fb0a730891468fb45bdba3b3692b00ea",
+        "check_gpg": true
+      },
+      {
+        "name": "libuser",
+        "epoch": 0,
+        "version": "0.62",
+        "release": "23.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libuser-0.62-23.el8.ppc64le.rpm",
+        "checksum": "sha256:b29c8cb61ef138fdf00a458f0646cf9390e0f39783f02f6b81a956585dc6b302",
+        "check_gpg": true
+      },
+      {
+        "name": "libutempter",
+        "epoch": 0,
+        "version": "1.1.6",
+        "release": "14.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libutempter-1.1.6-14.el8.ppc64le.rpm",
+        "checksum": "sha256:e217c2687212d931ad9a6a02afb20cc34f6d051786d136e337f91079c9f73d22",
+        "check_gpg": true
+      },
+      {
+        "name": "libuuid",
+        "epoch": 0,
+        "version": "2.32.1",
+        "release": "28.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libuuid-2.32.1-28.el8.ppc64le.rpm",
+        "checksum": "sha256:c1291b69a65a860069195a33cf6640df8667e960f9f030ceeea4497c47858b94",
+        "check_gpg": true
+      },
+      {
+        "name": "libverto",
+        "epoch": 0,
+        "version": "0.3.0",
+        "release": "5.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libverto-0.3.0-5.el8.ppc64le.rpm",
+        "checksum": "sha256:d8c00baf46e33f9e5f1b9e139bbea9fe0f27badb432c992b9cf8c4f7017094bf",
+        "check_gpg": true
+      },
+      {
+        "name": "libverto-libevent",
+        "epoch": 0,
+        "version": "0.3.0",
+        "release": "5.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libverto-libevent-0.3.0-5.el8.ppc64le.rpm",
+        "checksum": "sha256:d909f0e1b6ddb29ad2d3da21208077e3c976212e07471114745859f70be9738d",
+        "check_gpg": true
+      },
+      {
+        "name": "libvpd",
+        "epoch": 0,
+        "version": "2.2.8",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libvpd-2.2.8-1.el8.ppc64le.rpm",
+        "checksum": "sha256:62ac185c4d6d242b187022c8376469073c211e8deca2a7b2badf1d775e2fd5a3",
+        "check_gpg": true
+      },
+      {
+        "name": "libxcrypt",
+        "epoch": 0,
+        "version": "4.1.1",
+        "release": "6.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libxcrypt-4.1.1-6.el8.ppc64le.rpm",
+        "checksum": "sha256:1a968f65db066243cbd0a6e12d193ef674637f044299a15b5d6b910e91411812",
+        "check_gpg": true
+      },
+      {
+        "name": "libxml2",
+        "epoch": 0,
+        "version": "2.9.7",
+        "release": "11.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libxml2-2.9.7-11.el8.ppc64le.rpm",
+        "checksum": "sha256:4a167fa4a7238bd94b3134173f6267b19cdebc2fde98b583344749e1f4c9bf09",
+        "check_gpg": true
+      },
+      {
+        "name": "libyaml",
+        "epoch": 0,
+        "version": "0.1.7",
+        "release": "5.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libyaml-0.1.7-5.el8.ppc64le.rpm",
+        "checksum": "sha256:8904fdb492f34e5242ba483fb6b7b158342662575b3d5ac9abbc380568840d4a",
+        "check_gpg": true
+      },
+      {
+        "name": "libzstd",
+        "epoch": 0,
+        "version": "1.4.4",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/libzstd-1.4.4-1.el8.ppc64le.rpm",
+        "checksum": "sha256:6bfc201a12dc7bba21069a663aa692a96c5e8920b0d94a4e355c332d7ead15ba",
+        "check_gpg": true
+      },
+      {
+        "name": "linux-firmware",
+        "epoch": 0,
+        "version": "20210702",
+        "release": "103.gitd79c2677.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/linux-firmware-20210702-103.gitd79c2677.el8.noarch.rpm",
+        "checksum": "sha256:7aeb44195a1c984aff87cf8429d2aa40f6947b0a47d3603e1ca5c3cf8d284459",
+        "check_gpg": true
+      },
+      {
+        "name": "lmdb-libs",
+        "epoch": 0,
+        "version": "0.9.24",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/lmdb-libs-0.9.24-1.el8.ppc64le.rpm",
+        "checksum": "sha256:f6cd5ed6305952c1cd842fbca0e5d9613f736646cfac2082a2db37f5d065468c",
+        "check_gpg": true
+      },
+      {
+        "name": "logrotate",
+        "epoch": 0,
+        "version": "3.14.0",
+        "release": "4.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/logrotate-3.14.0-4.el8.ppc64le.rpm",
+        "checksum": "sha256:791acd72bc40be9ba5fa6b77d78def5da623544408b72baa4c81181c03a205cb",
+        "check_gpg": true
+      },
+      {
+        "name": "lshw",
+        "epoch": 0,
+        "version": "B.02.19.2",
+        "release": "6.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/lshw-B.02.19.2-6.el8.ppc64le.rpm",
+        "checksum": "sha256:906bffa419bdb1a6d3094d7a6f2308527f5ece250bfcb962df79e9867f28236d",
+        "check_gpg": true
+      },
+      {
+        "name": "lsscsi",
+        "epoch": 0,
+        "version": "0.32",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/lsscsi-0.32-2.el8.ppc64le.rpm",
+        "checksum": "sha256:deeeab9fcf6b9cb47235974158561967e299344e040c408e6b5d7464af2f3882",
+        "check_gpg": true
+      },
+      {
+        "name": "lsvpd",
+        "epoch": 0,
+        "version": "1.7.12",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/lsvpd-1.7.12-1.el8.ppc64le.rpm",
+        "checksum": "sha256:0eb36aba0f471119ccb001ea4f1819002ae535882df63e871be80e01f4f776bb",
+        "check_gpg": true
+      },
+      {
+        "name": "lua-libs",
+        "epoch": 0,
+        "version": "5.3.4",
+        "release": "11.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/lua-libs-5.3.4-11.el8.ppc64le.rpm",
+        "checksum": "sha256:393e7bb9f93ffb3cbba620fbfeb229f2b8345454bc60ac0508f76735544ed289",
+        "check_gpg": true
+      },
+      {
+        "name": "lz4-libs",
+        "epoch": 0,
+        "version": "1.8.3",
+        "release": "3.el8_4",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/lz4-libs-1.8.3-3.el8_4.ppc64le.rpm",
+        "checksum": "sha256:f24bce642ec88622490b2f09a45fa3985da7f6511a1aae131853c4ea4c309e6b",
+        "check_gpg": true
+      },
+      {
+        "name": "lzo",
+        "epoch": 0,
+        "version": "2.08",
+        "release": "14.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/lzo-2.08-14.el8.ppc64le.rpm",
+        "checksum": "sha256:4c5aabda0cd9edb40e141066d400d2e4b232bc22ab60e806a6399691c391cabc",
+        "check_gpg": true
+      },
+      {
+        "name": "man-db",
+        "epoch": 0,
+        "version": "2.7.6.1",
+        "release": "18.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/man-db-2.7.6.1-18.el8.ppc64le.rpm",
+        "checksum": "sha256:4079a1edf72a60c97ee48f0a98820b3b014575b402ea05a64cbc5f2b8af674de",
+        "check_gpg": true
+      },
+      {
+        "name": "memstrack",
+        "epoch": 0,
+        "version": "0.1.11",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/memstrack-0.1.11-1.el8.ppc64le.rpm",
+        "checksum": "sha256:9936485ac7111967d6962bc539de7b08807e310117adb78b11c21a5db0f0f890",
+        "check_gpg": true
+      },
+      {
+        "name": "mozjs60",
+        "epoch": 0,
+        "version": "60.9.0",
+        "release": "4.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/mozjs60-60.9.0-4.el8.ppc64le.rpm",
+        "checksum": "sha256:c62991989974533b86a29586b799623a908add501287f2c890be4fc8a6af2c7d",
+        "check_gpg": true
+      },
+      {
+        "name": "mpfr",
+        "epoch": 0,
+        "version": "3.1.6",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/mpfr-3.1.6-1.el8.ppc64le.rpm",
+        "checksum": "sha256:0230acdbc9da4b36da812f0e585a7602eda4982c899b3b3a4c2bc9b4546d8e74",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses",
+        "epoch": 0,
+        "version": "6.1",
+        "release": "9.20180224.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/ncurses-6.1-9.20180224.el8.ppc64le.rpm",
+        "checksum": "sha256:7abf49cabbaf996afc0c2604f10ea18f8f22a903fc4ba3728a18f5892353c5c9",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses-base",
+        "epoch": 0,
+        "version": "6.1",
+        "release": "9.20180224.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/ncurses-base-6.1-9.20180224.el8.noarch.rpm",
+        "checksum": "sha256:41716536ea16798238ac89fbc3041b3f9dc80f9a64ea4b19d6e67ad2c909269a",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses-libs",
+        "epoch": 0,
+        "version": "6.1",
+        "release": "9.20180224.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/ncurses-libs-6.1-9.20180224.el8.ppc64le.rpm",
+        "checksum": "sha256:17ffe1d683dbff48f9b2ef903401e471e5e51a992bf0890632bceb94561893de",
+        "check_gpg": true
+      },
+      {
+        "name": "net-tools",
+        "epoch": 0,
+        "version": "2.0",
+        "release": "0.52.20160912git.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/net-tools-2.0-0.52.20160912git.el8.ppc64le.rpm",
+        "checksum": "sha256:d2e9ef1d33330a14155d5bd6a8cf122f9390cceb8a7a12c0364ae8e44410fb8d",
+        "check_gpg": true
+      },
+      {
+        "name": "nettle",
+        "epoch": 0,
+        "version": "3.4.1",
+        "release": "7.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/nettle-3.4.1-7.el8.ppc64le.rpm",
+        "checksum": "sha256:8403cfc97e0e72e37639b8c54d92f1ee427e48a70d52d5260a37fa104f2df20d",
+        "check_gpg": true
+      },
+      {
+        "name": "newt",
+        "epoch": 0,
+        "version": "0.52.20",
+        "release": "11.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/newt-0.52.20-11.el8.ppc64le.rpm",
+        "checksum": "sha256:b64219f2278bf3f032b71593da63f563920778230946b66f1037bef2f2a7358b",
+        "check_gpg": true
+      },
+      {
+        "name": "nfs-utils",
+        "epoch": 1,
+        "version": "2.3.3",
+        "release": "46.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/nfs-utils-2.3.3-46.el8.ppc64le.rpm",
+        "checksum": "sha256:bd9a6c7fe7405aaeeeb7d351ca1def52737b8ec2344021263aed64c6dc363d56",
+        "check_gpg": true
+      },
+      {
+        "name": "npth",
+        "epoch": 0,
+        "version": "1.5",
+        "release": "4.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/npth-1.5-4.el8.ppc64le.rpm",
+        "checksum": "sha256:7a66928044c3478964aeaf6f9e981fdbcfa6b2ff7fad9f2ad57a8c09387cbbf2",
+        "check_gpg": true
+      },
+      {
+        "name": "numactl-libs",
+        "epoch": 0,
+        "version": "2.0.12",
+        "release": "13.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/numactl-libs-2.0.12-13.el8.ppc64le.rpm",
+        "checksum": "sha256:5bcb506bd5559870631aa838711e683a5a2a07c6c0171be6bbeda9ba92dcdf5e",
+        "check_gpg": true
+      },
+      {
+        "name": "opal-prd",
+        "epoch": 0,
+        "version": "6.7.1",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/opal-prd-6.7.1-1.el8.ppc64le.rpm",
+        "checksum": "sha256:6495f3b729a1ceecd7cfdf318cfaa8ecf776ffa16293aad9f97cc542b6901ef7",
+        "check_gpg": true
+      },
+      {
+        "name": "openldap",
+        "epoch": 0,
+        "version": "2.4.46",
+        "release": "18.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/openldap-2.4.46-18.el8.ppc64le.rpm",
+        "checksum": "sha256:c24b21415b737f18fad7aeb192e60f7d323f7ba69434ecc1e78b3af0003be8dc",
+        "check_gpg": true
+      },
+      {
+        "name": "openssh",
+        "epoch": 0,
+        "version": "8.0p1",
+        "release": "9.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/openssh-8.0p1-9.el8.ppc64le.rpm",
+        "checksum": "sha256:965dca9dc74ed26f4204debe15b8e4dd1b8e41a80b8608287a9ef22f0b6f507e",
+        "check_gpg": true
+      },
+      {
+        "name": "openssh-clients",
+        "epoch": 0,
+        "version": "8.0p1",
+        "release": "9.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/openssh-clients-8.0p1-9.el8.ppc64le.rpm",
+        "checksum": "sha256:bb4b6716669e27c7619f63751770cb87e7cfecd4e302e2ce6588035509168352",
+        "check_gpg": true
+      },
+      {
+        "name": "openssh-server",
+        "epoch": 0,
+        "version": "8.0p1",
+        "release": "9.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/openssh-server-8.0p1-9.el8.ppc64le.rpm",
+        "checksum": "sha256:f8130aecd446f997d0e2011481275db0552bf57bd7af0d7a655eded5f52ca94e",
+        "check_gpg": true
+      },
+      {
+        "name": "openssl",
+        "epoch": 1,
+        "version": "1.1.1k",
+        "release": "4.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/openssl-1.1.1k-4.el8.ppc64le.rpm",
+        "checksum": "sha256:c2479eb811f4d9b8624ef20119e1abdc109f639c2cf576eb945b340362d87b05",
+        "check_gpg": true
+      },
+      {
+        "name": "openssl-libs",
+        "epoch": 1,
+        "version": "1.1.1k",
+        "release": "4.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/openssl-libs-1.1.1k-4.el8.ppc64le.rpm",
+        "checksum": "sha256:46606c1ed76a4da2a9d18016aeb50f4dddf58e1b45d665c983c58f8e605bf73e",
+        "check_gpg": true
+      },
+      {
+        "name": "openssl-pkcs11",
+        "epoch": 0,
+        "version": "0.4.10",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/openssl-pkcs11-0.4.10-2.el8.ppc64le.rpm",
+        "checksum": "sha256:d87f7fa5e637442eb638bcaafdc44ca3895d91a153015ff9af6a87219f0dc372",
+        "check_gpg": true
+      },
+      {
+        "name": "os-prober",
+        "epoch": 0,
+        "version": "1.74",
+        "release": "6.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/os-prober-1.74-6.el8.ppc64le.rpm",
+        "checksum": "sha256:71c88f04921ae61a7009f9443f95c70ec3424a798429fc01e6c1432c1077aacb",
+        "check_gpg": true
+      },
+      {
+        "name": "p11-kit",
+        "epoch": 0,
+        "version": "0.23.22",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/p11-kit-0.23.22-1.el8.ppc64le.rpm",
+        "checksum": "sha256:bf994cb2e5c367d78483662c7de6e69950aaf04bc6cfdbbef4d1ef7ce153717c",
+        "check_gpg": true
+      },
+      {
+        "name": "p11-kit-trust",
+        "epoch": 0,
+        "version": "0.23.22",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/p11-kit-trust-0.23.22-1.el8.ppc64le.rpm",
+        "checksum": "sha256:b7330d40f75b8ec786e41c45a202e44f0e49ec29ddf8944120fbdb373a6c6617",
+        "check_gpg": true
+      },
+      {
+        "name": "pam",
+        "epoch": 0,
+        "version": "1.3.1",
+        "release": "15.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/pam-1.3.1-15.el8.ppc64le.rpm",
+        "checksum": "sha256:bb82b10a91493d745dc533b5de5335db650adb0c8a90548fdf5dad13569a16f4",
+        "check_gpg": true
+      },
+      {
+        "name": "parted",
+        "epoch": 0,
+        "version": "3.2",
+        "release": "39.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/parted-3.2-39.el8.ppc64le.rpm",
+        "checksum": "sha256:9e2ef90cb484b37232e829ec400dcddd3f9f0d189eb6f0074b3b5874d4553d1c",
+        "check_gpg": true
+      },
+      {
+        "name": "passwd",
+        "epoch": 0,
+        "version": "0.80",
+        "release": "3.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/passwd-0.80-3.el8.ppc64le.rpm",
+        "checksum": "sha256:dfb7add4926f9a350755294af3c20f114ac59f32e00cadc9ec625b2a51703ad0",
+        "check_gpg": true
+      },
+      {
+        "name": "pciutils",
+        "epoch": 0,
+        "version": "3.7.0",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/pciutils-3.7.0-1.el8.ppc64le.rpm",
+        "checksum": "sha256:7b334d84bf03876c5738efa3857faaa35ede5c8eab30a5621ecfd4efa7ce39a5",
+        "check_gpg": true
+      },
+      {
+        "name": "pciutils-libs",
+        "epoch": 0,
+        "version": "3.7.0",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/pciutils-libs-3.7.0-1.el8.ppc64le.rpm",
+        "checksum": "sha256:dd96950b4282e64ce3e37f0bd1a51834beb286037184f3796f9889bfa1ed0d72",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre",
+        "epoch": 0,
+        "version": "8.42",
+        "release": "6.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/pcre-8.42-6.el8.ppc64le.rpm",
+        "checksum": "sha256:3ed319e31a9c38e5f4e336195b5cbd253b3f8b17f93f185829f078c5ef420305",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre2",
+        "epoch": 0,
+        "version": "10.32",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/pcre2-10.32-2.el8.ppc64le.rpm",
+        "checksum": "sha256:5c46bef8c0e95e05716e9a53b77970c1378d93bcb9a800018a24f7e1763b45b9",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Carp",
+        "epoch": 0,
+        "version": "1.42",
+        "release": "396.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/perl-Carp-1.42-396.el8.noarch.rpm",
+        "checksum": "sha256:d03b9f4b9848e3a88d62bcf6e536d659c325b2dc03b2136be7342b5fe5e2b6a9",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Data-Dumper",
+        "epoch": 0,
+        "version": "2.167",
+        "release": "399.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/perl-Data-Dumper-2.167-399.el8.ppc64le.rpm",
+        "checksum": "sha256:a34e0c5859e5e8757afafba47d83396226b646f32954ef7ecda4ad3be464bed6",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Encode",
+        "epoch": 4,
+        "version": "2.97",
+        "release": "3.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/perl-Encode-2.97-3.el8.ppc64le.rpm",
+        "checksum": "sha256:fc9d3ee3946b87efcd9531f876d23a9e8d5769aab3e0ad6007ac2cdb4068499c",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Errno",
+        "epoch": 0,
+        "version": "1.28",
+        "release": "420.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/perl-Errno-1.28-420.el8.ppc64le.rpm",
+        "checksum": "sha256:cffc31e10891c58edc89cebd211bc0be69d99f54f67682c91f97dc53e6381f0f",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Exporter",
+        "epoch": 0,
+        "version": "5.72",
+        "release": "396.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/perl-Exporter-5.72-396.el8.noarch.rpm",
+        "checksum": "sha256:7edc503f5a919c489b651757095d8031982d530cc88088fdaeb743188364e9b0",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-File-Path",
+        "epoch": 0,
+        "version": "2.15",
+        "release": "2.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/perl-File-Path-2.15-2.el8.noarch.rpm",
+        "checksum": "sha256:e83928bd4552ecdf8e71d283e2358c7eccd006d284ba31fbc9c89e407989fd60",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-File-Temp",
+        "epoch": 0,
+        "version": "0.230.600",
+        "release": "1.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/perl-File-Temp-0.230.600-1.el8.noarch.rpm",
+        "checksum": "sha256:e269f7d33abbb790311ffa95fa7df9766cac8bf31ace24fce6ed732ba0db19ae",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Getopt-Long",
+        "epoch": 1,
+        "version": "2.50",
+        "release": "4.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/perl-Getopt-Long-2.50-4.el8.noarch.rpm",
+        "checksum": "sha256:da4c6daa0d5406bc967cc89b02a69689491f42c543aceea1a31136f0f1a8d991",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-HTTP-Tiny",
+        "epoch": 0,
+        "version": "0.074",
+        "release": "1.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/perl-HTTP-Tiny-0.074-1.el8.noarch.rpm",
+        "checksum": "sha256:a1af93a1b62e8ca05b7597d5749a2b3d28735a86928f0432064fec61db1ff844",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-IO",
+        "epoch": 0,
+        "version": "1.38",
+        "release": "420.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/perl-IO-1.38-420.el8.ppc64le.rpm",
+        "checksum": "sha256:74e11b9013f81bd30ec7934ea695d267d164967fec27a02652aa48602b94bc51",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-MIME-Base64",
+        "epoch": 0,
+        "version": "3.15",
+        "release": "396.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/perl-MIME-Base64-3.15-396.el8.ppc64le.rpm",
+        "checksum": "sha256:dc1d4f59ba0728e65433bc7f903b3799d61545ed3eed7427ad0fe36dcd0f831b",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-PathTools",
+        "epoch": 0,
+        "version": "3.74",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/perl-PathTools-3.74-1.el8.ppc64le.rpm",
+        "checksum": "sha256:6b588ff47d46d33b02bc296e6e5cc263d6c8ff51ee97b59ca8b34d5c45d57912",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Pod-Escapes",
+        "epoch": 1,
+        "version": "1.07",
+        "release": "395.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/perl-Pod-Escapes-1.07-395.el8.noarch.rpm",
+        "checksum": "sha256:545cd23ad8e4f71a5109551093668fd4b5e1a50d6a60364ce0f04f64eecd99d1",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Pod-Perldoc",
+        "epoch": 0,
+        "version": "3.28",
+        "release": "396.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/perl-Pod-Perldoc-3.28-396.el8.noarch.rpm",
+        "checksum": "sha256:0225dc3999e3d7b1bb57186a2fc93c98bd1e4e08e062fb51c966e1f2a2c91bb4",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Pod-Simple",
+        "epoch": 1,
+        "version": "3.35",
+        "release": "395.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/perl-Pod-Simple-3.35-395.el8.noarch.rpm",
+        "checksum": "sha256:51c3ee5d824bdde0a8faa10c99841c2590c0c26edfb17125aa97945a688c83ed",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Pod-Usage",
+        "epoch": 4,
+        "version": "1.69",
+        "release": "395.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/perl-Pod-Usage-1.69-395.el8.noarch.rpm",
+        "checksum": "sha256:794f970f498af07b37f914c19ad5dedc6b6c2f89d343af9dd1768d17232555de",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Scalar-List-Utils",
+        "epoch": 3,
+        "version": "1.49",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/perl-Scalar-List-Utils-1.49-2.el8.ppc64le.rpm",
+        "checksum": "sha256:61ee52dfdcbcd98acc765b45781ea5de94831f55675c0faaf615872f92268757",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Socket",
+        "epoch": 4,
+        "version": "2.027",
+        "release": "3.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/perl-Socket-2.027-3.el8.ppc64le.rpm",
+        "checksum": "sha256:8d19cdf57ba61fecd9e07f24fe88768f58196543f7c032adada8a0cc48eee6b3",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Storable",
+        "epoch": 1,
+        "version": "3.11",
+        "release": "3.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/perl-Storable-3.11-3.el8.ppc64le.rpm",
+        "checksum": "sha256:c238e0a5472c59c54093ffa23af6a963b4ae437eedfb6b9ebbcb482752c6d16b",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Term-ANSIColor",
+        "epoch": 0,
+        "version": "4.06",
+        "release": "396.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/perl-Term-ANSIColor-4.06-396.el8.noarch.rpm",
+        "checksum": "sha256:f4e3607f242bbca7ec2379822ca961860e6d9c276da51c6e2dfd17a29469ec78",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Term-Cap",
+        "epoch": 0,
+        "version": "1.17",
+        "release": "395.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/perl-Term-Cap-1.17-395.el8.noarch.rpm",
+        "checksum": "sha256:6bbb721dd2c411c85c75f7477b14c54c776d78ee9b93557615e919ef47577440",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Text-ParseWords",
+        "epoch": 0,
+        "version": "3.30",
+        "release": "395.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/perl-Text-ParseWords-3.30-395.el8.noarch.rpm",
+        "checksum": "sha256:2975de6545b4ca7907ae368a1716c531764e4afccbf27fb0a694d90e983c38e2",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Text-Tabs+Wrap",
+        "epoch": 0,
+        "version": "2013.0523",
+        "release": "395.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/perl-Text-Tabs+Wrap-2013.0523-395.el8.noarch.rpm",
+        "checksum": "sha256:7e50a5d0f2fbd8c95375f72f5772c7731186e999a447121b8247f448b065a4ef",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Time-Local",
+        "epoch": 1,
+        "version": "1.280",
+        "release": "1.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/perl-Time-Local-1.280-1.el8.noarch.rpm",
+        "checksum": "sha256:1edcf2b441ddf21417ef2b33e1ab2a30900758819335d7fabafe3b16bb3eab62",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Unicode-Normalize",
+        "epoch": 0,
+        "version": "1.25",
+        "release": "396.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/perl-Unicode-Normalize-1.25-396.el8.ppc64le.rpm",
+        "checksum": "sha256:04ee771fad226ade609b0e879d15c32898379360db27ef1bc6d9f5a77127d5a8",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-constant",
+        "epoch": 0,
+        "version": "1.33",
+        "release": "396.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/perl-constant-1.33-396.el8.noarch.rpm",
+        "checksum": "sha256:7559c097998db5e5d14dab1a7a1637a5749e9dab234ca68d17c9c21f8cfbf8d6",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-interpreter",
+        "epoch": 4,
+        "version": "5.26.3",
+        "release": "420.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/perl-interpreter-5.26.3-420.el8.ppc64le.rpm",
+        "checksum": "sha256:d5ee453757bd1b479881f0a57b968427404b81d9fed07d04afebcbcfcbf536ab",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-libs",
+        "epoch": 4,
+        "version": "5.26.3",
+        "release": "420.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/perl-libs-5.26.3-420.el8.ppc64le.rpm",
+        "checksum": "sha256:4b40402374fc4a9202a67d3ede77dedbe5ed1bab57479a5b5cb5cd6c45283bf4",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-macros",
+        "epoch": 4,
+        "version": "5.26.3",
+        "release": "420.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/perl-macros-5.26.3-420.el8.ppc64le.rpm",
+        "checksum": "sha256:926ce547a03e1bd2aac94b1792d7ccea16d1e6bd91903458e63a095268e1b02f",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-parent",
+        "epoch": 1,
+        "version": "0.237",
+        "release": "1.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/perl-parent-0.237-1.el8.noarch.rpm",
+        "checksum": "sha256:f5e73bbd776a2426a796971d8d38664f2e94898479fb76947dccdd28cf9fe1d0",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-podlators",
+        "epoch": 0,
+        "version": "4.11",
+        "release": "1.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/perl-podlators-4.11-1.el8.noarch.rpm",
+        "checksum": "sha256:78d17ed089151e7fa3d1a3cdbbac8ca3b1b5c484fae5ba025642cc9107991037",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-threads",
+        "epoch": 1,
+        "version": "2.21",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/perl-threads-2.21-2.el8.ppc64le.rpm",
+        "checksum": "sha256:47f414f515a2c3103d0e7dae67c47a3b2bc76ea2413d666052012b11dbdd0feb",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-threads-shared",
+        "epoch": 0,
+        "version": "1.58",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/perl-threads-shared-1.58-2.el8.ppc64le.rpm",
+        "checksum": "sha256:b566154cc9b2b1996716def297d58101f3015a1b868187f1f9e4cd3074ae9988",
+        "check_gpg": true
+      },
+      {
+        "name": "pigz",
+        "epoch": 0,
+        "version": "2.4",
+        "release": "4.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/pigz-2.4-4.el8.ppc64le.rpm",
+        "checksum": "sha256:3edfdbc82f97ec12e59c80c67897fc1eeb44c3d16820f761a8f15272965ea3a1",
+        "check_gpg": true
+      },
+      {
+        "name": "platform-python",
+        "epoch": 0,
+        "version": "3.6.8",
+        "release": "39.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/platform-python-3.6.8-39.el8.ppc64le.rpm",
+        "checksum": "sha256:cdd6594a3bca71d32a5061b85457cc8148611e7f042ba6e812a1c0a2faebac92",
+        "check_gpg": true
+      },
+      {
+        "name": "platform-python-pip",
+        "epoch": 0,
+        "version": "9.0.3",
+        "release": "20.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/platform-python-pip-9.0.3-20.el8.noarch.rpm",
+        "checksum": "sha256:56650f8b8f2b01c1090d184d7d6d396f0109f8a02f915c97b081be73ea12df08",
+        "check_gpg": true
+      },
+      {
+        "name": "platform-python-setuptools",
+        "epoch": 0,
+        "version": "39.2.0",
+        "release": "6.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/platform-python-setuptools-39.2.0-6.el8.noarch.rpm",
+        "checksum": "sha256:946ba273a3a3b6fdf140f3c03112918c0a556a5871c477f5dbbb98600e6ca557",
+        "check_gpg": true
+      },
+      {
+        "name": "policycoreutils",
+        "epoch": 0,
+        "version": "2.9",
+        "release": "15.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/policycoreutils-2.9-15.el8.ppc64le.rpm",
+        "checksum": "sha256:c64632c85c3a49dc82222cdb3d0ee87eafa64f3096ffeba5bcc16c49ee2d260e",
+        "check_gpg": true
+      },
+      {
+        "name": "policycoreutils-python-utils",
+        "epoch": 0,
+        "version": "2.9",
+        "release": "15.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/policycoreutils-python-utils-2.9-15.el8.noarch.rpm",
+        "checksum": "sha256:a9d4dd71786b3147d53da1aa44f134e61b1e5527b6c7ece6c2b19474b6ca9270",
+        "check_gpg": true
+      },
+      {
+        "name": "polkit",
+        "epoch": 0,
+        "version": "0.115",
+        "release": "12.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/polkit-0.115-12.el8.ppc64le.rpm",
+        "checksum": "sha256:e716fd0130980916f4b1aeac8f98dbcd8ced81e2c119b7877204cc6b1a058418",
+        "check_gpg": true
+      },
+      {
+        "name": "polkit-libs",
+        "epoch": 0,
+        "version": "0.115",
+        "release": "12.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/polkit-libs-0.115-12.el8.ppc64le.rpm",
+        "checksum": "sha256:15554476d03595246aec194e63ec9db7469d5b3ed81a27a8a2720e82df1f8bf4",
+        "check_gpg": true
+      },
+      {
+        "name": "polkit-pkla-compat",
+        "epoch": 0,
+        "version": "0.1",
+        "release": "12.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/polkit-pkla-compat-0.1-12.el8.ppc64le.rpm",
+        "checksum": "sha256:0727078eff2abaf1e5770b331ed8162d8e95cf2cf1de06de7540d034999d72ef",
+        "check_gpg": true
+      },
+      {
+        "name": "popt",
+        "epoch": 0,
+        "version": "1.18",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/popt-1.18-1.el8.ppc64le.rpm",
+        "checksum": "sha256:3b00ac82c31b447e306fcb47b4469fdc4e6d87385b42358c2e76badb51b074a3",
+        "check_gpg": true
+      },
+      {
+        "name": "powerpc-utils",
+        "epoch": 0,
+        "version": "1.3.8",
+        "release": "7.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/powerpc-utils-1.3.8-7.el8.ppc64le.rpm",
+        "checksum": "sha256:401a2690658194fdd92994c29aa57c18cc5e3100fe7bbdba33d0fa26f2213eb3",
+        "check_gpg": true
+      },
+      {
+        "name": "powerpc-utils-core",
+        "epoch": 0,
+        "version": "1.3.8",
+        "release": "7.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/powerpc-utils-core-1.3.8-7.el8.ppc64le.rpm",
+        "checksum": "sha256:720088f184124166386634a523f3566a7fc56f802dbd6e6f816e959236542770",
+        "check_gpg": true
+      },
+      {
+        "name": "ppc64-diag",
+        "epoch": 0,
+        "version": "2.7.7",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/ppc64-diag-2.7.7-1.el8.ppc64le.rpm",
+        "checksum": "sha256:2d77f4a2166122e3f7c5ace1bbfe5319ec6c2d24fff1c6f3e22ccb3e8b2327e0",
+        "check_gpg": true
+      },
+      {
+        "name": "ppc64-diag-rtas",
+        "epoch": 0,
+        "version": "2.7.7",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/ppc64-diag-rtas-2.7.7-1.el8.ppc64le.rpm",
+        "checksum": "sha256:0ad85fe7a6b42dae9248268706940b12c01e83141858df79e43223e173fe9840",
+        "check_gpg": true
+      },
+      {
+        "name": "prefixdevname",
+        "epoch": 0,
+        "version": "0.1.0",
+        "release": "6.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/prefixdevname-0.1.0-6.el8.ppc64le.rpm",
+        "checksum": "sha256:35983fb2e9104b81caaa9e6d40352ea8b2b987fb811f935602d04cc90fdee76a",
+        "check_gpg": true
+      },
+      {
+        "name": "procps-ng",
+        "epoch": 0,
+        "version": "3.3.15",
+        "release": "6.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/procps-ng-3.3.15-6.el8.ppc64le.rpm",
+        "checksum": "sha256:1cfa672c25cb5849bb2aa652e045e4a4a272c025befb1fe5e58cb32823faa30d",
+        "check_gpg": true
+      },
+      {
+        "name": "psmisc",
+        "epoch": 0,
+        "version": "23.1",
+        "release": "5.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/psmisc-23.1-5.el8.ppc64le.rpm",
+        "checksum": "sha256:2394d6a1ce4de90590e65111d870b172cb9d4e30e1e6f58a334b29e717fdd031",
+        "check_gpg": true
+      },
+      {
+        "name": "publicsuffix-list-dafsa",
+        "epoch": 0,
+        "version": "20180723",
+        "release": "1.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/publicsuffix-list-dafsa-20180723-1.el8.noarch.rpm",
+        "checksum": "sha256:65ecf1e479dc2b2f7f09c2e86d7457043b3470b3eab3c4ee8909b50b0a669fc2",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-audit",
+        "epoch": 0,
+        "version": "3.0",
+        "release": "0.17.20191104git1c2f876.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-audit-3.0-0.17.20191104git1c2f876.el8.ppc64le.rpm",
+        "checksum": "sha256:d816e850877d0fdbc5ee0951dbd78ca79613602aa5cccd1b324c10d700968d3b",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-cffi",
+        "epoch": 0,
+        "version": "1.11.5",
+        "release": "5.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-cffi-1.11.5-5.el8.ppc64le.rpm",
+        "checksum": "sha256:4c124ec5a10a5c32e390d848942a04baa8761f190a4a95d3ed7b5c626ca17fc8",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-chardet",
+        "epoch": 0,
+        "version": "3.0.4",
+        "release": "7.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-chardet-3.0.4-7.el8.noarch.rpm",
+        "checksum": "sha256:176ffcb2cf0fdcbdd2d8119cbd98eef60a30fdb0fb065a9382d2c95e90c79652",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-configobj",
+        "epoch": 0,
+        "version": "5.0.6",
+        "release": "11.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-configobj-5.0.6-11.el8.noarch.rpm",
+        "checksum": "sha256:1bd969e0521820374122f5132e5998d9bd2ab185be66565a7266096297419c8e",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-cryptography",
+        "epoch": 0,
+        "version": "3.2.1",
+        "release": "5.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-cryptography-3.2.1-5.el8.ppc64le.rpm",
+        "checksum": "sha256:49e68a65bf87ae9ba812ffce76589c09f6766a0eaa5001d7e4a1c782e91d71c0",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-dateutil",
+        "epoch": 1,
+        "version": "2.6.1",
+        "release": "6.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-dateutil-2.6.1-6.el8.noarch.rpm",
+        "checksum": "sha256:c5b5967a094ced90899052a82e2c245529b75ba3f46e0ce1a89cfc95edb935ea",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-dbus",
+        "epoch": 0,
+        "version": "1.2.4",
+        "release": "15.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-dbus-1.2.4-15.el8.ppc64le.rpm",
+        "checksum": "sha256:c59538d646715fdb1f94c6be3fa0949871b8c860d5c54db4640a1197663a130b",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-decorator",
+        "epoch": 0,
+        "version": "4.2.1",
+        "release": "2.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-decorator-4.2.1-2.el8.noarch.rpm",
+        "checksum": "sha256:0e9a8a0f823bf0ef948862f0ccb62353460bd07931e756c98f23908c1c526578",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-dnf",
+        "epoch": 0,
+        "version": "4.7.0",
+        "release": "2.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-dnf-4.7.0-2.el8.noarch.rpm",
+        "checksum": "sha256:ccfa1810aa19fae08aefd29cffe28b65d5123cd17bd7d2d4207f03cf9795594c",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-dnf-plugins-core",
+        "epoch": 0,
+        "version": "4.0.21",
+        "release": "2.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-dnf-plugins-core-4.0.21-2.el8.noarch.rpm",
+        "checksum": "sha256:28c0f457d67213319f0313d993a3b2f8a778a077b202cd75bf45eb2792949d32",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-gobject-base",
+        "epoch": 0,
+        "version": "3.28.3",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-gobject-base-3.28.3-2.el8.ppc64le.rpm",
+        "checksum": "sha256:8781993942f622945aefe59e449a5ff4608f969db79fbe893040890ff08fc1f9",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-gpg",
+        "epoch": 0,
+        "version": "1.13.1",
+        "release": "9.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-gpg-1.13.1-9.el8.ppc64le.rpm",
+        "checksum": "sha256:111d88db3a52121f04f2741cc72ce8dda6d6f6ef2cc36452c042e0141b316334",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-hawkey",
+        "epoch": 0,
+        "version": "0.63.0",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-hawkey-0.63.0-2.el8.ppc64le.rpm",
+        "checksum": "sha256:4715730da2b4a5bf6cc2ab85208071f00c7b279e4b2f75df0bd954446185e14c",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-idna",
+        "epoch": 0,
+        "version": "2.5",
+        "release": "5.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-idna-2.5-5.el8.noarch.rpm",
+        "checksum": "sha256:78c43d8a15ca018de1803e4baac5819e1baab1963fd31f1e44e54e8a573acbfc",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-jwt",
+        "epoch": 0,
+        "version": "1.6.1",
+        "release": "2.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-jwt-1.6.1-2.el8.noarch.rpm",
+        "checksum": "sha256:ebeb05a4a9cdd5d060859eabac1349029c0120615c98fc939e26664c030655c1",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libcomps",
+        "epoch": 0,
+        "version": "0.1.16",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-libcomps-0.1.16-2.el8.ppc64le.rpm",
+        "checksum": "sha256:594d8b368013caa4eaba4eade896fc1cec8ef569052bd491f493c193e07c6d80",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libdnf",
+        "epoch": 0,
+        "version": "0.63.0",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-libdnf-0.63.0-2.el8.ppc64le.rpm",
+        "checksum": "sha256:abc36bf7797a427b64c3c99b4f74714bfa66b906b62358be6fdafe493a66415e",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libs",
+        "epoch": 0,
+        "version": "3.6.8",
+        "release": "39.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-libs-3.6.8-39.el8.ppc64le.rpm",
+        "checksum": "sha256:405bda98fe97c1a5cf70511ae2d167256b25dd8721b88899465e9847525e2068",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libselinux",
+        "epoch": 0,
+        "version": "2.9",
+        "release": "5.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-libselinux-2.9-5.el8.ppc64le.rpm",
+        "checksum": "sha256:3b5d31b89683be71c72b77cfceb59238f4c76a796de6ae85525b3d5cfe2a8f23",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libsemanage",
+        "epoch": 0,
+        "version": "2.9",
+        "release": "6.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-libsemanage-2.9-6.el8.ppc64le.rpm",
+        "checksum": "sha256:882a327cb5e2d809bfe695e9622caced76e7d89c96dcb40203ad8b7d281630fa",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libxml2",
+        "epoch": 0,
+        "version": "2.9.7",
+        "release": "11.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-libxml2-2.9.7-11.el8.ppc64le.rpm",
+        "checksum": "sha256:d77a7b1602a9ab7543171091dcb37100552f4738d40389028cbf2992c3152f52",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-linux-procfs",
+        "epoch": 0,
+        "version": "0.6.3",
+        "release": "1.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-linux-procfs-0.6.3-1.el8.noarch.rpm",
+        "checksum": "sha256:dc835194ecfa6ebda81e0a764c953eff3422a61863e9a3e0dc74ea4cae7a4d94",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-oauthlib",
+        "epoch": 0,
+        "version": "2.1.0",
+        "release": "1.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-oauthlib-2.1.0-1.el8.noarch.rpm",
+        "checksum": "sha256:20874a9d40b12125c9e5b97fe4ccda3f94acbc03da1dec7299123901f5b56631",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-perf",
+        "epoch": 0,
+        "version": "4.18.0",
+        "release": "331.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-perf-4.18.0-331.el8.ppc64le.rpm",
+        "checksum": "sha256:cb21226326a5a695c993daba749f5d758658d58612b05280a04cca98cba3f83a",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-pip-wheel",
+        "epoch": 0,
+        "version": "9.0.3",
+        "release": "20.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-pip-wheel-9.0.3-20.el8.noarch.rpm",
+        "checksum": "sha256:6c9dfb73e199975275633f05d31388cd61c5a77dec5678db958b4e6624eb21ba",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-ply",
+        "epoch": 0,
+        "version": "3.9",
+        "release": "9.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-ply-3.9-9.el8.noarch.rpm",
+        "checksum": "sha256:d1e8c7a00924d1a6dee44ade189025853a501d4f77c73f3bfc006aa907d97daf",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-policycoreutils",
+        "epoch": 0,
+        "version": "2.9",
+        "release": "15.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-policycoreutils-2.9-15.el8.noarch.rpm",
+        "checksum": "sha256:3eca41ba67f8121586709b6fa2c57b20b4fab73bbb8a4c133269d0cc964f362c",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-pycparser",
+        "epoch": 0,
+        "version": "2.14",
+        "release": "14.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-pycparser-2.14-14.el8.noarch.rpm",
+        "checksum": "sha256:8891a9a4707611c13a5693b195201dd940254ffdb03cf5742952329282bb8cb7",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-pysocks",
+        "epoch": 0,
+        "version": "1.6.8",
+        "release": "3.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-pysocks-1.6.8-3.el8.noarch.rpm",
+        "checksum": "sha256:7f506879c64e0bb4d98782d025f46fb9a07517487ae4cbebbb3985a98f4e2154",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-pyudev",
+        "epoch": 0,
+        "version": "0.21.0",
+        "release": "7.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-pyudev-0.21.0-7.el8.noarch.rpm",
+        "checksum": "sha256:aa0007192287faeaecc72d9fa48efdb3108c764d450dc8fea65474476da32c45",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-pyyaml",
+        "epoch": 0,
+        "version": "3.12",
+        "release": "12.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-pyyaml-3.12-12.el8.ppc64le.rpm",
+        "checksum": "sha256:5b0f2f11c7d635630ced3cc6431b60d27a2c80f878420654df18a714b3df6c0e",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-requests",
+        "epoch": 0,
+        "version": "2.20.0",
+        "release": "2.1.el8_1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-requests-2.20.0-2.1.el8_1.noarch.rpm",
+        "checksum": "sha256:003ee19ec5b88de212c3246bdfdb3e97a9910a25a219fd7cf5030b7bc666fea9",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-rpm",
+        "epoch": 0,
+        "version": "4.14.3",
+        "release": "15.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-rpm-4.14.3-15.el8.ppc64le.rpm",
+        "checksum": "sha256:ccf848b42acc0f691b4cb6e2830dc4263c7ce4df89b3f4002c3d6b9cd99b362b",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-setools",
+        "epoch": 0,
+        "version": "4.3.0",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-setools-4.3.0-2.el8.ppc64le.rpm",
+        "checksum": "sha256:c2776b30c82ad5566fdbcce83fcf9c699ad83dae57c6499eb64f8b8a7bc00b60",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-setuptools-wheel",
+        "epoch": 0,
+        "version": "39.2.0",
+        "release": "6.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-setuptools-wheel-39.2.0-6.el8.noarch.rpm",
+        "checksum": "sha256:b19bd4f106ce301ee21c860183cc1c2ef9c09bdf495059bdf16e8d8ccc71bbe8",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-six",
+        "epoch": 0,
+        "version": "1.11.0",
+        "release": "8.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-six-1.11.0-8.el8.noarch.rpm",
+        "checksum": "sha256:a04cb3117395b962edc32bf45d8411f240632476b0706b2df7f4a1a87b2ce34b",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-slip",
+        "epoch": 0,
+        "version": "0.6.4",
+        "release": "11.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-slip-0.6.4-11.el8.noarch.rpm",
+        "checksum": "sha256:233e5f78027b684e5aaac1395cc574aea3039059bf86eb4494422bc74216a396",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-slip-dbus",
+        "epoch": 0,
+        "version": "0.6.4",
+        "release": "11.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-slip-dbus-0.6.4-11.el8.noarch.rpm",
+        "checksum": "sha256:563b3741d26b6af963fdb7b0634e0791445a707d0b6093ac71c3224299241639",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-syspurpose",
+        "epoch": 0,
+        "version": "1.28.20",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-syspurpose-1.28.20-1.el8.ppc64le.rpm",
+        "checksum": "sha256:07c65a3efc2bb32027206df4f117b893268d028cbb3741208d73615a63525158",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-urllib3",
+        "epoch": 0,
+        "version": "1.24.2",
+        "release": "5.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/python3-urllib3-1.24.2-5.el8.noarch.rpm",
+        "checksum": "sha256:aa1835fd302a37b84ac256db5dd0de09bd9883a5a07775aedb491faf46b18ee0",
+        "check_gpg": true
+      },
+      {
+        "name": "quota",
+        "epoch": 1,
+        "version": "4.04",
+        "release": "14.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/quota-4.04-14.el8.ppc64le.rpm",
+        "checksum": "sha256:612c21ec8de299b7244b931b492f17e811ecde1450e359f112bc88d20b115d73",
+        "check_gpg": true
+      },
+      {
+        "name": "quota-nls",
+        "epoch": 1,
+        "version": "4.04",
+        "release": "14.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/quota-nls-4.04-14.el8.noarch.rpm",
+        "checksum": "sha256:bc7fc2028a29ac7a406719ed4f6740f6bf12c20961223c1e839a2a39069af38d",
+        "check_gpg": true
+      },
+      {
+        "name": "rdma-core",
+        "epoch": 0,
+        "version": "35.0",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/rdma-core-35.0-1.el8.ppc64le.rpm",
+        "checksum": "sha256:4cc53ff12e7b8fcfafdd32eaac7b13266876766f22b3262b653eaa7b06fbbaaf",
+        "check_gpg": true
+      },
+      {
+        "name": "readline",
+        "epoch": 0,
+        "version": "7.0",
+        "release": "10.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/readline-7.0-10.el8.ppc64le.rpm",
+        "checksum": "sha256:0320663709136d07690fe299903700cc1dcc526d574fe8b952a01e1d24024ae4",
+        "check_gpg": true
+      },
+      {
+        "name": "rootfiles",
+        "epoch": 0,
+        "version": "8.1",
+        "release": "22.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/rootfiles-8.1-22.el8.noarch.rpm",
+        "checksum": "sha256:d967d6bbb33bf7a295a64807f81875c84e82a8ecc59b6c72fe955141b1660d39",
+        "check_gpg": true
+      },
+      {
+        "name": "rpcbind",
+        "epoch": 0,
+        "version": "1.2.5",
+        "release": "8.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/rpcbind-1.2.5-8.el8.ppc64le.rpm",
+        "checksum": "sha256:a81afd94bec26037880bccdb97937c7662ecb6c1006a8bbf657d8ffafc7c4614",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm",
+        "epoch": 0,
+        "version": "4.14.3",
+        "release": "15.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/rpm-4.14.3-15.el8.ppc64le.rpm",
+        "checksum": "sha256:4fae16ca54207cb952e3904b8eb8cc424f3f056f400e5e802ab1a9ef3e575834",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-build-libs",
+        "epoch": 0,
+        "version": "4.14.3",
+        "release": "15.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/rpm-build-libs-4.14.3-15.el8.ppc64le.rpm",
+        "checksum": "sha256:03ba1e86a04d912fd2878b457b06a6a7abad0ce96cd9a6932bf58cb4641b8fb7",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-libs",
+        "epoch": 0,
+        "version": "4.14.3",
+        "release": "15.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/rpm-libs-4.14.3-15.el8.ppc64le.rpm",
+        "checksum": "sha256:4e22015880d16cb7148d70895a2361f4fa05804f0391386e0e50554e6fd868b0",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-plugin-selinux",
+        "epoch": 0,
+        "version": "4.14.3",
+        "release": "15.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/rpm-plugin-selinux-4.14.3-15.el8.ppc64le.rpm",
+        "checksum": "sha256:9b1018a43b1a9245cdc71a342b962aa32fb799bd0ce66ee59b496cdd75200de9",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-plugin-systemd-inhibit",
+        "epoch": 0,
+        "version": "4.14.3",
+        "release": "15.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/rpm-plugin-systemd-inhibit-4.14.3-15.el8.ppc64le.rpm",
+        "checksum": "sha256:8cb953ea9ea1bd262bef00112e2c433583929cd7aec86ae60f1a725c6dcf7c09",
+        "check_gpg": true
+      },
+      {
+        "name": "rsync",
+        "epoch": 0,
+        "version": "3.1.3",
+        "release": "12.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/rsync-3.1.3-12.el8.ppc64le.rpm",
+        "checksum": "sha256:88ff01f3d3812bc3fb3d18970ecefde7ac8f1a6a29409946ed85173cf8645a3a",
+        "check_gpg": true
+      },
+      {
+        "name": "sed",
+        "epoch": 0,
+        "version": "4.5",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/sed-4.5-2.el8.ppc64le.rpm",
+        "checksum": "sha256:dbde46224833f804d8b92212fa3618ea53d0e0cb84ff07132a5ba36c1bc0b9df",
+        "check_gpg": true
+      },
+      {
+        "name": "selinux-policy",
+        "epoch": 0,
+        "version": "3.14.3",
+        "release": "76.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/selinux-policy-3.14.3-76.el8.noarch.rpm",
+        "checksum": "sha256:561a61d2d81bccb14d22a53b32301e0b6b9e9b9d80ad75991ee6ff796cae0ef7",
+        "check_gpg": true
+      },
+      {
+        "name": "selinux-policy-targeted",
+        "epoch": 0,
+        "version": "3.14.3",
+        "release": "76.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/selinux-policy-targeted-3.14.3-76.el8.noarch.rpm",
+        "checksum": "sha256:76df9e0fc779fcd7d3ee836ae254ead30b5f9492022b55901d1f8bd914d38ef6",
+        "check_gpg": true
+      },
+      {
+        "name": "servicelog",
+        "epoch": 0,
+        "version": "1.1.15",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/servicelog-1.1.15-1.el8.ppc64le.rpm",
+        "checksum": "sha256:605033c50f750dad4c344495a0d6b18dcfb2a091bba072441a38cbf9001c0363",
+        "check_gpg": true
+      },
+      {
+        "name": "setup",
+        "epoch": 0,
+        "version": "2.12.2",
+        "release": "6.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/setup-2.12.2-6.el8.noarch.rpm",
+        "checksum": "sha256:9e540fe1fcf866ba1e738e012eef5459d34cca30385df73973e6fc7c6eadb55f",
+        "check_gpg": true
+      },
+      {
+        "name": "sg3_utils",
+        "epoch": 0,
+        "version": "1.44",
+        "release": "5.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/sg3_utils-1.44-5.el8.ppc64le.rpm",
+        "checksum": "sha256:7d4c363f4a746f3a0946d19f303fe9c60c5fe178892528ec4f34d8ddd2c4c359",
+        "check_gpg": true
+      },
+      {
+        "name": "sg3_utils-libs",
+        "epoch": 0,
+        "version": "1.44",
+        "release": "5.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/sg3_utils-libs-1.44-5.el8.ppc64le.rpm",
+        "checksum": "sha256:8540be85295735194e0053eb2ab6b2bda2e27119b9b030877eff43f9272a20cf",
+        "check_gpg": true
+      },
+      {
+        "name": "shadow-utils",
+        "epoch": 2,
+        "version": "4.6",
+        "release": "14.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/shadow-utils-4.6-14.el8.ppc64le.rpm",
+        "checksum": "sha256:e1153055b6ea57ee81e6fb41b03023279059513d0fec728517ae0805186a5118",
+        "check_gpg": true
+      },
+      {
+        "name": "shared-mime-info",
+        "epoch": 0,
+        "version": "1.9",
+        "release": "3.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/shared-mime-info-1.9-3.el8.ppc64le.rpm",
+        "checksum": "sha256:f97b5915b3f75d2878104c198f205841813712103f1b3657d71d2c8d079cc947",
+        "check_gpg": true
+      },
+      {
+        "name": "slang",
+        "epoch": 0,
+        "version": "2.3.2",
+        "release": "3.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/slang-2.3.2-3.el8.ppc64le.rpm",
+        "checksum": "sha256:dd8998fa42db6769700a41203f5ef0efe523ed24734636ef0dc0d2a4d4a94747",
+        "check_gpg": true
+      },
+      {
+        "name": "snappy",
+        "epoch": 0,
+        "version": "1.1.8",
+        "release": "3.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/snappy-1.1.8-3.el8.ppc64le.rpm",
+        "checksum": "sha256:17c615aa31cf2afa434d1d1d42e0db85b564fe416d346721bd38c0db75f73119",
+        "check_gpg": true
+      },
+      {
+        "name": "sos",
+        "epoch": 0,
+        "version": "4.1",
+        "release": "5.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/sos-4.1-5.el8.noarch.rpm",
+        "checksum": "sha256:48f31b2798e2ebbf1a7b83f43c6aa2d2eb438a1e053906623c3a7391065c00d9",
+        "check_gpg": true
+      },
+      {
+        "name": "sqlite-libs",
+        "epoch": 0,
+        "version": "3.26.0",
+        "release": "15.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/sqlite-libs-3.26.0-15.el8.ppc64le.rpm",
+        "checksum": "sha256:31277c01ac529cc1c6a55fd87d6ce4dbb20290575d4e1e89cd40600eac9f3405",
+        "check_gpg": true
+      },
+      {
+        "name": "squashfs-tools",
+        "epoch": 0,
+        "version": "4.3",
+        "release": "20.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/squashfs-tools-4.3-20.el8.ppc64le.rpm",
+        "checksum": "sha256:4b00562fa291e956d910bb056c6120f0079f30093ea107757758683a6d418206",
+        "check_gpg": true
+      },
+      {
+        "name": "sssd-client",
+        "epoch": 0,
+        "version": "2.5.2",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/sssd-client-2.5.2-2.el8.ppc64le.rpm",
+        "checksum": "sha256:5796882ac3059835583bc399e8522c19646b717713ef553a71b20ca0535a1718",
+        "check_gpg": true
+      },
+      {
+        "name": "sssd-common",
+        "epoch": 0,
+        "version": "2.5.2",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/sssd-common-2.5.2-2.el8.ppc64le.rpm",
+        "checksum": "sha256:697f5bf30fbe44dd4dcba8392b85680952b7a1be9a0221349f4fde011a8cdd3c",
+        "check_gpg": true
+      },
+      {
+        "name": "sssd-kcm",
+        "epoch": 0,
+        "version": "2.5.2",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/sssd-kcm-2.5.2-2.el8.ppc64le.rpm",
+        "checksum": "sha256:c477e45fe5f8f5bab1ec1711210dd357392ad19eab48cda18d89b60df5067970",
+        "check_gpg": true
+      },
+      {
+        "name": "sssd-nfs-idmap",
+        "epoch": 0,
+        "version": "2.5.2",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/sssd-nfs-idmap-2.5.2-2.el8.ppc64le.rpm",
+        "checksum": "sha256:61b1d3440b078f35a3fe2b35c51d6d38498fb3dc8d8f5fedf52c7f0f8f6d8ecf",
+        "check_gpg": true
+      },
+      {
+        "name": "sudo",
+        "epoch": 0,
+        "version": "1.8.29",
+        "release": "7.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/sudo-1.8.29-7.el8.ppc64le.rpm",
+        "checksum": "sha256:bba1cd75958b43df5e3ceb820449008c19ed5fa562d54c2d46c5c57e79aa6b2a",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd",
+        "epoch": 0,
+        "version": "239",
+        "release": "49.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/systemd-239-49.el8.ppc64le.rpm",
+        "checksum": "sha256:8a501b9d8016eee68ce62a93a65842b15c8a57192b9f8189ebc85a11f2f47f9e",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-libs",
+        "epoch": 0,
+        "version": "239",
+        "release": "49.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/systemd-libs-239-49.el8.ppc64le.rpm",
+        "checksum": "sha256:3d175382237a94330d72af67ad2c41535dee7eade3e42178b86d2dc87478d030",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-pam",
+        "epoch": 0,
+        "version": "239",
+        "release": "49.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/systemd-pam-239-49.el8.ppc64le.rpm",
+        "checksum": "sha256:e95bb05fa5defeb16dd0e0957de676374b22b9daaf405273e636d1ce91001574",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-udev",
+        "epoch": 0,
+        "version": "239",
+        "release": "49.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/systemd-udev-239-49.el8.ppc64le.rpm",
+        "checksum": "sha256:3898e2ac4e04e80373bc7fe4092b26d502d4705177719117e25c083d44a9a150",
+        "check_gpg": true
+      },
+      {
+        "name": "tar",
+        "epoch": 2,
+        "version": "1.30",
+        "release": "5.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/tar-1.30-5.el8.ppc64le.rpm",
+        "checksum": "sha256:8c26cce4231f781db7b37d51ded377f9cfa01a5e6833d967082795f1220e2860",
+        "check_gpg": true
+      },
+      {
+        "name": "teamd",
+        "epoch": 0,
+        "version": "1.31",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/teamd-1.31-2.el8.ppc64le.rpm",
+        "checksum": "sha256:de9a24cdb3260850b49086745ba6f724aecff0bf7993729ae063c116da6915a4",
+        "check_gpg": true
+      },
+      {
+        "name": "timedatex",
+        "epoch": 0,
+        "version": "0.5",
+        "release": "3.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/timedatex-0.5-3.el8.ppc64le.rpm",
+        "checksum": "sha256:9dc236a8124d1fcbb41b970b5a4c45d6f7f97430c933c775121cae27f5f352a7",
+        "check_gpg": true
+      },
+      {
+        "name": "tpm2-tss",
+        "epoch": 0,
+        "version": "2.3.2",
+        "release": "4.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/tpm2-tss-2.3.2-4.el8.ppc64le.rpm",
+        "checksum": "sha256:d46ef49f8ddba1ee8cce6c9764014851cce2dbfb5dcb2457a31495393e6566c1",
+        "check_gpg": true
+      },
+      {
+        "name": "trousers",
+        "epoch": 0,
+        "version": "0.3.15",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/trousers-0.3.15-1.el8.ppc64le.rpm",
+        "checksum": "sha256:4164089bf1754c0ef18ae051e047f11299907204839ad4b7978f146a543a2e91",
+        "check_gpg": true
+      },
+      {
+        "name": "trousers-lib",
+        "epoch": 0,
+        "version": "0.3.15",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/trousers-lib-0.3.15-1.el8.ppc64le.rpm",
+        "checksum": "sha256:09096bc32e37443417cd625364df32674f9d5ff4ddbeb175e6d60637ed3d573f",
+        "check_gpg": true
+      },
+      {
+        "name": "tuned",
+        "epoch": 0,
+        "version": "2.16.0",
+        "release": "1.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/tuned-2.16.0-1.el8.noarch.rpm",
+        "checksum": "sha256:654d9074dc8ebb93230fe258188a17ba3f7dbac2f360f9f79cc4fb1516953018",
+        "check_gpg": true
+      },
+      {
+        "name": "tzdata",
+        "epoch": 0,
+        "version": "2021a",
+        "release": "1.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/tzdata-2021a-1.el8.noarch.rpm",
+        "checksum": "sha256:44999c555a6e4bb6cf5e6f6a79819e76912d036732cb50efaeefc20a180dd839",
+        "check_gpg": true
+      },
+      {
+        "name": "util-linux",
+        "epoch": 0,
+        "version": "2.32.1",
+        "release": "28.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/util-linux-2.32.1-28.el8.ppc64le.rpm",
+        "checksum": "sha256:ce954d3900cb547aea14df6ad5f310ea96bb5e83a155b93e2e64b2c13b686193",
+        "check_gpg": true
+      },
+      {
+        "name": "vim-minimal",
+        "epoch": 2,
+        "version": "8.0.1763",
+        "release": "15.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/vim-minimal-8.0.1763-15.el8.ppc64le.rpm",
+        "checksum": "sha256:368779f00f427680d954899dd73ad3b6a59c42baafb91cb100ea177f51185198",
+        "check_gpg": true
+      },
+      {
+        "name": "virt-what",
+        "epoch": 0,
+        "version": "1.18",
+        "release": "12.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/virt-what-1.18-12.el8.ppc64le.rpm",
+        "checksum": "sha256:f0c20dff5211f9c133ad5703daedcbe148528c634b0a1eea7887b420da4dc00c",
+        "check_gpg": true
+      },
+      {
+        "name": "which",
+        "epoch": 0,
+        "version": "2.21",
+        "release": "16.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/which-2.21-16.el8.ppc64le.rpm",
+        "checksum": "sha256:15cd74b4ad9d82417072fe867f086d68667afd4291b710b6c7feef985c492990",
+        "check_gpg": true
+      },
+      {
+        "name": "xfsprogs",
+        "epoch": 0,
+        "version": "5.0.0",
+        "release": "9.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/xfsprogs-5.0.0-9.el8.ppc64le.rpm",
+        "checksum": "sha256:480e0f1a9dcce6ed0728e9aba709e33f5522273da1e4b0859cf9d3bbe2216532",
+        "check_gpg": true
+      },
+      {
+        "name": "xz",
+        "epoch": 0,
+        "version": "5.2.4",
+        "release": "3.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/xz-5.2.4-3.el8.ppc64le.rpm",
+        "checksum": "sha256:cd8b0adfc4d2467a61ab2aa2b3e617bbd2a2592176da249365eef014faef827c",
+        "check_gpg": true
+      },
+      {
+        "name": "xz-libs",
+        "epoch": 0,
+        "version": "5.2.4",
+        "release": "3.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/xz-libs-5.2.4-3.el8.ppc64le.rpm",
+        "checksum": "sha256:a4577841148e7e2bf481447ae141eff319007e70a24295a22787bbfaecf4c4fe",
+        "check_gpg": true
+      },
+      {
+        "name": "yum",
+        "epoch": 0,
+        "version": "4.7.0",
+        "release": "2.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/yum-4.7.0-2.el8.noarch.rpm",
+        "checksum": "sha256:bc3e4dd9194760500ce9731d792f46afa049667185487bae88c23a38fdb10c37",
+        "check_gpg": true
+      },
+      {
+        "name": "yum-utils",
+        "epoch": 0,
+        "version": "4.0.21",
+        "release": "2.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/yum-utils-4.0.21-2.el8.noarch.rpm",
+        "checksum": "sha256:3c89b334988c0d1399d25baebe298d9e8cc768f28aefd581aae893aa1e69de84",
+        "check_gpg": true
+      },
+      {
+        "name": "zlib",
+        "epoch": 0,
+        "version": "1.2.11",
+        "release": "17.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20210827/Packages/zlib-1.2.11-17.el8.ppc64le.rpm",
+        "checksum": "sha256:33a92d88496e8aa410976f073e324f761b2ae02a94c20c0f291072df84f648be",
+        "check_gpg": true
+      },
+      {
+        "name": "PackageKit",
+        "epoch": 0,
+        "version": "1.1.12",
+        "release": "6.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/PackageKit-1.1.12-6.el8.ppc64le.rpm",
+        "checksum": "sha256:8b73e398f5a3cdc8a7ded303586ca7a50b26cc76213a3cebe36fdfdca769b316",
+        "check_gpg": true
+      },
+      {
+        "name": "PackageKit-glib",
+        "epoch": 0,
+        "version": "1.1.12",
+        "release": "6.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/PackageKit-glib-1.1.12-6.el8.ppc64le.rpm",
+        "checksum": "sha256:ff02d15997cec2391c7d49203e49f88068993252ac1f496a11e182c92d9d0e88",
+        "check_gpg": true
+      },
+      {
+        "name": "abattis-cantarell-fonts",
+        "epoch": 0,
+        "version": "0.0.25",
+        "release": "6.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/abattis-cantarell-fonts-0.0.25-6.el8.noarch.rpm",
+        "checksum": "sha256:11838afbfab4da7d5fa6e01046f76cce0b0a0c174a87c522eba440fce16e316f",
+        "check_gpg": true
+      },
+      {
+        "name": "authselect-compat",
+        "epoch": 0,
+        "version": "1.2.2",
+        "release": "3.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/authselect-compat-1.2.2-3.el8.ppc64le.rpm",
+        "checksum": "sha256:e526de1fefb832b3e6a025642c77ac2527595925933412a7921606eb072e5ca9",
+        "check_gpg": true
+      },
+      {
+        "name": "cairo",
+        "epoch": 0,
+        "version": "1.15.12",
+        "release": "3.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/cairo-1.15.12-3.el8.ppc64le.rpm",
+        "checksum": "sha256:3d4e54f6bb2f6ee5417613d5d9bef407343adc768a0841ea58f831ffa868cbd0",
+        "check_gpg": true
+      },
+      {
+        "name": "cairo-gobject",
+        "epoch": 0,
+        "version": "1.15.12",
+        "release": "3.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/cairo-gobject-1.15.12-3.el8.ppc64le.rpm",
+        "checksum": "sha256:8623975eac20e039a7ba14323490db10169cf205ec98f5df2f55f7d410202663",
+        "check_gpg": true
+      },
+      {
+        "name": "centos-logos",
+        "epoch": 0,
+        "version": "85.8",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/centos-logos-85.8-1.el8.ppc64le.rpm",
+        "checksum": "sha256:2b76d31dc0fdff399a5b1d396caff67b9eb2f5b8f6cfa8d7a430eeaf6a09104d",
+        "check_gpg": true
+      },
+      {
+        "name": "cloud-init",
+        "epoch": 0,
+        "version": "21.1",
+        "release": "3.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/cloud-init-21.1-3.el8.noarch.rpm",
+        "checksum": "sha256:43d4db89cf7aa96d57be2847577cf1dba8cba99d5d43118ee54d0b97a4ef8b7e",
+        "check_gpg": true
+      },
+      {
+        "name": "cloud-utils-growpart",
+        "epoch": 0,
+        "version": "0.31",
+        "release": "3.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/cloud-utils-growpart-0.31-3.el8.noarch.rpm",
+        "checksum": "sha256:80f3973c07c06dd095203553abbb95d6ce1c24ccc92f24f46659bf05416f4778",
+        "check_gpg": true
+      },
+      {
+        "name": "geolite2-city",
+        "epoch": 0,
+        "version": "20180605",
+        "release": "1.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/geolite2-city-20180605-1.el8.noarch.rpm",
+        "checksum": "sha256:cad86777bcb265db0da766952ff63e8d33f0fd4f3b90b22d0a1da587a785db44",
+        "check_gpg": true
+      },
+      {
+        "name": "geolite2-country",
+        "epoch": 0,
+        "version": "20180605",
+        "release": "1.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/geolite2-country-20180605-1.el8.noarch.rpm",
+        "checksum": "sha256:67419432fe7d373f8e5ddaa7b0dd1c25389608bf2f4ee76dbabcc2d96eb8c9d0",
+        "check_gpg": true
+      },
+      {
+        "name": "libX11",
+        "epoch": 0,
+        "version": "1.6.8",
+        "release": "4.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/libX11-1.6.8-4.el8.ppc64le.rpm",
+        "checksum": "sha256:4b81b6f8279b75714cbac2f77b2e006f65cd799c2ec3d1c9c40840b1ab60c885",
+        "check_gpg": true
+      },
+      {
+        "name": "libX11-common",
+        "epoch": 0,
+        "version": "1.6.8",
+        "release": "4.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/libX11-common-1.6.8-4.el8.noarch.rpm",
+        "checksum": "sha256:5f445b2b2a4bdeabd555e25dfa10119d9f4e4e500d1c4492219dd8647f119ce2",
+        "check_gpg": true
+      },
+      {
+        "name": "libXau",
+        "epoch": 0,
+        "version": "1.0.9",
+        "release": "3.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/libXau-1.0.9-3.el8.ppc64le.rpm",
+        "checksum": "sha256:8c893a8300f812ca179e1f8863eff109e1b8f1c70044bc5f08eb38a592ffdecd",
+        "check_gpg": true
+      },
+      {
+        "name": "libXext",
+        "epoch": 0,
+        "version": "1.3.4",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/libXext-1.3.4-1.el8.ppc64le.rpm",
+        "checksum": "sha256:fc8e4e96da6ee6201a5126473666831314938e98bf699677be296e7811f6b7dd",
+        "check_gpg": true
+      },
+      {
+        "name": "libXrender",
+        "epoch": 0,
+        "version": "0.9.10",
+        "release": "7.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/libXrender-0.9.10-7.el8.ppc64le.rpm",
+        "checksum": "sha256:32ecf5a37bacbeec9451c4ad39672ac2816f9241d5a92f038b45059da2f3ebae",
+        "check_gpg": true
+      },
+      {
+        "name": "libestr",
+        "epoch": 0,
+        "version": "0.1.10",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/libestr-0.1.10-1.el8.ppc64le.rpm",
+        "checksum": "sha256:e525544166da577edcd03c6596f1e8787a257caaa19eef98c3a481681d2d978a",
+        "check_gpg": true
+      },
+      {
+        "name": "libfastjson",
+        "epoch": 0,
+        "version": "0.99.9",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/libfastjson-0.99.9-1.el8.ppc64le.rpm",
+        "checksum": "sha256:b55df489f643b495984915a0671e74262192813e07cff5812d778c8cf4c0b9d1",
+        "check_gpg": true
+      },
+      {
+        "name": "libmaxminddb",
+        "epoch": 0,
+        "version": "1.2.0",
+        "release": "10.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/libmaxminddb-1.2.0-10.el8.ppc64le.rpm",
+        "checksum": "sha256:29214e4bf64efb65d82bd3f318d0ac3b7a6b03f6f6abfd469148bc2f894c6846",
+        "check_gpg": true
+      },
+      {
+        "name": "libxcb",
+        "epoch": 0,
+        "version": "1.13.1",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/libxcb-1.13.1-1.el8.ppc64le.rpm",
+        "checksum": "sha256:16b390c34ddb56c075fb6f4b77bf9a0fffab219fcb3f3588b9151215ab2b0ad4",
+        "check_gpg": true
+      },
+      {
+        "name": "libxkbcommon",
+        "epoch": 0,
+        "version": "0.9.1",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/libxkbcommon-0.9.1-1.el8.ppc64le.rpm",
+        "checksum": "sha256:b5bd11b47b5b690dc667dc486941331d7cd3aaa4f0e5c4d638ec7b294bcc5012",
+        "check_gpg": true
+      },
+      {
+        "name": "oddjob",
+        "epoch": 0,
+        "version": "0.34.7",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/oddjob-0.34.7-1.el8.ppc64le.rpm",
+        "checksum": "sha256:20c3abcc5556f09e557a398886684d1efe8ef59687bedbb78c130a7d1d55868a",
+        "check_gpg": true
+      },
+      {
+        "name": "oddjob-mkhomedir",
+        "epoch": 0,
+        "version": "0.34.7",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/oddjob-mkhomedir-0.34.7-1.el8.ppc64le.rpm",
+        "checksum": "sha256:1cdd6c2abf0132da0d956398eb1dc736c0b93fd8e8465e7f1111ad05b2c322d8",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Digest",
+        "epoch": 0,
+        "version": "1.17",
+        "release": "395.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/perl-Digest-1.17-395.el8.noarch.rpm",
+        "checksum": "sha256:7e67dba2509f90064325e62e49412d5284a55f09b7b6878b9c8222692c500dde",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Digest-MD5",
+        "epoch": 0,
+        "version": "2.55",
+        "release": "396.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/perl-Digest-MD5-2.55-396.el8.ppc64le.rpm",
+        "checksum": "sha256:9f1a745b208091d4b009ec321a6fdc72c8a5e89167effed81c50571a13f1c87d",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-IO-Socket-IP",
+        "epoch": 0,
+        "version": "0.39",
+        "release": "5.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/perl-IO-Socket-IP-0.39-5.el8.noarch.rpm",
+        "checksum": "sha256:c7dfa7d5a4917eed3b44af87ffb9c6e18242ecd847a8edd140bcdd178cc8946a",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-IO-Socket-SSL",
+        "epoch": 0,
+        "version": "2.066",
+        "release": "4.module_el8.4.0+517+be1595ff",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/perl-IO-Socket-SSL-2.066-4.module_el8.4.0+517+be1595ff.noarch.rpm",
+        "checksum": "sha256:46e371b6245113ebca446adcbd2db39f2887b67dc5a640f62f6d346ec9f6980f",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Mozilla-CA",
+        "epoch": 0,
+        "version": "20160104",
+        "release": "7.module_el8.3.0+416+dee7bcef",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/perl-Mozilla-CA-20160104-7.module_el8.3.0+416+dee7bcef.noarch.rpm",
+        "checksum": "sha256:cea5d052286c0a120f6cdd0f3e559f13b0eedf9f83d2538e4369b6e05526d43d",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Net-SSLeay",
+        "epoch": 0,
+        "version": "1.88",
+        "release": "1.module_el8.4.0+517+be1595ff",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/perl-Net-SSLeay-1.88-1.module_el8.4.0+517+be1595ff.ppc64le.rpm",
+        "checksum": "sha256:62da6a936871ab7b8c3efc0332fe41b4ac10ff96b357fb2bd67deecb312f9277",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-URI",
+        "epoch": 0,
+        "version": "1.73",
+        "release": "3.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/perl-URI-1.73-3.el8.noarch.rpm",
+        "checksum": "sha256:9feaf80c733951790bc3578db42ea2abef65643ebb36779e46dccdaf4c76b525",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-libnet",
+        "epoch": 0,
+        "version": "3.11",
+        "release": "3.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/perl-libnet-3.11-3.el8.noarch.rpm",
+        "checksum": "sha256:627d792d7cca1e97c121be5f0808c9da96f54d6c986622af246c60354b9c316e",
+        "check_gpg": true
+      },
+      {
+        "name": "pinentry",
+        "epoch": 0,
+        "version": "1.1.0",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/pinentry-1.1.0-2.el8.ppc64le.rpm",
+        "checksum": "sha256:12fda64dea45a7b085a35a816a7d8035be6600cae38f7df04a3bc22ced4d4502",
+        "check_gpg": true
+      },
+      {
+        "name": "pixman",
+        "epoch": 0,
+        "version": "0.38.4",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/pixman-0.38.4-1.el8.ppc64le.rpm",
+        "checksum": "sha256:685d8ca4ac9c909ac2daa8bf454d8ce1de993c8ae29a8c78417dfd5d1c3aa65e",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-babel",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "7.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/python3-babel-2.5.1-7.el8.noarch.rpm",
+        "checksum": "sha256:d2748115958b57c9c5125e23bad9462edbabb33c81197424a33d8060745ff646",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-cairo",
+        "epoch": 0,
+        "version": "1.16.3",
+        "release": "6.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/python3-cairo-1.16.3-6.el8.ppc64le.rpm",
+        "checksum": "sha256:5cf4db298bbda87532af2b2468a0692ec93d28393285ae157c1b4a18efbd1ba5",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-gobject",
+        "epoch": 0,
+        "version": "3.28.3",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/python3-gobject-3.28.3-2.el8.ppc64le.rpm",
+        "checksum": "sha256:7632176e2d324ee98701f5d79024361379d510590e477f560a264aa6e8db233d",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-jinja2",
+        "epoch": 0,
+        "version": "2.10.1",
+        "release": "3.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/python3-jinja2-2.10.1-3.el8.noarch.rpm",
+        "checksum": "sha256:95cb9c201ee3b54fe6331bd7e74f43485632e95448d31fd340ffaa84a32b41ab",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-jsonpatch",
+        "epoch": 0,
+        "version": "1.21",
+        "release": "2.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/python3-jsonpatch-1.21-2.el8.noarch.rpm",
+        "checksum": "sha256:85eb614fc608f3b3f4bbd08d4a3b0ff6af188677ea4e009be021680c521cedae",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-jsonpointer",
+        "epoch": 0,
+        "version": "1.10",
+        "release": "11.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/python3-jsonpointer-1.10-11.el8.noarch.rpm",
+        "checksum": "sha256:60b0cbc5e435be346bb06f45f3336f8936d7362022d8bceda80ff16bc3fb7dd2",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-jsonschema",
+        "epoch": 0,
+        "version": "2.6.0",
+        "release": "4.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/python3-jsonschema-2.6.0-4.el8.noarch.rpm",
+        "checksum": "sha256:0feac495306bbe6e3149a352025bea8d23cda512859a230cbd3f510cf48caaf7",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-markupsafe",
+        "epoch": 0,
+        "version": "0.23",
+        "release": "19.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/python3-markupsafe-0.23-19.el8.ppc64le.rpm",
+        "checksum": "sha256:0f54422e17766a9e7385a553d941d1849c9e7ca4caea085305ba9fb1e15ae607",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-pexpect",
+        "epoch": 0,
+        "version": "4.3.1",
+        "release": "3.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/python3-pexpect-4.3.1-3.el8.noarch.rpm",
+        "checksum": "sha256:0bc637f0d028043e8388b083cdd8d0a0acea7fdbc79c0bc9401dfb02c20fb817",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-prettytable",
+        "epoch": 0,
+        "version": "0.7.2",
+        "release": "14.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/python3-prettytable-0.7.2-14.el8.noarch.rpm",
+        "checksum": "sha256:1b53c868277dec628058b31b1a8a8a2ccd8efe832ce9694805b5f82564136eb3",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-ptyprocess",
+        "epoch": 0,
+        "version": "0.5.2",
+        "release": "4.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/python3-ptyprocess-0.5.2-4.el8.noarch.rpm",
+        "checksum": "sha256:499e48b35f3b5f5da45031fa78fba559fee6a480ecb106e6c300eb8344510958",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-pydbus",
+        "epoch": 0,
+        "version": "0.6.0",
+        "release": "5.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/python3-pydbus-0.6.0-5.el8.noarch.rpm",
+        "checksum": "sha256:bfa39369bd3c36833126b6f46b747de0736a66835d97196195c0810161c24549",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-pyserial",
+        "epoch": 0,
+        "version": "3.1.1",
+        "release": "8.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/python3-pyserial-3.1.1-8.el8.noarch.rpm",
+        "checksum": "sha256:82ce159a9e4e4b6b4fdce9ad954aa507f67108430bd261a4dcd826e44d0152a4",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-pytz",
+        "epoch": 0,
+        "version": "2017.2",
+        "release": "9.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/python3-pytz-2017.2-9.el8.noarch.rpm",
+        "checksum": "sha256:0edde19e0c027c8cff31b82e1f4b0b198c00bf924047fcf4dd610a7d4965ab52",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-systemd",
+        "epoch": 0,
+        "version": "234",
+        "release": "8.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/python3-systemd-234-8.el8.ppc64le.rpm",
+        "checksum": "sha256:6b096b1da49230942e736576396091530cecb3f9bd8cc70b8b8a9f72a5148a0d",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-unbound",
+        "epoch": 0,
+        "version": "1.7.3",
+        "release": "17.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/python3-unbound-1.7.3-17.el8.ppc64le.rpm",
+        "checksum": "sha256:8571a2aa115d42f8b5e87ef58d10e9c24e6fbe5470fc2612df96f8740f3d960f",
+        "check_gpg": true
+      },
+      {
+        "name": "qemu-guest-agent",
+        "epoch": 15,
+        "version": "4.2.0",
+        "release": "52.module_el8.5.0+853+a4d5519d",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/qemu-guest-agent-4.2.0-52.module_el8.5.0+853+a4d5519d.ppc64le.rpm",
+        "checksum": "sha256:2fcacd153d4aa4ddddee3357b717e8d3f411382b180add28328c9faa94dd2ae4",
+        "check_gpg": true
+      },
+      {
+        "name": "rsyslog",
+        "epoch": 0,
+        "version": "8.2102.0",
+        "release": "5.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/rsyslog-8.2102.0-5.el8.ppc64le.rpm",
+        "checksum": "sha256:8945279d57ad510e018f92571ba8e5d811cf8a3165adf930b0d4015c5a077a35",
+        "check_gpg": true
+      },
+      {
+        "name": "setroubleshoot-plugins",
+        "epoch": 0,
+        "version": "3.3.13",
+        "release": "1.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/setroubleshoot-plugins-3.3.13-1.el8.noarch.rpm",
+        "checksum": "sha256:30f37ca1fe1592e29d3e97c1dec0646015000d19bffc40f13dcfe73e15be66fc",
+        "check_gpg": true
+      },
+      {
+        "name": "setroubleshoot-server",
+        "epoch": 0,
+        "version": "3.3.24",
+        "release": "3.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/setroubleshoot-server-3.3.24-3.el8.ppc64le.rpm",
+        "checksum": "sha256:27f43a7a8d1b18f5ede27728ecded75e510195a78abd9f3d0c1965d341e5e45a",
+        "check_gpg": true
+      },
+      {
+        "name": "sscg",
+        "epoch": 0,
+        "version": "2.3.3",
+        "release": "14.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/sscg-2.3.3-14.el8.ppc64le.rpm",
+        "checksum": "sha256:ab2988acbe3a2580703de6070646324e95efe982598a386e69ed9857ab123855",
+        "check_gpg": true
+      },
+      {
+        "name": "tcpdump",
+        "epoch": 14,
+        "version": "4.9.3",
+        "release": "2.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/tcpdump-4.9.3-2.el8.ppc64le.rpm",
+        "checksum": "sha256:71f54759238edb9ae63dfc6ed893183a809e88321d8117dc40e0d403fc533585",
+        "check_gpg": true
+      },
+      {
+        "name": "unbound-libs",
+        "epoch": 0,
+        "version": "1.7.3",
+        "release": "17.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/unbound-libs-1.7.3-17.el8.ppc64le.rpm",
+        "checksum": "sha256:ebd64ac5cc7b9f58a40072fe9afefa2fd835e0eb18cdeaf085395c7e84affac3",
+        "check_gpg": true
+      },
+      {
+        "name": "xkeyboard-config",
+        "epoch": 0,
+        "version": "2.28",
+        "release": "1.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20210827/Packages/xkeyboard-config-2.28-1.el8.noarch.rpm",
+        "checksum": "sha256:a2aeabb3962859069a78acc288bc3bffb35485428e162caafec8134f5ce6ca67",
+        "check_gpg": true
+      }
+    ]
+  },
+  "image-info": {
+    "/etc/resolv.conf": [],
+    "/etc/udev/rules.d": {
+      "70-persistent-ipoib.rules": [],
+      "90-vpdupdate.rules": [
+        "DEVPATH!=\"/devices/*\", GOTO=\"vpd_end\"",
+        "DEVPATH==\"/devices/virtual/*\", GOTO=\"vpd_end\"",
+        "DEVPATH==\"/devices/system/*\", GOTO=\"vpd_end\"",
+        "DEVPATH==\"/devices/cpu/*\", GOTO=\"vpd_end\"",
+        "DEVPATH==\"/devices/breakpoint/*\", GOTO=\"vpd_end\"",
+        "DEVPATH==\"/devices/tracepoint/*\", GOTO=\"vpd_end\"",
+        "DEVPATH==\"/devices/software/*\", GOTO=\"vpd_end\"",
+        "ENV{DEVTYPE}==\"scsi_target\", GOTO=\"vpd_end\"",
+        "SUBSYSTEM==\"enclosure\", GOTO=\"vpd_end\"",
+        "ENV{DEVTYPE}==\"partition\", GOTO=\"vpd_end\"",
+        "DEVPATH==\"/devices/uprobe/*\", GOTO=\"vpd_end\"",
+        "DEVPATH==\"/devices/kprobe/*\", GOTO=\"vpd_end\"",
+        "DEVPATH==\"/devices/rbd/*\", GOTO=\"vpd_end\"",
+        "SUBSYSTEM==\"scsi_device\", GOTO=\"vpd_update\"",
+        "SUBSYSTEM==\"scsi_host\", GOTO=\"vpd_update\"",
+        "SUBSYSTEMS==\"scsi*\", GOTO=\"vpd_end\"",
+        "SUBSYSTEM==\"nvme\", GOTO=\"vpd_update\"",
+        "SUBSYSTEM==\"nvme-subsystem\", GOTO=\"vpd_update\"",
+        "SUBSYSTEMS==\"nvme*\", GOTO=\"vpd_end\"",
+        "LABEL=\"vpd_update\"",
+        "RUN+=\"/bin/touch /run/run.vpdupdate\"",
+        "LABEL=\"vpd_end\""
+      ]
+    },
+    "boot-environment": {
+      "kernelopts": "root=UUID=0194fdc2-fa2f-4cc0-81d3-ff12045b73c8 console=tty0 console=ttyS0,115200n8 no_timer_check net.ifnames=0 crashkernel=auto debug",
+      "saved_entry": "ffffffffffffffffffffffffffffffff-4.18.0-331.el8.ppc64le"
+    },
+    "bootloader": "unknown",
+    "bootmenu": [
+      {
+        "grub_arg": "--unrestricted",
+        "grub_class": "kernel",
+        "grub_users": "$grub_users",
+        "id": "centos-20210819165143-0-rescue-ffffffffffffffffffffffffffffffff",
+        "initrd": "/boot/initramfs-0-rescue-ffffffffffffffffffffffffffffffff.img",
+        "linux": "/boot/vmlinuz-0-rescue-ffffffffffffffffffffffffffffffff",
+        "options": "$kernelopts",
+        "title": "CentOS (0-rescue-ffffffffffffffffffffffffffffffff) 8",
+        "version": "0-rescue-ffffffffffffffffffffffffffffffff"
+      },
+      {
+        "grub_arg": "--unrestricted",
+        "grub_class": "kernel",
+        "grub_users": "$grub_users",
+        "id": "centos-20210819165143-4.18.0-331.el8.ppc64le",
+        "initrd": "/boot/initramfs-4.18.0-331.el8.ppc64le.img $tuned_initrd",
+        "linux": "/boot/vmlinuz-4.18.0-331.el8.ppc64le",
+        "options": "$kernelopts $tuned_params",
+        "title": "CentOS (4.18.0-331.el8.ppc64le) 8",
+        "version": "4.18.0-331.el8.ppc64le"
+      }
+    ],
+    "chrony": {
+      "leapsectz": [
+        "right/UTC"
+      ],
+      "server": [
+        "time.example.com iburst"
+      ]
+    },
+    "cloud-init": {
+      "/etc/cloud": {
+        "cloud.cfg": {
+          "cloud_config_modules": [
+            "mounts",
+            "locale",
+            "set-passwords",
+            "rh_subscription",
+            "yum-add-repo",
+            "package-update-upgrade-install",
+            "timezone",
+            "puppet",
+            "chef",
+            "salt-minion",
+            "mcollective",
+            "disable-ec2-metadata",
+            "runcmd"
+          ],
+          "cloud_final_modules": [
+            "rightscale_userdata",
+            "scripts-per-once",
+            "scripts-per-boot",
+            "scripts-per-instance",
+            "scripts-user",
+            "ssh-authkey-fingerprints",
+            "keys-to-console",
+            "phone-home",
+            "final-message",
+            "power-state-change"
+          ],
+          "cloud_init_modules": [
+            "disk_setup",
+            "migrator",
+            "bootcmd",
+            "write-files",
+            "growpart",
+            "resizefs",
+            "set_hostname",
+            "update_hostname",
+            "update_etc_hosts",
+            "rsyslog",
+            "users-groups",
+            "ssh"
+          ],
+          "disable_root": 1,
+          "disable_vmware_customization": false,
+          "mount_default_fields": [
+            null,
+            null,
+            "auto",
+            "defaults,nofail,x-systemd.requires=cloud-init.service",
+            "0",
+            "2"
+          ],
+          "resize_rootfs_tmp": "/dev",
+          "ssh_deletekeys": 1,
+          "ssh_genkeytypes": [
+            "rsa",
+            "ecdsa",
+            "ed25519"
+          ],
+          "ssh_pwauth": 0,
+          "syslog_fix_perms": null,
+          "system_info": {
+            "default_user": {
+              "gecos": "Cloud User",
+              "groups": [
+                "adm",
+                "systemd-journal"
+              ],
+              "lock_passwd": true,
+              "name": "cloud-user",
+              "shell": "/bin/bash",
+              "sudo": [
+                "ALL=(ALL) NOPASSWD:ALL"
+              ]
+            },
+            "distro": "rhel",
+            "paths": {
+              "cloud_dir": "/var/lib/cloud",
+              "templates_dir": "/etc/cloud/templates"
+            },
+            "ssh_svcname": "sshd"
+          },
+          "users": [
+            "default"
+          ]
+        }
+      },
+      "/etc/cloud/cloud.cfg.d": {
+        "05_logging.cfg": {
+          "_log": [
+            "[loggers]\nkeys=root,cloudinit\n\n[handlers]\nkeys=consoleHandler,cloudLogHandler\n\n[formatters]\nkeys=simpleFormatter,arg0Formatter\n\n[logger_root]\nlevel=DEBUG\nhandlers=consoleHandler,cloudLogHandler\n\n[logger_cloudinit]\nlevel=DEBUG\nqualname=cloudinit\nhandlers=\npropagate=1\n\n[handler_consoleHandler]\nclass=StreamHandler\nlevel=WARNING\nformatter=arg0Formatter\nargs=(sys.stderr,)\n\n[formatter_arg0Formatter]\nformat=%(asctime)s - %(filename)s[%(levelname)s]: %(message)s\n\n[formatter_simpleFormatter]\nformat=[CLOUDINIT] %(filename)s[%(levelname)s]: %(message)s\n",
+            "[handler_cloudLogHandler]\nclass=FileHandler\nlevel=DEBUG\nformatter=arg0Formatter\nargs=('/var/log/cloud-init.log', 'a', 'UTF-8')\n",
+            "[handler_cloudLogHandler]\nclass=handlers.SysLogHandler\nlevel=DEBUG\nformatter=simpleFormatter\nargs=(\"/dev/log\", handlers.SysLogHandler.LOG_USER)\n"
+          ],
+          "log_cfgs": [
+            [
+              "[loggers]\nkeys=root,cloudinit\n\n[handlers]\nkeys=consoleHandler,cloudLogHandler\n\n[formatters]\nkeys=simpleFormatter,arg0Formatter\n\n[logger_root]\nlevel=DEBUG\nhandlers=consoleHandler,cloudLogHandler\n\n[logger_cloudinit]\nlevel=DEBUG\nqualname=cloudinit\nhandlers=\npropagate=1\n\n[handler_consoleHandler]\nclass=StreamHandler\nlevel=WARNING\nformatter=arg0Formatter\nargs=(sys.stderr,)\n\n[formatter_arg0Formatter]\nformat=%(asctime)s - %(filename)s[%(levelname)s]: %(message)s\n\n[formatter_simpleFormatter]\nformat=[CLOUDINIT] %(filename)s[%(levelname)s]: %(message)s\n",
+              "[handler_cloudLogHandler]\nclass=FileHandler\nlevel=DEBUG\nformatter=arg0Formatter\nargs=('/var/log/cloud-init.log', 'a', 'UTF-8')\n"
+            ]
+          ],
+          "output": {
+            "all": "| tee -a /var/log/cloud-init-output.log"
+          }
+        }
+      }
+    },
+    "default-target": "multi-user.target",
+    "dnf": {
+      "vars": {
+        "contentdir": "centos",
+        "infra": "stock",
+        "stream": "8-stream"
+      }
+    },
+    "dracut": {
+      "/usr/lib/dracut/dracut.conf.d": {
+        "01-dist.conf": {
+          "early_microcode": "yes",
+          "hostonly": "yes",
+          "hostonly_cmdline": "no",
+          "i18n_default_font": "eurlatgr",
+          "i18n_install_all": "yes",
+          "i18n_vars": "/etc/sysconfig/keyboard:KEYTABLE-KEYMAP /etc/sysconfig/i18n:SYSFONT-FONT,FONTACM-FONT_MAP,FONT_UNIMAP",
+          "install_optional_items": " vi /etc/virc ps grep cat rm ",
+          "prefix": "/",
+          "reproducible": "yes",
+          "stdloglvl": "3",
+          "sysloglvl": "5",
+          "systemdsystemconfdir": "/etc/systemd/system",
+          "systemdsystemunitdir": "/usr/lib/systemd/system",
+          "systemdutildir": "/usr/lib/systemd",
+          "udevdir": "/usr/lib/udev"
+        },
+        "02-generic-image.conf": {
+          "hostonly": "no"
+        },
+        "02-rescue.conf": {
+          "dracut_rescue_image": "yes"
+        }
+      }
+    },
+    "firewall-enabled": [
+      "ssh",
+      "dhcpv6-client",
+      "cockpit"
+    ],
+    "fstab": [
+      [
+        "UUID=0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+        "/",
+        "xfs",
+        "defaults",
+        "0",
+        "0"
+      ]
+    ],
+    "groups": [
+      "adm:x:4:",
+      "audio:x:63:",
+      "bin:x:1:",
+      "cdrom:x:11:",
+      "chrony:x:988:",
+      "cockpit-ws:x:990:",
+      "cockpit-wsinstance:x:989:",
+      "daemon:x:2:",
+      "dbus:x:81:",
+      "dialout:x:18:",
+      "disk:x:6:",
+      "floppy:x:19:",
+      "ftp:x:50:",
+      "games:x:20:",
+      "group1:x:1030:user2",
+      "group2:x:1050:",
+      "input:x:999:",
+      "kmem:x:9:",
+      "kvm:x:36:",
+      "lock:x:54:",
+      "lp:x:7:",
+      "mail:x:12:",
+      "man:x:15:",
+      "mem:x:8:",
+      "nobody:x:65534:",
+      "polkitd:x:996:",
+      "render:x:998:",
+      "root:x:0:",
+      "rpc:x:32:",
+      "rpcuser:x:29:",
+      "service:x:995:",
+      "setroubleshoot:x:991:",
+      "ssh_keys:x:994:",
+      "sshd:x:74:",
+      "sssd:x:992:",
+      "sys:x:3:",
+      "systemd-coredump:x:997:",
+      "systemd-journal:x:190:",
+      "systemd-resolve:x:193:",
+      "tape:x:33:",
+      "tcpdump:x:72:",
+      "tss:x:59:",
+      "tty:x:5:",
+      "unbound:x:993:",
+      "user1:x:1000:",
+      "users:x:100:",
+      "utempter:x:35:",
+      "utmp:x:22:",
+      "video:x:39:",
+      "wheel:x:10:"
+    ],
+    "hostname": "my-host",
+    "hosts": [
+      "127.0.0.1   localhost localhost.localdomain localhost4 localhost4.localdomain4",
+      "::1         localhost localhost.localdomain localhost6 localhost6.localdomain6"
+    ],
+    "image-format": {
+      "compat": "0.10",
+      "type": "qcow2"
+    },
+    "keyboard": {
+      "vconsole": {
+        "KEYMAP": "dvorak"
+      }
+    },
+    "locale": {
+      "LANG": "el_CY.UTF-8"
+    },
+    "machine-id": "",
+    "modprobe": {
+      "/usr/lib/modprobe.d": {
+        "dist-blacklist.conf": {
+          "blacklist": [
+            "chsc_sch"
+          ]
+        }
+      }
+    },
+    "os-release": {
+      "ANSI_COLOR": "0;31",
+      "BUG_REPORT_URL": "https://bugzilla.redhat.com/",
+      "CPE_NAME": "cpe:/o:centos:centos:8",
+      "HOME_URL": "https://centos.org/",
+      "ID": "centos",
+      "ID_LIKE": "rhel fedora",
+      "NAME": "CentOS Stream",
+      "PLATFORM_ID": "platform:el8",
+      "PRETTY_NAME": "CentOS Stream 8",
+      "REDHAT_SUPPORT_PRODUCT": "Red Hat Enterprise Linux 8",
+      "REDHAT_SUPPORT_PRODUCT_VERSION": "CentOS Stream",
+      "VERSION": "8",
+      "VERSION_ID": "8"
+    },
+    "packages": [
+      "NetworkManager-1.32.8-1.el8.ppc64le",
+      "NetworkManager-libnm-1.32.8-1.el8.ppc64le",
+      "NetworkManager-team-1.32.8-1.el8.ppc64le",
+      "NetworkManager-tui-1.32.8-1.el8.ppc64le",
+      "PackageKit-1.1.12-6.el8.ppc64le",
+      "PackageKit-glib-1.1.12-6.el8.ppc64le",
+      "abattis-cantarell-fonts-0.0.25-6.el8.noarch",
+      "acl-2.2.53-1.el8.ppc64le",
+      "audit-3.0-0.17.20191104git1c2f876.el8.ppc64le",
+      "audit-libs-3.0-0.17.20191104git1c2f876.el8.ppc64le",
+      "authselect-1.2.2-3.el8.ppc64le",
+      "authselect-compat-1.2.2-3.el8.ppc64le",
+      "authselect-libs-1.2.2-3.el8.ppc64le",
+      "basesystem-11-5.el8.noarch",
+      "bash-4.4.20-2.el8.ppc64le",
+      "bc-1.07.1-5.el8.ppc64le",
+      "bind-export-libs-9.11.26-4.el8_4.ppc64le",
+      "brotli-1.0.6-3.el8.ppc64le",
+      "bzip2-1.0.6-26.el8.ppc64le",
+      "bzip2-libs-1.0.6-26.el8.ppc64le",
+      "c-ares-1.13.0-5.el8.ppc64le",
+      "ca-certificates-2021.2.50-82.el8.noarch",
+      "cairo-1.15.12-3.el8.ppc64le",
+      "cairo-gobject-1.15.12-3.el8.ppc64le",
+      "centos-gpg-keys-8-2.el8.noarch",
+      "centos-logos-85.8-1.el8.ppc64le",
+      "centos-stream-release-8.5-3.el8.noarch",
+      "centos-stream-repos-8-2.el8.noarch",
+      "checkpolicy-2.9-1.el8.ppc64le",
+      "chkconfig-1.19.1-1.el8.ppc64le",
+      "chrony-4.1-1.el8.ppc64le",
+      "cloud-init-21.1-3.el8.noarch",
+      "cloud-utils-growpart-0.31-3.el8.noarch",
+      "cockpit-bridge-250-1.el8.ppc64le",
+      "cockpit-system-250-1.el8.noarch",
+      "cockpit-ws-250-1.el8.ppc64le",
+      "coreutils-8.30-12.el8.ppc64le",
+      "coreutils-common-8.30-12.el8.ppc64le",
+      "cpio-2.12-10.el8.ppc64le",
+      "cracklib-2.9.6-15.el8.ppc64le",
+      "cracklib-dicts-2.9.6-15.el8.ppc64le",
+      "cronie-1.5.2-4.el8.ppc64le",
+      "cronie-anacron-1.5.2-4.el8.ppc64le",
+      "crontabs-1.11-17.20190603git.el8.noarch",
+      "crypto-policies-20210617-1.gitc776d3e.el8.noarch",
+      "crypto-policies-scripts-20210617-1.gitc776d3e.el8.noarch",
+      "cryptsetup-libs-2.3.3-4.el8.ppc64le",
+      "curl-7.61.1-18.el8_4.1.ppc64le",
+      "cyrus-sasl-lib-2.1.27-5.el8.ppc64le",
+      "dbus-1.12.8-14.el8.ppc64le",
+      "dbus-common-1.12.8-14.el8.noarch",
+      "dbus-daemon-1.12.8-14.el8.ppc64le",
+      "dbus-glib-0.110-2.el8.ppc64le",
+      "dbus-libs-1.12.8-14.el8.ppc64le",
+      "dbus-tools-1.12.8-14.el8.ppc64le",
+      "dejavu-fonts-common-2.35-7.el8.noarch",
+      "dejavu-sans-mono-fonts-2.35-7.el8.noarch",
+      "device-mapper-1.02.177-6.el8.ppc64le",
+      "device-mapper-libs-1.02.177-6.el8.ppc64le",
+      "dhcp-client-4.3.6-45.el8.ppc64le",
+      "dhcp-common-4.3.6-45.el8.noarch",
+      "dhcp-libs-4.3.6-45.el8.ppc64le",
+      "diffutils-3.6-6.el8.ppc64le",
+      "dnf-4.7.0-2.el8.noarch",
+      "dnf-data-4.7.0-2.el8.noarch",
+      "dnf-plugins-core-4.0.21-2.el8.noarch",
+      "dosfstools-4.1-6.el8.ppc64le",
+      "dracut-049-188.git20210802.el8.ppc64le",
+      "dracut-config-generic-049-188.git20210802.el8.ppc64le",
+      "dracut-config-rescue-049-188.git20210802.el8.ppc64le",
+      "dracut-network-049-188.git20210802.el8.ppc64le",
+      "dracut-squash-049-188.git20210802.el8.ppc64le",
+      "e2fsprogs-1.45.6-2.el8.ppc64le",
+      "e2fsprogs-libs-1.45.6-2.el8.ppc64le",
+      "elfutils-debuginfod-client-0.185-1.el8.ppc64le",
+      "elfutils-default-yama-scope-0.185-1.el8.noarch",
+      "elfutils-libelf-0.185-1.el8.ppc64le",
+      "elfutils-libs-0.185-1.el8.ppc64le",
+      "ethtool-5.8-6.el8.ppc64le",
+      "expat-2.2.5-4.el8.ppc64le",
+      "file-5.33-20.el8.ppc64le",
+      "file-libs-5.33-20.el8.ppc64le",
+      "filesystem-3.8-6.el8.ppc64le",
+      "findutils-4.6.0-20.el8.ppc64le",
+      "firewalld-0.9.3-7.el8.noarch",
+      "firewalld-filesystem-0.9.3-7.el8.noarch",
+      "fontconfig-2.13.1-3.el8.ppc64le",
+      "fontpackages-filesystem-1.44-22.el8.noarch",
+      "freetype-2.9.1-4.el8_3.1.ppc64le",
+      "fuse-libs-2.9.7-12.el8.ppc64le",
+      "gawk-4.2.1-2.el8.ppc64le",
+      "gdbm-1.18-1.el8.ppc64le",
+      "gdbm-libs-1.18-1.el8.ppc64le",
+      "gdk-pixbuf2-2.36.12-5.el8.ppc64le",
+      "geolite2-city-20180605-1.el8.noarch",
+      "geolite2-country-20180605-1.el8.noarch",
+      "gettext-0.19.8.1-17.el8.ppc64le",
+      "gettext-libs-0.19.8.1-17.el8.ppc64le",
+      "glib-networking-2.56.1-1.1.el8.ppc64le",
+      "glib2-2.56.4-156.el8.ppc64le",
+      "glibc-2.28-162.el8.ppc64le",
+      "glibc-all-langpacks-2.28-162.el8.ppc64le",
+      "glibc-common-2.28-162.el8.ppc64le",
+      "gmp-6.1.2-10.el8.ppc64le",
+      "gnupg2-2.2.20-2.el8.ppc64le",
+      "gnupg2-smime-2.2.20-2.el8.ppc64le",
+      "gnutls-3.6.16-4.el8.ppc64le",
+      "gobject-introspection-1.56.1-1.el8.ppc64le",
+      "gpg-pubkey-8483c65d-5ccc5b19",
+      "gpgme-1.13.1-9.el8.ppc64le",
+      "grep-3.1-6.el8.ppc64le",
+      "groff-base-1.22.3-18.el8.ppc64le",
+      "grub2-common-2.02-99.el8.noarch",
+      "grub2-ppc64le-2.02-99.el8.ppc64le",
+      "grub2-ppc64le-modules-2.02-99.el8.noarch",
+      "grub2-tools-2.02-99.el8.ppc64le",
+      "grub2-tools-extra-2.02-99.el8.ppc64le",
+      "grub2-tools-minimal-2.02-99.el8.ppc64le",
+      "grubby-8.40-41.el8.ppc64le",
+      "gsettings-desktop-schemas-3.32.0-6.el8.ppc64le",
+      "gssproxy-0.8.0-19.el8.ppc64le",
+      "gzip-1.9-12.el8.ppc64le",
+      "hardlink-1.3-6.el8.ppc64le",
+      "hdparm-9.54-4.el8.ppc64le",
+      "hostname-3.20-7.el8.0.1.ppc64le",
+      "hwdata-0.314-8.9.el8.noarch",
+      "ima-evm-utils-1.3.2-12.el8.ppc64le",
+      "info-6.5-6.el8.ppc64le",
+      "initscripts-10.00.15-1.el8.ppc64le",
+      "ipcalc-0.2.4-4.el8.ppc64le",
+      "iproute-5.12.0-2.el8.ppc64le",
+      "iprutils-2.4.19-1.el8.ppc64le",
+      "ipset-7.1-1.el8.ppc64le",
+      "ipset-libs-7.1-1.el8.ppc64le",
+      "iptables-1.8.4-19.el8.ppc64le",
+      "iptables-ebtables-1.8.4-19.el8.ppc64le",
+      "iptables-libs-1.8.4-19.el8.ppc64le",
+      "iputils-20180629-7.el8.ppc64le",
+      "irqbalance-1.4.0-6.el8.ppc64le",
+      "iwl100-firmware-39.31.5.1-103.el8.1.noarch",
+      "iwl1000-firmware-39.31.5.1-103.el8.1.noarch",
+      "iwl105-firmware-18.168.6.1-103.el8.1.noarch",
+      "iwl135-firmware-18.168.6.1-103.el8.1.noarch",
+      "iwl2000-firmware-18.168.6.1-103.el8.1.noarch",
+      "iwl2030-firmware-18.168.6.1-103.el8.1.noarch",
+      "iwl3160-firmware-25.30.13.0-103.el8.1.noarch",
+      "iwl5000-firmware-8.83.5.1_1-103.el8.1.noarch",
+      "iwl5150-firmware-8.24.2.2-103.el8.1.noarch",
+      "iwl6000-firmware-9.221.4.1-103.el8.1.noarch",
+      "iwl6000g2a-firmware-18.168.6.1-103.el8.1.noarch",
+      "iwl6050-firmware-41.28.5.1-103.el8.1.noarch",
+      "iwl7260-firmware-25.30.13.0-103.el8.1.noarch",
+      "jansson-2.11-3.el8.ppc64le",
+      "json-c-0.13.1-2.el8.ppc64le",
+      "json-glib-1.4.4-1.el8.ppc64le",
+      "kbd-2.0.4-10.el8.ppc64le",
+      "kbd-legacy-2.0.4-10.el8.noarch",
+      "kbd-misc-2.0.4-10.el8.noarch",
+      "kernel-4.18.0-331.el8.ppc64le",
+      "kernel-core-4.18.0-331.el8.ppc64le",
+      "kernel-modules-4.18.0-331.el8.ppc64le",
+      "kernel-tools-4.18.0-331.el8.ppc64le",
+      "kernel-tools-libs-4.18.0-331.el8.ppc64le",
+      "kexec-tools-2.0.20-56.el8.ppc64le",
+      "keyutils-1.5.10-9.el8.ppc64le",
+      "keyutils-libs-1.5.10-9.el8.ppc64le",
+      "kmod-25-18.el8.ppc64le",
+      "kmod-libs-25-18.el8.ppc64le",
+      "kpartx-0.8.4-17.el8.ppc64le",
+      "krb5-libs-1.18.2-13.el8.ppc64le",
+      "less-530-1.el8.ppc64le",
+      "libX11-1.6.8-4.el8.ppc64le",
+      "libX11-common-1.6.8-4.el8.noarch",
+      "libXau-1.0.9-3.el8.ppc64le",
+      "libXext-1.3.4-1.el8.ppc64le",
+      "libXrender-0.9.10-7.el8.ppc64le",
+      "libacl-2.2.53-1.el8.ppc64le",
+      "libappstream-glib-0.7.14-3.el8.ppc64le",
+      "libarchive-3.3.3-1.el8.ppc64le",
+      "libassuan-2.5.1-3.el8.ppc64le",
+      "libattr-2.4.48-3.el8.ppc64le",
+      "libbasicobjects-0.1.1-39.el8.ppc64le",
+      "libblkid-2.32.1-28.el8.ppc64le",
+      "libbpf-0.3.0-1.el8.ppc64le",
+      "libcap-2.26-4.el8.ppc64le",
+      "libcap-ng-0.7.11-1.el8.ppc64le",
+      "libcollection-0.7.0-39.el8.ppc64le",
+      "libcom_err-1.45.6-2.el8.ppc64le",
+      "libcomps-0.1.16-2.el8.ppc64le",
+      "libcroco-0.6.12-4.el8_2.1.ppc64le",
+      "libcurl-7.61.1-18.el8_4.1.ppc64le",
+      "libdaemon-0.14-15.el8.ppc64le",
+      "libdb-5.3.28-40.el8.ppc64le",
+      "libdb-utils-5.3.28-40.el8.ppc64le",
+      "libdhash-0.5.0-39.el8.ppc64le",
+      "libdnf-0.63.0-2.el8.ppc64le",
+      "libedit-3.1-23.20170329cvs.el8.ppc64le",
+      "libestr-0.1.10-1.el8.ppc64le",
+      "libevent-2.1.8-5.el8.ppc64le",
+      "libfastjson-0.99.9-1.el8.ppc64le",
+      "libfdisk-2.32.1-28.el8.ppc64le",
+      "libffi-3.1-22.el8.ppc64le",
+      "libgcc-8.5.0-3.el8.ppc64le",
+      "libgcrypt-1.8.5-6.el8.ppc64le",
+      "libgomp-8.5.0-3.el8.ppc64le",
+      "libgpg-error-1.31-1.el8.ppc64le",
+      "libibverbs-35.0-1.el8.ppc64le",
+      "libidn2-2.2.0-1.el8.ppc64le",
+      "libini_config-1.3.1-39.el8.ppc64le",
+      "libkcapi-1.2.0-2.el8.ppc64le",
+      "libkcapi-hmaccalc-1.2.0-2.el8.ppc64le",
+      "libksba-1.3.5-7.el8.ppc64le",
+      "libldb-2.3.0-2.el8.ppc64le",
+      "libmaxminddb-1.2.0-10.el8.ppc64le",
+      "libmnl-1.0.4-6.el8.ppc64le",
+      "libmodman-2.0.1-17.el8.ppc64le",
+      "libmodulemd-2.12.1-1.el8.ppc64le",
+      "libmount-2.32.1-28.el8.ppc64le",
+      "libndp-1.7-6.el8.ppc64le",
+      "libnetfilter_conntrack-1.0.6-5.el8.ppc64le",
+      "libnfnetlink-1.0.1-13.el8.ppc64le",
+      "libnfsidmap-2.3.3-46.el8.ppc64le",
+      "libnftnl-1.1.5-4.el8.ppc64le",
+      "libnghttp2-1.33.0-3.el8_2.1.ppc64le",
+      "libnl3-3.5.0-1.el8.ppc64le",
+      "libnl3-cli-3.5.0-1.el8.ppc64le",
+      "libnsl2-1.2.0-2.20180605git4a062cf.el8.ppc64le",
+      "libpath_utils-0.2.1-39.el8.ppc64le",
+      "libpcap-1.9.1-5.el8.ppc64le",
+      "libpipeline-1.5.0-2.el8.ppc64le",
+      "libpng-1.6.34-5.el8.ppc64le",
+      "libproxy-0.4.15-5.2.el8.ppc64le",
+      "libpsl-0.20.2-6.el8.ppc64le",
+      "libpwquality-1.4.4-3.el8.ppc64le",
+      "libref_array-0.1.5-39.el8.ppc64le",
+      "librepo-1.14.0-2.el8.ppc64le",
+      "libreport-filesystem-2.9.5-15.el8.ppc64le",
+      "librtas-2.0.2-1.el8.ppc64le",
+      "libseccomp-2.5.1-1.el8.ppc64le",
+      "libsecret-0.18.6-1.el8.ppc64le",
+      "libselinux-2.9-5.el8.ppc64le",
+      "libselinux-utils-2.9-5.el8.ppc64le",
+      "libsemanage-2.9-6.el8.ppc64le",
+      "libsepol-2.9-2.el8.ppc64le",
+      "libservicelog-1.1.19-2.el8.ppc64le",
+      "libsigsegv-2.11-5.el8.ppc64le",
+      "libsmartcols-2.32.1-28.el8.ppc64le",
+      "libsolv-0.7.19-1.el8.ppc64le",
+      "libsoup-2.62.3-2.el8.ppc64le",
+      "libss-1.45.6-2.el8.ppc64le",
+      "libssh-0.9.4-3.el8.ppc64le",
+      "libssh-config-0.9.4-3.el8.noarch",
+      "libsss_autofs-2.5.2-2.el8.ppc64le",
+      "libsss_certmap-2.5.2-2.el8.ppc64le",
+      "libsss_idmap-2.5.2-2.el8.ppc64le",
+      "libsss_nss_idmap-2.5.2-2.el8.ppc64le",
+      "libsss_sudo-2.5.2-2.el8.ppc64le",
+      "libstdc++-8.5.0-3.el8.ppc64le",
+      "libstemmer-0-10.585svn.el8.ppc64le",
+      "libsysfs-2.1.0-24.el8.ppc64le",
+      "libtalloc-2.3.2-1.el8.ppc64le",
+      "libtasn1-4.13-3.el8.ppc64le",
+      "libtdb-1.4.3-1.el8.ppc64le",
+      "libteam-1.31-2.el8.ppc64le",
+      "libtevent-0.11.0-0.el8.ppc64le",
+      "libtirpc-1.1.4-5.el8.ppc64le",
+      "libunistring-0.9.9-3.el8.ppc64le",
+      "libusbx-1.0.23-4.el8.ppc64le",
+      "libuser-0.62-23.el8.ppc64le",
+      "libutempter-1.1.6-14.el8.ppc64le",
+      "libuuid-2.32.1-28.el8.ppc64le",
+      "libverto-0.3.0-5.el8.ppc64le",
+      "libverto-libevent-0.3.0-5.el8.ppc64le",
+      "libvpd-2.2.8-1.el8.ppc64le",
+      "libxcb-1.13.1-1.el8.ppc64le",
+      "libxcrypt-4.1.1-6.el8.ppc64le",
+      "libxkbcommon-0.9.1-1.el8.ppc64le",
+      "libxml2-2.9.7-11.el8.ppc64le",
+      "libyaml-0.1.7-5.el8.ppc64le",
+      "libzstd-1.4.4-1.el8.ppc64le",
+      "linux-firmware-20210702-103.gitd79c2677.el8.noarch",
+      "lmdb-libs-0.9.24-1.el8.ppc64le",
+      "logrotate-3.14.0-4.el8.ppc64le",
+      "lshw-B.02.19.2-6.el8.ppc64le",
+      "lsscsi-0.32-2.el8.ppc64le",
+      "lsvpd-1.7.12-1.el8.ppc64le",
+      "lua-libs-5.3.4-11.el8.ppc64le",
+      "lz4-libs-1.8.3-3.el8_4.ppc64le",
+      "lzo-2.08-14.el8.ppc64le",
+      "man-db-2.7.6.1-18.el8.ppc64le",
+      "memstrack-0.1.11-1.el8.ppc64le",
+      "mozjs60-60.9.0-4.el8.ppc64le",
+      "mpfr-3.1.6-1.el8.ppc64le",
+      "ncurses-6.1-9.20180224.el8.ppc64le",
+      "ncurses-base-6.1-9.20180224.el8.noarch",
+      "ncurses-libs-6.1-9.20180224.el8.ppc64le",
+      "net-tools-2.0-0.52.20160912git.el8.ppc64le",
+      "nettle-3.4.1-7.el8.ppc64le",
+      "newt-0.52.20-11.el8.ppc64le",
+      "nfs-utils-2.3.3-46.el8.ppc64le",
+      "nftables-0.9.3-20.el8.ppc64le",
+      "npth-1.5-4.el8.ppc64le",
+      "numactl-libs-2.0.12-13.el8.ppc64le",
+      "oddjob-0.34.7-1.el8.ppc64le",
+      "oddjob-mkhomedir-0.34.7-1.el8.ppc64le",
+      "opal-prd-6.7.1-1.el8.ppc64le",
+      "openldap-2.4.46-18.el8.ppc64le",
+      "openssh-8.0p1-9.el8.ppc64le",
+      "openssh-clients-8.0p1-9.el8.ppc64le",
+      "openssh-server-8.0p1-9.el8.ppc64le",
+      "openssl-1.1.1k-4.el8.ppc64le",
+      "openssl-libs-1.1.1k-4.el8.ppc64le",
+      "openssl-pkcs11-0.4.10-2.el8.ppc64le",
+      "os-prober-1.74-6.el8.ppc64le",
+      "p11-kit-0.23.22-1.el8.ppc64le",
+      "p11-kit-trust-0.23.22-1.el8.ppc64le",
+      "pam-1.3.1-15.el8.ppc64le",
+      "parted-3.2-39.el8.ppc64le",
+      "passwd-0.80-3.el8.ppc64le",
+      "pciutils-3.7.0-1.el8.ppc64le",
+      "pciutils-libs-3.7.0-1.el8.ppc64le",
+      "pcre-8.42-6.el8.ppc64le",
+      "pcre2-10.32-2.el8.ppc64le",
+      "perl-Carp-1.42-396.el8.noarch",
+      "perl-Data-Dumper-2.167-399.el8.ppc64le",
+      "perl-Digest-1.17-395.el8.noarch",
+      "perl-Digest-MD5-2.55-396.el8.ppc64le",
+      "perl-Encode-2.97-3.el8.ppc64le",
+      "perl-Errno-1.28-420.el8.ppc64le",
+      "perl-Exporter-5.72-396.el8.noarch",
+      "perl-File-Path-2.15-2.el8.noarch",
+      "perl-File-Temp-0.230.600-1.el8.noarch",
+      "perl-Getopt-Long-2.50-4.el8.noarch",
+      "perl-HTTP-Tiny-0.074-1.el8.noarch",
+      "perl-IO-1.38-420.el8.ppc64le",
+      "perl-IO-Socket-IP-0.39-5.el8.noarch",
+      "perl-IO-Socket-SSL-2.066-4.module_el8.4.0+517+be1595ff.noarch",
+      "perl-MIME-Base64-3.15-396.el8.ppc64le",
+      "perl-Mozilla-CA-20160104-7.module_el8.3.0+416+dee7bcef.noarch",
+      "perl-Net-SSLeay-1.88-1.module_el8.4.0+517+be1595ff.ppc64le",
+      "perl-PathTools-3.74-1.el8.ppc64le",
+      "perl-Pod-Escapes-1.07-395.el8.noarch",
+      "perl-Pod-Perldoc-3.28-396.el8.noarch",
+      "perl-Pod-Simple-3.35-395.el8.noarch",
+      "perl-Pod-Usage-1.69-395.el8.noarch",
+      "perl-Scalar-List-Utils-1.49-2.el8.ppc64le",
+      "perl-Socket-2.027-3.el8.ppc64le",
+      "perl-Storable-3.11-3.el8.ppc64le",
+      "perl-Term-ANSIColor-4.06-396.el8.noarch",
+      "perl-Term-Cap-1.17-395.el8.noarch",
+      "perl-Text-ParseWords-3.30-395.el8.noarch",
+      "perl-Text-Tabs+Wrap-2013.0523-395.el8.noarch",
+      "perl-Time-Local-1.280-1.el8.noarch",
+      "perl-URI-1.73-3.el8.noarch",
+      "perl-Unicode-Normalize-1.25-396.el8.ppc64le",
+      "perl-constant-1.33-396.el8.noarch",
+      "perl-interpreter-5.26.3-420.el8.ppc64le",
+      "perl-libnet-3.11-3.el8.noarch",
+      "perl-libs-5.26.3-420.el8.ppc64le",
+      "perl-macros-5.26.3-420.el8.ppc64le",
+      "perl-parent-0.237-1.el8.noarch",
+      "perl-podlators-4.11-1.el8.noarch",
+      "perl-threads-2.21-2.el8.ppc64le",
+      "perl-threads-shared-1.58-2.el8.ppc64le",
+      "pigz-2.4-4.el8.ppc64le",
+      "pinentry-1.1.0-2.el8.ppc64le",
+      "pixman-0.38.4-1.el8.ppc64le",
+      "platform-python-3.6.8-39.el8.ppc64le",
+      "platform-python-pip-9.0.3-20.el8.noarch",
+      "platform-python-setuptools-39.2.0-6.el8.noarch",
+      "plymouth-0.9.4-9.20200615git1e36e30.el8.ppc64le",
+      "plymouth-core-libs-0.9.4-9.20200615git1e36e30.el8.ppc64le",
+      "plymouth-scripts-0.9.4-9.20200615git1e36e30.el8.ppc64le",
+      "policycoreutils-2.9-15.el8.ppc64le",
+      "policycoreutils-python-utils-2.9-15.el8.noarch",
+      "polkit-0.115-12.el8.ppc64le",
+      "polkit-libs-0.115-12.el8.ppc64le",
+      "polkit-pkla-compat-0.1-12.el8.ppc64le",
+      "popt-1.18-1.el8.ppc64le",
+      "powerpc-utils-1.3.8-7.el8.ppc64le",
+      "powerpc-utils-core-1.3.8-7.el8.ppc64le",
+      "ppc64-diag-2.7.7-1.el8.ppc64le",
+      "ppc64-diag-rtas-2.7.7-1.el8.ppc64le",
+      "prefixdevname-0.1.0-6.el8.ppc64le",
+      "procps-ng-3.3.15-6.el8.ppc64le",
+      "psmisc-23.1-5.el8.ppc64le",
+      "publicsuffix-list-dafsa-20180723-1.el8.noarch",
+      "python3-audit-3.0-0.17.20191104git1c2f876.el8.ppc64le",
+      "python3-babel-2.5.1-7.el8.noarch",
+      "python3-cairo-1.16.3-6.el8.ppc64le",
+      "python3-cffi-1.11.5-5.el8.ppc64le",
+      "python3-chardet-3.0.4-7.el8.noarch",
+      "python3-configobj-5.0.6-11.el8.noarch",
+      "python3-cryptography-3.2.1-5.el8.ppc64le",
+      "python3-dateutil-2.6.1-6.el8.noarch",
+      "python3-dbus-1.2.4-15.el8.ppc64le",
+      "python3-decorator-4.2.1-2.el8.noarch",
+      "python3-dnf-4.7.0-2.el8.noarch",
+      "python3-dnf-plugins-core-4.0.21-2.el8.noarch",
+      "python3-firewall-0.9.3-7.el8.noarch",
+      "python3-gobject-3.28.3-2.el8.ppc64le",
+      "python3-gobject-base-3.28.3-2.el8.ppc64le",
+      "python3-gpg-1.13.1-9.el8.ppc64le",
+      "python3-hawkey-0.63.0-2.el8.ppc64le",
+      "python3-idna-2.5-5.el8.noarch",
+      "python3-jinja2-2.10.1-3.el8.noarch",
+      "python3-jsonpatch-1.21-2.el8.noarch",
+      "python3-jsonpointer-1.10-11.el8.noarch",
+      "python3-jsonschema-2.6.0-4.el8.noarch",
+      "python3-jwt-1.6.1-2.el8.noarch",
+      "python3-libcomps-0.1.16-2.el8.ppc64le",
+      "python3-libdnf-0.63.0-2.el8.ppc64le",
+      "python3-libs-3.6.8-39.el8.ppc64le",
+      "python3-libselinux-2.9-5.el8.ppc64le",
+      "python3-libsemanage-2.9-6.el8.ppc64le",
+      "python3-libxml2-2.9.7-11.el8.ppc64le",
+      "python3-linux-procfs-0.6.3-1.el8.noarch",
+      "python3-markupsafe-0.23-19.el8.ppc64le",
+      "python3-nftables-0.9.3-20.el8.ppc64le",
+      "python3-oauthlib-2.1.0-1.el8.noarch",
+      "python3-perf-4.18.0-331.el8.ppc64le",
+      "python3-pexpect-4.3.1-3.el8.noarch",
+      "python3-pip-wheel-9.0.3-20.el8.noarch",
+      "python3-ply-3.9-9.el8.noarch",
+      "python3-policycoreutils-2.9-15.el8.noarch",
+      "python3-prettytable-0.7.2-14.el8.noarch",
+      "python3-ptyprocess-0.5.2-4.el8.noarch",
+      "python3-pycparser-2.14-14.el8.noarch",
+      "python3-pydbus-0.6.0-5.el8.noarch",
+      "python3-pyserial-3.1.1-8.el8.noarch",
+      "python3-pysocks-1.6.8-3.el8.noarch",
+      "python3-pytz-2017.2-9.el8.noarch",
+      "python3-pyudev-0.21.0-7.el8.noarch",
+      "python3-pyyaml-3.12-12.el8.ppc64le",
+      "python3-requests-2.20.0-2.1.el8_1.noarch",
+      "python3-rpm-4.14.3-15.el8.ppc64le",
+      "python3-setools-4.3.0-2.el8.ppc64le",
+      "python3-setuptools-wheel-39.2.0-6.el8.noarch",
+      "python3-six-1.11.0-8.el8.noarch",
+      "python3-slip-0.6.4-11.el8.noarch",
+      "python3-slip-dbus-0.6.4-11.el8.noarch",
+      "python3-syspurpose-1.28.20-1.el8.ppc64le",
+      "python3-systemd-234-8.el8.ppc64le",
+      "python3-unbound-1.7.3-17.el8.ppc64le",
+      "python3-urllib3-1.24.2-5.el8.noarch",
+      "qemu-guest-agent-4.2.0-52.module_el8.5.0+853+a4d5519d.ppc64le",
+      "quota-4.04-14.el8.ppc64le",
+      "quota-nls-4.04-14.el8.noarch",
+      "rdma-core-35.0-1.el8.ppc64le",
+      "readline-7.0-10.el8.ppc64le",
+      "rootfiles-8.1-22.el8.noarch",
+      "rpcbind-1.2.5-8.el8.ppc64le",
+      "rpm-4.14.3-15.el8.ppc64le",
+      "rpm-build-libs-4.14.3-15.el8.ppc64le",
+      "rpm-libs-4.14.3-15.el8.ppc64le",
+      "rpm-plugin-selinux-4.14.3-15.el8.ppc64le",
+      "rpm-plugin-systemd-inhibit-4.14.3-15.el8.ppc64le",
+      "rsync-3.1.3-12.el8.ppc64le",
+      "rsyslog-8.2102.0-5.el8.ppc64le",
+      "sed-4.5-2.el8.ppc64le",
+      "selinux-policy-3.14.3-76.el8.noarch",
+      "selinux-policy-targeted-3.14.3-76.el8.noarch",
+      "servicelog-1.1.15-1.el8.ppc64le",
+      "setroubleshoot-plugins-3.3.13-1.el8.noarch",
+      "setroubleshoot-server-3.3.24-3.el8.ppc64le",
+      "setup-2.12.2-6.el8.noarch",
+      "sg3_utils-1.44-5.el8.ppc64le",
+      "sg3_utils-libs-1.44-5.el8.ppc64le",
+      "shadow-utils-4.6-14.el8.ppc64le",
+      "shared-mime-info-1.9-3.el8.ppc64le",
+      "slang-2.3.2-3.el8.ppc64le",
+      "snappy-1.1.8-3.el8.ppc64le",
+      "sos-4.1-5.el8.noarch",
+      "sqlite-libs-3.26.0-15.el8.ppc64le",
+      "squashfs-tools-4.3-20.el8.ppc64le",
+      "sscg-2.3.3-14.el8.ppc64le",
+      "sssd-client-2.5.2-2.el8.ppc64le",
+      "sssd-common-2.5.2-2.el8.ppc64le",
+      "sssd-kcm-2.5.2-2.el8.ppc64le",
+      "sssd-nfs-idmap-2.5.2-2.el8.ppc64le",
+      "sudo-1.8.29-7.el8.ppc64le",
+      "systemd-239-49.el8.ppc64le",
+      "systemd-libs-239-49.el8.ppc64le",
+      "systemd-pam-239-49.el8.ppc64le",
+      "systemd-udev-239-49.el8.ppc64le",
+      "tar-1.30-5.el8.ppc64le",
+      "tcpdump-4.9.3-2.el8.ppc64le",
+      "teamd-1.31-2.el8.ppc64le",
+      "timedatex-0.5-3.el8.ppc64le",
+      "tpm2-tss-2.3.2-4.el8.ppc64le",
+      "trousers-0.3.15-1.el8.ppc64le",
+      "trousers-lib-0.3.15-1.el8.ppc64le",
+      "tuned-2.16.0-1.el8.noarch",
+      "tzdata-2021a-1.el8.noarch",
+      "unbound-libs-1.7.3-17.el8.ppc64le",
+      "util-linux-2.32.1-28.el8.ppc64le",
+      "vim-minimal-8.0.1763-15.el8.ppc64le",
+      "virt-what-1.18-12.el8.ppc64le",
+      "which-2.21-16.el8.ppc64le",
+      "xfsprogs-5.0.0-9.el8.ppc64le",
+      "xkeyboard-config-2.28-1.el8.noarch",
+      "xz-5.2.4-3.el8.ppc64le",
+      "xz-libs-5.2.4-3.el8.ppc64le",
+      "yum-4.7.0-2.el8.noarch",
+      "yum-utils-4.0.21-2.el8.noarch",
+      "zlib-1.2.11-17.el8.ppc64le"
+    ],
+    "partition-table": "dos",
+    "partition-table-id": "0x14fc63d2",
+    "partitions": [
+      {
+        "bootable": true,
+        "fstype": null,
+        "label": null,
+        "partuuid": "14fc63d2-01",
+        "size": 4194304,
+        "start": 1048576,
+        "type": "41",
+        "uuid": null
+      },
+      {
+        "bootable": false,
+        "fstype": "xfs",
+        "label": null,
+        "partuuid": "14fc63d2-02",
+        "size": 10732124160,
+        "start": 5242880,
+        "type": "83",
+        "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8"
+      }
+    ],
+    "passwd": [
+      "adm:x:3:4:adm:/var/adm:/sbin/nologin",
+      "bin:x:1:1:bin:/bin:/sbin/nologin",
+      "chrony:x:992:988::/var/lib/chrony:/sbin/nologin",
+      "cockpit-ws:x:994:990:User for cockpit web service:/nonexisting:/sbin/nologin",
+      "cockpit-wsinstance:x:993:989:User for cockpit-ws instances:/nonexisting:/sbin/nologin",
+      "daemon:x:2:2:daemon:/sbin:/sbin/nologin",
+      "dbus:x:81:81:System message bus:/:/sbin/nologin",
+      "ftp:x:14:50:FTP User:/var/ftp:/sbin/nologin",
+      "games:x:12:100:games:/usr/games:/sbin/nologin",
+      "halt:x:7:0:halt:/sbin:/sbin/halt",
+      "lp:x:4:7:lp:/var/spool/lpd:/sbin/nologin",
+      "mail:x:8:12:mail:/var/spool/mail:/sbin/nologin",
+      "nobody:x:65534:65534:Kernel Overflow User:/:/sbin/nologin",
+      "operator:x:11:0:operator:/root:/sbin/nologin",
+      "polkitd:x:998:996:User for polkitd:/:/sbin/nologin",
+      "root:x:0:0:root:/root:/bin/bash",
+      "rpc:x:32:32:Rpcbind Daemon:/var/lib/rpcbind:/sbin/nologin",
+      "rpcuser:x:29:29:RPC Service User:/var/lib/nfs:/sbin/nologin",
+      "setroubleshoot:x:995:991::/var/lib/setroubleshoot:/sbin/nologin",
+      "shutdown:x:6:0:shutdown:/sbin:/sbin/shutdown",
+      "sshd:x:74:74:Privilege-separated SSH:/var/empty/sshd:/sbin/nologin",
+      "sssd:x:996:992:User for sssd:/:/sbin/nologin",
+      "sync:x:5:0:sync:/sbin:/bin/sync",
+      "systemd-coredump:x:999:997:systemd Core Dumper:/:/sbin/nologin",
+      "systemd-resolve:x:193:193:systemd Resolver:/:/sbin/nologin",
+      "tcpdump:x:72:72::/:/sbin/nologin",
+      "tss:x:59:59:Account used for TPM access:/dev/null:/sbin/nologin",
+      "unbound:x:997:993:Unbound DNS resolver:/etc/unbound:/sbin/nologin",
+      "user1:x:1000:1000::/home/user1:/bin/bash",
+      "user2:x:1020:1050:description 2:/home/home2:/bin/sh"
+    ],
+    "rpm-verify": {
+      "changed": {
+        "/etc/chrony.conf": "S.5....T.",
+        "/etc/machine-id": ".M.......",
+        "/proc": ".M.......",
+        "/sys": ".M.......",
+        "/var/lib/powerpc-utils/smt.state": "..5....T.",
+        "/var/log/lastlog": ".M....G..",
+        "/var/spool/anacron/cron.daily": ".M.......",
+        "/var/spool/anacron/cron.monthly": ".M.......",
+        "/var/spool/anacron/cron.weekly": ".M......."
+      },
+      "missing": []
+    },
+    "selinux": {
+      "policy": {
+        "SELINUX": "enforcing",
+        "SELINUXTYPE": "targeted"
+      }
+    },
+    "services-disabled": [
+      "arp-ethers.service",
+      "chrony-dnssrv@.timer",
+      "chrony-wait.service",
+      "cockpit.socket",
+      "console-getty.service",
+      "cpupower.service",
+      "debug-shell.service",
+      "ebtables.service",
+      "exit.target",
+      "fstrim.timer",
+      "gssproxy.service",
+      "halt.target",
+      "iprdump.service",
+      "iprinit.service",
+      "iprupdate.service",
+      "iprutils.target",
+      "kexec.target",
+      "kvm_stat.service",
+      "man-db-restart-cache-update.service",
+      "nfs-blkmap.service",
+      "nfs-convert.service",
+      "nfs-server.service",
+      "nftables.service",
+      "oddjobd.service",
+      "poweroff.target",
+      "rdisc.service",
+      "remote-cryptsetup.target",
+      "runlevel0.target",
+      "serial-getty@.service",
+      "smt_off.service",
+      "smtstate.service",
+      "sshd-keygen@.service",
+      "sssd-autofs.socket",
+      "sssd-nss.socket",
+      "sssd-pac.socket",
+      "sssd-pam-priv.socket",
+      "sssd-pam.socket",
+      "sssd-ssh.socket",
+      "sssd-sudo.socket",
+      "systemd-resolved.service",
+      "tcsd.service",
+      "tmp.mount"
+    ],
+    "services-enabled": [
+      "NetworkManager-dispatcher.service",
+      "NetworkManager-wait-online.service",
+      "NetworkManager.service",
+      "auditd.service",
+      "autovt@.service",
+      "chronyd.service",
+      "cloud-config.service",
+      "cloud-final.service",
+      "cloud-init-local.service",
+      "cloud-init.service",
+      "crond.service",
+      "ctrl-alt-del.target",
+      "dbus-org.fedoraproject.FirewallD1.service",
+      "dbus-org.freedesktop.nm-dispatcher.service",
+      "dbus-org.freedesktop.timedate1.service",
+      "dnf-makecache.timer",
+      "firewalld.service",
+      "getty@.service",
+      "hcn-init.service",
+      "import-state.service",
+      "irqbalance.service",
+      "kdump.service",
+      "loadmodules.service",
+      "nfs-client.target",
+      "nis-domainname.service",
+      "opal-prd.service",
+      "opal_errd.service",
+      "qemu-guest-agent.service",
+      "reboot.target",
+      "remote-fs.target",
+      "rpcbind.service",
+      "rpcbind.socket",
+      "rsyslog.service",
+      "rtas_errd.service",
+      "runlevel6.target",
+      "selinux-autorelabel-mark.service",
+      "sshd.service",
+      "sshd.socket",
+      "sssd-kcm.socket",
+      "sssd.service",
+      "syslog.service",
+      "timedatex.service",
+      "tuned.service",
+      "unbound-anchor.timer"
+    ],
+    "sudoers": {
+      "/etc/sudoers": [
+        "Defaults   !visiblepw",
+        "Defaults    always_set_home",
+        "Defaults    match_group_by_gid",
+        "Defaults    always_query_group_plugin",
+        "Defaults    env_reset",
+        "Defaults    env_keep =  \"COLORS DISPLAY HOSTNAME HISTSIZE KDEDIR LS_COLORS\"",
+        "Defaults    env_keep += \"MAIL PS1 PS2 QTDIR USERNAME LANG LC_ADDRESS LC_CTYPE\"",
+        "Defaults    env_keep += \"LC_COLLATE LC_IDENTIFICATION LC_MEASUREMENT LC_MESSAGES\"",
+        "Defaults    env_keep += \"LC_MONETARY LC_NAME LC_NUMERIC LC_PAPER LC_TELEPHONE\"",
+        "Defaults    env_keep += \"LC_TIME LC_ALL LANGUAGE LINGUAS _XKB_CHARSET XAUTHORITY\"",
+        "Defaults    secure_path = /sbin:/bin:/usr/sbin:/usr/bin",
+        "root\tALL=(ALL) \tALL",
+        "%wheel\tALL=(ALL)\tALL"
+      ]
+    },
+    "sysconfig": {
+      "kernel": {
+        "DEFAULTKERNEL": "kernel",
+        "UPDATEDEFAULT": "yes"
+      },
+      "network": {
+        "NETWORKING": "yes",
+        "NOZEROCONF": "yes"
+      }
+    },
+    "sysctl.d": {
+      "/usr/lib/sysctl.d": {
+        "10-default-yama-scope.conf": [
+          "kernel.yama.ptrace_scope = 0"
+        ],
+        "50-coredump.conf": [
+          "kernel.core_pattern=|/usr/lib/systemd/systemd-coredump %P %u %g %s %t %c %h %e",
+          "kernel.core_pipe_limit=16"
+        ],
+        "50-default.conf": [
+          "kernel.sysrq = 16",
+          "kernel.core_uses_pid = 1",
+          "kernel.kptr_restrict = 1",
+          "net.ipv4.conf.all.rp_filter = 1",
+          "net.ipv4.conf.all.accept_source_route = 0",
+          "net.ipv4.conf.all.promote_secondaries = 1",
+          "net.core.default_qdisc = fq_codel",
+          "fs.protected_hardlinks = 1",
+          "fs.protected_symlinks = 1"
+        ],
+        "50-libkcapi-optmem_max.conf": [
+          "net.core.optmem_max = 81920"
+        ],
+        "50-pid-max.conf": [
+          "kernel.pid_max = 4194304"
+        ]
+      }
+    },
+    "systemd-service-dropins": {
+      "/usr/lib/systemd/system": {
+        "systemd-udev-trigger.service.d": {
+          "Unit": {
+            "RefuseManualStop": "true"
+          }
+        }
+      }
+    },
+    "timezone": "London",
+    "tmpfiles.d": {
+      "/usr/lib/tmpfiles.d": {
+        "cloud-init.conf": [
+          "d /run/cloud-init 0700 root root - -"
+        ],
+        "cockpit-tempfiles.conf": [
+          "C /run/cockpit/inactive.motd 0640 root wheel - /usr/share/cockpit/motd/inactive.motd",
+          "f /run/cockpit/active.motd   0640 root wheel -",
+          "L+ /run/cockpit/motd - - - - inactive.motd"
+        ],
+        "cryptsetup.conf": [
+          "d /run/cryptsetup 0700 root root -"
+        ],
+        "dbus.conf": [
+          "d /var/lib/dbus 0755 - - -",
+          "L /var/lib/dbus/machine-id - - - - /etc/machine-id"
+        ],
+        "dnf.conf": [
+          "R /var/tmp/dnf*/locks/*",
+          "r /var/cache/dnf/download_lock.pid",
+          "r /var/cache/dnf/metadata_lock.pid",
+          "r /var/lib/dnf/rpmdb_lock.pid",
+          "r /var/log/log_lock.pid"
+        ],
+        "etc.conf": [
+          "L /etc/os-release - - - - ../usr/lib/os-release",
+          "L /etc/localtime - - - - ../usr/share/zoneinfo/UTC",
+          "L+ /etc/mtab - - - - ../proc/self/mounts",
+          "C /etc/nsswitch.conf - - - -",
+          "C /etc/pam.d - - - -"
+        ],
+        "home.conf": [
+          "Q /home 0755 - - -",
+          "q /srv 0755 - - -"
+        ],
+        "journal-nocow.conf": [
+          "h /var/log/journal - - - - +C",
+          "h /var/log/journal/%m - - - - +C",
+          "h /var/log/journal/remote - - - - +C"
+        ],
+        "legacy.conf": [
+          "d /run/lock 0755 root root -",
+          "L /var/lock - - - - ../run/lock",
+          "d /run/lock/subsys 0755 root root -",
+          "r! /forcefsck",
+          "r! /fastboot",
+          "r! /forcequotacheck"
+        ],
+        "libselinux.conf": [
+          "d /run/setrans 0755 root root"
+        ],
+        "man-db.conf": [
+          "d /var/cache/man 0755 root root 1w"
+        ],
+        "openssh.conf": [
+          "d /var/empty/sshd 711 root root -"
+        ],
+        "pam.conf": [
+          "d /run/console 0755 root root -",
+          "d /run/faillock 0755 root root -",
+          "d /run/sepermit 0755 root root -"
+        ],
+        "portables.conf": [
+          "Q /var/lib/portables 0700"
+        ],
+        "rpcbind.conf": [
+          "D     /run/rpcbind 0700  rpc  rpc  -  -"
+        ],
+        "rpm.conf": [
+          "r /var/lib/rpm/__db.*"
+        ],
+        "selinux-policy.conf": [
+          "z /sys/devices/system/cpu/online - - -",
+          "Z /sys/class/net - - -",
+          "z /sys/kernel/uevent_helper - - -",
+          "w /sys/fs/selinux/checkreqprot - - - - 0"
+        ],
+        "setroubleshoot.conf": [
+          "d /run/setroubleshoot 711 setroubleshoot setroubleshoot -"
+        ],
+        "sudo.conf": [
+          "d /run/sudo 0711 root root",
+          "D /run/sudo/ts 0700 root root"
+        ],
+        "systemd-nologin.conf": [
+          "F! /run/nologin 0644 - - - \"System is booting up. Unprivileged users are not permitted to log in yet. Please come back later. For technical details, see pam_nologin(8).\""
+        ],
+        "systemd.conf": [
+          "d /run/user 0755 root root -",
+          "F! /run/utmp 0664 root utmp -",
+          "d /run/systemd/ask-password 0755 root root -",
+          "d /run/systemd/seats 0755 root root -",
+          "d /run/systemd/sessions 0755 root root -",
+          "d /run/systemd/users 0755 root root -",
+          "d /run/systemd/machines 0755 root root -",
+          "d /run/systemd/shutdown 0755 root root -",
+          "d /run/log 0755 root root -",
+          "z /run/log/journal 2755 root systemd-journal - -",
+          "Z /run/log/journal/%m ~2750 root systemd-journal - -",
+          "a+ /run/log/journal/%m - - - - d:group:adm:r-x,d:group:wheel:r-x",
+          "a+ /run/log/journal/%m - - - - group:adm:r-x,group:wheel:r-x",
+          "a+ /run/log/journal/%m/*.journal* - - - - group:adm:r--,group:wheel:r--",
+          "z /var/log/journal 2755 root systemd-journal - -",
+          "z /var/log/journal/%m 2755 root systemd-journal - -",
+          "z /var/log/journal/%m/system.journal 0640 root systemd-journal - -",
+          "a+ /var/log/journal    - - - - d:group::r-x,d:group:adm:r-x,d:group:wheel:r-x",
+          "a+ /var/log/journal    - - - - group::r-x,group:adm:r-x,group:wheel:r-x",
+          "a+ /var/log/journal/%m - - - - d:group:adm:r-x,d:group:wheel:r-x",
+          "a+ /var/log/journal/%m - - - - group:adm:r-x,group:wheel:r-x",
+          "a+ /var/log/journal/%m/system.journal - - - - group:adm:r--,group:wheel:r--",
+          "d /var/lib/systemd 0755 root root -",
+          "d /var/lib/systemd/coredump 0755 root root 3d",
+          "d /var/lib/private 0700 root root -",
+          "d /var/log/private 0700 root root -",
+          "d /var/cache/private 0700 root root -"
+        ],
+        "tmp.conf": [
+          "q /tmp 1777 root root 10d",
+          "q /var/tmp 1777 root root 30d",
+          "x /tmp/systemd-private-%b-*",
+          "X /tmp/systemd-private-%b-*/tmp",
+          "x /var/tmp/systemd-private-%b-*",
+          "X /var/tmp/systemd-private-%b-*/tmp",
+          "R! /tmp/systemd-private-*",
+          "R! /var/tmp/systemd-private-*"
+        ],
+        "tuned.conf": [
+          "d /run/tuned 0755 root root -"
+        ],
+        "var.conf": [
+          "q /var 0755 - - -",
+          "L /var/run - - - - ../run",
+          "d /var/log 0755 - - -",
+          "f /var/log/wtmp 0664 root utmp -",
+          "f /var/log/btmp 0660 root utmp -",
+          "f /var/log/lastlog 0664 root utmp -",
+          "d /var/cache 0755 - - -",
+          "d /var/lib 0755 - - -",
+          "d /var/spool 0755 - - -"
+        ],
+        "x11.conf": [
+          "D! /tmp/.X11-unix 1777 root root 10d",
+          "D! /tmp/.ICE-unix 1777 root root 10d",
+          "D! /tmp/.XIM-unix 1777 root root 10d",
+          "D! /tmp/.font-unix 1777 root root 10d",
+          "D! /tmp/.Test-unix 1777 root root 10d",
+          "r! /tmp/.X[0-9]*-lock"
+        ]
+      }
+    }
+  }
+}

--- a/test/data/manifests/centos_8-x86_64-ami-boot.json
+++ b/test/data/manifests/centos_8-x86_64-ami-boot.json
@@ -913,17 +913,6 @@
             }
           },
           {
-            "type": "org.osbuild.systemd-logind",
-            "options": {
-              "filename": "00-getty-fixes.conf",
-              "config": {
-                "Login": {
-                  "NAutoVTs": 0
-                }
-              }
-            }
-          },
-          {
             "type": "org.osbuild.sysconfig",
             "options": {
               "kernel": {
@@ -945,6 +934,17 @@
                     "type": "Ethernet",
                     "userctl": true
                   }
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.systemd-logind",
+            "options": {
+              "filename": "00-getty-fixes.conf",
+              "config": {
+                "Login": {
+                  "NAutoVTs": 0
                 }
               }
             }
@@ -986,6 +986,18 @@
             }
           },
           {
+            "type": "org.osbuild.dracut.conf",
+            "options": {
+              "filename": "ec2.conf",
+              "config": {
+                "add_drivers": [
+                  "nvme",
+                  "xen-blkfront"
+                ]
+              }
+            }
+          },
+          {
             "type": "org.osbuild.systemd.unit",
             "options": {
               "unit": "nm-cloud-setup.service",
@@ -1001,18 +1013,6 @@
             "type": "org.osbuild.authselect",
             "options": {
               "profile": "sssd"
-            }
-          },
-          {
-            "type": "org.osbuild.dracut.conf",
-            "options": {
-              "filename": "ec2.conf",
-              "config": {
-                "add_drivers": [
-                  "nvme",
-                  "xen-blkfront"
-                ]
-              }
             }
           },
           {

--- a/test/data/manifests/centos_8-x86_64-image_installer-boot.json
+++ b/test/data/manifests/centos_8-x86_64-image_installer-boot.json
@@ -418,7 +418,6 @@
                   "sha256:cd2f140bd1718b4403ad66568155264b69231748a3c813e2feaac1b704da62c6",
                   "sha256:42464424b9fa731f8122fe748aad0005519fc87b770dbbdb71f29f514ea0e889",
                   "sha256:45c48d32120739734ae97479cc0f3ca19796ea47e360ba39d52b77ce3ada61d7",
-                  "sha256:0265d45b4e949d977cef57a2d95f6d22ef906a05a5c7fbd486464bb1d55655e9",
                   "sha256:47b61754a278c4ca378871c874ccf6a0a07bffaef38505315cfa94f262887845",
                   "sha256:40676b73567e195228ba2a8bb53692f88f88d43612564613fb168383eee57f6a",
                   "sha256:9377ec604215c283f87df51305d163d07091808c30019954d145c6d73451965c",
@@ -694,26 +693,18 @@
                   "sha256:9d433d8c058e59c891c0852b95b3b87795ea30a85889c77ba0b12f965517d626",
                   "sha256:65ecf1e479dc2b2f7f09c2e86d7457043b3470b3eab3c4ee8909b50b0a669fc2",
                   "sha256:addf80c52d794aed47874eb9d5ddbbaa90cb248fda1634d793054a41da0d92d7",
-                  "sha256:176ffcb2cf0fdcbdd2d8119cbd98eef60a30fdb0fb065a9382d2c95e90c79652",
-                  "sha256:e0bb5476b38e4cfe2425262c4fce180ec97a79c6a11cc3e170c9013fff712e21",
                   "sha256:1bd969e0521820374122f5132e5998d9bd2ab185be66565a7266096297419c8e",
                   "sha256:c5b5967a094ced90899052a82e2c245529b75ba3f46e0ce1a89cfc95edb935ea",
                   "sha256:066f254f9ac7712b44214816de907a87eb8dfd0d2ea9570a7513db9a6617ba26",
                   "sha256:0e9a8a0f823bf0ef948862f0ccb62353460bd07931e756c98f23908c1c526578",
-                  "sha256:c39a53566ad66d6db9e101ca9a6db316843a1d1f6f5ac5f2286c6028638a8ab7",
                   "sha256:ccfa1810aa19fae08aefd29cffe28b65d5123cd17bd7d2d4207f03cf9795594c",
                   "sha256:28c0f457d67213319f0313d993a3b2f8a778a077b202cd75bf45eb2792949d32",
-                  "sha256:c746d43bd63dd184b8c585dd7323e261567928e521e830720d4754fca76157e0",
                   "sha256:acfee60459ffe722b9362696f58a26b606b637094d9439bf5f898310daf8ba24",
                   "sha256:15dc15a5be210707852f051f4d09949c063a7283edc7d4ca3d4289eedcc0b509",
                   "sha256:1cda7601799144cff400d4267ae164a558328815a34a935f38c6ef0429f24711",
                   "sha256:92b18871b06fbc6346ec7b49be753f31482a40b2f3c8e2e29f91bce71f109f38",
-                  "sha256:78c43d8a15ca018de1803e4baac5819e1baab1963fd31f1e44e54e8a573acbfc",
-                  "sha256:5c0957decce3babef9864904be13190b0072aef720e9f4ca820bab6c02a20178",
-                  "sha256:109d6db30e5515601b00954b2fd8750c421730a18afc12e1fa7781e24e5b0863",
                   "sha256:8ae9708ba5c5b90ecc4ae4e30b8291fdaa63ce4e7cdeeb081f409bf1b3003967",
                   "sha256:7d2455f252fc9bfd34323d0ca59bf2cab699f99d0a8e9d195d9f8ec384583f33",
-                  "sha256:85d87a486cb17e81aa7af6b17564424e3baf726facea2f0b264e69a5f5709f1b",
                   "sha256:958f4ef8efa6c2f1d7ac9be085ae1d90d4b9b128ef4fa31b46e72eb8d1d9a2fd",
                   "sha256:59ba5bf69953a5a2e902b0f08b7187b66d84968852d46a3579a059477547d1a0",
                   "sha256:451d0cb6e2284578e3279b4cbb5ec98e9d98a687556c6b424adf8f1282d4ef58",
@@ -723,24 +714,19 @@
                   "sha256:b8a4c3be228318e5917c971c0475cd2578d271eba6a715f5043ea0b5e9b63501",
                   "sha256:6c9dfb73e199975275633f05d31388cd61c5a77dec5678db958b4e6624eb21ba",
                   "sha256:3eca41ba67f8121586709b6fa2c57b20b4fab73bbb8a4c133269d0cc964f362c",
-                  "sha256:7f506879c64e0bb4d98782d025f46fb9a07517487ae4cbebbb3985a98f4e2154",
                   "sha256:aa0007192287faeaecc72d9fa48efdb3108c764d450dc8fea65474476da32c45",
                   "sha256:525393e4d658e395c6280bd2ff4afe54999796c4722986325297ba4bfade3ea5",
-                  "sha256:003ee19ec5b88de212c3246bdfdb3e97a9910a25a219fd7cf5030b7bc666fea9",
                   "sha256:344051091b56f4b8e73232c38411878ccce64e7b323e6fe44f40cf8af0c117c3",
                   "sha256:f56992135d789147285215cb062960fedcdf4b3296c62658fa430caa2c20165c",
                   "sha256:b19bd4f106ce301ee21c860183cc1c2ef9c09bdf495059bdf16e8d8ccc71bbe8",
                   "sha256:a04cb3117395b962edc32bf45d8411f240632476b0706b2df7f4a1a87b2ce34b",
                   "sha256:233e5f78027b684e5aaac1395cc574aea3039059bf86eb4494422bc74216a396",
                   "sha256:563b3741d26b6af963fdb7b0634e0791445a707d0b6093ac71c3224299241639",
-                  "sha256:34ab92d70d2d3ffb65b1893d34d7b40e4cfc528b920363fc85492afac0619453",
                   "sha256:e495b35bd222a13d9be2befa19bec66e64341f2f3d9f0064db8a5d42d91a8bae",
-                  "sha256:aa1835fd302a37b84ac256db5dd0de09bd9883a5a07775aedb491faf46b18ee0",
                   "sha256:cce5f4086e7ecc31a12b753b5d0d97cb6d6c6f61e5c3066322449781ab1f63d0",
                   "sha256:bc7fc2028a29ac7a406719ed4f6740f6bf12c20961223c1e839a2a39069af38d",
                   "sha256:ee2d61287b724b6088902016728fc5d9a17744d0b69aa7ccab9e133264f18603",
                   "sha256:fea868a7d82a7b6f392260ed4afb472dc4428fd71eab1456319f423a845b5084",
-                  "sha256:76acb678a5c1d93353d4f506e703ac9ce4925295d61c876f6a420e244102aaba",
                   "sha256:d967d6bbb33bf7a295a64807f81875c84e82a8ecc59b6c72fe955141b1660d39",
                   "sha256:e76ffaf54db6ac36f0aa56c8013431c352c6187c8d674c6d468e25c573e31597",
                   "sha256:38e2d7fd362b10b71aa0b357331314d0f370a35185dfa31818c899cbb56ff610",
@@ -767,9 +753,6 @@
                   "sha256:9ee6c231a808d732e85a1e31df05ce55388315709206df944f3afe9531a8442a",
                   "sha256:0612728d1655cc06a5897c2077d3e3fbf29891941211916f487203761970f5f7",
                   "sha256:9b74d2ef03a55cb9f830ba60734a8861b5d88cffeb78778e1c75557b127fa08c",
-                  "sha256:c8915f9ca548e02f73a7f2f37990820e958061e3ad0c779c92bcb39c0a4cb544",
-                  "sha256:3386ebe6e649b2cb6a4b3eef260d68f3c165d9ccf54b4e6767ee064aa32d3334",
-                  "sha256:f352a944211785838da583ab23741b774ec62abe8c0e0582a7558ce41ade2efd",
                   "sha256:cbcade4487fbf372b487b9f82ed85e04ff037551c96c4b461abc3716338ff9c4",
                   "sha256:f16942e337972452994ad32c3e5a5385450eb46857b8fba61aa11b764c484eef",
                   "sha256:0854686cc3009d2fdf8baf48cbef87c58b10baf85302e7061b25cc64a1848e64",
@@ -783,7 +766,6 @@
                   "sha256:ff4c97e0df6ed6090ef36ac853e11bed9aa13f657be1d068ac09ad33c11432cb",
                   "sha256:654d9074dc8ebb93230fe258188a17ba3f7dbac2f360f9f79cc4fb1516953018",
                   "sha256:44999c555a6e4bb6cf5e6f6a79819e76912d036732cb50efaeefc20a180dd839",
-                  "sha256:eec162a2757ee2ffbbee95e1dbcd33318119e5113e53af877ce9416529a19082",
                   "sha256:8213aa26dbe71291c0cd5969256f3f0bce13ee8e8cd76e3b949c1f6752142471",
                   "sha256:3efd6a2548813167fe37718546bc768a5aa8ba59aa80edcecd8ba408bec329b0",
                   "sha256:8beb58e28b4dd11a952e24c442b696416ce7a756016fe8147cc66be6fc01a9db",
@@ -2158,9 +2140,6 @@
           "sha256:0225dc3999e3d7b1bb57186a2fc93c98bd1e4e08e062fb51c966e1f2a2c91bb4": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20210827/Packages/perl-Pod-Perldoc-3.28-396.el8.noarch.rpm"
           },
-          "sha256:0265d45b4e949d977cef57a2d95f6d22ef906a05a5c7fbd486464bb1d55655e9": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20210827/Packages/dnf-plugin-subscription-manager-1.28.20-1.el8.x86_64.rpm"
-          },
           "sha256:02d728cf74eb47005babeeab5ac68ca04472c643203a1faef0037b5f33710fe2": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20210827/Packages/libsigsegv-2.11-5.el8.x86_64.rpm"
           },
@@ -2319,9 +2298,6 @@
           },
           "sha256:10814d88ff647e12aeceae4c3815f9eeb66ce7327099c642f934a391fd915f2c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20210827/Packages/iwl3160-firmware-25.30.13.0-103.el8.1.noarch.rpm"
-          },
-          "sha256:109d6db30e5515601b00954b2fd8750c421730a18afc12e1fa7781e24e5b0863": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20210827/Packages/python3-inotify-0.9.6-13.el8.noarch.rpm"
           },
           "sha256:10e88a1794107ea61f1441273be906704d66802b21800b0840a2870cad8b4d63": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20210827/Packages/cpio-2.12-10.el8.x86_64.rpm"
@@ -2665,9 +2641,6 @@
           "sha256:326d6828ba954583337c3807f0a2c901cd5b3bd4d14a0db89c4b8375592af665": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-appstream-20210827/Packages/drpm-0.4.1-3.el8.x86_64.rpm"
           },
-          "sha256:3386ebe6e649b2cb6a4b3eef260d68f3c165d9ccf54b4e6767ee064aa32d3334": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20210827/Packages/subscription-manager-cockpit-1.28.20-1.el8.noarch.rpm"
-          },
           "sha256:33996f2476ed82d68353ac5c6d22c204db4ee76821eefc4c0cc2dafcf44ae16b": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20210827/Packages/syslinux-6.04-5.el8.x86_64.rpm"
           },
@@ -2685,9 +2658,6 @@
           },
           "sha256:34a928cd01a998db63cbf930bea8c9f246848e479498866b7c026c3cc3c55778": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-appstream-20210827/Packages/sil-abyssinica-fonts-1.200-13.el8.noarch.rpm"
-          },
-          "sha256:34ab92d70d2d3ffb65b1893d34d7b40e4cfc528b920363fc85492afac0619453": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20210827/Packages/python3-subscription-manager-rhsm-1.28.20-1.el8.x86_64.rpm"
           },
           "sha256:34ad2163be045a57532629a5abf5b50dd27ac0fd359f96c55452f1666f7a271a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-appstream-20210827/Packages/xorg-x11-drv-intel-2.99.917-39.20200205.el8.x86_64.rpm"
@@ -3438,9 +3408,6 @@
           },
           "sha256:765d2234e06868f4556eb30153899da58b8ed532ff9df5a275a45c2692ab723b": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-appstream-20210827/Packages/anaconda-user-help-8.3.3-1.el8.centos.noarch.rpm"
-          },
-          "sha256:76acb678a5c1d93353d4f506e703ac9ce4925295d61c876f6a420e244102aaba": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20210827/Packages/rhsm-icons-1.28.20-1.el8.noarch.rpm"
           },
           "sha256:76d81e433a5291df491d2e289de9b33d4e5b98dcf48fd0a003c2767415d3e0aa": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20210827/Packages/gdbm-1.18-1.el8.x86_64.rpm"
@@ -4279,9 +4246,6 @@
           "sha256:c3794d79a690d94d03d59a045a9ff95b4967bd3846bf608ba45802680a8f3c2c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20210827/Packages/hostname-3.20-7.el8.0.1.x86_64.rpm"
           },
-          "sha256:c39a53566ad66d6db9e101ca9a6db316843a1d1f6f5ac5f2286c6028638a8ab7": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20210827/Packages/python3-dmidecode-3.12.2-15.el8.x86_64.rpm"
-          },
           "sha256:c3b8c553b166491d3114793e198cd1aad95e494d177af8d0dc7180b8b841124d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20210827/Packages/libmodman-2.0.1-17.el8.x86_64.rpm"
           },
@@ -4327,17 +4291,11 @@
           "sha256:c6f27b6e01d80e756408e3c1451e4af00e7d02da0aa24402644c0785118753fe": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20210827/Packages/python3-setuptools-39.2.0-6.el8.noarch.rpm"
           },
-          "sha256:c746d43bd63dd184b8c585dd7323e261567928e521e830720d4754fca76157e0": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20210827/Packages/python3-ethtool-0.14-3.el8.x86_64.rpm"
-          },
           "sha256:c7dfa7d5a4917eed3b44af87ffb9c6e18242ecd847a8edd140bcdd178cc8946a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-appstream-20210827/Packages/perl-IO-Socket-IP-0.39-5.el8.noarch.rpm"
           },
           "sha256:c879ce8eea2780a4cf4ffe67661fe56aaf2e6c110b45a1ead147925065a2eeb2": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20210827/Packages/daxctl-libs-71.1-2.el8.x86_64.rpm"
-          },
-          "sha256:c8915f9ca548e02f73a7f2f37990820e958061e3ad0c779c92bcb39c0a4cb544": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20210827/Packages/subscription-manager-1.28.20-1.el8.x86_64.rpm"
           },
           "sha256:c8c54c56bff9ca416c3ba6bccac483fb66c81a53d93a19420088715018ed5169": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20210827/Packages/libutempter-1.1.6-14.el8.x86_64.rpm"
@@ -4609,9 +4567,6 @@
           "sha256:e08ccdb3bbdb0285cc234433b47e817da7e1e15d2b45fda3f9fefb787c537166": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-appstream-20210827/Packages/nss-3.67.0-6.el8_4.x86_64.rpm"
           },
-          "sha256:e0bb5476b38e4cfe2425262c4fce180ec97a79c6a11cc3e170c9013fff712e21": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20210827/Packages/python3-cloud-what-1.28.20-1.el8.x86_64.rpm"
-          },
           "sha256:e0df63d8debeb6d2f736bae02756097af273c9c486255b03e5a89f2946b98ac9": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20210827/Packages/lshw-B.02.19.2-6.el8.x86_64.rpm"
           },
@@ -4744,9 +4699,6 @@
           "sha256:ee68c501b00be262d0dcf7157222145fe7bd7fb151bda91ba807de7e5f77988e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-appstream-20210827/Packages/python3-blivet-3.4.0-4.el8.noarch.rpm"
           },
-          "sha256:eec162a2757ee2ffbbee95e1dbcd33318119e5113e53af877ce9416529a19082": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20210827/Packages/usermode-1.113-1.el8.x86_64.rpm"
-          },
           "sha256:eee9b26d7dbd4de200524b1005dac492a75d712a13f20a62cdbd1ad68cf23b29": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20210827/Packages/grub2-efi-ia32-cdboot-2.02-99.el8.x86_64.rpm"
           },
@@ -4776,9 +4728,6 @@
           },
           "sha256:f1ce23ee43c747a35367dada19ca200a7758c50955ccc44aa946b86b647077ca": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20210827/Packages/cracklib-dicts-2.9.6-15.el8.x86_64.rpm"
-          },
-          "sha256:f352a944211785838da583ab23741b774ec62abe8c0e0582a7558ce41ade2efd": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20210827/Packages/subscription-manager-rhsm-certificates-1.28.20-1.el8.x86_64.rpm"
           },
           "sha256:f44bc36f2ab0406f0410a7d6013d34c6afb6192e6d89d2ff5a07d1f516b5eccd": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-appstream-20210827/Packages/lohit-odia-fonts-2.91.2-3.el8.noarch.rpm"
@@ -18151,16 +18100,6 @@
         "check_gpg": true
       },
       {
-        "name": "dnf-plugin-subscription-manager",
-        "epoch": 0,
-        "version": "1.28.20",
-        "release": "1.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20210827/Packages/dnf-plugin-subscription-manager-1.28.20-1.el8.x86_64.rpm",
-        "checksum": "sha256:0265d45b4e949d977cef57a2d95f6d22ef906a05a5c7fbd486464bb1d55655e9",
-        "check_gpg": true
-      },
-      {
         "name": "dnf-plugins-core",
         "epoch": 0,
         "version": "4.0.21",
@@ -20911,26 +20850,6 @@
         "check_gpg": true
       },
       {
-        "name": "python3-chardet",
-        "epoch": 0,
-        "version": "3.0.4",
-        "release": "7.el8",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20210827/Packages/python3-chardet-3.0.4-7.el8.noarch.rpm",
-        "checksum": "sha256:176ffcb2cf0fdcbdd2d8119cbd98eef60a30fdb0fb065a9382d2c95e90c79652",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-cloud-what",
-        "epoch": 0,
-        "version": "1.28.20",
-        "release": "1.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20210827/Packages/python3-cloud-what-1.28.20-1.el8.x86_64.rpm",
-        "checksum": "sha256:e0bb5476b38e4cfe2425262c4fce180ec97a79c6a11cc3e170c9013fff712e21",
-        "check_gpg": true
-      },
-      {
         "name": "python3-configobj",
         "epoch": 0,
         "version": "5.0.6",
@@ -20971,16 +20890,6 @@
         "check_gpg": true
       },
       {
-        "name": "python3-dmidecode",
-        "epoch": 0,
-        "version": "3.12.2",
-        "release": "15.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20210827/Packages/python3-dmidecode-3.12.2-15.el8.x86_64.rpm",
-        "checksum": "sha256:c39a53566ad66d6db9e101ca9a6db316843a1d1f6f5ac5f2286c6028638a8ab7",
-        "check_gpg": true
-      },
-      {
         "name": "python3-dnf",
         "epoch": 0,
         "version": "4.7.0",
@@ -20998,16 +20907,6 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20210827/Packages/python3-dnf-plugins-core-4.0.21-2.el8.noarch.rpm",
         "checksum": "sha256:28c0f457d67213319f0313d993a3b2f8a778a077b202cd75bf45eb2792949d32",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-ethtool",
-        "epoch": 0,
-        "version": "0.14",
-        "release": "3.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20210827/Packages/python3-ethtool-0.14-3.el8.x86_64.rpm",
-        "checksum": "sha256:c746d43bd63dd184b8c585dd7323e261567928e521e830720d4754fca76157e0",
         "check_gpg": true
       },
       {
@@ -21051,36 +20950,6 @@
         "check_gpg": true
       },
       {
-        "name": "python3-idna",
-        "epoch": 0,
-        "version": "2.5",
-        "release": "5.el8",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20210827/Packages/python3-idna-2.5-5.el8.noarch.rpm",
-        "checksum": "sha256:78c43d8a15ca018de1803e4baac5819e1baab1963fd31f1e44e54e8a573acbfc",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-iniparse",
-        "epoch": 0,
-        "version": "0.4",
-        "release": "31.el8",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20210827/Packages/python3-iniparse-0.4-31.el8.noarch.rpm",
-        "checksum": "sha256:5c0957decce3babef9864904be13190b0072aef720e9f4ca820bab6c02a20178",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-inotify",
-        "epoch": 0,
-        "version": "0.9.6",
-        "release": "13.el8",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20210827/Packages/python3-inotify-0.9.6-13.el8.noarch.rpm",
-        "checksum": "sha256:109d6db30e5515601b00954b2fd8750c421730a18afc12e1fa7781e24e5b0863",
-        "check_gpg": true
-      },
-      {
         "name": "python3-libcomps",
         "epoch": 0,
         "version": "0.1.16",
@@ -21098,16 +20967,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20210827/Packages/python3-libdnf-0.63.0-2.el8.x86_64.rpm",
         "checksum": "sha256:7d2455f252fc9bfd34323d0ca59bf2cab699f99d0a8e9d195d9f8ec384583f33",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-librepo",
-        "epoch": 0,
-        "version": "1.14.0",
-        "release": "2.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20210827/Packages/python3-librepo-1.14.0-2.el8.x86_64.rpm",
-        "checksum": "sha256:85d87a486cb17e81aa7af6b17564424e3baf726facea2f0b264e69a5f5709f1b",
         "check_gpg": true
       },
       {
@@ -21201,16 +21060,6 @@
         "check_gpg": true
       },
       {
-        "name": "python3-pysocks",
-        "epoch": 0,
-        "version": "1.6.8",
-        "release": "3.el8",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20210827/Packages/python3-pysocks-1.6.8-3.el8.noarch.rpm",
-        "checksum": "sha256:7f506879c64e0bb4d98782d025f46fb9a07517487ae4cbebbb3985a98f4e2154",
-        "check_gpg": true
-      },
-      {
         "name": "python3-pyudev",
         "epoch": 0,
         "version": "0.21.0",
@@ -21228,16 +21077,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20210827/Packages/python3-pyyaml-3.12-12.el8.x86_64.rpm",
         "checksum": "sha256:525393e4d658e395c6280bd2ff4afe54999796c4722986325297ba4bfade3ea5",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-requests",
-        "epoch": 0,
-        "version": "2.20.0",
-        "release": "2.1.el8_1",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20210827/Packages/python3-requests-2.20.0-2.1.el8_1.noarch.rpm",
-        "checksum": "sha256:003ee19ec5b88de212c3246bdfdb3e97a9910a25a219fd7cf5030b7bc666fea9",
         "check_gpg": true
       },
       {
@@ -21301,16 +21140,6 @@
         "check_gpg": true
       },
       {
-        "name": "python3-subscription-manager-rhsm",
-        "epoch": 0,
-        "version": "1.28.20",
-        "release": "1.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20210827/Packages/python3-subscription-manager-rhsm-1.28.20-1.el8.x86_64.rpm",
-        "checksum": "sha256:34ab92d70d2d3ffb65b1893d34d7b40e4cfc528b920363fc85492afac0619453",
-        "check_gpg": true
-      },
-      {
         "name": "python3-syspurpose",
         "epoch": 0,
         "version": "1.28.20",
@@ -21318,16 +21147,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20210827/Packages/python3-syspurpose-1.28.20-1.el8.x86_64.rpm",
         "checksum": "sha256:e495b35bd222a13d9be2befa19bec66e64341f2f3d9f0064db8a5d42d91a8bae",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-urllib3",
-        "epoch": 0,
-        "version": "1.24.2",
-        "release": "5.el8",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20210827/Packages/python3-urllib3-1.24.2-5.el8.noarch.rpm",
-        "checksum": "sha256:aa1835fd302a37b84ac256db5dd0de09bd9883a5a07775aedb491faf46b18ee0",
         "check_gpg": true
       },
       {
@@ -21368,16 +21187,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20210827/Packages/readline-7.0-10.el8.x86_64.rpm",
         "checksum": "sha256:fea868a7d82a7b6f392260ed4afb472dc4428fd71eab1456319f423a845b5084",
-        "check_gpg": true
-      },
-      {
-        "name": "rhsm-icons",
-        "epoch": 0,
-        "version": "1.28.20",
-        "release": "1.el8",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20210827/Packages/rhsm-icons-1.28.20-1.el8.noarch.rpm",
-        "checksum": "sha256:76acb678a5c1d93353d4f506e703ac9ce4925295d61c876f6a420e244102aaba",
         "check_gpg": true
       },
       {
@@ -21641,36 +21450,6 @@
         "check_gpg": true
       },
       {
-        "name": "subscription-manager",
-        "epoch": 0,
-        "version": "1.28.20",
-        "release": "1.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20210827/Packages/subscription-manager-1.28.20-1.el8.x86_64.rpm",
-        "checksum": "sha256:c8915f9ca548e02f73a7f2f37990820e958061e3ad0c779c92bcb39c0a4cb544",
-        "check_gpg": true
-      },
-      {
-        "name": "subscription-manager-cockpit",
-        "epoch": 0,
-        "version": "1.28.20",
-        "release": "1.el8",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20210827/Packages/subscription-manager-cockpit-1.28.20-1.el8.noarch.rpm",
-        "checksum": "sha256:3386ebe6e649b2cb6a4b3eef260d68f3c165d9ccf54b4e6767ee064aa32d3334",
-        "check_gpg": true
-      },
-      {
-        "name": "subscription-manager-rhsm-certificates",
-        "epoch": 0,
-        "version": "1.28.20",
-        "release": "1.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20210827/Packages/subscription-manager-rhsm-certificates-1.28.20-1.el8.x86_64.rpm",
-        "checksum": "sha256:f352a944211785838da583ab23741b774ec62abe8c0e0582a7558ce41ade2efd",
-        "check_gpg": true
-      },
-      {
         "name": "sudo",
         "epoch": 0,
         "version": "1.8.29",
@@ -21798,16 +21577,6 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20210827/Packages/tzdata-2021a-1.el8.noarch.rpm",
         "checksum": "sha256:44999c555a6e4bb6cf5e6f6a79819e76912d036732cb50efaeefc20a180dd839",
-        "check_gpg": true
-      },
-      {
-        "name": "usermode",
-        "epoch": 0,
-        "version": "1.113",
-        "release": "1.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20210827/Packages/usermode-1.113-1.el8.x86_64.rpm",
-        "checksum": "sha256:eec162a2757ee2ffbbee95e1dbcd33318119e5113e53af877ce9416529a19082",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/centos_8-x86_64-qcow2-boot.json
+++ b/test/data/manifests/centos_8-x86_64-qcow2-boot.json
@@ -380,7 +380,6 @@
                   "sha256:cd2f140bd1718b4403ad66568155264b69231748a3c813e2feaac1b704da62c6",
                   "sha256:42464424b9fa731f8122fe748aad0005519fc87b770dbbdb71f29f514ea0e889",
                   "sha256:45c48d32120739734ae97479cc0f3ca19796ea47e360ba39d52b77ce3ada61d7",
-                  "sha256:0265d45b4e949d977cef57a2d95f6d22ef906a05a5c7fbd486464bb1d55655e9",
                   "sha256:47b61754a278c4ca378871c874ccf6a0a07bffaef38505315cfa94f262887845",
                   "sha256:40676b73567e195228ba2a8bb53692f88f88d43612564613fb168383eee57f6a",
                   "sha256:9377ec604215c283f87df51305d163d07091808c30019954d145c6d73451965c",
@@ -617,26 +616,20 @@
                   "sha256:addf80c52d794aed47874eb9d5ddbbaa90cb248fda1634d793054a41da0d92d7",
                   "sha256:07ed1209e898552e6aeac0e6d148271d562c576f7d903cb7a99a697643068f58",
                   "sha256:176ffcb2cf0fdcbdd2d8119cbd98eef60a30fdb0fb065a9382d2c95e90c79652",
-                  "sha256:e0bb5476b38e4cfe2425262c4fce180ec97a79c6a11cc3e170c9013fff712e21",
                   "sha256:1bd969e0521820374122f5132e5998d9bd2ab185be66565a7266096297419c8e",
                   "sha256:db2adf35874e77b875de93df9b5ac17d9c93f17248c77b4be6a22a50cb51a0f2",
                   "sha256:c5b5967a094ced90899052a82e2c245529b75ba3f46e0ce1a89cfc95edb935ea",
                   "sha256:066f254f9ac7712b44214816de907a87eb8dfd0d2ea9570a7513db9a6617ba26",
                   "sha256:0e9a8a0f823bf0ef948862f0ccb62353460bd07931e756c98f23908c1c526578",
-                  "sha256:c39a53566ad66d6db9e101ca9a6db316843a1d1f6f5ac5f2286c6028638a8ab7",
                   "sha256:ccfa1810aa19fae08aefd29cffe28b65d5123cd17bd7d2d4207f03cf9795594c",
                   "sha256:28c0f457d67213319f0313d993a3b2f8a778a077b202cd75bf45eb2792949d32",
-                  "sha256:c746d43bd63dd184b8c585dd7323e261567928e521e830720d4754fca76157e0",
                   "sha256:15dc15a5be210707852f051f4d09949c063a7283edc7d4ca3d4289eedcc0b509",
                   "sha256:1cda7601799144cff400d4267ae164a558328815a34a935f38c6ef0429f24711",
                   "sha256:92b18871b06fbc6346ec7b49be753f31482a40b2f3c8e2e29f91bce71f109f38",
                   "sha256:78c43d8a15ca018de1803e4baac5819e1baab1963fd31f1e44e54e8a573acbfc",
-                  "sha256:5c0957decce3babef9864904be13190b0072aef720e9f4ca820bab6c02a20178",
-                  "sha256:109d6db30e5515601b00954b2fd8750c421730a18afc12e1fa7781e24e5b0863",
                   "sha256:ebeb05a4a9cdd5d060859eabac1349029c0120615c98fc939e26664c030655c1",
                   "sha256:8ae9708ba5c5b90ecc4ae4e30b8291fdaa63ce4e7cdeeb081f409bf1b3003967",
                   "sha256:7d2455f252fc9bfd34323d0ca59bf2cab699f99d0a8e9d195d9f8ec384583f33",
-                  "sha256:85d87a486cb17e81aa7af6b17564424e3baf726facea2f0b264e69a5f5709f1b",
                   "sha256:958f4ef8efa6c2f1d7ac9be085ae1d90d4b9b128ef4fa31b46e72eb8d1d9a2fd",
                   "sha256:59ba5bf69953a5a2e902b0f08b7187b66d84968852d46a3579a059477547d1a0",
                   "sha256:451d0cb6e2284578e3279b4cbb5ec98e9d98a687556c6b424adf8f1282d4ef58",
@@ -658,14 +651,12 @@
                   "sha256:a04cb3117395b962edc32bf45d8411f240632476b0706b2df7f4a1a87b2ce34b",
                   "sha256:233e5f78027b684e5aaac1395cc574aea3039059bf86eb4494422bc74216a396",
                   "sha256:563b3741d26b6af963fdb7b0634e0791445a707d0b6093ac71c3224299241639",
-                  "sha256:34ab92d70d2d3ffb65b1893d34d7b40e4cfc528b920363fc85492afac0619453",
                   "sha256:e495b35bd222a13d9be2befa19bec66e64341f2f3d9f0064db8a5d42d91a8bae",
                   "sha256:aa1835fd302a37b84ac256db5dd0de09bd9883a5a07775aedb491faf46b18ee0",
                   "sha256:cce5f4086e7ecc31a12b753b5d0d97cb6d6c6f61e5c3066322449781ab1f63d0",
                   "sha256:bc7fc2028a29ac7a406719ed4f6740f6bf12c20961223c1e839a2a39069af38d",
                   "sha256:ee2d61287b724b6088902016728fc5d9a17744d0b69aa7ccab9e133264f18603",
                   "sha256:fea868a7d82a7b6f392260ed4afb472dc4428fd71eab1456319f423a845b5084",
-                  "sha256:76acb678a5c1d93353d4f506e703ac9ce4925295d61c876f6a420e244102aaba",
                   "sha256:d967d6bbb33bf7a295a64807f81875c84e82a8ecc59b6c72fe955141b1660d39",
                   "sha256:e76ffaf54db6ac36f0aa56c8013431c352c6187c8d674c6d468e25c573e31597",
                   "sha256:38e2d7fd362b10b71aa0b357331314d0f370a35185dfa31818c899cbb56ff610",
@@ -692,9 +683,6 @@
                   "sha256:9ee6c231a808d732e85a1e31df05ce55388315709206df944f3afe9531a8442a",
                   "sha256:0612728d1655cc06a5897c2077d3e3fbf29891941211916f487203761970f5f7",
                   "sha256:9b74d2ef03a55cb9f830ba60734a8861b5d88cffeb78778e1c75557b127fa08c",
-                  "sha256:c8915f9ca548e02f73a7f2f37990820e958061e3ad0c779c92bcb39c0a4cb544",
-                  "sha256:3386ebe6e649b2cb6a4b3eef260d68f3c165d9ccf54b4e6767ee064aa32d3334",
-                  "sha256:f352a944211785838da583ab23741b774ec62abe8c0e0582a7558ce41ade2efd",
                   "sha256:cbcade4487fbf372b487b9f82ed85e04ff037551c96c4b461abc3716338ff9c4",
                   "sha256:f16942e337972452994ad32c3e5a5385450eb46857b8fba61aa11b764c484eef",
                   "sha256:0854686cc3009d2fdf8baf48cbef87c58b10baf85302e7061b25cc64a1848e64",
@@ -708,7 +696,6 @@
                   "sha256:ff4c97e0df6ed6090ef36ac853e11bed9aa13f657be1d068ac09ad33c11432cb",
                   "sha256:654d9074dc8ebb93230fe258188a17ba3f7dbac2f360f9f79cc4fb1516953018",
                   "sha256:44999c555a6e4bb6cf5e6f6a79819e76912d036732cb50efaeefc20a180dd839",
-                  "sha256:eec162a2757ee2ffbbee95e1dbcd33318119e5113e53af877ce9416529a19082",
                   "sha256:8213aa26dbe71291c0cd5969256f3f0bce13ee8e8cd76e3b949c1f6752142471",
                   "sha256:3efd6a2548813167fe37718546bc768a5aa8ba59aa80edcecd8ba408bec329b0",
                   "sha256:8beb58e28b4dd11a952e24c442b696416ce7a756016fe8147cc66be6fc01a9db",
@@ -988,19 +975,6 @@
             }
           },
           {
-            "type": "org.osbuild.rhsm",
-            "options": {
-              "dnf-plugins": {
-                "product-id": {
-                  "enabled": false
-                },
-                "subscription-manager": {
-                  "enabled": false
-                }
-              }
-            }
-          },
-          {
             "type": "org.osbuild.fstab",
             "options": {
               "filesystems": [
@@ -1242,9 +1216,6 @@
           "sha256:0221e6e3671c2bd130e9519a7b352404b7e510584b4707d38e1a733e19c7f74f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-appstream-20210827/Packages/libxcb-1.13.1-1.el8.x86_64.rpm"
           },
-          "sha256:0265d45b4e949d977cef57a2d95f6d22ef906a05a5c7fbd486464bb1d55655e9": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20210827/Packages/dnf-plugin-subscription-manager-1.28.20-1.el8.x86_64.rpm"
-          },
           "sha256:02d728cf74eb47005babeeab5ac68ca04472c643203a1faef0037b5f33710fe2": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20210827/Packages/libsigsegv-2.11-5.el8.x86_64.rpm"
           },
@@ -1316,9 +1287,6 @@
           },
           "sha256:0feac495306bbe6e3149a352025bea8d23cda512859a230cbd3f510cf48caaf7": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-appstream-20210827/Packages/python3-jsonschema-2.6.0-4.el8.noarch.rpm"
-          },
-          "sha256:109d6db30e5515601b00954b2fd8750c421730a18afc12e1fa7781e24e5b0863": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20210827/Packages/python3-inotify-0.9.6-13.el8.noarch.rpm"
           },
           "sha256:10e88a1794107ea61f1441273be906704d66802b21800b0840a2870cad8b4d63": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20210827/Packages/cpio-2.12-10.el8.x86_64.rpm"
@@ -1497,9 +1465,6 @@
           "sha256:30fab73ee155f03dbbd99c1e30fe59dfba4ae8fdb2e7213451ccc36d6918bfcc": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20210827/Packages/libmnl-1.0.4-6.el8.x86_64.rpm"
           },
-          "sha256:3386ebe6e649b2cb6a4b3eef260d68f3c165d9ccf54b4e6767ee064aa32d3334": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20210827/Packages/subscription-manager-cockpit-1.28.20-1.el8.noarch.rpm"
-          },
           "sha256:33996f2476ed82d68353ac5c6d22c204db4ee76821eefc4c0cc2dafcf44ae16b": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20210827/Packages/syslinux-6.04-5.el8.x86_64.rpm"
           },
@@ -1511,9 +1476,6 @@
           },
           "sha256:344051091b56f4b8e73232c38411878ccce64e7b323e6fe44f40cf8af0c117c3": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20210827/Packages/python3-rpm-4.14.3-15.el8.x86_64.rpm"
-          },
-          "sha256:34ab92d70d2d3ffb65b1893d34d7b40e4cfc528b920363fc85492afac0619453": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20210827/Packages/python3-subscription-manager-rhsm-1.28.20-1.el8.x86_64.rpm"
           },
           "sha256:3705a3d6c18aea20fd77cd44d91a33fdb5f15e8a8a8eae658ba952323261de94": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20210827/Packages/rpm-libs-4.14.3-15.el8.x86_64.rpm"
@@ -1865,9 +1827,6 @@
           },
           "sha256:7533e19781d1b7e354315b15ef3d3011a8f1eec8980f9e8a6c633af3a806db2a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20210827/Packages/dbus-libs-1.12.8-14.el8.x86_64.rpm"
-          },
-          "sha256:76acb678a5c1d93353d4f506e703ac9ce4925295d61c876f6a420e244102aaba": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20210827/Packages/rhsm-icons-1.28.20-1.el8.noarch.rpm"
           },
           "sha256:76d81e433a5291df491d2e289de9b33d4e5b98dcf48fd0a003c2767415d3e0aa": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20210827/Packages/gdbm-1.18-1.el8.x86_64.rpm"
@@ -2292,9 +2251,6 @@
           "sha256:c3794d79a690d94d03d59a045a9ff95b4967bd3846bf608ba45802680a8f3c2c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20210827/Packages/hostname-3.20-7.el8.0.1.x86_64.rpm"
           },
-          "sha256:c39a53566ad66d6db9e101ca9a6db316843a1d1f6f5ac5f2286c6028638a8ab7": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20210827/Packages/python3-dmidecode-3.12.2-15.el8.x86_64.rpm"
-          },
           "sha256:c3b8c553b166491d3114793e198cd1aad95e494d177af8d0dc7180b8b841124d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20210827/Packages/libmodman-2.0.1-17.el8.x86_64.rpm"
           },
@@ -2312,12 +2268,6 @@
           },
           "sha256:c6f27b6e01d80e756408e3c1451e4af00e7d02da0aa24402644c0785118753fe": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20210827/Packages/python3-setuptools-39.2.0-6.el8.noarch.rpm"
-          },
-          "sha256:c746d43bd63dd184b8c585dd7323e261567928e521e830720d4754fca76157e0": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20210827/Packages/python3-ethtool-0.14-3.el8.x86_64.rpm"
-          },
-          "sha256:c8915f9ca548e02f73a7f2f37990820e958061e3ad0c779c92bcb39c0a4cb544": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20210827/Packages/subscription-manager-1.28.20-1.el8.x86_64.rpm"
           },
           "sha256:c8c54c56bff9ca416c3ba6bccac483fb66c81a53d93a19420088715018ed5169": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20210827/Packages/libutempter-1.1.6-14.el8.x86_64.rpm"
@@ -2451,9 +2401,6 @@
           "sha256:e065695c34b4621a40793a64f1327b2cae6e39d4e8d2c70357bc0a2fb8ec4ee9": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20210827/Packages/libsss_nss_idmap-2.5.2-2.el8.x86_64.rpm"
           },
-          "sha256:e0bb5476b38e4cfe2425262c4fce180ec97a79c6a11cc3e170c9013fff712e21": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20210827/Packages/python3-cloud-what-1.28.20-1.el8.x86_64.rpm"
-          },
           "sha256:e0df63d8debeb6d2f736bae02756097af273c9c486255b03e5a89f2946b98ac9": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20210827/Packages/lshw-B.02.19.2-6.el8.x86_64.rpm"
           },
@@ -2529,9 +2476,6 @@
           "sha256:ee4413fda60078f82c3b209557f0fc730871bb2a24cc380db6d01b511322ac85": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-appstream-20210827/Packages/cairo-gobject-1.15.12-3.el8.x86_64.rpm"
           },
-          "sha256:eec162a2757ee2ffbbee95e1dbcd33318119e5113e53af877ce9416529a19082": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20210827/Packages/usermode-1.113-1.el8.x86_64.rpm"
-          },
           "sha256:ef86061338fa321c959cadc75ecbdfd405eebaa1042eec9d9c737d4d9d92568f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20210827/Packages/kbd-misc-2.0.4-10.el8.noarch.rpm"
           },
@@ -2546,9 +2490,6 @@
           },
           "sha256:f1ce23ee43c747a35367dada19ca200a7758c50955ccc44aa946b86b647077ca": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20210827/Packages/cracklib-dicts-2.9.6-15.el8.x86_64.rpm"
-          },
-          "sha256:f352a944211785838da583ab23741b774ec62abe8c0e0582a7558ce41ade2efd": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20210827/Packages/subscription-manager-rhsm-certificates-1.28.20-1.el8.x86_64.rpm"
           },
           "sha256:f46dee25409f262173a127102dd9c7a3aced4feecf935a2340a043c17b1f8c61": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20210827/Packages/e2fsprogs-1.45.6-2.el8.x86_64.rpm"
@@ -7254,16 +7195,6 @@
         "check_gpg": true
       },
       {
-        "name": "dnf-plugin-subscription-manager",
-        "epoch": 0,
-        "version": "1.28.20",
-        "release": "1.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20210827/Packages/dnf-plugin-subscription-manager-1.28.20-1.el8.x86_64.rpm",
-        "checksum": "sha256:0265d45b4e949d977cef57a2d95f6d22ef906a05a5c7fbd486464bb1d55655e9",
-        "check_gpg": true
-      },
-      {
         "name": "dnf-plugins-core",
         "epoch": 0,
         "version": "4.0.21",
@@ -9624,16 +9555,6 @@
         "check_gpg": true
       },
       {
-        "name": "python3-cloud-what",
-        "epoch": 0,
-        "version": "1.28.20",
-        "release": "1.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20210827/Packages/python3-cloud-what-1.28.20-1.el8.x86_64.rpm",
-        "checksum": "sha256:e0bb5476b38e4cfe2425262c4fce180ec97a79c6a11cc3e170c9013fff712e21",
-        "check_gpg": true
-      },
-      {
         "name": "python3-configobj",
         "epoch": 0,
         "version": "5.0.6",
@@ -9684,16 +9605,6 @@
         "check_gpg": true
       },
       {
-        "name": "python3-dmidecode",
-        "epoch": 0,
-        "version": "3.12.2",
-        "release": "15.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20210827/Packages/python3-dmidecode-3.12.2-15.el8.x86_64.rpm",
-        "checksum": "sha256:c39a53566ad66d6db9e101ca9a6db316843a1d1f6f5ac5f2286c6028638a8ab7",
-        "check_gpg": true
-      },
-      {
         "name": "python3-dnf",
         "epoch": 0,
         "version": "4.7.0",
@@ -9711,16 +9622,6 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20210827/Packages/python3-dnf-plugins-core-4.0.21-2.el8.noarch.rpm",
         "checksum": "sha256:28c0f457d67213319f0313d993a3b2f8a778a077b202cd75bf45eb2792949d32",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-ethtool",
-        "epoch": 0,
-        "version": "0.14",
-        "release": "3.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20210827/Packages/python3-ethtool-0.14-3.el8.x86_64.rpm",
-        "checksum": "sha256:c746d43bd63dd184b8c585dd7323e261567928e521e830720d4754fca76157e0",
         "check_gpg": true
       },
       {
@@ -9764,26 +9665,6 @@
         "check_gpg": true
       },
       {
-        "name": "python3-iniparse",
-        "epoch": 0,
-        "version": "0.4",
-        "release": "31.el8",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20210827/Packages/python3-iniparse-0.4-31.el8.noarch.rpm",
-        "checksum": "sha256:5c0957decce3babef9864904be13190b0072aef720e9f4ca820bab6c02a20178",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-inotify",
-        "epoch": 0,
-        "version": "0.9.6",
-        "release": "13.el8",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20210827/Packages/python3-inotify-0.9.6-13.el8.noarch.rpm",
-        "checksum": "sha256:109d6db30e5515601b00954b2fd8750c421730a18afc12e1fa7781e24e5b0863",
-        "check_gpg": true
-      },
-      {
         "name": "python3-jwt",
         "epoch": 0,
         "version": "1.6.1",
@@ -9811,16 +9692,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20210827/Packages/python3-libdnf-0.63.0-2.el8.x86_64.rpm",
         "checksum": "sha256:7d2455f252fc9bfd34323d0ca59bf2cab699f99d0a8e9d195d9f8ec384583f33",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-librepo",
-        "epoch": 0,
-        "version": "1.14.0",
-        "release": "2.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20210827/Packages/python3-librepo-1.14.0-2.el8.x86_64.rpm",
-        "checksum": "sha256:85d87a486cb17e81aa7af6b17564424e3baf726facea2f0b264e69a5f5709f1b",
         "check_gpg": true
       },
       {
@@ -10034,16 +9905,6 @@
         "check_gpg": true
       },
       {
-        "name": "python3-subscription-manager-rhsm",
-        "epoch": 0,
-        "version": "1.28.20",
-        "release": "1.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20210827/Packages/python3-subscription-manager-rhsm-1.28.20-1.el8.x86_64.rpm",
-        "checksum": "sha256:34ab92d70d2d3ffb65b1893d34d7b40e4cfc528b920363fc85492afac0619453",
-        "check_gpg": true
-      },
-      {
         "name": "python3-syspurpose",
         "epoch": 0,
         "version": "1.28.20",
@@ -10101,16 +9962,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20210827/Packages/readline-7.0-10.el8.x86_64.rpm",
         "checksum": "sha256:fea868a7d82a7b6f392260ed4afb472dc4428fd71eab1456319f423a845b5084",
-        "check_gpg": true
-      },
-      {
-        "name": "rhsm-icons",
-        "epoch": 0,
-        "version": "1.28.20",
-        "release": "1.el8",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20210827/Packages/rhsm-icons-1.28.20-1.el8.noarch.rpm",
-        "checksum": "sha256:76acb678a5c1d93353d4f506e703ac9ce4925295d61c876f6a420e244102aaba",
         "check_gpg": true
       },
       {
@@ -10374,36 +10225,6 @@
         "check_gpg": true
       },
       {
-        "name": "subscription-manager",
-        "epoch": 0,
-        "version": "1.28.20",
-        "release": "1.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20210827/Packages/subscription-manager-1.28.20-1.el8.x86_64.rpm",
-        "checksum": "sha256:c8915f9ca548e02f73a7f2f37990820e958061e3ad0c779c92bcb39c0a4cb544",
-        "check_gpg": true
-      },
-      {
-        "name": "subscription-manager-cockpit",
-        "epoch": 0,
-        "version": "1.28.20",
-        "release": "1.el8",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20210827/Packages/subscription-manager-cockpit-1.28.20-1.el8.noarch.rpm",
-        "checksum": "sha256:3386ebe6e649b2cb6a4b3eef260d68f3c165d9ccf54b4e6767ee064aa32d3334",
-        "check_gpg": true
-      },
-      {
-        "name": "subscription-manager-rhsm-certificates",
-        "epoch": 0,
-        "version": "1.28.20",
-        "release": "1.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20210827/Packages/subscription-manager-rhsm-certificates-1.28.20-1.el8.x86_64.rpm",
-        "checksum": "sha256:f352a944211785838da583ab23741b774ec62abe8c0e0582a7558ce41ade2efd",
-        "check_gpg": true
-      },
-      {
         "name": "sudo",
         "epoch": 0,
         "version": "1.8.29",
@@ -10531,16 +10352,6 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20210827/Packages/tzdata-2021a-1.el8.noarch.rpm",
         "checksum": "sha256:44999c555a6e4bb6cf5e6f6a79819e76912d036732cb50efaeefc20a180dd839",
-        "check_gpg": true
-      },
-      {
-        "name": "usermode",
-        "epoch": 0,
-        "version": "1.113",
-        "release": "1.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20210827/Packages/usermode-1.113-1.el8.x86_64.rpm",
-        "checksum": "sha256:eec162a2757ee2ffbbee95e1dbcd33318119e5113e53af877ce9416529a19082",
         "check_gpg": true
       },
       {
@@ -11479,7 +11290,6 @@
       "dmidecode-3.2-10.el8.x86_64",
       "dnf-4.7.0-2.el8.noarch",
       "dnf-data-4.7.0-2.el8.noarch",
-      "dnf-plugin-subscription-manager-1.28.20-1.el8.x86_64",
       "dnf-plugins-core-4.0.21-2.el8.noarch",
       "dosfstools-4.1-6.el8.x86_64",
       "dracut-049-188.git20210802.el8.x86_64",
@@ -11735,23 +11545,18 @@
       "python3-cairo-1.16.3-6.el8.x86_64",
       "python3-cffi-1.11.5-5.el8.x86_64",
       "python3-chardet-3.0.4-7.el8.noarch",
-      "python3-cloud-what-1.28.20-1.el8.x86_64",
       "python3-configobj-5.0.6-11.el8.noarch",
       "python3-cryptography-3.2.1-5.el8.x86_64",
       "python3-dateutil-2.6.1-6.el8.noarch",
       "python3-dbus-1.2.4-15.el8.x86_64",
       "python3-decorator-4.2.1-2.el8.noarch",
-      "python3-dmidecode-3.12.2-15.el8.x86_64",
       "python3-dnf-4.7.0-2.el8.noarch",
       "python3-dnf-plugins-core-4.0.21-2.el8.noarch",
-      "python3-ethtool-0.14-3.el8.x86_64",
       "python3-gobject-3.28.3-2.el8.x86_64",
       "python3-gobject-base-3.28.3-2.el8.x86_64",
       "python3-gpg-1.13.1-9.el8.x86_64",
       "python3-hawkey-0.63.0-2.el8.x86_64",
       "python3-idna-2.5-5.el8.noarch",
-      "python3-iniparse-0.4-31.el8.noarch",
-      "python3-inotify-0.9.6-13.el8.noarch",
       "python3-jinja2-2.10.1-3.el8.noarch",
       "python3-jsonpatch-1.21-2.el8.noarch",
       "python3-jsonpointer-1.10-11.el8.noarch",
@@ -11759,7 +11564,6 @@
       "python3-jwt-1.6.1-2.el8.noarch",
       "python3-libcomps-0.1.16-2.el8.x86_64",
       "python3-libdnf-0.63.0-2.el8.x86_64",
-      "python3-librepo-1.14.0-2.el8.x86_64",
       "python3-libs-3.6.8-39.el8.x86_64",
       "python3-libselinux-2.9-5.el8.x86_64",
       "python3-libsemanage-2.9-6.el8.x86_64",
@@ -11788,7 +11592,6 @@
       "python3-six-1.11.0-8.el8.noarch",
       "python3-slip-0.6.4-11.el8.noarch",
       "python3-slip-dbus-0.6.4-11.el8.noarch",
-      "python3-subscription-manager-rhsm-1.28.20-1.el8.x86_64",
       "python3-syspurpose-1.28.20-1.el8.x86_64",
       "python3-systemd-234-8.el8.x86_64",
       "python3-unbound-1.7.3-17.el8.x86_64",
@@ -11798,7 +11601,6 @@
       "quota-nls-4.04-14.el8.noarch",
       "rdma-core-35.0-1.el8.x86_64",
       "readline-7.0-10.el8.x86_64",
-      "rhsm-icons-1.28.20-1.el8.noarch",
       "rootfiles-8.1-22.el8.noarch",
       "rpcbind-1.2.5-8.el8.x86_64",
       "rpm-4.14.3-15.el8.x86_64",
@@ -11829,9 +11631,6 @@
       "sssd-common-2.5.2-2.el8.x86_64",
       "sssd-kcm-2.5.2-2.el8.x86_64",
       "sssd-nfs-idmap-2.5.2-2.el8.x86_64",
-      "subscription-manager-1.28.20-1.el8.x86_64",
-      "subscription-manager-cockpit-1.28.20-1.el8.noarch",
-      "subscription-manager-rhsm-certificates-1.28.20-1.el8.x86_64",
       "sudo-1.8.29-7.el8.x86_64",
       "systemd-239-49.el8.x86_64",
       "systemd-libs-239-49.el8.x86_64",
@@ -11847,7 +11646,6 @@
       "tuned-2.16.0-1.el8.noarch",
       "tzdata-2021a-1.el8.noarch",
       "unbound-libs-1.7.3-17.el8.x86_64",
-      "usermode-1.113-1.el8.x86_64",
       "util-linux-2.32.1-28.el8.x86_64",
       "vim-minimal-8.0.1763-15.el8.x86_64",
       "virt-what-1.18-12.el8.x86_64",
@@ -11925,64 +11723,9 @@
       "tss:x:59:59:Account used for TPM access:/dev/null:/sbin/nologin",
       "unbound:x:997:994:Unbound DNS resolver:/etc/unbound:/sbin/nologin"
     ],
-    "rhsm": {
-      "dnf-plugins": {
-        "product-id": {
-          "enabled": false
-        },
-        "subscription-manager": {
-          "enabled": false
-        }
-      },
-      "rhsm.conf": {
-        "logging": {
-          "default_log_level": "INFO"
-        },
-        "rhsm": {
-          "auto_enable_yum_plugins": "1",
-          "baseurl": "https://cdn.redhat.com",
-          "ca_cert_dir": "/etc/rhsm/ca/",
-          "consumercertdir": "/etc/pki/consumer",
-          "entitlementcertdir": "/etc/pki/entitlement",
-          "full_refresh_on_yum": "0",
-          "inotify": "1",
-          "manage_repos": "1",
-          "package_profile_on_trans": "0",
-          "pluginconfdir": "/etc/rhsm/pluginconf.d",
-          "plugindir": "/usr/share/rhsm-plugins",
-          "productcertdir": "/etc/pki/product",
-          "repo_ca_cert": "/etc/rhsm/ca/redhat-uep.pem",
-          "repomd_gpg_url": "",
-          "report_package_profile": "1"
-        },
-        "rhsmcertd": {
-          "auto_registration": "0",
-          "auto_registration_interval": "60",
-          "autoattachinterval": "1440",
-          "certcheckinterval": "240",
-          "disable": "0",
-          "splay": "1"
-        },
-        "server": {
-          "hostname": "subscription.rhsm.redhat.com",
-          "insecure": "0",
-          "no_proxy": "",
-          "port": "443",
-          "prefix": "/subscription",
-          "proxy_hostname": "",
-          "proxy_password": "",
-          "proxy_port": "",
-          "proxy_scheme": "http",
-          "proxy_user": "",
-          "ssl_verify_depth": "3"
-        }
-      }
-    },
     "rpm-verify": {
       "changed": {
         "/boot/efi/EFI/centos/grubx64.efi": ".......T.",
-        "/etc/dnf/plugins/product-id.conf": "..5....T.",
-        "/etc/dnf/plugins/subscription-manager.conf": ".......T.",
         "/etc/machine-id": ".M.......",
         "/proc": ".M.......",
         "/sys": ".M.......",
@@ -12022,8 +11765,6 @@
       "poweroff.target",
       "rdisc.service",
       "remote-cryptsetup.target",
-      "rhsm-facts.service",
-      "rhsm.service",
       "runlevel0.target",
       "serial-getty@.service",
       "sshd-keygen@.service",
@@ -12066,7 +11807,6 @@
       "qemu-guest-agent.service",
       "reboot.target",
       "remote-fs.target",
-      "rhsmcertd.service",
       "rpcbind.service",
       "rpcbind.socket",
       "rsyslog.service",
@@ -12224,9 +11964,6 @@
         ],
         "setroubleshoot.conf": [
           "d /run/setroubleshoot 711 setroubleshoot setroubleshoot -"
-        ],
-        "subscription-manager.conf": [
-          "d /run/rhsm 0755 root root -"
         ],
         "sudo.conf": [
           "d /run/sudo 0711 root root",

--- a/test/data/manifests/centos_8-x86_64-qcow2_customize-boot.json
+++ b/test/data/manifests/centos_8-x86_64-qcow2_customize-boot.json
@@ -438,7 +438,6 @@
                   "sha256:cd2f140bd1718b4403ad66568155264b69231748a3c813e2feaac1b704da62c6",
                   "sha256:42464424b9fa731f8122fe748aad0005519fc87b770dbbdb71f29f514ea0e889",
                   "sha256:45c48d32120739734ae97479cc0f3ca19796ea47e360ba39d52b77ce3ada61d7",
-                  "sha256:0265d45b4e949d977cef57a2d95f6d22ef906a05a5c7fbd486464bb1d55655e9",
                   "sha256:47b61754a278c4ca378871c874ccf6a0a07bffaef38505315cfa94f262887845",
                   "sha256:40676b73567e195228ba2a8bb53692f88f88d43612564613fb168383eee57f6a",
                   "sha256:9377ec604215c283f87df51305d163d07091808c30019954d145c6d73451965c",
@@ -675,26 +674,20 @@
                   "sha256:addf80c52d794aed47874eb9d5ddbbaa90cb248fda1634d793054a41da0d92d7",
                   "sha256:07ed1209e898552e6aeac0e6d148271d562c576f7d903cb7a99a697643068f58",
                   "sha256:176ffcb2cf0fdcbdd2d8119cbd98eef60a30fdb0fb065a9382d2c95e90c79652",
-                  "sha256:e0bb5476b38e4cfe2425262c4fce180ec97a79c6a11cc3e170c9013fff712e21",
                   "sha256:1bd969e0521820374122f5132e5998d9bd2ab185be66565a7266096297419c8e",
                   "sha256:db2adf35874e77b875de93df9b5ac17d9c93f17248c77b4be6a22a50cb51a0f2",
                   "sha256:c5b5967a094ced90899052a82e2c245529b75ba3f46e0ce1a89cfc95edb935ea",
                   "sha256:066f254f9ac7712b44214816de907a87eb8dfd0d2ea9570a7513db9a6617ba26",
                   "sha256:0e9a8a0f823bf0ef948862f0ccb62353460bd07931e756c98f23908c1c526578",
-                  "sha256:c39a53566ad66d6db9e101ca9a6db316843a1d1f6f5ac5f2286c6028638a8ab7",
                   "sha256:ccfa1810aa19fae08aefd29cffe28b65d5123cd17bd7d2d4207f03cf9795594c",
                   "sha256:28c0f457d67213319f0313d993a3b2f8a778a077b202cd75bf45eb2792949d32",
-                  "sha256:c746d43bd63dd184b8c585dd7323e261567928e521e830720d4754fca76157e0",
                   "sha256:15dc15a5be210707852f051f4d09949c063a7283edc7d4ca3d4289eedcc0b509",
                   "sha256:1cda7601799144cff400d4267ae164a558328815a34a935f38c6ef0429f24711",
                   "sha256:92b18871b06fbc6346ec7b49be753f31482a40b2f3c8e2e29f91bce71f109f38",
                   "sha256:78c43d8a15ca018de1803e4baac5819e1baab1963fd31f1e44e54e8a573acbfc",
-                  "sha256:5c0957decce3babef9864904be13190b0072aef720e9f4ca820bab6c02a20178",
-                  "sha256:109d6db30e5515601b00954b2fd8750c421730a18afc12e1fa7781e24e5b0863",
                   "sha256:ebeb05a4a9cdd5d060859eabac1349029c0120615c98fc939e26664c030655c1",
                   "sha256:8ae9708ba5c5b90ecc4ae4e30b8291fdaa63ce4e7cdeeb081f409bf1b3003967",
                   "sha256:7d2455f252fc9bfd34323d0ca59bf2cab699f99d0a8e9d195d9f8ec384583f33",
-                  "sha256:85d87a486cb17e81aa7af6b17564424e3baf726facea2f0b264e69a5f5709f1b",
                   "sha256:958f4ef8efa6c2f1d7ac9be085ae1d90d4b9b128ef4fa31b46e72eb8d1d9a2fd",
                   "sha256:59ba5bf69953a5a2e902b0f08b7187b66d84968852d46a3579a059477547d1a0",
                   "sha256:451d0cb6e2284578e3279b4cbb5ec98e9d98a687556c6b424adf8f1282d4ef58",
@@ -716,14 +709,12 @@
                   "sha256:a04cb3117395b962edc32bf45d8411f240632476b0706b2df7f4a1a87b2ce34b",
                   "sha256:233e5f78027b684e5aaac1395cc574aea3039059bf86eb4494422bc74216a396",
                   "sha256:563b3741d26b6af963fdb7b0634e0791445a707d0b6093ac71c3224299241639",
-                  "sha256:34ab92d70d2d3ffb65b1893d34d7b40e4cfc528b920363fc85492afac0619453",
                   "sha256:e495b35bd222a13d9be2befa19bec66e64341f2f3d9f0064db8a5d42d91a8bae",
                   "sha256:aa1835fd302a37b84ac256db5dd0de09bd9883a5a07775aedb491faf46b18ee0",
                   "sha256:cce5f4086e7ecc31a12b753b5d0d97cb6d6c6f61e5c3066322449781ab1f63d0",
                   "sha256:bc7fc2028a29ac7a406719ed4f6740f6bf12c20961223c1e839a2a39069af38d",
                   "sha256:ee2d61287b724b6088902016728fc5d9a17744d0b69aa7ccab9e133264f18603",
                   "sha256:fea868a7d82a7b6f392260ed4afb472dc4428fd71eab1456319f423a845b5084",
-                  "sha256:76acb678a5c1d93353d4f506e703ac9ce4925295d61c876f6a420e244102aaba",
                   "sha256:d967d6bbb33bf7a295a64807f81875c84e82a8ecc59b6c72fe955141b1660d39",
                   "sha256:e76ffaf54db6ac36f0aa56c8013431c352c6187c8d674c6d468e25c573e31597",
                   "sha256:38e2d7fd362b10b71aa0b357331314d0f370a35185dfa31818c899cbb56ff610",
@@ -750,9 +741,6 @@
                   "sha256:9ee6c231a808d732e85a1e31df05ce55388315709206df944f3afe9531a8442a",
                   "sha256:0612728d1655cc06a5897c2077d3e3fbf29891941211916f487203761970f5f7",
                   "sha256:9b74d2ef03a55cb9f830ba60734a8861b5d88cffeb78778e1c75557b127fa08c",
-                  "sha256:c8915f9ca548e02f73a7f2f37990820e958061e3ad0c779c92bcb39c0a4cb544",
-                  "sha256:3386ebe6e649b2cb6a4b3eef260d68f3c165d9ccf54b4e6767ee064aa32d3334",
-                  "sha256:f352a944211785838da583ab23741b774ec62abe8c0e0582a7558ce41ade2efd",
                   "sha256:cbcade4487fbf372b487b9f82ed85e04ff037551c96c4b461abc3716338ff9c4",
                   "sha256:f16942e337972452994ad32c3e5a5385450eb46857b8fba61aa11b764c484eef",
                   "sha256:0854686cc3009d2fdf8baf48cbef87c58b10baf85302e7061b25cc64a1848e64",
@@ -766,7 +754,6 @@
                   "sha256:ff4c97e0df6ed6090ef36ac853e11bed9aa13f657be1d068ac09ad33c11432cb",
                   "sha256:654d9074dc8ebb93230fe258188a17ba3f7dbac2f360f9f79cc4fb1516953018",
                   "sha256:44999c555a6e4bb6cf5e6f6a79819e76912d036732cb50efaeefc20a180dd839",
-                  "sha256:eec162a2757ee2ffbbee95e1dbcd33318119e5113e53af877ce9416529a19082",
                   "sha256:8213aa26dbe71291c0cd5969256f3f0bce13ee8e8cd76e3b949c1f6752142471",
                   "sha256:3efd6a2548813167fe37718546bc768a5aa8ba59aa80edcecd8ba408bec329b0",
                   "sha256:8beb58e28b4dd11a952e24c442b696416ce7a756016fe8147cc66be6fc01a9db",
@@ -1289,19 +1276,6 @@
             }
           },
           {
-            "type": "org.osbuild.rhsm",
-            "options": {
-              "dnf-plugins": {
-                "product-id": {
-                  "enabled": false
-                },
-                "subscription-manager": {
-                  "enabled": false
-                }
-              }
-            }
-          },
-          {
             "type": "org.osbuild.fstab",
             "options": {
               "filesystems": [
@@ -1543,9 +1517,6 @@
           "sha256:0221e6e3671c2bd130e9519a7b352404b7e510584b4707d38e1a733e19c7f74f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-appstream-20210827/Packages/libxcb-1.13.1-1.el8.x86_64.rpm"
           },
-          "sha256:0265d45b4e949d977cef57a2d95f6d22ef906a05a5c7fbd486464bb1d55655e9": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20210827/Packages/dnf-plugin-subscription-manager-1.28.20-1.el8.x86_64.rpm"
-          },
           "sha256:02d728cf74eb47005babeeab5ac68ca04472c643203a1faef0037b5f33710fe2": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20210827/Packages/libsigsegv-2.11-5.el8.x86_64.rpm"
           },
@@ -1629,9 +1600,6 @@
           },
           "sha256:10814d88ff647e12aeceae4c3815f9eeb66ce7327099c642f934a391fd915f2c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20210827/Packages/iwl3160-firmware-25.30.13.0-103.el8.1.noarch.rpm"
-          },
-          "sha256:109d6db30e5515601b00954b2fd8750c421730a18afc12e1fa7781e24e5b0863": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20210827/Packages/python3-inotify-0.9.6-13.el8.noarch.rpm"
           },
           "sha256:10e88a1794107ea61f1441273be906704d66802b21800b0840a2870cad8b4d63": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20210827/Packages/cpio-2.12-10.el8.x86_64.rpm"
@@ -1819,9 +1787,6 @@
           "sha256:30fab73ee155f03dbbd99c1e30fe59dfba4ae8fdb2e7213451ccc36d6918bfcc": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20210827/Packages/libmnl-1.0.4-6.el8.x86_64.rpm"
           },
-          "sha256:3386ebe6e649b2cb6a4b3eef260d68f3c165d9ccf54b4e6767ee064aa32d3334": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20210827/Packages/subscription-manager-cockpit-1.28.20-1.el8.noarch.rpm"
-          },
           "sha256:33996f2476ed82d68353ac5c6d22c204db4ee76821eefc4c0cc2dafcf44ae16b": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20210827/Packages/syslinux-6.04-5.el8.x86_64.rpm"
           },
@@ -1833,9 +1798,6 @@
           },
           "sha256:344051091b56f4b8e73232c38411878ccce64e7b323e6fe44f40cf8af0c117c3": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20210827/Packages/python3-rpm-4.14.3-15.el8.x86_64.rpm"
-          },
-          "sha256:34ab92d70d2d3ffb65b1893d34d7b40e4cfc528b920363fc85492afac0619453": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20210827/Packages/python3-subscription-manager-rhsm-1.28.20-1.el8.x86_64.rpm"
           },
           "sha256:3705a3d6c18aea20fd77cd44d91a33fdb5f15e8a8a8eae658ba952323261de94": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20210827/Packages/rpm-libs-4.14.3-15.el8.x86_64.rpm"
@@ -2220,9 +2182,6 @@
           },
           "sha256:7533e19781d1b7e354315b15ef3d3011a8f1eec8980f9e8a6c633af3a806db2a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20210827/Packages/dbus-libs-1.12.8-14.el8.x86_64.rpm"
-          },
-          "sha256:76acb678a5c1d93353d4f506e703ac9ce4925295d61c876f6a420e244102aaba": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20210827/Packages/rhsm-icons-1.28.20-1.el8.noarch.rpm"
           },
           "sha256:76d81e433a5291df491d2e289de9b33d4e5b98dcf48fd0a003c2767415d3e0aa": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20210827/Packages/gdbm-1.18-1.el8.x86_64.rpm"
@@ -2683,9 +2642,6 @@
           "sha256:c3794d79a690d94d03d59a045a9ff95b4967bd3846bf608ba45802680a8f3c2c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20210827/Packages/hostname-3.20-7.el8.0.1.x86_64.rpm"
           },
-          "sha256:c39a53566ad66d6db9e101ca9a6db316843a1d1f6f5ac5f2286c6028638a8ab7": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20210827/Packages/python3-dmidecode-3.12.2-15.el8.x86_64.rpm"
-          },
           "sha256:c3b8c553b166491d3114793e198cd1aad95e494d177af8d0dc7180b8b841124d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20210827/Packages/libmodman-2.0.1-17.el8.x86_64.rpm"
           },
@@ -2703,12 +2659,6 @@
           },
           "sha256:c6f27b6e01d80e756408e3c1451e4af00e7d02da0aa24402644c0785118753fe": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20210827/Packages/python3-setuptools-39.2.0-6.el8.noarch.rpm"
-          },
-          "sha256:c746d43bd63dd184b8c585dd7323e261567928e521e830720d4754fca76157e0": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20210827/Packages/python3-ethtool-0.14-3.el8.x86_64.rpm"
-          },
-          "sha256:c8915f9ca548e02f73a7f2f37990820e958061e3ad0c779c92bcb39c0a4cb544": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20210827/Packages/subscription-manager-1.28.20-1.el8.x86_64.rpm"
           },
           "sha256:c8c54c56bff9ca416c3ba6bccac483fb66c81a53d93a19420088715018ed5169": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20210827/Packages/libutempter-1.1.6-14.el8.x86_64.rpm"
@@ -2848,9 +2798,6 @@
           "sha256:e065695c34b4621a40793a64f1327b2cae6e39d4e8d2c70357bc0a2fb8ec4ee9": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20210827/Packages/libsss_nss_idmap-2.5.2-2.el8.x86_64.rpm"
           },
-          "sha256:e0bb5476b38e4cfe2425262c4fce180ec97a79c6a11cc3e170c9013fff712e21": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20210827/Packages/python3-cloud-what-1.28.20-1.el8.x86_64.rpm"
-          },
           "sha256:e0df63d8debeb6d2f736bae02756097af273c9c486255b03e5a89f2946b98ac9": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20210827/Packages/lshw-B.02.19.2-6.el8.x86_64.rpm"
           },
@@ -2926,9 +2873,6 @@
           "sha256:ee4413fda60078f82c3b209557f0fc730871bb2a24cc380db6d01b511322ac85": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-appstream-20210827/Packages/cairo-gobject-1.15.12-3.el8.x86_64.rpm"
           },
-          "sha256:eec162a2757ee2ffbbee95e1dbcd33318119e5113e53af877ce9416529a19082": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20210827/Packages/usermode-1.113-1.el8.x86_64.rpm"
-          },
           "sha256:ef86061338fa321c959cadc75ecbdfd405eebaa1042eec9d9c737d4d9d92568f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20210827/Packages/kbd-misc-2.0.4-10.el8.noarch.rpm"
           },
@@ -2943,9 +2887,6 @@
           },
           "sha256:f1ce23ee43c747a35367dada19ca200a7758c50955ccc44aa946b86b647077ca": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20210827/Packages/cracklib-dicts-2.9.6-15.el8.x86_64.rpm"
-          },
-          "sha256:f352a944211785838da583ab23741b774ec62abe8c0e0582a7558ce41ade2efd": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20210827/Packages/subscription-manager-rhsm-certificates-1.28.20-1.el8.x86_64.rpm"
           },
           "sha256:f46dee25409f262173a127102dd9c7a3aced4feecf935a2340a043c17b1f8c61": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20210827/Packages/e2fsprogs-1.45.6-2.el8.x86_64.rpm"
@@ -9551,16 +9492,6 @@
         "check_gpg": true
       },
       {
-        "name": "dnf-plugin-subscription-manager",
-        "epoch": 0,
-        "version": "1.28.20",
-        "release": "1.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20210827/Packages/dnf-plugin-subscription-manager-1.28.20-1.el8.x86_64.rpm",
-        "checksum": "sha256:0265d45b4e949d977cef57a2d95f6d22ef906a05a5c7fbd486464bb1d55655e9",
-        "check_gpg": true
-      },
-      {
         "name": "dnf-plugins-core",
         "epoch": 0,
         "version": "4.0.21",
@@ -11921,16 +11852,6 @@
         "check_gpg": true
       },
       {
-        "name": "python3-cloud-what",
-        "epoch": 0,
-        "version": "1.28.20",
-        "release": "1.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20210827/Packages/python3-cloud-what-1.28.20-1.el8.x86_64.rpm",
-        "checksum": "sha256:e0bb5476b38e4cfe2425262c4fce180ec97a79c6a11cc3e170c9013fff712e21",
-        "check_gpg": true
-      },
-      {
         "name": "python3-configobj",
         "epoch": 0,
         "version": "5.0.6",
@@ -11981,16 +11902,6 @@
         "check_gpg": true
       },
       {
-        "name": "python3-dmidecode",
-        "epoch": 0,
-        "version": "3.12.2",
-        "release": "15.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20210827/Packages/python3-dmidecode-3.12.2-15.el8.x86_64.rpm",
-        "checksum": "sha256:c39a53566ad66d6db9e101ca9a6db316843a1d1f6f5ac5f2286c6028638a8ab7",
-        "check_gpg": true
-      },
-      {
         "name": "python3-dnf",
         "epoch": 0,
         "version": "4.7.0",
@@ -12008,16 +11919,6 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20210827/Packages/python3-dnf-plugins-core-4.0.21-2.el8.noarch.rpm",
         "checksum": "sha256:28c0f457d67213319f0313d993a3b2f8a778a077b202cd75bf45eb2792949d32",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-ethtool",
-        "epoch": 0,
-        "version": "0.14",
-        "release": "3.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20210827/Packages/python3-ethtool-0.14-3.el8.x86_64.rpm",
-        "checksum": "sha256:c746d43bd63dd184b8c585dd7323e261567928e521e830720d4754fca76157e0",
         "check_gpg": true
       },
       {
@@ -12061,26 +11962,6 @@
         "check_gpg": true
       },
       {
-        "name": "python3-iniparse",
-        "epoch": 0,
-        "version": "0.4",
-        "release": "31.el8",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20210827/Packages/python3-iniparse-0.4-31.el8.noarch.rpm",
-        "checksum": "sha256:5c0957decce3babef9864904be13190b0072aef720e9f4ca820bab6c02a20178",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-inotify",
-        "epoch": 0,
-        "version": "0.9.6",
-        "release": "13.el8",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20210827/Packages/python3-inotify-0.9.6-13.el8.noarch.rpm",
-        "checksum": "sha256:109d6db30e5515601b00954b2fd8750c421730a18afc12e1fa7781e24e5b0863",
-        "check_gpg": true
-      },
-      {
         "name": "python3-jwt",
         "epoch": 0,
         "version": "1.6.1",
@@ -12108,16 +11989,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20210827/Packages/python3-libdnf-0.63.0-2.el8.x86_64.rpm",
         "checksum": "sha256:7d2455f252fc9bfd34323d0ca59bf2cab699f99d0a8e9d195d9f8ec384583f33",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-librepo",
-        "epoch": 0,
-        "version": "1.14.0",
-        "release": "2.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20210827/Packages/python3-librepo-1.14.0-2.el8.x86_64.rpm",
-        "checksum": "sha256:85d87a486cb17e81aa7af6b17564424e3baf726facea2f0b264e69a5f5709f1b",
         "check_gpg": true
       },
       {
@@ -12331,16 +12202,6 @@
         "check_gpg": true
       },
       {
-        "name": "python3-subscription-manager-rhsm",
-        "epoch": 0,
-        "version": "1.28.20",
-        "release": "1.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20210827/Packages/python3-subscription-manager-rhsm-1.28.20-1.el8.x86_64.rpm",
-        "checksum": "sha256:34ab92d70d2d3ffb65b1893d34d7b40e4cfc528b920363fc85492afac0619453",
-        "check_gpg": true
-      },
-      {
         "name": "python3-syspurpose",
         "epoch": 0,
         "version": "1.28.20",
@@ -12398,16 +12259,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20210827/Packages/readline-7.0-10.el8.x86_64.rpm",
         "checksum": "sha256:fea868a7d82a7b6f392260ed4afb472dc4428fd71eab1456319f423a845b5084",
-        "check_gpg": true
-      },
-      {
-        "name": "rhsm-icons",
-        "epoch": 0,
-        "version": "1.28.20",
-        "release": "1.el8",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20210827/Packages/rhsm-icons-1.28.20-1.el8.noarch.rpm",
-        "checksum": "sha256:76acb678a5c1d93353d4f506e703ac9ce4925295d61c876f6a420e244102aaba",
         "check_gpg": true
       },
       {
@@ -12671,36 +12522,6 @@
         "check_gpg": true
       },
       {
-        "name": "subscription-manager",
-        "epoch": 0,
-        "version": "1.28.20",
-        "release": "1.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20210827/Packages/subscription-manager-1.28.20-1.el8.x86_64.rpm",
-        "checksum": "sha256:c8915f9ca548e02f73a7f2f37990820e958061e3ad0c779c92bcb39c0a4cb544",
-        "check_gpg": true
-      },
-      {
-        "name": "subscription-manager-cockpit",
-        "epoch": 0,
-        "version": "1.28.20",
-        "release": "1.el8",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20210827/Packages/subscription-manager-cockpit-1.28.20-1.el8.noarch.rpm",
-        "checksum": "sha256:3386ebe6e649b2cb6a4b3eef260d68f3c165d9ccf54b4e6767ee064aa32d3334",
-        "check_gpg": true
-      },
-      {
-        "name": "subscription-manager-rhsm-certificates",
-        "epoch": 0,
-        "version": "1.28.20",
-        "release": "1.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20210827/Packages/subscription-manager-rhsm-certificates-1.28.20-1.el8.x86_64.rpm",
-        "checksum": "sha256:f352a944211785838da583ab23741b774ec62abe8c0e0582a7558ce41ade2efd",
-        "check_gpg": true
-      },
-      {
         "name": "sudo",
         "epoch": 0,
         "version": "1.8.29",
@@ -12828,16 +12649,6 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20210827/Packages/tzdata-2021a-1.el8.noarch.rpm",
         "checksum": "sha256:44999c555a6e4bb6cf5e6f6a79819e76912d036732cb50efaeefc20a180dd839",
-        "check_gpg": true
-      },
-      {
-        "name": "usermode",
-        "epoch": 0,
-        "version": "1.113",
-        "release": "1.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20210827/Packages/usermode-1.113-1.el8.x86_64.rpm",
-        "checksum": "sha256:eec162a2757ee2ffbbee95e1dbcd33318119e5113e53af877ce9416529a19082",
         "check_gpg": true
       },
       {
@@ -13804,7 +13615,6 @@
       "dmidecode-3.2-10.el8.x86_64",
       "dnf-4.7.0-2.el8.noarch",
       "dnf-data-4.7.0-2.el8.noarch",
-      "dnf-plugin-subscription-manager-1.28.20-1.el8.x86_64",
       "dnf-plugins-core-4.0.21-2.el8.noarch",
       "dosfstools-4.1-6.el8.x86_64",
       "dracut-049-188.git20210802.el8.x86_64",
@@ -14089,24 +13899,19 @@
       "python3-cairo-1.16.3-6.el8.x86_64",
       "python3-cffi-1.11.5-5.el8.x86_64",
       "python3-chardet-3.0.4-7.el8.noarch",
-      "python3-cloud-what-1.28.20-1.el8.x86_64",
       "python3-configobj-5.0.6-11.el8.noarch",
       "python3-cryptography-3.2.1-5.el8.x86_64",
       "python3-dateutil-2.6.1-6.el8.noarch",
       "python3-dbus-1.2.4-15.el8.x86_64",
       "python3-decorator-4.2.1-2.el8.noarch",
-      "python3-dmidecode-3.12.2-15.el8.x86_64",
       "python3-dnf-4.7.0-2.el8.noarch",
       "python3-dnf-plugins-core-4.0.21-2.el8.noarch",
-      "python3-ethtool-0.14-3.el8.x86_64",
       "python3-firewall-0.9.3-7.el8.noarch",
       "python3-gobject-3.28.3-2.el8.x86_64",
       "python3-gobject-base-3.28.3-2.el8.x86_64",
       "python3-gpg-1.13.1-9.el8.x86_64",
       "python3-hawkey-0.63.0-2.el8.x86_64",
       "python3-idna-2.5-5.el8.noarch",
-      "python3-iniparse-0.4-31.el8.noarch",
-      "python3-inotify-0.9.6-13.el8.noarch",
       "python3-jinja2-2.10.1-3.el8.noarch",
       "python3-jsonpatch-1.21-2.el8.noarch",
       "python3-jsonpointer-1.10-11.el8.noarch",
@@ -14114,7 +13919,6 @@
       "python3-jwt-1.6.1-2.el8.noarch",
       "python3-libcomps-0.1.16-2.el8.x86_64",
       "python3-libdnf-0.63.0-2.el8.x86_64",
-      "python3-librepo-1.14.0-2.el8.x86_64",
       "python3-libs-3.6.8-39.el8.x86_64",
       "python3-libselinux-2.9-5.el8.x86_64",
       "python3-libsemanage-2.9-6.el8.x86_64",
@@ -14144,7 +13948,6 @@
       "python3-six-1.11.0-8.el8.noarch",
       "python3-slip-0.6.4-11.el8.noarch",
       "python3-slip-dbus-0.6.4-11.el8.noarch",
-      "python3-subscription-manager-rhsm-1.28.20-1.el8.x86_64",
       "python3-syspurpose-1.28.20-1.el8.x86_64",
       "python3-systemd-234-8.el8.x86_64",
       "python3-unbound-1.7.3-17.el8.x86_64",
@@ -14154,7 +13957,6 @@
       "quota-nls-4.04-14.el8.noarch",
       "rdma-core-35.0-1.el8.x86_64",
       "readline-7.0-10.el8.x86_64",
-      "rhsm-icons-1.28.20-1.el8.noarch",
       "rootfiles-8.1-22.el8.noarch",
       "rpcbind-1.2.5-8.el8.x86_64",
       "rpm-4.14.3-15.el8.x86_64",
@@ -14185,9 +13987,6 @@
       "sssd-common-2.5.2-2.el8.x86_64",
       "sssd-kcm-2.5.2-2.el8.x86_64",
       "sssd-nfs-idmap-2.5.2-2.el8.x86_64",
-      "subscription-manager-1.28.20-1.el8.x86_64",
-      "subscription-manager-cockpit-1.28.20-1.el8.noarch",
-      "subscription-manager-rhsm-certificates-1.28.20-1.el8.x86_64",
       "sudo-1.8.29-7.el8.x86_64",
       "systemd-239-49.el8.x86_64",
       "systemd-libs-239-49.el8.x86_64",
@@ -14203,7 +14002,6 @@
       "tuned-2.16.0-1.el8.noarch",
       "tzdata-2021a-1.el8.noarch",
       "unbound-libs-1.7.3-17.el8.x86_64",
-      "usermode-1.113-1.el8.x86_64",
       "util-linux-2.32.1-28.el8.x86_64",
       "vim-minimal-8.0.1763-15.el8.x86_64",
       "virt-what-1.18-12.el8.x86_64",
@@ -14282,65 +14080,10 @@
       "user1:x:1000:1000::/home/user1:/bin/bash",
       "user2:x:1020:1050:description 2:/home/home2:/bin/sh"
     ],
-    "rhsm": {
-      "dnf-plugins": {
-        "product-id": {
-          "enabled": false
-        },
-        "subscription-manager": {
-          "enabled": false
-        }
-      },
-      "rhsm.conf": {
-        "logging": {
-          "default_log_level": "INFO"
-        },
-        "rhsm": {
-          "auto_enable_yum_plugins": "1",
-          "baseurl": "https://cdn.redhat.com",
-          "ca_cert_dir": "/etc/rhsm/ca/",
-          "consumercertdir": "/etc/pki/consumer",
-          "entitlementcertdir": "/etc/pki/entitlement",
-          "full_refresh_on_yum": "0",
-          "inotify": "1",
-          "manage_repos": "1",
-          "package_profile_on_trans": "0",
-          "pluginconfdir": "/etc/rhsm/pluginconf.d",
-          "plugindir": "/usr/share/rhsm-plugins",
-          "productcertdir": "/etc/pki/product",
-          "repo_ca_cert": "/etc/rhsm/ca/redhat-uep.pem",
-          "repomd_gpg_url": "",
-          "report_package_profile": "1"
-        },
-        "rhsmcertd": {
-          "auto_registration": "0",
-          "auto_registration_interval": "60",
-          "autoattachinterval": "1440",
-          "certcheckinterval": "240",
-          "disable": "0",
-          "splay": "1"
-        },
-        "server": {
-          "hostname": "subscription.rhsm.redhat.com",
-          "insecure": "0",
-          "no_proxy": "",
-          "port": "443",
-          "prefix": "/subscription",
-          "proxy_hostname": "",
-          "proxy_password": "",
-          "proxy_port": "",
-          "proxy_scheme": "http",
-          "proxy_user": "",
-          "ssl_verify_depth": "3"
-        }
-      }
-    },
     "rpm-verify": {
       "changed": {
         "/boot/efi/EFI/centos/grubx64.efi": ".......T.",
         "/etc/chrony.conf": "S.5....T.",
-        "/etc/dnf/plugins/product-id.conf": "..5....T.",
-        "/etc/dnf/plugins/subscription-manager.conf": ".......T.",
         "/etc/machine-id": ".M.......",
         "/proc": ".M.......",
         "/sys": ".M.......",
@@ -14386,8 +14129,6 @@
       "poweroff.target",
       "rdisc.service",
       "remote-cryptsetup.target",
-      "rhsm-facts.service",
-      "rhsm.service",
       "runlevel0.target",
       "serial-getty@.service",
       "sshd-keygen@.service",
@@ -14431,7 +14172,6 @@
       "qemu-guest-agent.service",
       "reboot.target",
       "remote-fs.target",
-      "rhsmcertd.service",
       "rpcbind.service",
       "rpcbind.socket",
       "rsyslog.service",
@@ -14590,9 +14330,6 @@
         ],
         "setroubleshoot.conf": [
           "d /run/setroubleshoot 711 setroubleshoot setroubleshoot -"
-        ],
-        "subscription-manager.conf": [
-          "d /run/rhsm 0755 root root -"
         ],
         "sudo.conf": [
           "d /run/sudo 0711 root root",

--- a/test/data/manifests/rhel_86-aarch64-ami-boot.json
+++ b/test/data/manifests/rhel_86-aarch64-ami-boot.json
@@ -958,17 +958,6 @@
             }
           },
           {
-            "type": "org.osbuild.systemd-logind",
-            "options": {
-              "filename": "00-getty-fixes.conf",
-              "config": {
-                "Login": {
-                  "NAutoVTs": 0
-                }
-              }
-            }
-          },
-          {
             "type": "org.osbuild.sysconfig",
             "options": {
               "kernel": {
@@ -990,6 +979,27 @@
                     "type": "Ethernet",
                     "userctl": true
                   }
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.rhsm",
+            "options": {
+              "subscription-manager": {
+                "rhsmcertd": {
+                  "auto_registration": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.systemd-logind",
+            "options": {
+              "filename": "00-getty-fixes.conf",
+              "config": {
+                "Login": {
+                  "NAutoVTs": 0
                 }
               }
             }
@@ -1046,16 +1056,6 @@
             "type": "org.osbuild.authselect",
             "options": {
               "profile": "sssd"
-            }
-          },
-          {
-            "type": "org.osbuild.rhsm",
-            "options": {
-              "subscription-manager": {
-                "rhsmcertd": {
-                  "auto_registration": true
-                }
-              }
             }
           },
           {

--- a/test/data/manifests/rhel_86-aarch64-ec2-boot.json
+++ b/test/data/manifests/rhel_86-aarch64-ec2-boot.json
@@ -969,17 +969,6 @@
             }
           },
           {
-            "type": "org.osbuild.systemd-logind",
-            "options": {
-              "filename": "00-getty-fixes.conf",
-              "config": {
-                "Login": {
-                  "NAutoVTs": 0
-                }
-              }
-            }
-          },
-          {
             "type": "org.osbuild.sysconfig",
             "options": {
               "kernel": {
@@ -1001,6 +990,30 @@
                     "type": "Ethernet",
                     "userctl": true
                   }
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.rhsm",
+            "options": {
+              "subscription-manager": {
+                "rhsm": {
+                  "manage_repos": false
+                },
+                "rhsmcertd": {
+                  "auto_registration": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.systemd-logind",
+            "options": {
+              "filename": "00-getty-fixes.conf",
+              "config": {
+                "Login": {
+                  "NAutoVTs": 0
                 }
               }
             }
@@ -1057,19 +1070,6 @@
             "type": "org.osbuild.authselect",
             "options": {
               "profile": "sssd"
-            }
-          },
-          {
-            "type": "org.osbuild.rhsm",
-            "options": {
-              "subscription-manager": {
-                "rhsm": {
-                  "manage_repos": false
-                },
-                "rhsmcertd": {
-                  "auto_registration": true
-                }
-              }
             }
           },
           {

--- a/test/data/manifests/rhel_86-x86_64-ami-boot.json
+++ b/test/data/manifests/rhel_86-x86_64-ami-boot.json
@@ -933,17 +933,6 @@
             }
           },
           {
-            "type": "org.osbuild.systemd-logind",
-            "options": {
-              "filename": "00-getty-fixes.conf",
-              "config": {
-                "Login": {
-                  "NAutoVTs": 0
-                }
-              }
-            }
-          },
-          {
             "type": "org.osbuild.sysconfig",
             "options": {
               "kernel": {
@@ -965,6 +954,27 @@
                     "type": "Ethernet",
                     "userctl": true
                   }
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.rhsm",
+            "options": {
+              "subscription-manager": {
+                "rhsmcertd": {
+                  "auto_registration": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.systemd-logind",
+            "options": {
+              "filename": "00-getty-fixes.conf",
+              "config": {
+                "Login": {
+                  "NAutoVTs": 0
                 }
               }
             }
@@ -1006,6 +1016,18 @@
             }
           },
           {
+            "type": "org.osbuild.dracut.conf",
+            "options": {
+              "filename": "ec2.conf",
+              "config": {
+                "add_drivers": [
+                  "nvme",
+                  "xen-blkfront"
+                ]
+              }
+            }
+          },
+          {
             "type": "org.osbuild.systemd.unit",
             "options": {
               "unit": "nm-cloud-setup.service",
@@ -1021,28 +1043,6 @@
             "type": "org.osbuild.authselect",
             "options": {
               "profile": "sssd"
-            }
-          },
-          {
-            "type": "org.osbuild.rhsm",
-            "options": {
-              "subscription-manager": {
-                "rhsmcertd": {
-                  "auto_registration": true
-                }
-              }
-            }
-          },
-          {
-            "type": "org.osbuild.dracut.conf",
-            "options": {
-              "filename": "ec2.conf",
-              "config": {
-                "add_drivers": [
-                  "nvme",
-                  "xen-blkfront"
-                ]
-              }
             }
           },
           {

--- a/test/data/manifests/rhel_86-x86_64-ec2-boot.json
+++ b/test/data/manifests/rhel_86-x86_64-ec2-boot.json
@@ -946,17 +946,6 @@
             }
           },
           {
-            "type": "org.osbuild.systemd-logind",
-            "options": {
-              "filename": "00-getty-fixes.conf",
-              "config": {
-                "Login": {
-                  "NAutoVTs": 0
-                }
-              }
-            }
-          },
-          {
             "type": "org.osbuild.sysconfig",
             "options": {
               "kernel": {
@@ -978,6 +967,30 @@
                     "type": "Ethernet",
                     "userctl": true
                   }
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.rhsm",
+            "options": {
+              "subscription-manager": {
+                "rhsm": {
+                  "manage_repos": false
+                },
+                "rhsmcertd": {
+                  "auto_registration": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.systemd-logind",
+            "options": {
+              "filename": "00-getty-fixes.conf",
+              "config": {
+                "Login": {
+                  "NAutoVTs": 0
                 }
               }
             }
@@ -1019,6 +1032,18 @@
             }
           },
           {
+            "type": "org.osbuild.dracut.conf",
+            "options": {
+              "filename": "ec2.conf",
+              "config": {
+                "add_drivers": [
+                  "nvme",
+                  "xen-blkfront"
+                ]
+              }
+            }
+          },
+          {
             "type": "org.osbuild.systemd.unit",
             "options": {
               "unit": "nm-cloud-setup.service",
@@ -1034,31 +1059,6 @@
             "type": "org.osbuild.authselect",
             "options": {
               "profile": "sssd"
-            }
-          },
-          {
-            "type": "org.osbuild.rhsm",
-            "options": {
-              "subscription-manager": {
-                "rhsm": {
-                  "manage_repos": false
-                },
-                "rhsmcertd": {
-                  "auto_registration": true
-                }
-              }
-            }
-          },
-          {
-            "type": "org.osbuild.dracut.conf",
-            "options": {
-              "filename": "ec2.conf",
-              "config": {
-                "add_drivers": [
-                  "nvme",
-                  "xen-blkfront"
-                ]
-              }
             }
           },
           {

--- a/test/data/manifests/rhel_86-x86_64-ec2_ha-boot.json
+++ b/test/data/manifests/rhel_86-x86_64-ec2_ha-boot.json
@@ -1133,17 +1133,6 @@
             }
           },
           {
-            "type": "org.osbuild.systemd-logind",
-            "options": {
-              "filename": "00-getty-fixes.conf",
-              "config": {
-                "Login": {
-                  "NAutoVTs": 0
-                }
-              }
-            }
-          },
-          {
             "type": "org.osbuild.sysconfig",
             "options": {
               "kernel": {
@@ -1165,6 +1154,30 @@
                     "type": "Ethernet",
                     "userctl": true
                   }
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.rhsm",
+            "options": {
+              "subscription-manager": {
+                "rhsm": {
+                  "manage_repos": false
+                },
+                "rhsmcertd": {
+                  "auto_registration": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.systemd-logind",
+            "options": {
+              "filename": "00-getty-fixes.conf",
+              "config": {
+                "Login": {
+                  "NAutoVTs": 0
                 }
               }
             }
@@ -1206,6 +1219,18 @@
             }
           },
           {
+            "type": "org.osbuild.dracut.conf",
+            "options": {
+              "filename": "ec2.conf",
+              "config": {
+                "add_drivers": [
+                  "nvme",
+                  "xen-blkfront"
+                ]
+              }
+            }
+          },
+          {
             "type": "org.osbuild.systemd.unit",
             "options": {
               "unit": "nm-cloud-setup.service",
@@ -1221,31 +1246,6 @@
             "type": "org.osbuild.authselect",
             "options": {
               "profile": "sssd"
-            }
-          },
-          {
-            "type": "org.osbuild.rhsm",
-            "options": {
-              "subscription-manager": {
-                "rhsm": {
-                  "manage_repos": false
-                },
-                "rhsmcertd": {
-                  "auto_registration": true
-                }
-              }
-            }
-          },
-          {
-            "type": "org.osbuild.dracut.conf",
-            "options": {
-              "filename": "ec2.conf",
-              "config": {
-                "add_drivers": [
-                  "nvme",
-                  "xen-blkfront"
-                ]
-              }
             }
           },
           {

--- a/test/data/manifests/rhel_86-x86_64-ec2_sap-boot.json
+++ b/test/data/manifests/rhel_86-x86_64-ec2_sap-boot.json
@@ -1184,17 +1184,6 @@
             }
           },
           {
-            "type": "org.osbuild.systemd-logind",
-            "options": {
-              "filename": "00-getty-fixes.conf",
-              "config": {
-                "Login": {
-                  "NAutoVTs": 0
-                }
-              }
-            }
-          },
-          {
             "type": "org.osbuild.sysconfig",
             "options": {
               "kernel": {
@@ -1216,6 +1205,30 @@
                     "type": "Ethernet",
                     "userctl": true
                   }
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.rhsm",
+            "options": {
+              "subscription-manager": {
+                "rhsm": {
+                  "manage_repos": false
+                },
+                "rhsmcertd": {
+                  "auto_registration": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.systemd-logind",
+            "options": {
+              "filename": "00-getty-fixes.conf",
+              "config": {
+                "Login": {
+                  "NAutoVTs": 0
                 }
               }
             }
@@ -1257,6 +1270,18 @@
             }
           },
           {
+            "type": "org.osbuild.dracut.conf",
+            "options": {
+              "filename": "ec2.conf",
+              "config": {
+                "add_drivers": [
+                  "nvme",
+                  "xen-blkfront"
+                ]
+              }
+            }
+          },
+          {
             "type": "org.osbuild.systemd.unit",
             "options": {
               "unit": "nm-cloud-setup.service",
@@ -1272,31 +1297,6 @@
             "type": "org.osbuild.authselect",
             "options": {
               "profile": "sssd"
-            }
-          },
-          {
-            "type": "org.osbuild.rhsm",
-            "options": {
-              "subscription-manager": {
-                "rhsm": {
-                  "manage_repos": false
-                },
-                "rhsmcertd": {
-                  "auto_registration": true
-                }
-              }
-            }
-          },
-          {
-            "type": "org.osbuild.dracut.conf",
-            "options": {
-              "filename": "ec2.conf",
-              "config": {
-                "add_drivers": [
-                  "nvme",
-                  "xen-blkfront"
-                ]
-              }
             }
           },
           {

--- a/test/data/manifests/rhel_90-aarch64-ami-boot.json
+++ b/test/data/manifests/rhel_90-aarch64-ami-boot.json
@@ -877,17 +877,6 @@
             }
           },
           {
-            "type": "org.osbuild.systemd-logind",
-            "options": {
-              "filename": "00-getty-fixes.conf",
-              "config": {
-                "Login": {
-                  "NAutoVTs": 0
-                }
-              }
-            }
-          },
-          {
             "type": "org.osbuild.sysconfig",
             "options": {
               "kernel": {
@@ -909,6 +898,17 @@
                     "type": "Ethernet",
                     "userctl": true
                   }
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.systemd-logind",
+            "options": {
+              "filename": "00-getty-fixes.conf",
+              "config": {
+                "Login": {
+                  "NAutoVTs": 0
                 }
               }
             }

--- a/test/data/manifests/rhel_90-aarch64-ami-boot.json
+++ b/test/data/manifests/rhel_90-aarch64-ami-boot.json
@@ -903,6 +903,16 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm",
+            "options": {
+              "subscription-manager": {
+                "rhsmcertd": {
+                  "auto_registration": true
+                }
+              }
+            }
+          },
+          {
             "type": "org.osbuild.systemd-logind",
             "options": {
               "filename": "00-getty-fixes.conf",
@@ -965,16 +975,6 @@
             "type": "org.osbuild.authselect",
             "options": {
               "profile": "sssd"
-            }
-          },
-          {
-            "type": "org.osbuild.rhsm",
-            "options": {
-              "subscription-manager": {
-                "rhsmcertd": {
-                  "auto_registration": true
-                }
-              }
             }
           },
           {

--- a/test/data/manifests/rhel_90-aarch64-ec2-boot.json
+++ b/test/data/manifests/rhel_90-aarch64-ec2-boot.json
@@ -914,6 +914,19 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm",
+            "options": {
+              "subscription-manager": {
+                "rhsm": {
+                  "manage_repos": false
+                },
+                "rhsmcertd": {
+                  "auto_registration": true
+                }
+              }
+            }
+          },
+          {
             "type": "org.osbuild.systemd-logind",
             "options": {
               "filename": "00-getty-fixes.conf",
@@ -976,19 +989,6 @@
             "type": "org.osbuild.authselect",
             "options": {
               "profile": "sssd"
-            }
-          },
-          {
-            "type": "org.osbuild.rhsm",
-            "options": {
-              "subscription-manager": {
-                "rhsm": {
-                  "manage_repos": false
-                },
-                "rhsmcertd": {
-                  "auto_registration": true
-                }
-              }
             }
           },
           {

--- a/test/data/manifests/rhel_90-aarch64-ec2-boot.json
+++ b/test/data/manifests/rhel_90-aarch64-ec2-boot.json
@@ -888,17 +888,6 @@
             }
           },
           {
-            "type": "org.osbuild.systemd-logind",
-            "options": {
-              "filename": "00-getty-fixes.conf",
-              "config": {
-                "Login": {
-                  "NAutoVTs": 0
-                }
-              }
-            }
-          },
-          {
             "type": "org.osbuild.sysconfig",
             "options": {
               "kernel": {
@@ -920,6 +909,17 @@
                     "type": "Ethernet",
                     "userctl": true
                   }
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.systemd-logind",
+            "options": {
+              "filename": "00-getty-fixes.conf",
+              "config": {
+                "Login": {
+                  "NAutoVTs": 0
                 }
               }
             }

--- a/test/data/manifests/rhel_90-x86_64-ami-boot.json
+++ b/test/data/manifests/rhel_90-x86_64-ami-boot.json
@@ -886,6 +886,16 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm",
+            "options": {
+              "subscription-manager": {
+                "rhsmcertd": {
+                  "auto_registration": true
+                }
+              }
+            }
+          },
+          {
             "type": "org.osbuild.systemd-logind",
             "options": {
               "filename": "00-getty-fixes.conf",
@@ -948,16 +958,6 @@
             "type": "org.osbuild.authselect",
             "options": {
               "profile": "sssd"
-            }
-          },
-          {
-            "type": "org.osbuild.rhsm",
-            "options": {
-              "subscription-manager": {
-                "rhsmcertd": {
-                  "auto_registration": true
-                }
-              }
             }
           },
           {

--- a/test/data/manifests/rhel_90-x86_64-ami-boot.json
+++ b/test/data/manifests/rhel_90-x86_64-ami-boot.json
@@ -943,6 +943,18 @@
             }
           },
           {
+            "type": "org.osbuild.dracut.conf",
+            "options": {
+              "filename": "ec2.conf",
+              "config": {
+                "add_drivers": [
+                  "nvme",
+                  "xen-blkfront"
+                ]
+              }
+            }
+          },
+          {
             "type": "org.osbuild.systemd.unit",
             "options": {
               "unit": "nm-cloud-setup.service",
@@ -958,18 +970,6 @@
             "type": "org.osbuild.authselect",
             "options": {
               "profile": "sssd"
-            }
-          },
-          {
-            "type": "org.osbuild.dracut.conf",
-            "options": {
-              "filename": "ec2.conf",
-              "config": {
-                "add_drivers": [
-                  "nvme",
-                  "xen-blkfront"
-                ]
-              }
             }
           },
           {

--- a/test/data/manifests/rhel_90-x86_64-ami-boot.json
+++ b/test/data/manifests/rhel_90-x86_64-ami-boot.json
@@ -860,17 +860,6 @@
             }
           },
           {
-            "type": "org.osbuild.systemd-logind",
-            "options": {
-              "filename": "00-getty-fixes.conf",
-              "config": {
-                "Login": {
-                  "NAutoVTs": 0
-                }
-              }
-            }
-          },
-          {
             "type": "org.osbuild.sysconfig",
             "options": {
               "kernel": {
@@ -892,6 +881,17 @@
                     "type": "Ethernet",
                     "userctl": true
                   }
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.systemd-logind",
+            "options": {
+              "filename": "00-getty-fixes.conf",
+              "config": {
+                "Login": {
+                  "NAutoVTs": 0
                 }
               }
             }

--- a/test/data/manifests/rhel_90-x86_64-ec2-boot.json
+++ b/test/data/manifests/rhel_90-x86_64-ec2-boot.json
@@ -959,6 +959,18 @@
             }
           },
           {
+            "type": "org.osbuild.dracut.conf",
+            "options": {
+              "filename": "ec2.conf",
+              "config": {
+                "add_drivers": [
+                  "nvme",
+                  "xen-blkfront"
+                ]
+              }
+            }
+          },
+          {
             "type": "org.osbuild.systemd.unit",
             "options": {
               "unit": "nm-cloud-setup.service",
@@ -974,18 +986,6 @@
             "type": "org.osbuild.authselect",
             "options": {
               "profile": "sssd"
-            }
-          },
-          {
-            "type": "org.osbuild.dracut.conf",
-            "options": {
-              "filename": "ec2.conf",
-              "config": {
-                "add_drivers": [
-                  "nvme",
-                  "xen-blkfront"
-                ]
-              }
             }
           },
           {

--- a/test/data/manifests/rhel_90-x86_64-ec2-boot.json
+++ b/test/data/manifests/rhel_90-x86_64-ec2-boot.json
@@ -873,17 +873,6 @@
             }
           },
           {
-            "type": "org.osbuild.systemd-logind",
-            "options": {
-              "filename": "00-getty-fixes.conf",
-              "config": {
-                "Login": {
-                  "NAutoVTs": 0
-                }
-              }
-            }
-          },
-          {
             "type": "org.osbuild.sysconfig",
             "options": {
               "kernel": {
@@ -905,6 +894,17 @@
                     "type": "Ethernet",
                     "userctl": true
                   }
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.systemd-logind",
+            "options": {
+              "filename": "00-getty-fixes.conf",
+              "config": {
+                "Login": {
+                  "NAutoVTs": 0
                 }
               }
             }

--- a/test/data/manifests/rhel_90-x86_64-ec2-boot.json
+++ b/test/data/manifests/rhel_90-x86_64-ec2-boot.json
@@ -899,6 +899,19 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm",
+            "options": {
+              "subscription-manager": {
+                "rhsm": {
+                  "manage_repos": false
+                },
+                "rhsmcertd": {
+                  "auto_registration": true
+                }
+              }
+            }
+          },
+          {
             "type": "org.osbuild.systemd-logind",
             "options": {
               "filename": "00-getty-fixes.conf",
@@ -961,19 +974,6 @@
             "type": "org.osbuild.authselect",
             "options": {
               "profile": "sssd"
-            }
-          },
-          {
-            "type": "org.osbuild.rhsm",
-            "options": {
-              "subscription-manager": {
-                "rhsm": {
-                  "manage_repos": false
-                },
-                "rhsmcertd": {
-                  "auto_registration": true
-                }
-              }
             }
           },
           {

--- a/test/data/manifests/rhel_90-x86_64-ec2_ha-boot.json
+++ b/test/data/manifests/rhel_90-x86_64-ec2_ha-boot.json
@@ -1093,6 +1093,19 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm",
+            "options": {
+              "subscription-manager": {
+                "rhsm": {
+                  "manage_repos": false
+                },
+                "rhsmcertd": {
+                  "auto_registration": true
+                }
+              }
+            }
+          },
+          {
             "type": "org.osbuild.systemd-logind",
             "options": {
               "filename": "00-getty-fixes.conf",
@@ -1155,19 +1168,6 @@
             "type": "org.osbuild.authselect",
             "options": {
               "profile": "sssd"
-            }
-          },
-          {
-            "type": "org.osbuild.rhsm",
-            "options": {
-              "subscription-manager": {
-                "rhsm": {
-                  "manage_repos": false
-                },
-                "rhsmcertd": {
-                  "auto_registration": true
-                }
-              }
             }
           },
           {

--- a/test/data/manifests/rhel_90-x86_64-ec2_ha-boot.json
+++ b/test/data/manifests/rhel_90-x86_64-ec2_ha-boot.json
@@ -1067,17 +1067,6 @@
             }
           },
           {
-            "type": "org.osbuild.systemd-logind",
-            "options": {
-              "filename": "00-getty-fixes.conf",
-              "config": {
-                "Login": {
-                  "NAutoVTs": 0
-                }
-              }
-            }
-          },
-          {
             "type": "org.osbuild.sysconfig",
             "options": {
               "kernel": {
@@ -1099,6 +1088,17 @@
                     "type": "Ethernet",
                     "userctl": true
                   }
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.systemd-logind",
+            "options": {
+              "filename": "00-getty-fixes.conf",
+              "config": {
+                "Login": {
+                  "NAutoVTs": 0
                 }
               }
             }

--- a/test/data/manifests/rhel_90-x86_64-ec2_ha-boot.json
+++ b/test/data/manifests/rhel_90-x86_64-ec2_ha-boot.json
@@ -1153,6 +1153,18 @@
             }
           },
           {
+            "type": "org.osbuild.dracut.conf",
+            "options": {
+              "filename": "ec2.conf",
+              "config": {
+                "add_drivers": [
+                  "nvme",
+                  "xen-blkfront"
+                ]
+              }
+            }
+          },
+          {
             "type": "org.osbuild.systemd.unit",
             "options": {
               "unit": "nm-cloud-setup.service",
@@ -1168,18 +1180,6 @@
             "type": "org.osbuild.authselect",
             "options": {
               "profile": "sssd"
-            }
-          },
-          {
-            "type": "org.osbuild.dracut.conf",
-            "options": {
-              "filename": "ec2.conf",
-              "config": {
-                "add_drivers": [
-                  "nvme",
-                  "xen-blkfront"
-                ]
-              }
             }
           },
           {

--- a/test/data/manifests/rhel_90-x86_64-ec2_sap-boot.json
+++ b/test/data/manifests/rhel_90-x86_64-ec2_sap-boot.json
@@ -1147,6 +1147,19 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm",
+            "options": {
+              "subscription-manager": {
+                "rhsm": {
+                  "manage_repos": false
+                },
+                "rhsmcertd": {
+                  "auto_registration": true
+                }
+              }
+            }
+          },
+          {
             "type": "org.osbuild.systemd-logind",
             "options": {
               "filename": "00-getty-fixes.conf",
@@ -1209,19 +1222,6 @@
             "type": "org.osbuild.authselect",
             "options": {
               "profile": "sssd"
-            }
-          },
-          {
-            "type": "org.osbuild.rhsm",
-            "options": {
-              "subscription-manager": {
-                "rhsm": {
-                  "manage_repos": false
-                },
-                "rhsmcertd": {
-                  "auto_registration": true
-                }
-              }
             }
           },
           {

--- a/test/data/manifests/rhel_90-x86_64-ec2_sap-boot.json
+++ b/test/data/manifests/rhel_90-x86_64-ec2_sap-boot.json
@@ -1121,17 +1121,6 @@
             }
           },
           {
-            "type": "org.osbuild.systemd-logind",
-            "options": {
-              "filename": "00-getty-fixes.conf",
-              "config": {
-                "Login": {
-                  "NAutoVTs": 0
-                }
-              }
-            }
-          },
-          {
             "type": "org.osbuild.sysconfig",
             "options": {
               "kernel": {
@@ -1153,6 +1142,17 @@
                     "type": "Ethernet",
                     "userctl": true
                   }
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.systemd-logind",
+            "options": {
+              "filename": "00-getty-fixes.conf",
+              "config": {
+                "Login": {
+                  "NAutoVTs": 0
                 }
               }
             }

--- a/test/data/manifests/rhel_90-x86_64-ec2_sap-boot.json
+++ b/test/data/manifests/rhel_90-x86_64-ec2_sap-boot.json
@@ -1207,6 +1207,18 @@
             }
           },
           {
+            "type": "org.osbuild.dracut.conf",
+            "options": {
+              "filename": "ec2.conf",
+              "config": {
+                "add_drivers": [
+                  "nvme",
+                  "xen-blkfront"
+                ]
+              }
+            }
+          },
+          {
             "type": "org.osbuild.systemd.unit",
             "options": {
               "unit": "nm-cloud-setup.service",
@@ -1222,18 +1234,6 @@
             "type": "org.osbuild.authselect",
             "options": {
               "profile": "sssd"
-            }
-          },
-          {
-            "type": "org.osbuild.dracut.conf",
-            "options": {
-              "filename": "ec2.conf",
-              "config": {
-                "add_drivers": [
-                  "nvme",
-                  "xen-blkfront"
-                ]
-              }
             }
           },
           {


### PR DESCRIPTION
### Goals
- Reduce `osPipeline` variants (`ec2BaseTreePipeline`, `osPipeline` and `ostreeTreePipeline`) to a single `osPipeline`, which handles all the potential OS customizations. Nevertheless there are still other pipeline functions which handle pieces of customizations (mostly related to EDGE images).
- Do not hardcode any default configuration values in the `osPipeline` to prevent us from having to introduce yet another variant of the function in case a new image type needs different defaults (e.g. timezone or keyboard layout).

### Approach

- Introduce a new data structure `ImageConfig`, which holds the default configuration values for a specific image. There are however still some configuration values left in the `imageType` structure, which could be moved to the `ImageConfig` structure.
- The `ImageConfig` is defined on the distribution level, providing defaults for the whole distro.
- Specific image types can define their own `ImageConfig` which extends and/or overrides options set in the distribution-wide default configuration. The way this works is that any options not set on the Image Type-level are inherited from the distribution defaults. For options which are set in both, the distribution and image type, the image type option is preferred.
- The `osPipeline` becomes a generic function (which could be even shared among distributions), which simply adds appropriate stages to the OS pipeline based on the default Image Type configuration and user-provided BP customizations.

### Changes

- The patch set first gradually modifies the RHEL-90 pipelines with the goal to replace `ec2BaseTreePipeline` and `ostreeTreePipeline` by `osPipeline`.
- Configuration values previously hard-coded in `ec2BaseTreePipeline`, `osPipeline` and `ostreeTreePipeline` are moved to `ImageConfig` structure instances defined in the distribution and respective image types.
- Image test cases are regenerated in every commit that could affect them, so that it is clear which commit changed what.
- As part of the pipeline functions unification, the subscription customizations and RHSM configuration stages are now applied only to RHEL variant of the distribution (meaning not applied on CentOS Stream). In addition, no `subscription-manager` packages are installed any more on CentOS Stream images. This reflects upstream CentOS Stream image definitions. Details are explained in the respective commits.
- As the last step, the pipeline refactoring done for RHEL-90 is applied as a whole to RHEL-86.

### Notable points

- While there are some changes in the image manifests, these are mainly related to reordering of stages in the `os` pipeline resulting from the pipeline functions consolidation. These changes have no effect on the resulting image that is produced, which is apparent from no changes in the `image-info` report.
- The only changes in image test cases, which resulted in changes in the `image-info` report, are related to CentOS Stream images due to the subscriptions and RHSM configuration being applied only on RHEL and `subscription-manager` packages not being installed by default on CentOS Stream.
- The huge number of added lines in this PR comes from two added image test cases, which were previously forgotten to be generated:
  - `centos_8-ppc64le-qcow2-boot.json`
  - `centos_8-ppc64le-qcow2_customize-boot.json`

### Ideas

- Having the image configuration represented as a data structure (`ImageConfig`) can prove to be handy to represent a specific variant of any image. E.g. we could have a default definition of what it means for an image to be a SAP image (configuration-wise) and potentially easily apply it to an existing image type configuration. There may be definitely differences in the needed configuration for a specific footprint, but even then it should be easier to share the common parts.
- In an ideal case, we could end up with just generic functions defined in `<distro>/pipelines.go`, which could be eventually shared among all the distro definitions. The core of what is a distro would become the content, configuration and export format of images, which could be hopefully represented just as a data, not as as a code.

This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`
-->
