### PR TITLE
tests: update IDs in Openstack image boot test

### DIFF
--- a/internal/boot/openstacktest/openstack.go
+++ b/internal/boot/openstacktest/openstack.go
@@ -83,9 +83,9 @@ func WithBootedImageInOpenStack(p *gophercloud.ProviderClient, imageID, userData
 
 	server, err := servers.Create(client, servers.CreateOpts{
 		Name:      "osbuild-composer-vm-for-" + imageID,
-		FlavorRef: "77b8cf27-be16-40d9-95b1-81db4522be1e", // ci.m1.medium.ephemeral
-		Networks: []servers.Network{ // provider_net_cci_2
-			servers.Network{UUID: "74e8faa7-87ba-41b2-a000-438013194814"},
+		FlavorRef: "f2c4469b-f516-46d1-8b87-1dcca68fb3d9", // ci-ssd.standard.medium
+		Networks: []servers.Network{ // shared_net_2
+			servers.Network{UUID: "0bb5a1a2-cf3b-4371-9b31-3ae78313971d"},
 		},
 		ImageRef: imageID,
 		UserData: []byte(userData),
@@ -118,7 +118,7 @@ func WithBootedImageInOpenStack(p *gophercloud.ProviderClient, imageID, userData
 	// server.AccessIPv4 is empty so list all addresses and
 	// get the first fixed one. ssh should be equally happy with v4 or v6
 	var fixedIP string
-	for _, networkAddresses := range server.Addresses["provider_net_cci_2"].([]interface{}) {
+	for _, networkAddresses := range server.Addresses["shared_net_2"].([]interface{}) {
 		address := networkAddresses.(map[string]interface{})
 		if address["OS-EXT-IPS:type"] == "fixed" {
 			fixedIP = address["addr"].(string)


### PR DESCRIPTION
Update flavor and network ID for booting Openstack images in rhos-01
cloud.


This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`
-->
