### PR TITLE
tools/provision: community.general ansible collection for RHEL 8.6

### DIFF
--- a/test/data/ansible/check_ostree.yaml
+++ b/test/data/ansible/check_ostree.yaml
@@ -43,12 +43,12 @@
 
     # case: check ostree commit correctly updated
     - name: get deployed ostree commit
-      command: rpm-ostree status --json
+      shell: rpm-ostree status --json | jq -r '.deployments[0].checksum'
       register: result_commit
 
     - name: make a json result
       set_fact:
-        deploy_commit: "{{ result_commit.stdout | from_json | json_query('deployments[0].checksum') }}"
+        deploy_commit: "{{ result_commit.stdout }}"
 
     - name: check commit deployed and built
       block:
@@ -468,12 +468,12 @@
     - name: check ostree commit after rollback
       block:
         - name: check ostree commit after rollback
-          command: rpm-ostree status --json
+          shell: rpm-ostree status --json | jq -r '.deployments[0].checksum'
           register: result_commit
 
         - name: make a json result
           set_fact:
-            deploy_commit: "{{ result_commit.stdout | from_json | json_query('deployments[0].checksum') }}"
+            deploy_commit: "{{ result_commit.stdout }}"
 
         - assert:
             that:

--- a/test/data/ansible/check_ostree_nort.yaml
+++ b/test/data/ansible/check_ostree_nort.yaml
@@ -26,12 +26,12 @@
 
     # case: check ostree commit correctly updated
     - name: get deployed ostree commit
-      command: rpm-ostree status --json
+      shell: rpm-ostree status --json | jq -r '.deployments[0].checksum'
       register: result_commit
 
     - name: make a json result
       set_fact:
-        deploy_commit: "{{ result_commit.stdout | from_json | json_query('deployments[0].checksum') }}"
+        deploy_commit: "{{ result_commit.stdout }}"
 
     - name: check commit deployed and built
       block:
@@ -451,12 +451,12 @@
     - name: check ostree commit after rollback
       block:
         - name: check ostree commit after rollback
-          command: rpm-ostree status --json
+          shell: rpm-ostree status --json | jq -r '.deployments[0].checksum'
           register: result_commit
 
         - name: make a json result
           set_fact:
-            deploy_commit: "{{ result_commit.stdout | from_json | json_query('deployments[0].checksum') }}"
+            deploy_commit: "{{ result_commit.stdout }}"
 
         - assert:
             that:

--- a/tools/provision.sh
+++ b/tools/provision.sh
@@ -18,11 +18,15 @@ elif [[ $ID == rhel || $ID == centos ]] && [[ ${VERSION_ID%.*} == 9 ]]; then
     curl -LO --insecure https://hdn.corp.redhat.com/rhel8-csb/RPMS/noarch/redhat-internal-cert-install-0.1-23.el7.csb.noarch.rpm
     sudo dnf install -y ./redhat-internal-cert-install-0.1-23.el7.csb.noarch.rpm dnf-plugins-core
     sudo dnf copr enable -y copr.devel.redhat.com/osbuild-team/epel-el9 "rhel-9.dev-$ARCH"
-    # jmespath required for json_query
-    sudo dnf install -y ansible-core koji python3-jmespath
+fi
 
-    # json_query filter, used in our ansible playbooks, was moved to the
-    # 'community.general' collection
+# RHEL 8.6+ and CentOS 9 require different handling for ansible
+ge86=$(echo "${VERSION_ID}" | awk '{print $1 >= 8.6}')  # do a numerical comparison for the version
+echo -n "${ID}=${VERSION_ID} "
+if [[ "${ID}" == "rhel" || "${ID}" == "centos" ]] && (( ge86 )); then
+    sudo dnf install -y ansible-core koji
+
+    # NOTE: do we need this?
     sudo ansible-galaxy collection install community.general
 fi
 


### PR DESCRIPTION
Required for the `json_query` which we use in our test playbooks.  Also requires python3-jmespath.

This is the same change that we made for RHEL 9 ab5d560b1c02e79166b377c344a78e9f89c91901 and it is now required for RHEL 8.6 as well.

The conditions are a bit weird, but it's the cleanest way I could figure out to compare the versions properly to catch future versions as well.