### PR TITLE
Skip CI for draft PRs or WIP label

### DIFF
--- a/.github/workflows/trigger-gitlab.yml
+++ b/.github/workflows/trigger-gitlab.yml
@@ -40,6 +40,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       SCHUTZBOT_SSH_KEY: ${{ secrets.SCHUTZBOT_SSH_KEY }}
+      SKIP_CI: ${{ github.event.pull_request.draft == true || contains(github.event.pull_request.labels.*.name, 'WIP') }}
     steps:
       - name: Clone repository
         uses: actions/checkout@v2.4.0
@@ -60,4 +61,5 @@ jobs:
             git checkout -b PR-${{ github.event.pull_request.number }}
           fi
 
-          git push -f ci
+          [[ "${SKIP_CI}" == true ]] && PUSH_OPTION="-o ci.skip" || PUSH_OPTION=""
+          git push -f ci "${PUSH_OPTION}"


### PR DESCRIPTION
Save resources and needless CI runs by skipping the trigger-gitlab job if a PR is 'draft' (can be set in the pull request page at any time) or by setting a label "WIP".

Aside from saving resources, WIP PRs that don't trigger CI are a good message to contributors to keep testing it locally and to only get the project resources after serious testing been made on their side.