### PR TITLE
test: split test script regression behind satellite

### DIFF
--- a/test/cases/regression.sh
+++ b/test/cases/regression.sh
@@ -14,6 +14,7 @@ TEST_CASES=(
     "regression-excluded-dependency.sh"
     "regression-include-excluded-packages.sh"
     "regression-composer-works-behind-satellite.sh"
+    "regression-composer-works-behind-satellite-fallback.sh"
 )
 
 # Print out a nice test divider so we know when tests stop and start.


### PR DESCRIPTION
The test script regression-composer-works-behind-satellite.sh should be split in two parts to make it more visible and also because it contains two scenarios that are independent.

This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/