### PR TITLE
ci: enable zure testing on centos-8

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -334,12 +334,6 @@ Integration:
           - aws/fedora-33-x86_64
           # See COMPOSER-919
           # - aws/fedora-34-x86_64
-          # See COMPOSER-1118
-          # - aws/centos-stream-8-x86_64
-      - SCRIPT:
-          - koji.sh
-          - aws.sh
-        RUNNER:
           - aws/centos-stream-8-x86_64
       - <<: *INTEGRATION_TESTS
         RUNNER:


### PR DESCRIPTION
this test was disabled because it blocked CI, to be solved later. See
[COMPOSER-1118](https://drive.google.com/file/d/10XamNYu7lOpDUcfvBUm8sW51JL3eO_QI/view)

Related [PR](https://github.com/osbuild/osbuild-composer/pull/1758)

This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/