### PR TITLE
weldr: return an error if host distro wasn't found in distro registry

### DIFF
--- a/internal/weldr/api.go
+++ b/internal/weldr/api.go
@@ -155,6 +155,10 @@ func New(repoPaths []string, stateDir string, rpm rpmmd.RPMMD, dr *distroregistr
 	archName := common.CurrentArch()
 
 	hostDistro := dr.GetDistro(hostDistroName)
+	if hostDistro == nil {
+		return nil, fmt.Errorf("host distro is not supported")
+	}
+
 	hostArch, err := hostDistro.GetArch(archName)
 	if err != nil {
 		return nil, fmt.Errorf("Host distro does not support host architecture: %v", err)


### PR DESCRIPTION
Prevents a nil panic, see rhbz#2035956

Signed-off-by: Ondřej Budai <ondrej@budai.cz>


This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`
-->
