### PR TITLE
jwt: support multiple key providers

### DIFF
--- a/cmd/osbuild-composer/composer.go
+++ b/cmd/osbuild-composer/composer.go
@@ -220,8 +220,12 @@ func (c *Composer) Start() error {
 			handler := c.workers.Handler()
 			var err error
 			if c.config.Worker.EnableJWT {
+				keysURLs := c.config.Worker.JWTKeysURLs
+				if c.config.Worker.JWTKeysURL != "" {
+					keysURLs = append(keysURLs, c.config.Worker.JWTKeysURL)
+				}
 				handler, err = auth.BuildJWTAuthHandler(
-					c.config.Worker.JWTKeysURL,
+					keysURLs,
 					c.config.Worker.JWTKeysCA,
 					c.config.Worker.JWTACLFile,
 					[]string{
@@ -265,8 +269,12 @@ func (c *Composer) Start() error {
 			handler := http.Handler(mux)
 			var err error
 			if c.config.Koji.EnableJWT {
+				keysURLs := c.config.Koji.JWTKeysURLs
+				if c.config.Koji.JWTKeysURL != "" {
+					keysURLs = append(keysURLs, c.config.Koji.JWTKeysURL)
+				}
 				handler, err = auth.BuildJWTAuthHandler(
-					c.config.Koji.JWTKeysURL,
+					keysURLs,
 					c.config.Koji.JWTKeysCA,
 					c.config.Koji.JWTACLFile,
 					[]string{

--- a/cmd/osbuild-composer/config.go
+++ b/cmd/osbuild-composer/config.go
@@ -25,6 +25,7 @@ type KojiAPIConfig struct {
 	EnableMTLS     bool      `toml:"enable_mtls"`
 	EnableJWT      bool      `toml:"enable_jwt"`
 	JWTKeysURL     string    `toml:"jwt_keys_url"`
+	JWTKeysURLs    []string  `toml:"jwt_keys_urls"`
 	JWTKeysCA      string    `toml:"jwt_ca_file"`
 	JWTACLFile     string    `toml:"jwt_acl_file"`
 	AWS            AWSConfig `toml:"aws_config"`
@@ -51,6 +52,7 @@ type WorkerAPIConfig struct {
 	EnableMTLS        bool     `toml:"enable_mtls"`
 	EnableJWT         bool     `toml:"enable_jwt"`
 	JWTKeysURL        string   `toml:"jwt_keys_url"`
+	JWTKeysURLs       []string `toml:"jwt_keys_urls"`
 	JWTKeysCA         string   `toml:"jwt_ca_file"`
 	JWTACLFile        string   `toml:"jwt_acl_file"`
 }

--- a/internal/auth/jwt_auth_handler.go
+++ b/internal/auth/jwt_auth_handler.go
@@ -15,7 +15,7 @@ import (
 
 // When using this handler for auth, it should be run as high up as possible.
 // Exceptions can be registered in the `exclude` slice
-func BuildJWTAuthHandler(keysURL, caFile, aclFile string, exclude []string, next http.Handler) (handler http.Handler, err error) {
+func BuildJWTAuthHandler(keysURLs []string, caFile, aclFile string, exclude []string, next http.Handler) (handler http.Handler, err error) {
 	logBuilder := logging.NewGoLoggerBuilder()
 	if caFile != "" {
 		logBuilder = logBuilder.Debug(true)
@@ -29,8 +29,11 @@ func BuildJWTAuthHandler(keysURL, caFile, aclFile string, exclude []string, next
 	logger.Info(context.Background(), aclFile)
 
 	builder := authentication.NewHandler().
-		Logger(logger).
-		KeysURL(keysURL)
+		Logger(logger)
+
+	for _, keysURL := range keysURLs {
+		builder = builder.KeysURL(keysURL)
+	}
 
 	// Used during testing
 	if caFile != "" {


### PR DESCRIPTION
We may need to use several SSO providers, so extend our
configuration to allow that.

Based on PoC from Sanne:

```
package main

import (
	"net/http"
	"log"

	"github.com/openshift-online/ocm-sdk-go/authentication"
	"github.com/openshift-online/ocm-sdk-go/logging"
)

type H struct{}

func (h *H) ServeHTTP(w http.ResponseWriter, r *http.Request) {
	log.Println("HURRAY")
}

func main() {

	logBuilder := logging.NewGoLoggerBuilder()
	logger, err := logBuilder.Build()
	if err != nil {
		panic(err)
	}

	aH, err := authentication.NewHandler().
		KeysURL("https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/certs").
		KeysURL("https://identity.api.openshift.com/auth/realms/rhoas/protocol/openid-connect/certs").
			Logger(logger).Next(&H{}).Build()
	if err != nil {
		panic(err)
	}

	log.Fatal(http.ListenAndServe(":8080", aH))

}
```


This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`
-->
