### PR TITLE
test: regenerate RHEL 8.5 and 8.6 EC2 image test cases

### DIFF
--- a/test/data/manifests/rhel_85-aarch64-ami-boot.json
+++ b/test/data/manifests/rhel_85-aarch64-ami-boot.json
@@ -10871,6 +10871,7 @@
         "/etc/pam.d/smartcard-auth": "....L....",
         "/etc/pam.d/system-auth": "....L....",
         "/etc/rhsm/rhsm.conf": "..5....T.",
+        "/etc/ssh/sshd_config": "S.5....T.",
         "/proc": ".M.......",
         "/sys": ".M.......",
         "/var/log/lastlog": ".M....G..",

--- a/test/data/manifests/rhel_85-aarch64-ec2-boot.json
+++ b/test/data/manifests/rhel_85-aarch64-ec2-boot.json
@@ -10921,6 +10921,7 @@
         "/etc/pam.d/smartcard-auth": "....L....",
         "/etc/pam.d/system-auth": "....L....",
         "/etc/rhsm/rhsm.conf": "..5....T.",
+        "/etc/ssh/sshd_config": "S.5....T.",
         "/etc/yum.repos.d/redhat-rhui-beta.repo": "..5....T.",
         "/etc/yum.repos.d/redhat-rhui-client-config.repo": "..5....T.",
         "/proc": ".M.......",

--- a/test/data/manifests/rhel_85-x86_64-ami-boot.json
+++ b/test/data/manifests/rhel_85-x86_64-ami-boot.json
@@ -10454,6 +10454,7 @@
         "/etc/pam.d/smartcard-auth": "....L....",
         "/etc/pam.d/system-auth": "....L....",
         "/etc/rhsm/rhsm.conf": "..5....T.",
+        "/etc/ssh/sshd_config": "S.5....T.",
         "/proc": ".M.......",
         "/sys": ".M.......",
         "/var/log/lastlog": ".M....G..",

--- a/test/data/manifests/rhel_85-x86_64-ec2-boot.json
+++ b/test/data/manifests/rhel_85-x86_64-ec2-boot.json
@@ -10505,6 +10505,7 @@
         "/etc/pam.d/smartcard-auth": "....L....",
         "/etc/pam.d/system-auth": "....L....",
         "/etc/rhsm/rhsm.conf": "..5....T.",
+        "/etc/ssh/sshd_config": "S.5....T.",
         "/etc/yum.repos.d/redhat-rhui-beta.repo": "..5....T.",
         "/etc/yum.repos.d/redhat-rhui-client-config.repo": "..5....T.",
         "/proc": ".M.......",

--- a/test/data/manifests/rhel_85-x86_64-ec2_ha-boot.json
+++ b/test/data/manifests/rhel_85-x86_64-ec2_ha-boot.json
@@ -12949,6 +12949,7 @@
         "/etc/pam.d/smartcard-auth": "....L....",
         "/etc/pam.d/system-auth": "....L....",
         "/etc/rhsm/rhsm.conf": "..5....T.",
+        "/etc/ssh/sshd_config": "S.5....T.",
         "/etc/yum.repos.d/redhat-rhui-client-config-ha.repo": "..5....T.",
         "/etc/yum.repos.d/redhat-rhui-ha.repo": "..5....T.",
         "/proc": ".M.......",

--- a/test/data/manifests/rhel_86-aarch64-ami-boot.json
+++ b/test/data/manifests/rhel_86-aarch64-ami-boot.json
@@ -10737,8 +10737,8 @@
         "fstype": "xfs",
         "label": "root",
         "partuuid": "6264D520-3FB9-423F-8AB8-7A0A8E3D3562",
-        "size": 9989681152,
-        "start": 747685888,
+        "size": 9989732352,
+        "start": 747634688,
         "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
         "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75"
       },
@@ -10757,7 +10757,7 @@
         "fstype": "xfs",
         "label": null,
         "partuuid": "CB07C243-BC44-4717-853E-28852021225B",
-        "size": 536922112,
+        "size": 536870912,
         "start": 210763776,
         "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
         "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8"
@@ -10851,6 +10851,7 @@
         "/etc/pam.d/smartcard-auth": "....L....",
         "/etc/pam.d/system-auth": "....L....",
         "/etc/rhsm/rhsm.conf": "..5....T.",
