### PR TITLE
packit: re-enable builds for s390x architecture

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -34,7 +34,7 @@ jobs:
     - epel-8-aarch64
     - epel-8-x86_64
     - fedora-all-aarch64
-    #- fedora-all-s390x  # go binary segfaults in the emulated environment
+    - fedora-all-s390x
     - fedora-all-ppc64le
     - fedora-all
 - job: copr_build
@@ -51,6 +51,6 @@ jobs:
     - epel-8-aarch64
     - epel-8-x86_64
     - fedora-all-aarch64
-    #- fedora-all-s390x  # go binary segfaults in the emulated environment
+    - fedora-all-s390x
     - fedora-all-ppc64le
     - fedora-all


### PR DESCRIPTION
Fedora Copr has native s390x builders now:
https://lists.fedoraproject.org/archives/list/copr-devel@lists.fedorahosted.org/message/AR3ZDKET3EXZHV3MSU3UHMO7EIKBGAN2/