### PR TITLE
Worker error validation

### DIFF
--- a/cmd/osbuild-worker/jobimpl-osbuild.go
+++ b/cmd/osbuild-worker/jobimpl-osbuild.go
@@ -57,7 +57,7 @@ func validateResult(result *worker.OSBuildJobResult, jobID string) {
 	}
 	// if the job failed, but the JobError is
 	// nil, we still need to handle this as an error
-	if !result.OSBuildOutput.Success {
+	if result.OSBuildOutput == nil || !result.OSBuildOutput.Success {
 		reason := "osbuild job was unsuccessful"
 		logWithId.Errorf("osbuild job failed: %s", reason)
 		result.JobError = clienterrors.WorkerClientError(clienterrors.ErrorBuildJob, reason)
@@ -111,6 +111,7 @@ func (impl *OSBuildJobImpl) Run(job worker.Job) error {
 		var manifestJR worker.ManifestJobByIDResult
 		err = job.DynamicArgs(0, &manifestJR)
 		if err != nil {
+			osbuildJobResult.JobError = clienterrors.WorkerClientError(clienterrors.ErrorParsingDynamicArgs, "Error parsing dynamic args")
 			return err
 		}
 


### PR DESCRIPTION
This pull request includes adds additional checks to ensure there aren't any gaps in the
error handling for `OSBuildJob` and `KojiOSBuildJob` jobs.

The osbuild jobs were mostly fine the output is not nil from the start:
https://github.com/osbuild/osbuild-composer/blob/main/cmd/osbuild-worker/jobimpl-osbuild.go#L74-L76

But could get overridden here:
https://github.com/osbuild/osbuild-composer/blob/main/cmd/osbuild-worker/jobimpl-osbuild.go#L146

The osbuild worker now explicitly checks for nil `OsbuildOutput`.

Similarly, a function was added to validate koji build results and update the job with a job error if the worker exits
early due to an error.

The PR adds a few extra error cases too.


- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`
-->
