### PR TITLE
PackIt: enable Fedora builds on s390x

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -34,7 +34,7 @@ jobs:
     - epel-8-aarch64
     - epel-8-x86_64
     - fedora-all-aarch64
-    #- fedora-all-s390x  # go binary segfaults in the emulated environment
+    - fedora-all-s390x
     - fedora-all-ppc64le
     - fedora-all
 - job: copr_build
@@ -51,6 +51,6 @@ jobs:
     - epel-8-aarch64
     - epel-8-x86_64
     - fedora-all-aarch64
-    #- fedora-all-s390x  # go binary segfaults in the emulated environment
+    - fedora-all-s390x
     - fedora-all-ppc64le
     - fedora-all


### PR DESCRIPTION
Fedora COPR now builds s390x on real hardware, so the issues caused
by emulation should be gone.

Signed-off-by: Tomas Hozza <thozza@redhat.com>


This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`
-->
