### PR TITLE
Mock OpenID: add token type, expires in and scope fields

### DIFF
--- a/cmd/osbuild-mock-openid-provider/main.go
+++ b/cmd/osbuild-mock-openid-provider/main.go
@@ -22,12 +22,14 @@ func main() {
 	var tlsCert string
 	var tlsKey string
 	var tokenExpires int
+	var tokenScope string
 	flag.StringVar(&addr, "a", "localhost:8080", "Address to serve on")
 	flag.StringVar(&rsaPubPem, "rsaPubPem", "", "rsa pubkey in pem format (path)")
 	flag.StringVar(&rsaPem, "rsaPem", "", "rsa privkey in pem format (path)")
 	flag.StringVar(&tlsCert, "cert", "", "tls cert")
 	flag.StringVar(&tlsKey, "key", "", "tls key")
 	flag.IntVar(&tokenExpires, "expires", 60, "Expiration of the token in seconds (default: 360))")
+	flag.StringVar(&tokenScope, "scope", "", "The scope of the token (default: not set)")
 	flag.Parse()
 
 	if rsaPubPem == "" || rsaPem == "" {
@@ -109,12 +111,14 @@ func main() {
 			AccessToken string `json:"access_token"`
 			TokenType   string `json:"token_type"`           // required
 			ExpiresIn   int    `json:"expires_in,omitempty"` // lifetime in seconds
+			Scope       string `json:"scope,omitempty"`
 		}
 
 		err = json.NewEncoder(w).Encode(response{
 			AccessToken: tokenStr,
 			TokenType:   "Bearer",
 			ExpiresIn:   tokenExpires,
+			Scope:       tokenScope,
 		})
 		if err != nil {
 			panic(err)

--- a/cmd/osbuild-mock-openid-provider/main.go
+++ b/cmd/osbuild-mock-openid-provider/main.go
@@ -21,11 +21,13 @@ func main() {
 	var rsaPem string
 	var tlsCert string
 	var tlsKey string
+	var tokenExpires int
 	flag.StringVar(&addr, "a", "localhost:8080", "Address to serve on")
 	flag.StringVar(&rsaPubPem, "rsaPubPem", "", "rsa pubkey in pem format (path)")
 	flag.StringVar(&rsaPem, "rsaPem", "", "rsa privkey in pem format (path)")
 	flag.StringVar(&tlsCert, "cert", "", "tls cert")
 	flag.StringVar(&tlsKey, "key", "", "tls key")
+	flag.IntVar(&tokenExpires, "expires", 60, "Expiration of the token in seconds (default: 360))")
 	flag.Parse()
 
 	if rsaPubPem == "" || rsaPem == "" {
@@ -102,12 +104,17 @@ func main() {
 			panic(err)
 		}
 
+		// See https://datatracker.ietf.org/doc/html/rfc6749
 		type response struct {
 			AccessToken string `json:"access_token"`
+			TokenType   string `json:"token_type"`           // required
+			ExpiresIn   int    `json:"expires_in,omitempty"` // lifetime in seconds
 		}
 
 		err = json.NewEncoder(w).Encode(response{
 			AccessToken: tokenStr,
+			TokenType:   "Bearer",
+			ExpiresIn:   tokenExpires,
 		})
 		if err != nil {
 			panic(err)


### PR DESCRIPTION
According to (rfc6749)[https://datatracker.ietf.org/doc/html/rfc6749#section-3.3] the `token_type` is required. Additionally, allow setting `expires_in` and `scope`.