### PR TITLE
Extend scheduled cloud cleaner to vmware

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -469,6 +469,7 @@ SCHEDULED_CLOUD_CLEANER:
     - terraform
   variables:
     RUNNER: aws/centos-stream-8-x86_64
+    INTERNAL_NETWORK: "true"
   rules:
     - if: '$CI_PIPELINE_SOURCE == "schedule" && $CLEANUP == "true"'
   script:

--- a/schutzbot/scheduled_cloud_cleaner.sh
+++ b/schutzbot/scheduled_cloud_cleaner.sh
@@ -276,3 +276,38 @@ for image in $IMAGES; do
                 echo "deleted image: ${NAME}"        
 	fi
 done
+
+
+#---------------------------------------------------------------
+#                       vmware cleanup
+#---------------------------------------------------------------
+
+greenprint "starting vmware cleanup"
+
+GOVC_CMD=/tmp/govc
+
+# We need govc to talk to vSphere
+if ! hash govc; then
+    greenprint "Installing govc"
+    pushd /tmp || exit
+        curl -Ls --retry 5 --output govc.gz \
+            https://github.com/vmware/govmomi/releases/download/v0.24.0/govc_linux_amd64.gz
+        gunzip -f govc.gz
+        chmod +x /tmp/govc
+        $GOVC_CMD version
+    popd || exit
+fi
+
+GOVC_AUTH="${GOVMOMI_USERNAME}:${GOVMOMI_PASSWORD}@${GOVMOMI_URL}"
+
+TAGGED=$($GOVC_CMD tags.attached.ls -u "${GOVC_AUTH}" -k "gitlab-ci-test" | xargs -r ${GOVC_CMD} ls -u "${GOVC_AUTH}" -k -L)
+
+for vm in $TAGGED; do
+	# Could use JSON output, but it takes much longer, as it includes more properties
+	CREATION_TIME=$($GOVC_CMD vm.info -u "${GOVC_AUTH}" -k "${vm}" | awk '$1 ~ /^ *Boot/ { print $3 " " $4 $5 }')
+	
+	if [[ $(date -d "${CREATION_TIME}" +%s) -lt ${DELETE_TIME} ]]; then
+                $GOVC_CMD vm.destroy -u "${GOVC_AUTH}" -k "${vm}"
+                echo "destroyed vm: ${vm}"
+	fi
+done

--- a/test/cases/vmware.sh
+++ b/test/cases/vmware.sh
@@ -196,6 +196,12 @@ $GOVC_CMD vm.create -u "${GOVMOMI_USERNAME}":"${GOVMOMI_PASSWORD}"@"${GOVMOMI_UR
     --disk.controller=ide \
     "${IMAGE_KEY}"
 
+# tagging vm as testing object
+$GOVC_CMD tags.attach -u "${GOVMOMI_USERNAME}":"${GOVMOMI_PASSWORD}"@"${GOVMOMI_URL}" \
+    -k=true \
+    -c "osbuild-composer testing" gitlab-ci-test \
+    "/${GOVMOMI_DATACENTER}/vm/${GOVMOMI_FOLDER}/${IMAGE_KEY}"
+
 greenprint "Getting IP of created VM"
 VM_IP=$($GOVC_CMD vm.ip -u "${GOVMOMI_USERNAME}":"${GOVMOMI_PASSWORD}"@"${GOVMOMI_URL}" -k=true "${IMAGE_KEY}")
 


### PR DESCRIPTION
Currently scheduled cloud cleaner only takes care of azure, aws and gcp resources. Extend this functionality to vmware.

To do so, tag every vmware resource with "gitlab-ci-tag". And then remove the old enough ones in scheduled cloud cleaner.

This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

