### PR TITLE
Add Image Tests to nightly pipelines

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -201,6 +201,33 @@ Regression:
       - "*.repo"
     when: always
 
+
+Image Tests:
+  stage: test
+  extends: .terraform
+  rules:
+    - if: '$CI_PIPELINE_SOURCE == "schedule" && $RUNNER =~ /[\S]+rhel-9.0-[^ga][\S]+/ && $NIGHTLY == "true" && $RHEL_MAJOR == "9"'
+    - if: '$CI_PIPELINE_SOURCE == "schedule" && $RUNNER =~ /[\S]+rhel-8.6-[^ga][\S]+/ && $NIGHTLY == "true" && $RHEL_MAJOR == "8"'
+  script:
+    - schutzbot/deploy.sh
+    - /usr/libexec/tests/osbuild-composer/image_tests.sh
+  interruptible: true
+  parallel:
+    matrix:
+      - RUNNER:
+          - aws/rhel-8.6-nightly-x86_64
+          - aws/rhel-8.6-nightly-aarch64
+          # See https://github.com/osbuild/osbuild-composer/issues/1819 and related issues
+          - aws/rhel-9.0-nightly-x86_64
+          - aws/rhel-9.0-nightly-aarch64
+        INTERNAL_NETWORK: ["true"]
+  artifacts:
+    paths:
+      - journal-log.gpg
+      - "*.repo"
+    when: always
+
+
 Test Case Generation:
   stage: test
   extends: .terraform


### PR DESCRIPTION
This is executed from osbuild's CI triggers but doesn't run against nightly trees so adding it here.

Note: The issue reference in the comment may be related to this test failing on 9.0. It's been disabled inside the osbuild repository. 

NOTE: needed to verify https://bugzilla.redhat.com/show_bug.cgi?id=2002724#c6