### PR TITLE
service-maintenance: Skip db cleanup

### DIFF
--- a/cmd/osbuild-service-maintenance/main.go
+++ b/cmd/osbuild-service-maintenance/main.go
@@ -39,19 +39,6 @@ func main() {
 		logrus.Info("Dry run, no state will be changed")
 	}
 
-	dbURL := fmt.Sprintf("postgres://%s:%s@%s:%s/%s?sslmode=%s",
-		conf.PGUser,
-		conf.PGPassword,
-		conf.PGHost,
-		conf.PGPort,
-		conf.PGDatabase,
-		conf.PGSSLMode,
-	)
-	jobs, err := dbjobqueue.New(dbURL)
-	if err != nil {
-		panic(err)
-	}
-
 	var wg sync.WaitGroup
 	wg.Add(1)
 	go func() {
@@ -93,6 +80,24 @@ func main() {
 
 	wg.Wait()
 	logrus.Info("🦀🦀🦀 cloud cleanup done 🦀🦀🦀")
+
+	if conf.PGHost == "" {
+		logrus.Info("🦀🦀🦀 db host not defined, skipping db cleanup 🦀🦀🦀")
+		return
+	}
+
+	dbURL := fmt.Sprintf("postgres://%s:%s@%s:%s/%s?sslmode=%s",
+		conf.PGUser,
+		conf.PGPassword,
+		conf.PGHost,
+		conf.PGPort,
+		conf.PGDatabase,
+		conf.PGSSLMode,
+	)
+	jobs, err := dbjobqueue.New(dbURL)
+	if err != nil {
+		panic(err)
+	}
 
 	var jobTypes []string
 	for _, a := range archs {

--- a/templates/composer.yml
+++ b/templates/composer.yml
@@ -248,33 +248,6 @@ objects:
                   cpu: "${CPU_LIMIT}"
                   memory: "${MEMORY_LIMIT}"
               env:
-              - name: PGHOST
-                valueFrom:
-                  secretKeyRef:
-                    name: composer-db
-                    key: db.host
-              - name: PGPORT
-                valueFrom:
-                  secretKeyRef:
-                    name: composer-db
-                    key: db.port
-              - name: PGDATABASE
-                valueFrom:
-                  secretKeyRef:
-                    name: composer-db
-                    key: db.name
-              - name: PGUSER
-                valueFrom:
-                  secretKeyRef:
-                    name: composer-db
-                    key: db.user
-              - name: PGPASSWORD
-                valueFrom:
-                  secretKeyRef:
-                    name: composer-db
-                    key: db.password
-              - name: PGSSLMODE
-                value: "${PGSSLMODE}"
               - name: GCP_AUTH_PROVIDER_X509_CERT_URL
                 valueFrom:
                   secretKeyRef:


### PR DESCRIPTION
Let's enable the cloud cleanup first, and then move on the db.


