### PR TITLE
Workers error metrics

### DIFF
--- a/internal/worker/clienterrors/errors.go
+++ b/internal/worker/clienterrors/errors.go
@@ -34,6 +34,40 @@ type Error struct {
 	Details interface{}     `json:"details"`
 }
 
+const (
+	JobStatusSuccess        = "2xx"
+	JobStatusUserInputError = "4xx"
+	JobStatusInternalError  = "5xx"
+)
+
+type StatusCode string
+
+func (s *StatusCode) ToString() string {
+	return string(*s)
+}
+
+func GetStatusCode(err *Error) StatusCode {
+	if err == nil {
+		return JobStatusSuccess
+	}
+	switch err.ID {
+	case ErrorDNFDepsolveError:
+		return JobStatusInternalError
+	case ErrorDNFMarkingError:
+		return JobStatusInternalError
+	case ErrorNoDynamicArgs:
+		return JobStatusUserInputError
+	case ErrorInvalidTargetConfig:
+		return JobStatusUserInputError
+	case ErrorSharingTarget:
+		return JobStatusUserInputError
+	case ErrorInvalidTarget:
+		return JobStatusUserInputError
+	default:
+		return JobStatusInternalError
+	}
+}
+
 func WorkerClientError(code ClientErrorCode, reason string, details ...interface{}) *Error {
 	return &Error{
 		ID:      code,

--- a/internal/worker/server.go
+++ b/internal/worker/server.go
@@ -486,7 +486,8 @@ func (s *Server) FinishJob(token uuid.UUID, result json.RawMessage) error {
 	if err != nil {
 		logrus.Errorf("error finding job status: %v", err)
 	} else {
-		prometheus.FinishJobMetrics(status.Started, status.Finished, status.Canceled, jobType)
+		statusCode := clienterrors.GetStatusCode(jobResult.JobError)
+		prometheus.FinishJobMetrics(status.Started, status.Finished, status.Canceled, jobType, statusCode)
 	}
 
 	// Move artifacts from the temporary location to the final job


### PR DESCRIPTION
This pull request includes:
- moving the metrics to the worker/server
- the ability to gather metrics on successful/unsuccessful jobs
- add the error status to job duration metrics

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`
-->
