### PR TITLE
EC2: Disable password based authentication

### DIFF
--- a/internal/distro/image_config.go
+++ b/internal/distro/image_config.go
@@ -36,6 +36,7 @@ type ImageConfig struct {
 	PamLimitsConf []*osbuild2.PamLimitsConfStageOptions
 	Sysctld       []*osbuild2.SysctldStageOptions
 	DNFConfig     []*osbuild2.DNFConfigStageOptions
+	SshdConfig    *osbuild2.SshdConfigStageOptions
 }
 
 // InheritFrom inherits unset values from the provided parent configuration and
@@ -105,6 +106,9 @@ func (c *ImageConfig) InheritFrom(parentConfig *ImageConfig) *ImageConfig {
 		}
 		if finalConfig.DNFConfig == nil {
 			finalConfig.DNFConfig = parentConfig.DNFConfig
+		}
+		if finalConfig.SshdConfig == nil {
+			finalConfig.SshdConfig = parentConfig.SshdConfig
 		}
 	}
 	return &finalConfig

--- a/internal/distro/rhel85/pipelines.go
+++ b/internal/distro/rhel85/pipelines.go
@@ -371,6 +371,12 @@ func ec2BaseTreePipeline(repos []rpmmd.RepoConfig, packages []rpmmd.PackageSpec,
 		p.AddStage(osbuild.NewRHSMStage(rhsmStageOptions))
 	}
 
+	p.AddStage((osbuild.NewSshdConfigStage(&osbuild.SshdConfigStageOptions{
+		Config: osbuild.SshdConfigConfig{
+			PasswordAuthentication: common.BoolToPtr(false),
+		},
+	})))
+
 	return p, nil
 }
 

--- a/internal/distro/rhel86/distro.go
+++ b/internal/distro/rhel86/distro.go
@@ -944,6 +944,11 @@ func newDistro(distroName string) distro.Distro {
 		Authselect: &osbuild.AuthselectStageOptions{
 			Profile: "sssd",
 		},
+		SshdConfig: &osbuild.SshdConfigStageOptions{
+			Config: osbuild.SshdConfigConfig{
+				PasswordAuthentication: common.BoolToPtr(false),
+			},
+		},
 	}
 
 	// default EC2 images config (x86_64)

--- a/internal/distro/rhel86/pipelines.go
+++ b/internal/distro/rhel86/pipelines.go
@@ -515,6 +515,10 @@ func osPipeline(t *imageType,
 		p.AddStage(osbuild.NewDNFConfigStage(dnfConfig))
 	}
 
