### PR TITLE
distro/rhel86: fix ec2 boot partition for arm64

### DIFF
--- a/internal/distro/rhel86/partition_tables.go
+++ b/internal/distro/rhel86/partition_tables.go
@@ -155,7 +155,7 @@ var ec2BasePartitionTables = distro.BasePartitionTableMap{
 				},
 			},
 			{
-				Size: 1048676,
+				Size: 1048576,
 				Type: disk.FilesystemDataGUID,
 				UUID: disk.FilesystemDataUUID,
 				Filesystem: &disk.Filesystem{

--- a/test/data/manifests/centos_8-aarch64-ami-boot.json
+++ b/test/data/manifests/centos_8-aarch64-ami-boot.json
@@ -1101,14 +1101,14 @@
                   "uuid": "68B2905B-DF3E-4FB3-80FA-49D1E773AA33"
                 },
                 {
-                  "size": 1048676,
+                  "size": 1048576,
                   "start": 411648,
                   "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
                   "uuid": "CB07C243-BC44-4717-853E-28852021225B"
                 },
                 {
-                  "size": 19511096,
-                  "start": 1460324,
+                  "size": 19511196,
+                  "start": 1460224,
                   "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
                   "uuid": "6264D520-3FB9-423F-8AB8-7A0A8E3D3562"
                 }
@@ -1150,7 +1150,7 @@
                 "options": {
                   "filename": "image.raw",
                   "start": 411648,
-                  "size": 1048676
+                  "size": 1048576
                 }
               }
             }
@@ -1166,8 +1166,8 @@
                 "type": "org.osbuild.loopback",
                 "options": {
                   "filename": "image.raw",
-                  "start": 1460324,
-                  "size": 19511096
+                  "start": 1460224,
+                  "size": 19511196
                 }
               }
             }
@@ -1197,7 +1197,7 @@
                 "options": {
                   "filename": "image.raw",
                   "start": 411648,
-                  "size": 1048676
+                  "size": 1048576
                 }
               },
               "efi": {
@@ -1212,8 +1212,8 @@
                 "type": "org.osbuild.loopback",
                 "options": {
                   "filename": "image.raw",
-                  "start": 1460324,
-                  "size": 19511096
+                  "start": 1460224,
+                  "size": 19511196
                 }
               }
             },

--- a/test/data/manifests/rhel_86-aarch64-ami-boot.json
+++ b/test/data/manifests/rhel_86-aarch64-ami-boot.json
@@ -1128,14 +1128,14 @@
                   "uuid": "68B2905B-DF3E-4FB3-80FA-49D1E773AA33"
                 },
                 {
-                  "size": 1048676,
+                  "size": 1048576,
                   "start": 411648,
                   "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
                   "uuid": "CB07C243-BC44-4717-853E-28852021225B"
                 },
                 {
-                  "size": 19511096,
-                  "start": 1460324,
+                  "size": 19511196,
+                  "start": 1460224,
                   "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
                   "uuid": "6264D520-3FB9-423F-8AB8-7A0A8E3D3562"
                 }
@@ -1177,7 +1177,7 @@
                 "options": {
                   "filename": "image.raw",
                   "start": 411648,
-                  "size": 1048676
+                  "size": 1048576
                 }
               }
             }
@@ -1193,8 +1193,8 @@
                 "type": "org.osbuild.loopback",
                 "options": {
                   "filename": "image.raw",
-                  "start": 1460324,
-                  "size": 19511096
+                  "start": 1460224,
+                  "size": 19511196
                 }
               }
             }
@@ -1224,7 +1224,7 @@
                 "options": {
                   "filename": "image.raw",
                   "start": 411648,
-                  "size": 1048676
+                  "size": 1048576
                 }
               },
               "efi": {
@@ -1239,8 +1239,8 @@
                 "type": "org.osbuild.loopback",
                 "options": {
                   "filename": "image.raw",
-                  "start": 1460324,
-                  "size": 19511096
+                  "start": 1460224,
+                  "size": 19511196
                 }
               }
             },

--- a/test/data/manifests/rhel_86-aarch64-ec2-boot.json
+++ b/test/data/manifests/rhel_86-aarch64-ec2-boot.json
@@ -1142,14 +1142,14 @@
                   "uuid": "68B2905B-DF3E-4FB3-80FA-49D1E773AA33"
                 },
                 {
-                  "size": 1048676,
+                  "size": 1048576,
                   "start": 411648,
                   "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
                   "uuid": "CB07C243-BC44-4717-853E-28852021225B"
                 },
                 {
-                  "size": 19511096,
-                  "start": 1460324,
+                  "size": 19511196,
+                  "start": 1460224,
                   "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
                   "uuid": "6264D520-3FB9-423F-8AB8-7A0A8E3D3562"
                 }
@@ -1191,7 +1191,7 @@
                 "options": {
                   "filename": "image.raw",
                   "start": 411648,
-                  "size": 1048676
+                  "size": 1048576
                 }
               }
             }
@@ -1207,8 +1207,8 @@
                 "type": "org.osbuild.loopback",
                 "options": {
                   "filename": "image.raw",
-                  "start": 1460324,
-                  "size": 19511096
+                  "start": 1460224,
+                  "size": 19511196
                 }
               }
             }
@@ -1238,7 +1238,7 @@
                 "options": {
                   "filename": "image.raw",
                   "start": 411648,
-                  "size": 1048676
+                  "size": 1048576
                 }
               },
               "efi": {
@@ -1253,8 +1253,8 @@
                 "type": "org.osbuild.loopback",
                 "options": {
                   "filename": "image.raw",
-                  "start": 1460324,
-                  "size": 19511096
+                  "start": 1460224,
+                  "size": 19511196
                 }
               }
             },


### PR DESCRIPTION
It should be `1048576` (exactly 512 MiB), like it is for all other distributions. It somehow got mingled in when the distribution was forked off from 8.5/9.0 beta (1048676 to 1048576 strongly suggests a `sed` command was involved, so we blame that).