+        "/etc/ssh/sshd_config": "S.5....T.",
         "/proc": ".M.......",
         "/sys": ".M.......",
         "/var/log/lastlog": ".M....G..",

--- a/test/data/manifests/rhel_86-aarch64-ec2-boot.json
+++ b/test/data/manifests/rhel_86-aarch64-ec2-boot.json
@@ -10787,8 +10787,8 @@
         "fstype": "xfs",
         "label": "root",
         "partuuid": "6264D520-3FB9-423F-8AB8-7A0A8E3D3562",
-        "size": 9989681152,
-        "start": 747685888,
+        "size": 9989732352,
+        "start": 747634688,
         "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
         "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75"
       },
@@ -10807,7 +10807,7 @@
         "fstype": "xfs",
         "label": null,
         "partuuid": "CB07C243-BC44-4717-853E-28852021225B",
-        "size": 536922112,
+        "size": 536870912,
         "start": 210763776,
         "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
         "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8"
@@ -10901,6 +10901,7 @@
         "/etc/pam.d/smartcard-auth": "....L....",
         "/etc/pam.d/system-auth": "....L....",
         "/etc/rhsm/rhsm.conf": "..5....T.",
+        "/etc/ssh/sshd_config": "S.5....T.",
         "/etc/yum.repos.d/redhat-rhui-beta.repo": "..5....T.",
         "/etc/yum.repos.d/redhat-rhui-client-config.repo": "..5....T.",
         "/proc": ".M.......",

--- a/test/data/manifests/rhel_86-x86_64-ami-boot.json
+++ b/test/data/manifests/rhel_86-x86_64-ami-boot.json
@@ -10434,6 +10434,7 @@
         "/etc/pam.d/smartcard-auth": "....L....",
         "/etc/pam.d/system-auth": "....L....",
         "/etc/rhsm/rhsm.conf": "..5....T.",
+        "/etc/ssh/sshd_config": "S.5....T.",
         "/proc": ".M.......",
         "/sys": ".M.......",
         "/var/log/lastlog": ".M....G..",

--- a/test/data/manifests/rhel_86-x86_64-ec2-boot.json
+++ b/test/data/manifests/rhel_86-x86_64-ec2-boot.json
@@ -10486,6 +10486,7 @@
         "/etc/pam.d/smartcard-auth": "....L....",
         "/etc/pam.d/system-auth": "....L....",
         "/etc/rhsm/rhsm.conf": "..5....T.",
+        "/etc/ssh/sshd_config": "S.5....T.",
         "/etc/yum.repos.d/redhat-rhui-beta.repo": "..5....T.",
         "/etc/yum.repos.d/redhat-rhui-client-config.repo": "..5....T.",
         "/proc": ".M.......",

--- a/test/data/manifests/rhel_86-x86_64-ec2_ha-boot.json
+++ b/test/data/manifests/rhel_86-x86_64-ec2_ha-boot.json
@@ -12959,6 +12959,7 @@
         "/etc/pam.d/smartcard-auth": "....L....",
         "/etc/pam.d/system-auth": "....L....",
         "/etc/rhsm/rhsm.conf": "..5....T.",
+        "/etc/ssh/sshd_config": "S.5....T.",
         "/etc/yum.repos.d/redhat-rhui-client-config-ha.repo": "..5....T.",
         "/etc/yum.repos.d/redhat-rhui-ha.repo": "..5....T.",
         "/proc": ".M.......",

--- a/test/data/manifests/rhel_86-x86_64-ec2_sap-boot.json
+++ b/test/data/manifests/rhel_86-x86_64-ec2_sap-boot.json
@@ -13410,6 +13410,7 @@
         "/etc/pam.d/smartcard-auth": "....L....",
         "/etc/pam.d/system-auth": "....L....",
         "/etc/rhsm/rhsm.conf": "..5....T.",
+        "/etc/ssh/sshd_config": "S.5....T.",
         "/etc/yum.repos.d/redhat-rhui-client-config-sap-bundle.repo": "..5....T.",
         "/etc/yum.repos.d/redhat-rhui-sap-bundle-e4s.repo": "..5....T.",
         "/proc": ".M.......",


### PR DESCRIPTION
Fix missing missing `image-info` report updates after PR #2235.

Signed-off-by: Tomas Hozza <thozza@redhat.com>


This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`
-->
