### PR TITLE
worker: fix error status codes

### DIFF
--- a/internal/worker/clienterrors/errors.go
+++ b/internal/worker/clienterrors/errors.go
@@ -52,9 +52,9 @@ func GetStatusCode(err *Error) StatusCode {
 	}
 	switch err.ID {
 	case ErrorDNFDepsolveError:
-		return JobStatusInternalError
+		return JobStatusUserInputError
 	case ErrorDNFMarkingError:
-		return JobStatusInternalError
+		return JobStatusUserInputError
 	case ErrorNoDynamicArgs:
 		return JobStatusUserInputError
 	case ErrorInvalidTargetConfig:


### PR DESCRIPTION
The DNFDepsolveError and DNFMarking error should have
a `4xx` code instead of a `5xx` error code.

This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`
-->
