### PR TITLE
templates/dashboards: Fixed grafana uids

### DIFF
--- a/templates/dashboards/grafana-dashboard-image-builder-composer-general.configmap.yml
+++ b/templates/dashboards/grafana-dashboard-image-builder-composer-general.configmap.yml
@@ -1323,6 +1323,6 @@ data:
       },
       "timezone": "",
       "title": "Image Builder Composer",
-      "uid": "cNGfs4Knz",
+      "uid": "image-builder-composer",
       "version": 3
     }

--- a/templates/dashboards/grafana-dashboard-image-builder-worker-general.configmap.yml
+++ b/templates/dashboards/grafana-dashboard-image-builder-worker-general.configmap.yml
@@ -1771,6 +1771,6 @@ data:
       },
       "timezone": "",
       "title": "Image Builder Worker",
-      "uid": "y8lhL9hnz",
+      "uid": "image-builder-worker",
       "version": 1
     }


### PR DESCRIPTION
This way we get a nice URL `.../d/image-builder-(composer|worker)`.
