### PR TITLE
Fix problem with undo creating empty blueprint

### DIFF
--- a/internal/mocks/rpmmd/fixtures.go
+++ b/internal/mocks/rpmmd/fixtures.go
@@ -182,3 +182,20 @@ func BadFetch(tmpdir string) Fixture {
 		createBaseWorkersFixture(tmpdir),
 	}
 }
+
+func OldChangesFixture(tmpdir string) Fixture {
+	return Fixture{
+		fetchPackageList{
+			generatePackageList(),
+			map[string]string{"base": "sha256:f34848ca92665c342abd5816c9e3eda0e82180671195362bcd0080544a3bc2ac"},
+			nil,
+		},
+		depsolve{
+			createBaseDepsolveFixture(),
+			map[string]string{"base": "sha256:f34848ca92665c342abd5816c9e3eda0e82180671195362bcd0080544a3bc2ac"},
+			nil,
+		},
+		store.FixtureOldChanges(),
+		createBaseWorkersFixture(tmpdir),
+	}
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -131,6 +131,9 @@ func (s *Store) ListBlueprints() []string {
 
 	names := make([]string, 0, len(s.blueprints))
 	for name := range s.blueprints {
+		if len(name) == 0 {
+			continue
+		}
 		names = append(names, name)
 	}
 	sort.Strings(names)

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -198,6 +198,10 @@ func (s *Store) GetBlueprintChanges(name string) []blueprint.Change {
 
 func (s *Store) PushBlueprint(bp blueprint.Blueprint, commitMsg string) error {
 	return s.change(func() error {
+		if len(bp.Name) == 0 {
+			return fmt.Errorf("empty blueprint name not allowed")
+		}
+
 		commit, err := randomSHA1String()
 		if err != nil {
 			return err
@@ -237,6 +241,10 @@ func (s *Store) PushBlueprint(bp blueprint.Blueprint, commitMsg string) error {
 
 func (s *Store) PushBlueprintToWorkspace(bp blueprint.Blueprint) error {
 	return s.change(func() error {
+		if len(bp.Name) == 0 {
+			return fmt.Errorf("empty blueprint name not allowed")
+		}
+
 		// Make sure the blueprint has default values and that the version is valid
 		err := bp.Initialize()
 		if err != nil {

--- a/internal/weldr/api.go
+++ b/internal/weldr/api.go
@@ -2022,6 +2022,15 @@ func (api *API) blueprintUndoHandler(writer http.ResponseWriter, request *http.R
 	}
 
 	bp := bpChange.Blueprint
+	if len(bpChange.Blueprint.Name) == 0 {
+		errors := responseError{
+			ID:  "BlueprintsError",
+			Msg: fmt.Sprintf("no blueprint found for commit %s", commit),
+		}
+		statusResponseError(writer, http.StatusBadRequest, errors)
+		return
+	}
+
 	commitMsg := name + ".toml reverted to commit " + commit
 	err = api.store.PushBlueprint(bp, commitMsg)
 	if err != nil {

--- a/internal/weldr/api_test.go
+++ b/internal/weldr/api_test.go
@@ -629,7 +629,7 @@ func TestOldBlueprintsUndo(t *testing.T) {
 	commit := changes.BlueprintsChanges[0].Changes[2].Commit
 
 	// Undo a known commit, that is old
-	test.TestRoute(t, api, true, "POST", "/api/v0/blueprints/undo/test-old-changes/"+commit, ``, http.StatusOK, `{"status":true}`)
+	test.TestRoute(t, api, true, "POST", "/api/v0/blueprints/undo/test-old-changes/"+commit, ``, http.StatusBadRequest, `{"errors":[{"id":"BlueprintsError", "msg":"empty blueprint name not allowed"}], "status":false}`)
 
 	// Check to make sure the undo is not present (can't undo something not there)
 	test.TestRoute(t, api, true, "GET", "/api/v0/blueprints/changes/test-old-changes", ``, http.StatusOK, `{"blueprints":[{"changes":[{"commit":"","message":"Change tmux version","revision":null,"timestamp":""},{"commit":"","message":"Add tmux package","revision":null,"timestamp":""},{"commit":"","message":"Initial commit","revision":null,"timestamp":""}],"name":"test-old-changes","total":3}],"errors":[],"limit":20,"offset":0}`, ignoreFields...)

--- a/internal/weldr/api_test.go
+++ b/internal/weldr/api_test.go
@@ -629,7 +629,7 @@ func TestOldBlueprintsUndo(t *testing.T) {
 	commit := changes.BlueprintsChanges[0].Changes[2].Commit
 
 	// Undo a known commit, that is old
-	test.TestRoute(t, api, true, "POST", "/api/v0/blueprints/undo/test-old-changes/"+commit, ``, http.StatusBadRequest, `{"errors":[{"id":"BlueprintsError", "msg":"empty blueprint name not allowed"}], "status":false}`)
+	test.TestRoute(t, api, true, "POST", "/api/v0/blueprints/undo/test-old-changes/"+commit, ``, http.StatusBadRequest, `{"errors":[{"id":"BlueprintsError", "msg":"no blueprint found for commit `+commit+`"}], "status":false}`)
 
 	// Check to make sure the undo is not present (can't undo something not there)
 	test.TestRoute(t, api, true, "GET", "/api/v0/blueprints/changes/test-old-changes", ``, http.StatusOK, `{"blueprints":[{"changes":[{"commit":"","message":"Change tmux version","revision":null,"timestamp":""},{"commit":"","message":"Add tmux package","revision":null,"timestamp":""},{"commit":"","message":"Initial commit","revision":null,"timestamp":""}],"name":"test-old-changes","total":3}],"errors":[],"limit":20,"offset":0}`, ignoreFields...)


### PR DESCRIPTION
This pull request includes:

- [x] adequate testing for the new functionality or fixed issue
- [x] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:
-->

- [x] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [x] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`
