### PR TITLE
tests: Add missing /var/log/audit to explicit checks

### DIFF
--- a/test/cases/filesystem.sh
+++ b/test/cases/filesystem.sh
@@ -175,9 +175,11 @@ greenprint "💬 Checking mountpoints"
 INFO="$(sudo /usr/libexec/osbuild-composer-test/image-info "${IMAGE_FILENAME}")"
 FAILED_MOUNTPOINTS=()
 
-for MOUNTPOINT in '/var' '/usr' '/' '/var/log'; do
+for MOUNTPOINT in '/' '/var' '/var/log' '/var/log/audit' '/usr'; do
   EXISTS=$(jq -e --arg m "$MOUNTPOINT" 'any(.fstab[] | .[] == $m; .)' <<< "${INFO}")
-  if ! $EXISTS; then
+  if $EXISTS; then
+    greenprint "INFO: mountpoint $MOUNTPOINT exists"
+  else
     FAILED_MOUNTPOINTS+=("$MOUNTPOINT")
   fi
 done


### PR DESCRIPTION
- the /var/log/audit mountpoint has been added previously to the
  blueprint but wasn't explicitly checked
- reordered the list of mountpoints to match the blueprint
  (alphabetically)
- added logging of successfull results we that QE can see what has been
  tested in the logs and use it for verification purposes.

Related: rhbz#2002727, rhbz#2001891


This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`
-->
