### PR TITLE
Kojiapi: fix error check in koji job

### DIFF
--- a/cmd/osbuild-worker/jobimpl-osbuild-koji.go
+++ b/cmd/osbuild-worker/jobimpl-osbuild-koji.go
@@ -87,7 +87,7 @@ func (impl *OSBuildKojiJobImpl) Run(job worker.Job) error {
 		return err
 	}
 
-	if initArgs.JobError != nil {
+	if initArgs.JobError == nil {
 		exports := args.Exports
 		if len(exports) == 0 {
 			// job did not define exports, likely coming from an older version of composer

--- a/internal/kojiapi/server.go
+++ b/internal/kojiapi/server.go
@@ -260,7 +260,7 @@ func composeStatusFromJobStatus(js *worker.JobStatus, initResult *worker.KojiIni
 	}
 
 	for _, buildResult := range buildResults {
-		if buildResult.OSBuildOutput != nil && !buildResult.OSBuildOutput.Success {
+		if buildResult.OSBuildOutput == nil || !buildResult.OSBuildOutput.Success {
 			return api.ComposeStatusValueFailure
 		}
 		if buildResult.JobError != nil {


### PR DESCRIPTION
It seems that during the "Worker errors backwards compatibility" work an error check got inverted, leading to `osbuild` not actually being run in the koji job. Sadly this was not uncovered by CI since our overall status reporting was also not complete and ignored build job results with empty `buildResult.OSBuildOutput` fields. See e.g. the CI job [2023038227]( https://gitlab.com/osbuild/ci/osbuild-composer/-/jobs/2023038227#L2605): 

```
success
Compose worked!
{"image_statuses":[{"status":"failure"},{"status":"failure"}],"koji_build_id":1,"koji_task_id":0,"status":"success"}
```