### PR TITLE
Packer improvements

### DIFF
--- a/templates/packer/README.md
+++ b/templates/packer/README.md
@@ -1,0 +1,95 @@
+# osbuild-composer Packer configuration
+
+This directory contains a packer configuration for building osbuild-composer
+worker AMIs based on RHEL.
+
+## Running packer locally
+
+Run the following command in the root directory of this repository:
+```
+PKR_VAR_aws_access_key="" \
+PKR_VAR_aws_secret_key="" \
+PKR_VAR_image_name=YOUR_UNIQUE_IMAGE_NAME \
+PKR_VAR_composer_commit=OSBUILD_COMPOSER_COMMIT_SHA \
+PKR_VAR_osbuild_commit=OSBUILD_COMMIT_SHA \
+  packer build templates/packer
+```
+
+## Launching an instance from the built AMI
+
+The AMI expects that cloud-init is used to create a `/tmp/cloud_init_vars`
+file that contains configuration values for the particular instance.
+
+The following block shows an example of such a file. The order of the
+key-value pairs is not fixed but all of them are required.
+
+```
+# Domain name of the composer instance that the worker connects to
+COMPOSER_HOST=api.stage.openshift.com
+
+# Port number of the composer instance that the worker connects to
+COMPOSER_PORT=443
+
+# AWS ARN of a secret containing a OAuth offline token that is used to authenticate to composer
+# The secret contains only one key "offline_token". Its value is the offline token to be used. 
+OFFLINE_TOKEN_ARN=arn:aws:secretsmanager:us-east-1:123456789012:secret:offline-token-abcdef
+
+# AWS ARN of a secret containing a command to subscribe the instance using subscription-manager
+# The secrets contains only one key "subscription_manager_command" that contains the subscription-manager command
+SUBSCRIPTION_MANAGER_COMMAND_ARN=arn:aws:secretsmanager:us-east-1:123456789012:secret:subscription-manager-command-abcdef
+
+# AWS ARN of a secret containing GCP service account credentials
+# The secret contains a JSON key file, see https://cloud.google.com/docs/authentication/getting-started
+GCP_SERVICE_ACCOUNT_IMAGE_BUILDER_ARN=arn:aws:secretsmanager:us-east-1:123456789012:secret:gcp_service_account_image_builder-abcdef
+
+# AWS ARN of a secret containing Azure account credentials
+# The secret contains two keys: "client_secret" and "client_id".
+AZURE_ACCOUNT_IMAGE_BUILDER_ARN=arn:aws:secretsmanager:us-east-1:123456789012:secret:azure_account_image_builder-abcdef
+
+# AWS ARN of a secret containing AWS account credentials
+# The secret contains two keys: "access_key_id" and "secret_access_key".
+AWS_ACCOUNT_IMAGE_BUILDER_ARN=arn:aws:secretsmanager:us-east-1:123456789012:secret:aws_account_image_builder-abcdef
+
+# The auto-generated EC2 instance ID is prefixed with this string to simplify searching in logs
+SYSTEM_HOSTNAME_PREFIX=staging-worker-aoc
+
+# Endpoint URL for AWS Secrets Manager
+SECRETS_MANAGER_ENDPOINT_URL=https://secretsmanager.us-east-1.amazonaws.com/
+
+# Endpoint URL for AWS Cloudwatch Logs
+CLOUDWATCH_LOGS_ENDPOINT_URL=https://logs.us-east-1.amazonaws.com/
+
+# AWS Cloudwatch log group that the instance logs into
+CLOUDWATCH_LOG_GROUP=staging_workers_aoc
+```
+
+### IAM considerations
+The instance must have a IAM policy attached that permits it:
+
+- to access all configured secrets
+- to create new log streams in the configured log group and to put log entried in them
+
+
+### Cloud-init example
+
+The simplest way is to inject the file is to just use cloud-init's
+`write_files` directive:
+
+```
+#cloud-config
+
+write_files:
+  - path: /tmp/cloud_init_vars
+    content: |
+      COMPOSER_HOST=api.stage.openshift.com
+      COMPOSER_PORT=443 
+      OFFLINE_TOKEN_ARN=arn:aws:secretsmanager:us-east-1:123456789012:secret:offline-token-abcdef
+      SUBSCRIPTION_MANAGER_COMMAND_ARN=arn:aws:secretsmanager:us-east-1:123456789012:secret:subscription-manager-command-abcdef
+      GCP_SERVICE_ACCOUNT_IMAGE_BUILDER_ARN=arn:aws:secretsmanager:us-east-1:123456789012:secret:gcp_service_account_image_builder-abcdef
+      AZURE_ACCOUNT_IMAGE_BUILDER_ARN=arn:aws:secretsmanager:us-east-1:123456789012:secret:azure_account_image_builder-abcdef
+      AWS_ACCOUNT_IMAGE_BUILDER_ARN=arn:aws:secretsmanager:us-east-1:123456789012:secret:aws_account_image_builder-abcdef
+      SYSTEM_HOSTNAME_PREFIX=staging-worker-aoc
+      SECRETS_MANAGER_ENDPOINT_URL=https://secretsmanager.us-east-1.amazonaws.com/
+      CLOUDWATCH_LOGS_ENDPOINT_URL=https://logs.us-east-1.amazonaws.com/
+      CLOUDWATCH_LOG_GROUP=staging_workers_aoc
+```

