### PR TITLE
templates/packer: Correct priority for worker rpms

### DIFF
--- a/templates/packer/ansible/roles/common/tasks/packages.yml
+++ b/templates/packer/ansible/roles/common/tasks/packages.yml
@@ -107,7 +107,7 @@
       baseurl=file:///tmp/rpmbuild/RPMS
       enabled=1
       gpgcheck=0
-      priority=100
+      priority=1
 
 - name: Install worker rpm
   package:


### PR DESCRIPTION
Lower priority means higher, currently the images built through AppSRE's
infra install the worker from epel.