+	if sshdConfig := imageConfig.SshdConfig; sshdConfig != nil {
+		p.AddStage((osbuild.NewSshdConfigStage(sshdConfig)))
+	}
+
 	if pt != nil {
 		p = prependKernelCmdlineStage(p, t, pt)
 		p.AddStage(osbuild.NewFSTabStage(pt.FSTabStageOptionsV2()))

--- a/internal/distro/rhel90/distro.go
+++ b/internal/distro/rhel90/distro.go
@@ -945,6 +945,11 @@ func newDistro(distroName string) distro.Distro {
 		Authselect: &osbuild.AuthselectStageOptions{
 			Profile: "sssd",
 		},
+		SshdConfig: &osbuild.SshdConfigStageOptions{
+			Config: osbuild.SshdConfigConfig{
+				PasswordAuthentication: common.BoolToPtr(false),
+			},
+		},
 	}
 
 	// default EC2 images config (x86_64)

--- a/internal/distro/rhel90/pipelines.go
+++ b/internal/distro/rhel90/pipelines.go
@@ -501,6 +501,10 @@ func osPipeline(t *imageType,
 		p.AddStage(osbuild.NewDNFConfigStage(dnfConfig))
 	}
 
+	if sshdConfig := imageConfig.SshdConfig; sshdConfig != nil {
+		p.AddStage((osbuild.NewSshdConfigStage(sshdConfig)))
+	}
+
 	if pt != nil {
 		p = prependKernelCmdlineStage(p, t, pt)
 		p.AddStage(osbuild.NewFSTabStage(pt.FSTabStageOptionsV2()))

--- a/test/data/manifests/centos_8-aarch64-ami-boot.json
+++ b/test/data/manifests/centos_8-aarch64-ami-boot.json
@@ -1032,6 +1032,14 @@
             }
           },
           {
+            "type": "org.osbuild.sshd.config",
+            "options": {
+              "config": {
+                "PasswordAuthentication": false
+              }
+            }
+          },
+          {
             "type": "org.osbuild.fstab",
             "options": {
               "filesystems": [

--- a/test/data/manifests/centos_8-x86_64-ami-boot.json
+++ b/test/data/manifests/centos_8-x86_64-ami-boot.json
@@ -1016,6 +1016,14 @@
             }
           },
           {
+            "type": "org.osbuild.sshd.config",
+            "options": {
+              "config": {
+                "PasswordAuthentication": false
+              }
+            }
+          },
+          {
             "type": "org.osbuild.fstab",
             "options": {
               "filesystems": [

--- a/test/data/manifests/rhel_85-aarch64-ami-boot.json
+++ b/test/data/manifests/rhel_85-aarch64-ami-boot.json
@@ -1061,6 +1061,14 @@
             }
           },
           {
+            "type": "org.osbuild.sshd.config",
+            "options": {
+              "config": {
+                "PasswordAuthentication": false
+              }
+            }
+          },
+          {
             "type": "org.osbuild.fstab",
             "options": {
               "filesystems": [

--- a/test/data/manifests/rhel_85-aarch64-ec2-boot.json
+++ b/test/data/manifests/rhel_85-aarch64-ec2-boot.json
@@ -1075,6 +1075,14 @@
             }
           },
           {
+            "type": "org.osbuild.sshd.config",
+            "options": {
+              "config": {
+                "PasswordAuthentication": false
+              }
+            }
+          },
+          {
             "type": "org.osbuild.fstab",
             "options": {
               "filesystems": [

--- a/test/data/manifests/rhel_85-x86_64-ami-boot.json
+++ b/test/data/manifests/rhel_85-x86_64-ami-boot.json
@@ -1036,6 +1036,14 @@
             }
           },
           {
+            "type": "org.osbuild.sshd.config",
+            "options": {
+              "config": {
+                "PasswordAuthentication": false
+              }
+            }
+          },
+          {
             "type": "org.osbuild.dracut.conf",
             "options": {
               "filename": "ec2.conf",

--- a/test/data/manifests/rhel_85-x86_64-ec2-boot.json
+++ b/test/data/manifests/rhel_85-x86_64-ec2-boot.json
@@ -1051,6 +1051,14 @@
             }
           },
           {
+            "type": "org.osbuild.sshd.config",
+            "options": {
+              "config": {
+                "PasswordAuthentication": false
+              }
+            }
+          },
+          {
             "type": "org.osbuild.dracut.conf",
             "options": {
               "filename": "ec2.conf",

--- a/test/data/manifests/rhel_85-x86_64-ec2_ha-boot.json
+++ b/test/data/manifests/rhel_85-x86_64-ec2_ha-boot.json
@@ -1235,6 +1235,14 @@
             }
           },
           {
+            "type": "org.osbuild.sshd.config",
+            "options": {
+              "config": {
+                "PasswordAuthentication": false
+              }
+            }
+          },
+          {
             "type": "org.osbuild.dracut.conf",
             "options": {
               "filename": "ec2.conf",

--- a/test/data/manifests/rhel_86-aarch64-ami-boot.json
+++ b/test/data/manifests/rhel_86-aarch64-ami-boot.json
@@ -1059,6 +1059,14 @@
             }
           },
           {
+            "type": "org.osbuild.sshd.config",
+            "options": {
+              "config": {
+                "PasswordAuthentication": false
+              }
+            }
+          },
+          {
             "type": "org.osbuild.fstab",
             "options": {
               "filesystems": [

--- a/test/data/manifests/rhel_86-aarch64-ec2-boot.json
+++ b/test/data/manifests/rhel_86-aarch64-ec2-boot.json
@@ -1073,6 +1073,14 @@
             }
           },
           {
+            "type": "org.osbuild.sshd.config",
+            "options": {
+              "config": {
+                "PasswordAuthentication": false
+              }
+            }
+          },
+          {
             "type": "org.osbuild.fstab",
             "options": {
               "filesystems": [

--- a/test/data/manifests/rhel_86-x86_64-ami-boot.json
+++ b/test/data/manifests/rhel_86-x86_64-ami-boot.json
@@ -1046,6 +1046,14 @@
             }
           },
           {
+            "type": "org.osbuild.sshd.config",
+            "options": {
+              "config": {
+                "PasswordAuthentication": false
+              }
+            }
+          },
+          {
             "type": "org.osbuild.fstab",
             "options": {
               "filesystems": [

--- a/test/data/manifests/rhel_86-x86_64-ec2-boot.json
+++ b/test/data/manifests/rhel_86-x86_64-ec2-boot.json
@@ -1062,6 +1062,14 @@
             }
           },
           {
+            "type": "org.osbuild.sshd.config",
+            "options": {
+              "config": {
+                "PasswordAuthentication": false
+              }
+            }
+          },
+          {
             "type": "org.osbuild.fstab",
             "options": {
               "filesystems": [

--- a/test/data/manifests/rhel_86-x86_64-ec2_ha-boot.json
+++ b/test/data/manifests/rhel_86-x86_64-ec2_ha-boot.json
@@ -1249,6 +1249,14 @@
             }
           },
           {
+            "type": "org.osbuild.sshd.config",
+            "options": {
+              "config": {
+                "PasswordAuthentication": false
+              }
+            }
+          },
+          {
             "type": "org.osbuild.fstab",
             "options": {
               "filesystems": [

--- a/test/data/manifests/rhel_86-x86_64-ec2_sap-boot.json
+++ b/test/data/manifests/rhel_86-x86_64-ec2_sap-boot.json
@@ -1417,6 +1417,14 @@
             }
           },
           {
+            "type": "org.osbuild.sshd.config",
+            "options": {
+              "config": {
+                "PasswordAuthentication": false
+              }
+            }
+          },
+          {
             "type": "org.osbuild.fstab",
             "options": {
               "filesystems": [

--- a/test/data/manifests/rhel_90-aarch64-ami-boot.json
+++ b/test/data/manifests/rhel_90-aarch64-ami-boot.json
@@ -978,6 +978,14 @@
             }
           },
           {
+            "type": "org.osbuild.sshd.config",
+            "options": {
+              "config": {
+                "PasswordAuthentication": false
+              }
+            }
+          },
+          {
             "type": "org.osbuild.fstab",
             "options": {
               "filesystems": [

--- a/test/data/manifests/rhel_90-aarch64-ec2-boot.json
+++ b/test/data/manifests/rhel_90-aarch64-ec2-boot.json
@@ -992,6 +992,14 @@
             }
           },
           {
+            "type": "org.osbuild.sshd.config",
+            "options": {
+              "config": {
+                "PasswordAuthentication": false
+              }
+            }
+          },
+          {
             "type": "org.osbuild.fstab",
             "options": {
               "filesystems": [

--- a/test/data/manifests/rhel_90-x86_64-ami-boot.json
+++ b/test/data/manifests/rhel_90-x86_64-ami-boot.json
@@ -973,6 +973,14 @@
             }
           },
           {
+            "type": "org.osbuild.sshd.config",
+            "options": {
+              "config": {
+                "PasswordAuthentication": false
+              }
+            }
+          },
+          {
             "type": "org.osbuild.fstab",
             "options": {
               "filesystems": [

--- a/test/data/manifests/rhel_90-x86_64-ec2-boot.json
+++ b/test/data/manifests/rhel_90-x86_64-ec2-boot.json
@@ -989,6 +989,14 @@
             }
           },
           {
+            "type": "org.osbuild.sshd.config",
+            "options": {
+              "config": {
+                "PasswordAuthentication": false
+              }
+            }
+          },
+          {
             "type": "org.osbuild.fstab",
             "options": {
               "filesystems": [

--- a/test/data/manifests/rhel_90-x86_64-ec2_ha-boot.json
+++ b/test/data/manifests/rhel_90-x86_64-ec2_ha-boot.json
@@ -1183,6 +1183,14 @@
             }
           },
           {
+            "type": "org.osbuild.sshd.config",
+            "options": {
+              "config": {
+                "PasswordAuthentication": false
+              }
+            }
+          },
+          {
             "type": "org.osbuild.fstab",
             "options": {
               "filesystems": [

--- a/test/data/manifests/rhel_90-x86_64-ec2_sap-boot.json
+++ b/test/data/manifests/rhel_90-x86_64-ec2_sap-boot.json
@@ -1354,6 +1354,14 @@
             }
           },
           {
+            "type": "org.osbuild.sshd.config",
+            "options": {
+              "config": {
+                "PasswordAuthentication": false
+              }
+            }
+          },
+          {
             "type": "org.osbuild.fstab",
             "options": {
               "filesystems": [


### PR DESCRIPTION
Disable loging in via password authentication since this is an
official Amazon marketplace requirement:

>  Linux-based AMIs must not allow SSH password authentication.
  Disable password authentication via your sshd_config file by
  setting PasswordAuthentication to NO.

 See section "Security policies" from https://docs.aws.amazon.com/marketplace/latest/userguide/product-and-ami-policies.html