--- a/templates/packer/ansible/roles/common/files/worker-initialization-scripts/offline_token.sh
+++ b/templates/packer/ansible/roles/common/files/worker-initialization-scripts/offline_token.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -euo pipefail
+source /tmp/cloud_init_vars
+
+echo "Writing offline token."
+
+# get offline token
+/usr/local/bin/aws secretsmanager get-secret-value \
+  --endpoint-url "${SECRETS_MANAGER_ENDPOINT_URL}" \
+  --secret-id "${OFFLINE_TOKEN_ARN}" | jq -r ".SecretString" > /tmp/offline-token.json
+
+mkdir /etc/osbuild-worker
+jq -r ".offline_token" /tmp/offline-token.json > /etc/osbuild-worker/offline-token
+rm -f /tmp/offline-token.json

--- a/templates/packer/ansible/roles/common/files/worker-initialization-scripts/set_hostname.sh
+++ b/templates/packer/ansible/roles/common/files/worker-initialization-scripts/set_hostname.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -euo pipefail
+source /tmp/cloud_init_vars
+
+# Get the instance ID.
+INSTANCE_ID=$(curl -Ls http://169.254.169.254/latest/meta-data/instance-id)
+
+# Assemble hostname.
+FULL_HOSTNAME="${SYSTEM_HOSTNAME_PREFIX}-${INSTANCE_ID}"
+
+# Print out the new hostname.
+echo "Setting system hostname to ${FULL_HOSTNAME}."
+
+# Set the system hostname.
+hostnamectl set-hostname "$FULL_HOSTNAME"

--- a/templates/packer/ansible/roles/common/files/worker-initialization-scripts/subscription_manager.sh
+++ b/templates/packer/ansible/roles/common/files/worker-initialization-scripts/subscription_manager.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -euo pipefail
+source /tmp/cloud_init_vars
+
+echo "Subscribing instance to RHN."
+
+# Register the instance with RHN.
+# TODO: don't store the command in a secret, only the key/org-id
+/usr/local/bin/aws secretsmanager get-secret-value \
+  --endpoint-url "${SECRETS_MANAGER_ENDPOINT_URL}" \
+  --secret-id "${SUBSCRIPTION_MANAGER_COMMAND_ARN}" | jq -r ".SecretString" > /tmp/subscription_manager_command.json
+jq -r ".subscription_manager_command" /tmp/subscription_manager_command.json | bash
+rm -f /tmp/subscription_manager_command.json
+
+subscription-manager attach --auto

--- a/templates/packer/ansible/roles/common/files/worker-initialization-scripts/vector.sh
+++ b/templates/packer/ansible/roles/common/files/worker-initialization-scripts/vector.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+set -euo pipefail
+source /tmp/cloud_init_vars
+
+echo "Writing vector config."
+
+sudo mkdir -p /etc/vector
+sudo tee /etc/vector/vector.toml > /dev/null << EOF
+[sources.journald]
+type = "journald"
+exclude_units = ["vector.service"]
+
+[sinks.out]
+type = "aws_cloudwatch_logs"
+inputs = [ "journald" ]
+endpoint = "${CLOUDWATCH_LOGS_ENDPOINT_URL}"
+group_name = "${CLOUDWATCH_LOG_GROUP}"
+stream_name = "worker_syslog_{{ host }}"
+encoding.codec = "json"
+EOF
+
+sudo systemctl enable --now vector

--- a/templates/packer/ansible/roles/common/files/worker-initialization-scripts/worker_external_creds.sh
+++ b/templates/packer/ansible/roles/common/files/worker-initialization-scripts/worker_external_creds.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+set -euo pipefail
+source /tmp/cloud_init_vars
+
+echo "Deploy cloud credentials for workers."
+
+# Deploy the GCP Service Account credentials file.
+/usr/local/bin/aws secretsmanager get-secret-value \
+  --endpoint-url "${SECRETS_MANAGER_ENDPOINT_URL}" \
+  --secret-id "${GCP_SERVICE_ACCOUNT_IMAGE_BUILDER_ARN}" | jq -r ".SecretString" > /etc/osbuild-worker/gcp_credentials.json
+
+# Deploy the Azure credentials file.
+/usr/local/bin/aws secretsmanager get-secret-value \
+  --endpoint-url "${SECRETS_MANAGER_ENDPOINT_URL}" \
+  --secret-id "${AZURE_ACCOUNT_IMAGE_BUILDER_ARN}" | jq -r ".SecretString" > /tmp/azure_credentials.json
+CLIENT_ID=$(jq -r ".client_id" /tmp/azure_credentials.json)
+CLIENT_SECRET=$(jq -r ".client_secret" /tmp/azure_credentials.json)
+rm /tmp/azure_credentials.json
+
+sudo tee /etc/osbuild-worker/azure_credentials.toml > /dev/null << EOF
+client_id =     "$CLIENT_ID"
+client_secret = "$CLIENT_SECRET"
+EOF
+
+# Deploy the AWS credentials file if the secret ARN was set.
+if [[ -n "$AWS_ACCOUNT_IMAGE_BUILDER_ARN" ]]; then
+  /usr/local/bin/aws secretsmanager get-secret-value \
+    --endpoint-url "${SECRETS_MANAGER_ENDPOINT_URL}" \
+    --secret-id "${AWS_ACCOUNT_IMAGE_BUILDER_ARN}" | jq -r ".SecretString" > /tmp/aws_credentials.json
+  ACCESS_KEY_ID=$(jq -r ".access_key_id" /tmp/aws_credentials.json)
+  SECRET_ACCESS_KEY=$(jq -r ".secret_access_key" /tmp/aws_credentials.json)
+  rm /tmp/aws_credentials.json
+
+  sudo tee /etc/osbuild-worker/aws_credentials.toml > /dev/null << EOF
+[default]
+aws_access_key_id = "$ACCESS_KEY_ID"
+aws_secret_access_key = "$SECRET_ACCESS_KEY"
+EOF
+
+fi

--- a/templates/packer/ansible/roles/common/files/worker-initialization-scripts/worker_service.sh
+++ b/templates/packer/ansible/roles/common/files/worker-initialization-scripts/worker_service.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+set -euo pipefail
+source /tmp/cloud_init_vars
+
+echo "Setting up worker services."
+
+sudo tee /etc/osbuild-worker/osbuild-worker.toml > /dev/null << EOF
+base_path = "/api/image-builder-worker/v1"
+[authentication]
+oauth_url = "https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token"
+offline_token = "/etc/osbuild-worker/offline-token"
+[gcp]
+credentials = "/etc/osbuild-worker/gcp_credentials.json"
+[azure]
+credentials = "/etc/osbuild-worker/azure_credentials.toml"
+[aws]
+credentials = "/etc/osbuild-worker/aws_credentials.toml"
+EOF
+
+# Prepare osbuild-composer's remote worker services and sockets.
+systemctl enable --now "osbuild-remote-worker@${COMPOSER_HOST}:${COMPOSER_PORT}"
+
+# Now that everything is configured, ensure monit is monitoring everything.
+systemctl enable --now monit

--- a/templates/packer/ansible/roles/common/files/worker-initialization.service
+++ b/templates/packer/ansible/roles/common/files/worker-initialization.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=Worker Initialization Service
+ConditionPathExists=!/etc/worker-first-boot
+Wants=cloud-final.service
+After=cloud-final.service
+
+[Service]
+Type=oneshot
+ExecStart=touch /etc/worker-first-boot
+ExecStart=/usr/local/libexec/worker-initialization-scripts/set_hostname.sh
+ExecStart=/usr/local/libexec/worker-initialization-scripts/vector.sh
+ExecStart=/usr/local/libexec/worker-initialization-scripts/offline_token.sh
+ExecStart=/usr/local/libexec/worker-initialization-scripts/subscription_manager.sh
+ExecStart=/usr/local/libexec/worker-initialization-scripts/worker_external_creds.sh
+ExecStart=/usr/local/libexec/worker-initialization-scripts/worker_service.sh
+
+[Install]
+WantedBy=multi-user.target

--- a/templates/packer/ansible/roles/common/tasks/main.yml
+++ b/templates/packer/ansible/roles/common/tasks/main.yml
@@ -6,5 +6,8 @@
 # Configure monitoring.
 - include_tasks: monitoring.yml
 
+# Configure worker initialization service.
+- include_tasks: worker-initialization-service.yml
+
 - name: Ensure SELinux contexts are updated
   command: restorecon -Rv /etc

--- a/templates/packer/ansible/roles/common/tasks/worker-initialization-service.yml
+++ b/templates/packer/ansible/roles/common/tasks/worker-initialization-service.yml
@@ -1,0 +1,26 @@
+---
+
+- name: Copy worker initialization service
+  copy:
+    src: "{{ playbook_dir }}/roles/common/files/worker-initialization.service"
+    dest: /etc/systemd/system/
+
+- name: Enable worker initialization service
+  systemd:
+    name: worker-initialization.service
+    enabled: yes
+    daemon_reload: yes # make sure the new service is loaded before enabling it
+
+- name: Create a directory for initialization scripts
+  file:
+    path: /usr/local/libexec/worker-initialization-scripts
+    state: directory
+
+- name: Copy scripts used by the initialization service
+  copy:
+    src: "{{ item }}"
+    dest: /usr/local/libexec/worker-initialization-scripts
+    mode: preserve
+  with_fileglob:
+    - "{{ playbook_dir }}/roles/common/files/worker-initialization-scripts/*"
+

--- a/templates/packer/ansible/roles/common/templates/monitrc.j2
+++ b/templates/packer/ansible/roles/common/templates/monitrc.j2
@@ -26,14 +26,6 @@ CHECK FILESYSTEM root PATH /
     then exec {{ pozorbot_script }}
     else if succeeded then exec {{ pozorbot_script }}
 
-# Ensure the osbuild-composer filesystem isn't full.
-CHECK FILESYSTEM composer_persistent PATH /var/lib/osbuild-composer
-  if space usage > 80%
-    for 5 times
-    within 15 cycles
-    then exec {{ pozorbot_script }}
-    else if succeeded then exec {{ pozorbot_script }}
-
 # Check to see if we can reach cdn.redhat.com.
 # NOTE(mhayden): We will always get a 403 here because of client certs.
 CHECK HOST rhel_cdn WITH ADDRESS cdn.redhat.com

--- a/templates/packer/composer.pkr.hcl
+++ b/templates/packer/composer.pkr.hcl
@@ -5,8 +5,8 @@ source "amazon-ebs" "image_builder" {
   secret_key = var.aws_secret_key
   region = var.region
 
-  # Use a static RHEL Cloud Access Image.
-  source_ami          = "ami-0b0af3577fe5e3532"
+  # Use a static RHEL 8.5 Cloud Access Image.
+  source_ami          = "ami-06f1e6f8b3457ae7c"
 
   # Remove previous image before making the new one.
   force_deregister = true


### PR DESCRIPTION
Three commits:
- bump the RHEL version to 8.5
- move configuration scripts from terraform to packer
- remove a broken monit check

The most important is the move of configuration. Previously, we had a huge cloud-init user-data configuration. With this change, all this configuration now lives inside the image and cloud-init must only provide a static file with several values. This should greatly help with testability.

The new image was tested manually and it's awesome. I also added some docs.

This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [x] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`
-->
